### PR TITLE
fix: pass HIVE_JWT_SECRET_PARAM env var to Lambda functions

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -148,6 +148,8 @@ class HiveStack(cdk.Stack):
         common_env = {
             "HIVE_TABLE_NAME": table.table_name,
             "HIVE_ISSUER": f"https://{issuer_host}.{self.account}.{self.region}.on.aws",
+            # Tell both Lambdas which SSM parameter holds the JWT secret.
+            "HIVE_JWT_SECRET_PARAM": ssm_param_name,
             # APP_VERSION is injected at deploy time via the APP_VERSION env var.
             # Falls back to "dev" for local synth/deploy without a version set.
             "APP_VERSION": os.environ.get("APP_VERSION", "dev"),


### PR DESCRIPTION
## Summary

Both MCP and API Lambdas were falling back to the default SSM path `/hive/jwt-secret` (prod) instead of `/hive/dev/jwt-secret` on the dev stack, causing JWT signature verification failures when the API issued a token that MCP couldn't verify.

Fix: add `HIVE_JWT_SECRET_PARAM` to `common_env` in the CDK stack so both Lambdas always know exactly which SSM path to use. The live dev Lambda env vars were already patched directly.

## Test plan

- [ ] E2E tests pass (no more "Signature verification failed")

🤖 Generated with [Claude Code](https://claude.com/claude-code)