### PR TITLE
feat: dynamic versioning with hatch-vcs, version in health + UI + tags

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -150,6 +150,7 @@ class HiveStack(cdk.Stack):
 
         # JWT issuer URL embedded in tokens — must be unique per environment.
         issuer_host = "hive" if is_prod else f"hive-{env_name}"
+        app_version = os.environ.get("APP_VERSION", "dev")
         common_env = {
             "HIVE_TABLE_NAME": table.table_name,
             "HIVE_ISSUER": f"https://{issuer_host}.{self.account}.{self.region}.on.aws",
@@ -157,8 +158,11 @@ class HiveStack(cdk.Stack):
             "HIVE_JWT_SECRET_PARAM": ssm_param_name,
             # APP_VERSION is injected at deploy time via the APP_VERSION env var.
             # Falls back to "dev" for local synth/deploy without a version set.
-            "APP_VERSION": os.environ.get("APP_VERSION", "dev"),
+            "APP_VERSION": app_version,
         }
+
+        # Tag every resource with the deployed version for operational visibility.
+        cdk.Tags.of(self).add("version", app_version)
 
         # ----------------------------------------------------------------
         # MCP Lambda
@@ -359,4 +363,10 @@ class HiveStack(cdk.Stack):
             "DeployRoleArn",
             value=deploy_role.role_arn,
             description=f"GitHub Actions OIDC deploy role ARN ({env_name})",
+        )
+        cdk.CfnOutput(
+            self,
+            "AppVersion",
+            value=app_version,
+            description="Deployed application version",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hive"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Shared persistent memory MCP server for Claude agents and teams"
 requires-python = ">=3.10"
 dependencies = [
@@ -60,8 +60,11 @@ module = ["jose.*", "moto.*"]
 ignore_missing_imports = true
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hive"]

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -9,6 +9,7 @@ OAuth endpoints (/oauth/*, /.well-known/*) are public.
 
 from __future__ import annotations
 
+import importlib.metadata
 import os
 
 from fastapi import FastAPI
@@ -19,9 +20,23 @@ from hive.api.memories import router as memories_router
 from hive.api.stats import router as stats_router
 from hive.auth.oauth import router as oauth_router
 
+
+# APP_VERSION is injected at deploy time via Lambda env var.
+# Falls back to the installed package version, then "dev" for local runs.
+def _app_version() -> str:
+    if v := os.environ.get("APP_VERSION"):
+        return v
+    try:
+        return importlib.metadata.version("hive")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
+APP_VERSION = _app_version()
+
 app = FastAPI(
     title="Hive Management API",
-    version="0.1.0",
+    version=APP_VERSION,
     description="REST API for managing Hive memories, OAuth clients, and viewing activity stats.",
 )
 
@@ -47,7 +62,7 @@ app.include_router(stats_router, prefix="/api")
 
 @app.get("/health", include_in_schema=False)
 async def health() -> dict:
-    return {"status": "ok"}
+    return {"status": "ok", "version": APP_VERSION}
 
 
 def lambda_handler(event: dict, context: object) -> dict:

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -15,6 +15,8 @@ Tools:
 
 from __future__ import annotations
 
+import importlib.metadata
+import os
 from datetime import datetime, timezone
 from typing import Annotated
 
@@ -26,10 +28,20 @@ from hive.auth.tokens import validate_bearer_token
 from hive.models import ActivityEvent, EventType, Memory
 from hive.storage import HiveStorage
 
+
+def _app_version() -> str:
+    if v := os.environ.get("APP_VERSION"):
+        return v
+    try:
+        return importlib.metadata.version("hive")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
 mcp = FastMCP(
     name="Hive",
     instructions=(
-        "Hive is a shared persistent memory server for Claude agents and teams. "
+        f"Hive {_app_version()} — shared persistent memory server for Claude agents and teams. "
         "Use the memory tools to store, retrieve, and organise information across "
         "conversations and agent runs."
     ),

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import MemoryBrowser from "./components/MemoryBrowser.jsx";
 import ClientManager from "./components/ClientManager.jsx";
 import ActivityLog from "./components/ActivityLog.jsx";
+const API_BASE = import.meta.env.VITE_API_BASE ?? "";
 
 const TABS = [
   { id: "memories", label: "Memories" },
@@ -13,6 +14,14 @@ const TABS = [
 export default function App() {
   const [tab, setTab] = useState("memories");
   const [token, setToken] = useState(localStorage.getItem("hive_token") ?? "");
+  const [version, setVersion] = useState(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/health`)
+      .then((r) => r.json())
+      .then((data) => setVersion(data.version ?? null))
+      .catch(() => {});
+  }, []);
 
   function saveToken(t) {
     setToken(t);
@@ -68,6 +77,20 @@ export default function App() {
         {tab === "clients" && <ClientManager />}
         {tab === "activity" && <ActivityLog />}
       </main>
+
+      {version && (
+        <footer
+          style={{
+            textAlign: "center",
+            padding: "8px 0",
+            fontSize: 12,
+            color: "#888",
+            borderTop: "1px solid #eee",
+          }}
+        >
+          Hive {version}
+        </footer>
+      )}
     </div>
   );
 }

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,6 @@ wheels = [
 
 [[package]]
 name = "hive"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- `pyproject.toml` switches from static `version = "0.1.0"` to `hatch-vcs` (version derived from git tags at build time)
- `GET /health` now returns `{"status": "ok", "version": "1.2.3"}`
- FastAPI metadata and MCP server description include version
- Version displayed in UI footer, fetched from `/health` on load
- All AWS resources tagged with `version=` for operational visibility
- `AppVersion` added as a CloudFormation stack output (`uv run inv outputs` shows it)

## Version resolution at runtime
1. `APP_VERSION` env var (set at Lambda deploy time) — used in prod/dev/jc
2. `importlib.metadata.version("hive")` — used when running locally with `uv run`
3. `"dev"` — fallback

## Test plan
- [x] Lint passes
- [x] All tests pass (42 unit, 15 integration, 3 frontend)
- [x] Deployed to `jc` env — `GET /health` returns `{"status":"ok","version":"0.1.0-jc.c8a5b18"}`
- [x] All 7 e2e tests pass against `jc`

Closes #12