### PR TITLE
feat: two-branch dev/prod pipeline with multi-environment CDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,19 @@ name: CI / Deploy
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, development]
   push:
-    branches: [main]
+    branches: [main, development]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Minimal default permissions — jobs that need more declare their own.
 permissions:
-  id-token: write   # required for OIDC (deploy job only)
   contents: read
+
+# ── CI jobs (run on every push and PR) ────────────────────────────────────────
 
 jobs:
   lint-typecheck:
@@ -139,12 +141,164 @@ jobs:
       - name: Build
         run: npm run build
 
-  deploy:
-    name: CDK Deploy
-    needs: [lint-typecheck, audit, unit-tests, integration-tests, frontend]
+  infra-synth:
+    name: Infra Synth
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install CDK
+        run: npm install -g aws-cdk
+
+      - name: Install Python dependencies
+        run: uv sync --group dev --group infra
+
+      - name: Synth prod stack
+        working-directory: infra
+        run: cdk synth HiveStack --no-staging -c env=prod
+
+      - name: Synth dev stack
+        working-directory: infra
+        run: cdk synth HiveStack-dev --no-staging -c env=dev
+
+# ── Deploy to dev (push to development) ───────────────────────────────────────
+
+  deploy-dev:
+    name: Deploy (dev)
+    needs: [lint-typecheck, audit, unit-tests, integration-tests, frontend, infra-synth]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/development'
+    runs-on: ubuntu-latest
+    environment: development
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      mcp_url: ${{ steps.urls.outputs.mcp_url }}
+      api_url: ${{ steps.urls.outputs.api_url }}
+      ui_url: ${{ steps.urls.outputs.ui_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEV_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Install CDK
+        run: npm install -g aws-cdk
+
+      - name: Install Python dependencies
+        run: uv sync --group dev --group infra
+
+      - name: Build React UI
+        working-directory: ui
+        run: npm install && npm run build
+
+      - name: Deploy dev stack
+        run: uv run inv deploy --env dev
+
+      - name: Export stack URLs
+        id: urls
+        run: |
+          STACK=HiveStack-dev
+          query() { aws cloudformation describe-stacks --stack-name $STACK --region us-east-1 \
+            --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" --output text; }
+          echo "mcp_url=$(query McpFunctionUrl)" >> "$GITHUB_OUTPUT"
+          echo "api_url=$(query ApiFunctionUrl)"  >> "$GITHUB_OUTPUT"
+          echo "ui_url=$(query UiUrl)"            >> "$GITHUB_OUTPUT"
+
+  e2e-dev:
+    name: E2E Tests (dev)
+    needs: deploy-dev
+    if: github.event_name == 'push' && github.ref == 'refs/heads/development'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Install Playwright
+        run: uv run playwright install chromium --with-deps
+
+      - name: Run auth + MCP e2e tests
+        env:
+          HIVE_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
+          HIVE_MCP_URL: ${{ needs.deploy-dev.outputs.mcp_url }}
+        run: uv run pytest tests/e2e/test_auth_e2e.py tests/e2e/test_mcp_e2e.py -v
+
+      - name: Run UI e2e tests (Playwright)
+        env:
+          HIVE_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
+          HIVE_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
+        run: uv run pytest tests/e2e/test_ui_e2e.py -v
+
+# ── Release + deploy to prod (push to main) ───────────────────────────────────
+
+  release:
+    name: Release
+    needs: [lint-typecheck, audit, unit-tests, integration-tests, frontend, infra-synth]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # needed for git describe to find the previous tag
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Infer version and create release
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(uv run inv version)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          gh release create "v$VERSION" --generate-notes --title "v$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  deploy-prod:
+    name: Deploy (prod)
+    needs: release
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       mcp_url: ${{ steps.urls.outputs.mcp_url }}
       api_url: ${{ steps.urls.outputs.api_url }}
@@ -174,25 +328,26 @@ jobs:
 
       - name: Build React UI
         working-directory: ui
-        run: |
-          npm install
-          npm run build
+        run: npm install && npm run build
 
-      - name: CDK Deploy
-        working-directory: infra
-        run: cdk deploy --require-approval never --outputs-file outputs.json
+      - name: Deploy prod stack
+        env:
+          APP_VERSION: ${{ needs.release.outputs.version }}
+        run: uv run inv deploy --env prod
 
-      - name: Export Lambda URLs
+      - name: Export stack URLs
         id: urls
-        working-directory: infra
         run: |
-          echo "mcp_url=$(jq -r '.HiveStack.McpFunctionUrl' outputs.json)" >> "$GITHUB_OUTPUT"
-          echo "api_url=$(jq -r '.HiveStack.ApiFunctionUrl' outputs.json)" >> "$GITHUB_OUTPUT"
-          echo "ui_url=$(jq -r '.HiveStack.UiUrl' outputs.json)" >> "$GITHUB_OUTPUT"
+          STACK=HiveStack
+          query() { aws cloudformation describe-stacks --stack-name $STACK --region us-east-1 \
+            --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" --output text; }
+          echo "mcp_url=$(query McpFunctionUrl)" >> "$GITHUB_OUTPUT"
+          echo "api_url=$(query ApiFunctionUrl)"  >> "$GITHUB_OUTPUT"
+          echo "ui_url=$(query UiUrl)"            >> "$GITHUB_OUTPUT"
 
-  e2e:
-    name: E2E Tests
-    needs: deploy
+  e2e-prod:
+    name: E2E Tests (prod)
+    needs: deploy-prod
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -210,12 +365,35 @@ jobs:
 
       - name: Run auth + MCP e2e tests
         env:
-          HIVE_API_URL: ${{ needs.deploy.outputs.api_url }}
-          HIVE_MCP_URL: ${{ needs.deploy.outputs.mcp_url }}
+          HIVE_API_URL: ${{ needs.deploy-prod.outputs.api_url }}
+          HIVE_MCP_URL: ${{ needs.deploy-prod.outputs.mcp_url }}
         run: uv run pytest tests/e2e/test_auth_e2e.py tests/e2e/test_mcp_e2e.py -v
 
       - name: Run UI e2e tests (Playwright)
         env:
-          HIVE_API_URL: ${{ needs.deploy.outputs.api_url }}
-          HIVE_UI_URL: ${{ needs.deploy.outputs.ui_url }}
+          HIVE_API_URL: ${{ needs.deploy-prod.outputs.api_url }}
+          HIVE_UI_URL: ${{ needs.deploy-prod.outputs.ui_url }}
         run: uv run pytest tests/e2e/test_ui_e2e.py -v
+
+  back-merge:
+    name: Back-merge main → development
+    needs: e2e-prod
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Create back-merge PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uv run inv back-merge

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,43 @@
+name: Deploy Dev (manual)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-dev:
+    name: CDK Deploy (dev)
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEV_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Install CDK
+        run: npm install -g aws-cdk
+
+      - name: Install Python dependencies
+        run: uv sync --group dev --group infra
+
+      - name: Build React UI
+        working-directory: ui
+        run: npm install && npm run build
+
+      - name: Deploy
+        run: uv run inv deploy --env dev

--- a/infra/app.py
+++ b/infra/app.py
@@ -6,11 +6,18 @@ from stacks.hive_stack import HiveStack
 
 app = cdk.App()
 
+# env_name is passed at deploy time: cdk deploy -c env=dev
+# Defaults to "prod" if not provided.
+env_name = app.node.try_get_context("env") or "prod"
+stack_id = "HiveStack" if env_name == "prod" else f"HiveStack-{env_name}"
+
 env = cdk.Environment(
+    # account is passed at deploy time: cdk deploy -c account=123456789012
+    # Falls back to the CloudFormation pseudo-parameter for synth without credentials.
     account=app.node.try_get_context("account") or cdk.Aws.ACCOUNT_ID,
     region=app.node.try_get_context("region") or "us-east-1",
 )
 
-HiveStack(app, "HiveStack", env=env)
+HiveStack(app, stack_id, env_name=env_name, env=env)
 
 app.synth()

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -3,12 +3,18 @@ Hive CDK Stack — defines all AWS infrastructure.
 
 Resources:
   - DynamoDB table (single-table design) with GSIs and TTL
-  - Lambda function for the MCP server (FastMCP + FastAPI via Mangum)
-  - Lambda function for the management API (FastAPI via Mangum)
+  - Lambda function for the MCP server (FastMCP + Mangum)
+  - Lambda function for the management API (FastAPI + Mangum)
   - Function URLs for both Lambdas (auth=NONE, TLS enforced)
-  - IAM roles scoped to DynamoDB table access
+  - IAM roles scoped to DynamoDB table and SSM access
   - SSM Parameter for JWT secret
   - S3 bucket + CloudFront distribution for the React management UI
+  - GitHub Actions OIDC deploy role (one per environment)
+
+Multi-environment usage:
+  cdk deploy HiveStack         -c env=prod   # production
+  cdk deploy HiveStack-dev     -c env=dev    # development
+  cdk deploy HiveStack-staging -c env=staging
 """
 
 from __future__ import annotations
@@ -26,26 +32,48 @@ from aws_cdk import aws_s3_deployment as s3deploy
 from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
+GITHUB_REPO = "warlordofmars/hive"
+
 
 class HiveStack(cdk.Stack):
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        env_name: str = "prod",
+        **kwargs,
+    ) -> None:
         super().__init__(scope, construct_id, **kwargs)
+
+        is_prod = env_name == "prod"
+
+        # Non-prod stacks destroy resources on `cdk destroy` for easy teardown.
+        # The JWT secret is always retained to prevent accidental key loss.
+        data_removal = cdk.RemovalPolicy.RETAIN if is_prod else cdk.RemovalPolicy.DESTROY
+
+        # GitHub Actions environment name used in the OIDC trust condition.
+        # prod → "production" (matches existing GitHub environment); others → env_name.
+        github_env = "production" if is_prod else env_name
 
         # ----------------------------------------------------------------
         # DynamoDB single table
         # ----------------------------------------------------------------
+        # Table name is derived from env_name so arbitrary envs never conflict.
+        # Prod keeps "hive" for backward compatibility with existing data.
+        table_name = "hive" if is_prod else f"hive-{env_name}"
+
         table = dynamodb.Table(
             self,
             "HiveTable",
-            table_name="hive",
+            table_name=table_name,
             partition_key=dynamodb.Attribute(name="PK", type=dynamodb.AttributeType.STRING),
             sort_key=dynamodb.Attribute(name="SK", type=dynamodb.AttributeType.STRING),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
-            removal_policy=cdk.RemovalPolicy.RETAIN,
+            removal_policy=data_removal,
+            # PITR is expensive — only enable in prod
             point_in_time_recovery_specification=dynamodb.PointInTimeRecoverySpecification(
-                point_in_time_recovery_enabled=True
+                point_in_time_recovery_enabled=is_prod
             ),
-            # TTL attribute used by token and auth-code items
             time_to_live_attribute="ttl",
         )
 
@@ -65,7 +93,7 @@ class HiveStack(cdk.Stack):
             projection_type=dynamodb.ProjectionType.ALL,
         )
 
-        # GSI 3 — ClientIndex: client lookups (reserved for future cross-entity queries)
+        # GSI 3 — ClientIndex: OAuth client lookups
         table.add_global_secondary_index(
             index_name="ClientIndex",
             partition_key=dynamodb.Attribute(name="GSI3PK", type=dynamodb.AttributeType.STRING),
@@ -75,17 +103,23 @@ class HiveStack(cdk.Stack):
         # ----------------------------------------------------------------
         # SSM Parameter — JWT secret
         # ----------------------------------------------------------------
+        # Parameter path is per-environment to prevent secret sharing.
+        # Prod keeps the existing path for backward compatibility.
+        ssm_param_name = "/hive/jwt-secret" if is_prod else f"/hive/{env_name}/jwt-secret"
+
         jwt_secret_param = ssm.StringParameter(
             self,
             "JwtSecret",
-            parameter_name="/hive/jwt-secret",
+            parameter_name=ssm_param_name,
             string_value="CHANGE_ME_ON_FIRST_DEPLOY",
-            description="Hive JWT signing secret — rotate after first deploy",
+            description=f"Hive JWT signing secret ({env_name}) — rotate after first deploy",
             tier=ssm.ParameterTier.STANDARD,
         )
+        # Always retain the JWT secret — losing it invalidates all issued tokens.
+        jwt_secret_param.apply_removal_policy(cdk.RemovalPolicy.RETAIN)
 
         # ----------------------------------------------------------------
-        # Shared Lambda code (from the built package)
+        # Shared Lambda code (Docker-bundled at cdk deploy time)
         # ----------------------------------------------------------------
         lambda_code = lambda_.Code.from_asset(
             "..",
@@ -107,10 +141,14 @@ class HiveStack(cdk.Stack):
             ),
         )
 
+        # JWT issuer URL embedded in tokens — must be unique per environment.
+        issuer_host = "hive" if is_prod else f"hive-{env_name}"
         common_env = {
             "HIVE_TABLE_NAME": table.table_name,
-            # AWS_REGION is reserved by the Lambda runtime — do not set it
-            "HIVE_ISSUER": f"https://hive.{self.account}.{self.region}.on.aws",
+            "HIVE_ISSUER": f"https://{issuer_host}.{self.account}.{self.region}.on.aws",
+            # APP_VERSION is injected at deploy time via the APP_VERSION env var.
+            # Falls back to "dev" for local synth/deploy without a version set.
+            "APP_VERSION": os.environ.get("APP_VERSION", "dev"),
         }
 
         # ----------------------------------------------------------------
@@ -139,7 +177,7 @@ class HiveStack(cdk.Stack):
             environment=common_env,
             memory_size=512,
             timeout=cdk.Duration.seconds(30),
-            description="Hive MCP server (FastMCP)",
+            description=f"Hive MCP server (FastMCP) [{env_name}]",
         )
 
         mcp_url = mcp_fn.add_function_url(
@@ -177,7 +215,7 @@ class HiveStack(cdk.Stack):
             environment=common_env,
             memory_size=512,
             timeout=cdk.Duration.seconds(30),
-            description="Hive management API (FastAPI)",
+            description=f"Hive management API (FastAPI) [{env_name}]",
         )
 
         api_url = api_fn.add_function_url(
@@ -195,8 +233,8 @@ class HiveStack(cdk.Stack):
         ui_bucket = s3.Bucket(
             self,
             "UiBucket",
-            removal_policy=cdk.RemovalPolicy.DESTROY,
-            auto_delete_objects=True,
+            removal_policy=data_removal,
+            auto_delete_objects=not is_prod,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
         )
 
@@ -264,6 +302,38 @@ class HiveStack(cdk.Stack):
             )
 
         # ----------------------------------------------------------------
+        # GitHub Actions OIDC deploy role
+        # ----------------------------------------------------------------
+        # One role per environment, scoped to its GitHub Actions environment.
+        # The OIDC provider must already exist in the account (created once via
+        # AWS console or: aws iam create-open-id-connect-provider).
+        github_oidc = iam.OpenIdConnectProvider.from_open_id_connect_provider_arn(
+            self,
+            "GitHubOidcProvider",
+            f"arn:aws:iam::{self.account}:oidc-provider/token.actions.githubusercontent.com",
+        )
+
+        deploy_role = iam.Role(
+            self,
+            "GitHubActionsDeployRole",
+            assumed_by=iam.WebIdentityPrincipal(
+                github_oidc.open_id_connect_provider_arn,
+                conditions={
+                    "StringEquals": {
+                        "token.actions.githubusercontent.com:sub": (
+                            f"repo:{GITHUB_REPO}:environment:{github_env}"
+                        ),
+                        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                    }
+                },
+            ),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("AdministratorAccess")
+            ],
+            description=f"GitHub Actions OIDC deploy role for Hive ({env_name})",
+        )
+
+        # ----------------------------------------------------------------
         # Outputs
         # ----------------------------------------------------------------
         cdk.CfnOutput(self, "McpFunctionUrl", value=mcp_url.url, description="MCP server URL")
@@ -274,4 +344,10 @@ class HiveStack(cdk.Stack):
             "UiUrl",
             value=f"https://{distribution.domain_name}",
             description="Management UI URL (CloudFront)",
+        )
+        cdk.CfnOutput(
+            self,
+            "DeployRoleArn",
+            value=deploy_role.role_arn,
+            description=f"GitHub Actions OIDC deploy role ARN ({env_name})",
         )

--- a/tasks.py
+++ b/tasks.py
@@ -78,6 +78,14 @@ def _infer_next_version(ctx):
 
 
 
+def _aws_account(ctx) -> str:
+    """Get the current AWS account ID via STS."""
+    return ctx.run(
+        "aws sts get-caller-identity --query Account --output text",
+        hide=True,
+    ).stdout.strip()
+
+
 def _cfn_output(ctx, key, env="prod"):
     stack = _stack_name(env)
     return ctx.run(
@@ -315,26 +323,40 @@ def dev(ctx):
 @task
 def synth(ctx, env="prod"):
     """Synthesize CDK template locally (skips Docker bundling). Use --env dev for dev stack."""
+    account = _aws_account(ctx)
     stack = _stack_name(env)
     with ctx.cd(INFRA):
-        ctx.run(f"uv run cdk synth {stack} --no-staging -c env={env}", pty=True)
+        ctx.run(
+            f"uv run cdk synth {stack} --no-staging -c account={account} -c env={env}",
+            pty=True,
+        )
 
 
 @task
 def diff(ctx, env="prod"):
     """Show CDK diff against the deployed stack. Use --env dev for dev stack."""
+    account = _aws_account(ctx)
     stack = _stack_name(env)
     with ctx.cd(INFRA):
-        ctx.run(f"uv run cdk diff {stack} -c env={env}", pty=True)
+        ctx.run(f"uv run cdk diff {stack} -c account={account} -c env={env}", pty=True)
 
 
 @task
 def deploy(ctx, env="prod"):
     """Deploy CDK stack to AWS. Use --env dev for dev stack."""
+    account = _aws_account(ctx)
     stack = _stack_name(env)
+    if env == "prod":
+        # In CI, APP_VERSION is set by the release job. Locally, infer from commits.
+        app_version = os.environ.get("APP_VERSION", _infer_next_version(ctx))
+    else:
+        short_sha = ctx.run("git rev-parse --short HEAD", hide=True).stdout.strip()
+        app_version = f"{_infer_next_version(ctx)}-{env}.{short_sha}"
     with ctx.cd(INFRA):
         ctx.run(
-            f"uv run cdk deploy {stack} --require-approval never -c env={env}",
+            f"uv run cdk deploy {stack} --require-approval never"
+            f" -c account={account} -c env={env}",
+            env={"APP_VERSION": app_version},
             pty=True,
         )
 
@@ -386,6 +408,26 @@ def logs_api(ctx, env="prod"):
 def version(ctx):
     """Print the next semantic version inferred from conventional commits."""
     print(_infer_next_version(ctx))
+
+
+@task
+def back_merge(ctx):
+    """Open a PR to merge main back into development after a prod release (auto-merges)."""
+    result = ctx.run(
+        "gh pr create"
+        " --base development"
+        " --head main"
+        " --title 'chore: merge main back to development'"
+        " --body 'Back-merge after prod release. Merge using **merge commit** (not squash).'",
+        warn=True,
+        hide="both",
+    )
+    if result.ok:
+        pr_url = result.stdout.strip().splitlines()[-1]
+        print(f"PR created: {pr_url}")
+        ctx.run(f"gh pr merge '{pr_url}' --auto --merge", warn=True)
+    else:
+        print("PR already exists or nothing to merge — skipping")
 
 
 # ── Clean ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **CDK multi-env**: `HiveStack` accepts `env_name`; table name, SSM path, removal policy, and OIDC deploy role are all derived from it — arbitrary envs (dev, staging, etc.) never conflict with prod
- **Per-env OIDC roles**: each stack creates its own deploy role scoped to `environment:{env_name}`; `DeployRoleArn` is a stack output so you can grab it after first deploy
- **CI split**: push to `development` → deploy-dev → e2e-dev; push to `main` → release (semver tag) → deploy-prod → e2e-prod → back-merge
- **`infra-synth` CI job**: validates both prod and dev CDK templates on every PR (no AWS credentials needed)
- **`deploy-dev.yml`**: manual `workflow_dispatch` for on-demand dev redeployment
- **`back-merge` task**: after prod e2e passes, auto-creates and merges PR `main → development`

## Bootstrap steps (after this merges)

1. Create `development` GitHub Actions environment (already done via branch creation)
2. Deploy dev stack locally once: `uv run inv deploy --env dev`
3. Grab `DeployRoleArn` from `HiveStack-dev` outputs → set `AWS_DEV_DEPLOY_ROLE_ARN` secret in GitHub (environment: development)
4. Rotate dev JWT secret: `aws ssm put-parameter --name /hive/dev/jwt-secret --value "$(openssl rand -hex 32)" --overwrite`
5. Push a change to `development` to confirm the full dev pipeline works

## Test plan

- [ ] CI checks pass on this PR
- [ ] `uv run inv synth --env dev` works locally
- [ ] `uv run inv synth --env prod` works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)