### PR TITLE
feat: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Python dependencies (pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      python-deps:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "aws-cdk-lib"
+        update-types: ["version-update:semver-major"]
+
+  # npm dependencies (ui/)
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      npm-deps:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly grouped PRs for Python, npm, and GitHub Actions
- Major version bumps for `aws-cdk-lib` and npm packages excluded from auto-grouping
- Directly motivated by the `fastmcp` CVEs caught today

## Test plan
- [x] Lint passes
- [x] All tests pass (40 unit, 14 integration, 3 frontend)
- [x] Deployed to `jc` env
- [x] All 7 e2e tests pass against `jc`

Closes #29