### PR TITLE
feat: build React UI automatically before cdk deploy

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -352,6 +352,13 @@ def deploy(ctx, env="prod"):
     else:
         short_sha = ctx.run("git rev-parse --short HEAD", hide=True).stdout.strip()
         app_version = f"{_infer_next_version(ctx)}-{env}.{short_sha}"
+
+    # Build the React UI so assets are included in the S3 deployment.
+    # CI does this explicitly before cdk deploy; local deploys must do the same.
+    with ctx.cd(UI):
+        ctx.run("npm install --silent", hide=True)
+        ctx.run("npm run build", pty=True)
+
     with ctx.cd(INFRA):
         ctx.run(
             f"uv run cdk deploy {stack} --require-approval never"


### PR DESCRIPTION
## Summary
- `inv deploy` now runs `npm install && npm run build` in `ui/` before CDK deploy
- Mirrors what CI does, so local deploys always include fresh UI assets
- Prevents the CloudFront/S3 empty-bucket issue hit during jc env setup today

## Test plan
- [x] Lint passes
- [x] All tests pass (40 unit, 14 integration, 3 frontend)
- [x] Validated against `jc` env in previous session