### PR TITLE
feat: add copyright notices to all source files

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 John Carter. All rights reserved.
 """CDK app entry point for Hive infrastructure."""
 
 import aws_cdk as cdk

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Hive CDK Stack — defines all AWS infrastructure.
 

--- a/src/hive/api/_auth.py
+++ b/src/hive/api/_auth.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """Shared FastAPI auth dependency for management API routes."""
 
 from __future__ import annotations

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 OAuth client management endpoints for the Hive management API.
 """

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Hive management FastAPI application.
 

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Memory CRUD endpoints for the Hive management API.
 

--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Usage stats and activity log endpoints for the Hive management API.
 """

--- a/src/hive/auth/dcr.py
+++ b/src/hive/auth/dcr.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Dynamic Client Registration (RFC 7591) for Hive OAuth 2.1.
 

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 OAuth 2.1 Authorization Server endpoints for Hive.
 

--- a/src/hive/auth/tokens.py
+++ b/src/hive/auth/tokens.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Token issuance and validation for Hive OAuth 2.1.
 

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Data models for Hive — shared persistent memory MCP server.
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Hive MCP Server — FastMCP tool definitions.
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 DynamoDB storage layer for Hive.
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Invoke task definitions for Hive.
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Shared e2e fixtures.
 """

--- a/tests/e2e/test_auth_e2e.py
+++ b/tests/e2e/test_auth_e2e.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 E2E tests for the deployed OAuth 2.1 authorization server.
 """

--- a/tests/e2e/test_mcp_e2e.py
+++ b/tests/e2e/test_mcp_e2e.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 E2E tests for the deployed Hive MCP server.
 Requires environment variables:

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Playwright E2E tests for the Hive management UI.
 Requires:

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Integration tests for the Hive management API.
 Runs against DynamoDB Local (Docker) — set DYNAMODB_ENDPOINT env var.

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Integration tests for the FastMCP tools against DynamoDB Local.
 """

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Integration tests for the OAuth 2.1 authorization flow.
 Requires DYNAMODB_ENDPOINT env var (DynamoDB Local).

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """Unit tests for OAuth auth logic — fully mocked, no AWS deps."""
 
 from __future__ import annotations

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """Unit tests for Hive data models — no AWS deps."""
 
 from __future__ import annotations

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
 """
 Unit tests for the storage layer using moto to mock DynamoDB.
 """

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useState } from "react";
 import MemoryBrowser from "./components/MemoryBrowser.jsx";
 import ClientManager from "./components/ClientManager.jsx";

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
 /**
  * Hive API client — thin wrapper around fetch.
  * Token is read from localStorage.

--- a/ui/src/components/ActivityLog.jsx
+++ b/ui/src/components/ActivityLog.jsx
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useState } from "react";
 import { api } from "../api.js";
 

--- a/ui/src/components/ClientManager.jsx
+++ b/ui/src/components/ClientManager.jsx
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useState } from "react";
 import { api } from "../api.js";
 

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useState } from "react";
 import { api } from "../api.js";
 

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import MemoryBrowser from "./MemoryBrowser.jsx";

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -1,1 +1,2 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
 import "@testing-library/jest-dom";


### PR DESCRIPTION
## Summary
- Adds `# Copyright (c) 2026 John Carter. All rights reserved.` to all Python source files
- Adds `// Copyright (c) 2026 John Carter. All rights reserved.` to all JS/JSX source files
- Covers: src/, infra/, tests/, ui/src/ (32 files total)
- Shebang lines preserved as first line where present

## Test plan
- [x] Lint passes
- [x] All tests pass (40 unit, 14 integration, 3 frontend)
- [x] Deployed to `jc` env
- [x] All 7 e2e tests pass against `jc`

Closes #14