### PR TITLE
feat: add MCP server to local dev stack

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -230,21 +230,30 @@ async def summarize_context(
 
 
 # ---------------------------------------------------------------------------
-# Entry point — run as a Lambda handler or local stdio server
+# Entry points
 # ---------------------------------------------------------------------------
+
+# Module-level ASGI app — used by uvicorn for local dev:
+#   uvicorn hive.server:asgi_app --port 8002
+# Uvicorn manages lifespan correctly (startup once, shutdown once).
+asgi_app = mcp.http_app(stateless_http=True, json_response=True)
 
 
 def lambda_handler(event: dict, context: object) -> dict:
-    """AWS Lambda + Function URL handler (HTTP mode)."""
+    """AWS Lambda + Function URL handler (HTTP mode).
 
-    # Re-use FastAPI ASGI app via Mangum
+    Creates a fresh ASGI app per Lambda container initialisation.
+    FastMCP's StreamableHTTPSessionManager can only be started once per
+    instance, so we cannot reuse the module-level asgi_app across warm
+    Lambda invocations where Mangum re-runs the lifespan on each call.
+    """
     try:
         from mangum import Mangum
     except ImportError as exc:
         raise RuntimeError("mangum is required for Lambda deployment") from exc
 
-    asgi_app = mcp.http_app(stateless_http=True, json_response=True)
-    handler = Mangum(asgi_app, lifespan="on")
+    _app = mcp.http_app(stateless_http=True, json_response=True)
+    handler = Mangum(_app, lifespan="on")
     return handler(event, context)  # type: ignore[arg-type]
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -35,6 +35,7 @@ REGION = "us-east-1"
 DYNAMO_CONTAINER = "hive-dynamo-local"
 DYNAMO_PORT = 8000
 API_PORT = 8001
+MCP_PORT = 8002
 UI_PORT = 5173
 
 
@@ -249,10 +250,11 @@ def dynamo_stop(ctx):
 
 @task
 def dev(ctx):
-    """Start DynamoDB Local + management API + UI dev server (Ctrl-C to stop all)"""
+    """Start DynamoDB Local + MCP server + management API + UI dev server (Ctrl-C to stop all)"""
+    jwt_secret = os.environ.get("HIVE_JWT_SECRET", "dev-secret")
     dev_env = {
         **os.environ,
-        "HIVE_JWT_SECRET": os.environ.get("HIVE_JWT_SECRET", "dev-secret"),
+        "HIVE_JWT_SECRET": jwt_secret,
         "HIVE_TABLE_NAME": "hive",
         "DYNAMODB_ENDPOINT": f"http://localhost:{DYNAMO_PORT}",
         "AWS_ACCESS_KEY_ID": "local",
@@ -283,6 +285,20 @@ def dev(ctx):
         stderr=subprocess.DEVNULL,
     )
 
+    # Start MCP server (HTTP transport, matches production)
+    mcp_proc = subprocess.Popen(
+        [
+            "uv",
+            "run",
+            "uvicorn",
+            "hive.server:asgi_app",
+            f"--port={MCP_PORT}",
+            "--reload",
+        ],
+        cwd=ROOT,
+        env=dev_env,
+    )
+
     # Start management API
     api_proc = subprocess.Popen(
         ["uv", "run", "uvicorn", "hive.api.main:app", f"--port={API_PORT}", "--reload"],
@@ -297,7 +313,7 @@ def dev(ctx):
         env=ui_env,
     )
 
-    procs = [dynamo_proc, api_proc, ui_proc]
+    procs = [dynamo_proc, mcp_proc, api_proc, ui_proc]
 
     def _shutdown(sig, frame):
         print("\nShutting down...")
@@ -311,8 +327,27 @@ def dev(ctx):
 
     print("\nServices starting:")
     print(f"  DynamoDB Local → http://localhost:{DYNAMO_PORT}")
+    print(f"  MCP server      → http://localhost:{MCP_PORT}/mcp")
     print(f"  Management API  → http://localhost:{API_PORT}")
     print(f"  UI dev server   → http://localhost:{UI_PORT}")
+    print()
+    print("Claude Desktop stdio config (add to claude_desktop_config.json):")
+    print("  {")
+    print('    "mcpServers": {')
+    print('      "hive-local": {')
+    print('        "command": "uv",')
+    print('        "args": ["run", "python", "-m", "hive.server"],')
+    print('        "env": {')
+    print(f'          "HIVE_JWT_SECRET": "{jwt_secret}",')
+    print('          "HIVE_TABLE_NAME": "hive",')
+    print(f'          "DYNAMODB_ENDPOINT": "http://localhost:{DYNAMO_PORT}",')
+    print('          "AWS_ACCESS_KEY_ID": "local",')
+    print('          "AWS_SECRET_ACCESS_KEY": "local",')
+    print('          "AWS_DEFAULT_REGION": "us-east-1"')
+    print("        }")
+    print("      }")
+    print("    }")
+    print("  }")
     print("\nPress Ctrl-C to stop all services.\n")
 
     for p in procs:


### PR DESCRIPTION
## Summary
- `inv dev` now starts 4 services: DynamoDB Local, MCP server (port 8002), management API (port 8001), UI (port 5173)
- Prints Claude Desktop stdio config snippet on startup for easy copy-paste
- Exposes `asgi_app` at module level in `server.py` for `uvicorn hive.server:asgi_app`
- Lambda handler creates a fresh ASGI app per invocation — workaround for FastMCP's `StreamableHTTPSessionManager` single-use constraint (can't reuse module-level app across warm Lambda invocations with Mangum `lifespan="on"`)

## Test plan
- [x] Lint passes
- [x] All tests pass (42 unit, 15 integration, 3 frontend)
- [x] Deployed to `jc` env
- [x] All 7 e2e tests pass against `jc`

Closes #22