### PR TITLE
fix: map env_name to GitHub environment name for OIDC trust

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -52,8 +52,10 @@ class HiveStack(cdk.Stack):
         data_removal = cdk.RemovalPolicy.RETAIN if is_prod else cdk.RemovalPolicy.DESTROY
 
         # GitHub Actions environment name used in the OIDC trust condition.
-        # prod → "production" (matches existing GitHub environment); others → env_name.
-        github_env = "production" if is_prod else env_name
+        # Must match the `environment:` key in the workflow job exactly.
+        # prod → "production", dev → "development", others → env_name as-is.
+        _github_env_map = {"prod": "production", "dev": "development"}
+        github_env = _github_env_map.get(env_name, env_name)
 
         # ----------------------------------------------------------------
         # DynamoDB single table


### PR DESCRIPTION
## Summary

- The OIDC trust condition on the dev deploy role had `environment:dev` but GitHub sends `environment:development` (the GitHub environment name, not the CDK env_name)
- Added a `_github_env_map` dict in the stack: `dev → "development"`, `prod → "production"`, others pass through as-is
- The deployed role trust policy was already patched directly; this ensures future `cdk deploy -c env=dev` generates the correct condition

## Test plan

- [ ] CI passes (deploy-dev job authenticates via OIDC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)