### PR TITLE
fix: hour-shard activity log to prevent DynamoDB hot partition

### DIFF
--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -7,7 +7,7 @@ DynamoDB single-table design:
                  PK=MEMORY#{memory_id}   SK=META          (canonical item)
   OAuth clients: PK=CLIENT#{client_id}   SK=META
   Token items:   PK=TOKEN#{jti}          SK=META          (TTL enabled)
-  Activity log:  PK=LOG#{date}           SK={timestamp}#{event_id}
+  Activity log:  PK=LOG#{date}#{hour}     SK={timestamp}#{event_id}  (hour sharding)
 
 GSIs:
   TagIndex:      PK=tag, SK=memory_id    — for list_memories(tag)
@@ -301,10 +301,12 @@ class ActivityEvent(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_dynamo(self) -> dict[str, Any]:
-        date_str = self.timestamp.strftime("%Y-%m-%d")
+        # Hour-sharded PK: spreads writes across 24 partitions per day,
+        # avoiding DynamoDB hot-partition throttling under heavy write load.
+        date_hour_str = self.timestamp.strftime("%Y-%m-%d#%H")
         ts_str = self.timestamp.isoformat()
         return {
-            "PK": f"LOG#{date_str}",
+            "PK": f"LOG#{date_hour_str}",
             "SK": f"{ts_str}#{self.event_id}",
             "event_id": self.event_id,
             "event_type": self.event_type.value,

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -256,11 +256,29 @@ class HiveStorage:
         self.table.put_item(Item=event.to_dynamo())
 
     def get_events_for_date(self, date: str) -> list[ActivityEvent]:
-        """Query activity log for a specific date (YYYY-MM-DD)."""
-        resp = self.table.query(
-            KeyConditionExpression=Key("PK").eq(f"LOG#{date}"),
-        )
-        return [ActivityEvent.from_dynamo(i) for i in resp.get("Items", [])]
+        """Query activity log for a specific date (YYYY-MM-DD).
+
+        Queries all 24 hour-sharded partitions (LOG#{date}#{HH}) in parallel
+        and merges results. Also queries the legacy LOG#{date} partition for
+        backward compatibility with items written before the hour-sharding migration.
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        def _query(pk: str) -> list[ActivityEvent]:
+            resp = self.table.query(KeyConditionExpression=Key("PK").eq(pk))
+            return [ActivityEvent.from_dynamo(i) for i in resp.get("Items", [])]
+
+        # Build all partition keys: 24 hour shards + legacy unsharded key
+        pks = [f"LOG#{date}#{hour:02d}" for hour in range(24)]
+        pks.append(f"LOG#{date}")  # backward compat
+
+        events: list[ActivityEvent] = []
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = {executor.submit(_query, pk): pk for pk in pks}
+            for future in as_completed(futures):
+                events.extend(future.result())
+
+        return events
 
     def get_events_for_dates(self, dates: list[str]) -> list[ActivityEvent]:
         events: list[ActivityEvent] = []

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -209,3 +209,21 @@ class TestActivityLog:
         events = storage.get_events_for_date(date_str)
         assert len(events) == 1
         assert events[0].event_id == event.event_id
+
+    def test_hour_sharded_pk(self, storage):
+        """Events must be written to LOG#{date}#{hour} partitions."""
+        event = ActivityEvent(
+            event_type=EventType.memory_recalled,
+            client_id="c1",
+            metadata={},
+        )
+        storage.log_event(event)
+
+        item = storage.table.get_item(
+            Key={
+                "PK": f"LOG#{event.timestamp.strftime('%Y-%m-%d#%H')}",
+                "SK": f"{event.timestamp.isoformat()}#{event.event_id}",
+            }
+        ).get("Item")
+        assert item is not None
+        assert item["event_id"] == event.event_id


### PR DESCRIPTION
## Summary
- Changes activity log PK from `LOG#{date}` → `LOG#{date}#{hour}`, spreading writes across 24 partitions per day
- `get_events_for_date` queries all 24 hour partitions in parallel via `ThreadPoolExecutor` and merges results
- Also queries legacy `LOG#{date}` partition for backward compatibility with pre-migration items
- New unit test `test_hour_sharded_pk` verifies items land in the correct hour partition

## Test plan
- [x] Lint passes
- [x] All tests pass (42 unit, 15 integration, 3 frontend)
- [x] Deployed to `jc` env
- [x] All 7 e2e tests pass against `jc`

Closes #21