### PR TITLE
feat: fine-grained OAuth scopes per client registration

### DIFF
--- a/src/hive/api/_auth.py
+++ b/src/hive/api/_auth.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
-"""Shared FastAPI auth dependency for management API routes."""
+"""Shared FastAPI auth dependencies for management API routes."""
 
 from __future__ import annotations
 
@@ -31,3 +31,32 @@ async def require_token(
         await emit_metric("TokenValidationFailures")
         raise HTTPException(status_code=401, detail=str(exc)) from exc
     return storage, token.client_id
+
+
+def require_scope(required_scope: str):
+    """Return a FastAPI dependency that validates the Bearer token and checks for a scope."""
+
+    async def _dep(
+        credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+        storage: HiveStorage = Depends(_get_storage),
+    ) -> tuple[HiveStorage, str]:
+        try:
+            token = validate_bearer_token(f"Bearer {credentials.credentials}", storage)
+        except ValueError as exc:
+            await emit_metric("TokenValidationFailures")
+            raise HTTPException(status_code=401, detail=str(exc)) from exc
+        if required_scope not in set(token.scope.split()):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Insufficient scope: '{required_scope}' required",
+            )
+        return storage, token.client_id
+
+    return _dep
+
+
+# Module-level instances so tests can override them via app.dependency_overrides
+require_memories_read = require_scope("memories:read")
+require_memories_write = require_scope("memories:write")
+require_clients_read = require_scope("clients:read")
+require_clients_write = require_scope("clients:write")

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from hive.api._auth import require_token
+from hive.api._auth import require_clients_read, require_clients_write
 from hive.auth.dcr import register_client
 from hive.models import (
     ActivityEvent,
@@ -28,7 +28,7 @@ _LIMIT_MAX = 200
 async def list_clients(
     limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
     cursor: str | None = Query(None),
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_clients_read),
 ) -> PagedResponse:
     storage, _ = auth
     clients, next_cursor = storage.list_clients(limit=limit, cursor=cursor)
@@ -43,7 +43,7 @@ async def list_clients(
 @router.post("/clients", response_model=ClientRegistrationResponse, status_code=201)
 async def create_client(
     body: ClientRegistrationRequest,
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_clients_write),
 ) -> ClientRegistrationResponse:
     storage, _ = auth
     try:
@@ -63,7 +63,7 @@ async def create_client(
 @router.get("/clients/{client_id}", response_model=ClientRegistrationResponse)
 async def get_client(
     client_id: str,
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_clients_read),
 ) -> ClientRegistrationResponse:
     storage, _ = auth
     client = storage.get_client(client_id)
@@ -75,7 +75,7 @@ async def get_client(
 @router.delete("/clients/{client_id}", status_code=204)
 async def delete_client(
     client_id: str,
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_clients_write),
 ) -> None:
     storage, caller_client_id = auth
     deleted = storage.delete_client(client_id)

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
-from hive.api._auth import require_token
+from hive.api._auth import require_memories_read, require_memories_write
 from hive.models import (
     ActivityEvent,
     EventType,
@@ -34,7 +34,7 @@ async def list_memories(
     tag: str | None = Query(None, description="Filter by tag"),
     limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX, description="Max items to return"),
     cursor: str | None = Query(None, description="Pagination cursor from previous response"),
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_memories_read),
 ) -> PagedResponse:
     storage, _ = auth
     if tag:
@@ -53,7 +53,7 @@ async def list_memories(
 async def create_memory(
     body: MemoryCreate,
     response: Response,
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_memories_write),
 ) -> MemoryResponse:
     storage, client_id = auth
 
@@ -96,7 +96,7 @@ async def create_memory(
 @router.get("/memories/{memory_id}", response_model=MemoryResponse)
 async def get_memory(
     memory_id: str,
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_memories_read),
 ) -> MemoryResponse:
     storage, _ = auth
     memory = storage.get_memory_by_id(memory_id)
@@ -109,7 +109,7 @@ async def get_memory(
 async def update_memory(
     memory_id: str,
     body: MemoryUpdate,
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_memories_write),
 ) -> MemoryResponse:
     storage, client_id = auth
     memory = storage.get_memory_by_id(memory_id)
@@ -139,7 +139,7 @@ async def update_memory(
 @router.delete("/memories/{memory_id}", status_code=204)
 async def delete_memory(
     memory_id: str,
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_memories_write),
 ) -> None:
     storage, client_id = auth
     deleted = storage.delete_memory(memory_id)

--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -9,7 +9,7 @@ from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, Query
 
-from hive.api._auth import require_token
+from hive.api._auth import require_clients_read
 from hive.models import PagedResponse, StatsResponse
 from hive.storage import HiveStorage
 
@@ -21,7 +21,7 @@ _ACTIVITY_LIMIT_MAX = 500
 
 @router.get("/stats", response_model=StatsResponse)
 async def get_stats(
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_clients_read),
 ) -> StatsResponse:
     storage, _ = auth
     today = date.today()
@@ -47,7 +47,7 @@ async def get_activity(
         le=_ACTIVITY_LIMIT_MAX,
         description="Max events to return",
     ),
-    auth: tuple[HiveStorage, str] = Depends(require_token),
+    auth: tuple[HiveStorage, str] = Depends(require_clients_read),
 ) -> PagedResponse:
     storage, _ = auth
     today = date.today()

--- a/src/hive/auth/dcr.py
+++ b/src/hive/auth/dcr.py
@@ -20,6 +20,7 @@ from hive.storage import HiveStorage
 SUPPORTED_GRANT_TYPES = {"authorization_code", "refresh_token"}
 SUPPORTED_RESPONSE_TYPES = {"code"}
 SUPPORTED_AUTH_METHODS = {"none", "client_secret_post", "client_secret_basic"}
+ALLOWED_SCOPES = frozenset({"memories:read", "memories:write", "clients:read", "clients:write"})
 
 
 def register_client(
@@ -45,6 +46,12 @@ def register_client(
         raise ValueError(
             f"Unsupported token_endpoint_auth_method: {req.token_endpoint_auth_method}"
         )
+
+    # Validate requested scopes against the allowed set
+    requested_scopes = set(req.scope.split())
+    unknown_scopes = requested_scopes - ALLOWED_SCOPES
+    if unknown_scopes:
+        raise ValueError(f"Unknown scope(s): {unknown_scopes}")
 
     # Determine client type
     is_confidential = req.token_endpoint_auth_method in {

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -126,10 +126,20 @@ async def authorize(
     if code_challenge_method != "S256":
         raise HTTPException(status_code=400, detail="Only code_challenge_method=S256 is supported")
 
+    # Restrict requested scope to what the client is authorised for
+    client_scopes = set(client.scope.split())
+    requested_scopes = set(scope.split())
+    effective_scope = " ".join(sorted(client_scopes & requested_scopes))
+    if not effective_scope:
+        raise HTTPException(
+            status_code=400,
+            detail="Requested scope has no overlap with client's registered scope",
+        )
+
     auth_code = storage.create_auth_code(
         client_id=client_id,
         redirect_uri=redirect_uri,
-        scope=scope,
+        scope=effective_scope,
         code_challenge=code_challenge,
         code_challenge_method=code_challenge_method,
     )
@@ -235,9 +245,13 @@ async def token(
             raise HTTPException(status_code=400, detail="refresh_token not issued to this client")
 
         # Rotate: revoke old refresh token, issue new pair
+        # Re-intersect scope in case client's registered scope was narrowed since issuance
+        effective_scope = (
+            " ".join(sorted(set(stored.scope.split()) & set(client.scope.split()))) or stored.scope
+        )
         assert jti is not None
         storage.revoke_token(jti)
-        access, refresh = storage.create_token_pair(client_id, stored.scope)
+        access, refresh = storage.create_token_pair(client_id, effective_scope)
 
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported grant_type: {grant_type}")

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -58,13 +58,15 @@ mcp = FastMCP(
 # ---------------------------------------------------------------------------
 
 
-def _auth(ctx: Context | None) -> tuple[HiveStorage, str]:
+def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple[HiveStorage, str]:
     """Validate Bearer token; return (storage, client_id).
 
     Reads the Authorization header from the HTTP request when running under
     FastMCP's HTTP transport, falling back to ctx.request_context.meta for
     direct invocation (integration tests).  Also sets per-request logging
     context (request_id, client_id).
+
+    If required_scope is given, raises ToolError if the token lacks that scope.
     """
     storage = HiveStorage()
     auth_header: str | None = None
@@ -93,6 +95,9 @@ def _auth(ctx: Context | None) -> tuple[HiveStorage, str]:
     except ValueError as exc:
         raise ToolError(f"Unauthorized: {exc}") from exc
 
+    if required_scope and required_scope not in set(token.scope.split()):
+        raise ToolError(f"Insufficient scope: '{required_scope}' required")
+
     set_request_context(request_id, token.client_id)
     return storage, token.client_id
 
@@ -111,7 +116,7 @@ async def remember(
 ) -> str:
     """Store or update a memory with optional tags."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx)
+    storage, client_id = _auth(ctx, required_scope="memories:write")
     tags = tags or []
 
     # Check if a memory with this key already exists (upsert path)
@@ -181,7 +186,7 @@ async def recall(
 ) -> str:
     """Retrieve a memory by its key."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx)
+    storage, client_id = _auth(ctx, required_scope="memories:read")
 
     memory = storage.get_memory_by_key(key)
     if memory is None:
@@ -228,7 +233,7 @@ async def forget(
 ) -> str:
     """Delete a memory by its key."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx)
+    storage, client_id = _auth(ctx, required_scope="memories:write")
 
     existing = storage.get_memory_by_key(key)
     if existing is None:
@@ -278,7 +283,7 @@ async def list_memories(
 ) -> dict[str, Any]:
     """List memories that have a specific tag, with optional pagination."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx)
+    storage, client_id = _auth(ctx, required_scope="memories:read")
 
     limit = max(1, min(limit, 500))
     memories, next_cursor = storage.list_memories_by_tag(tag, limit=limit, cursor=cursor)
@@ -326,7 +331,7 @@ async def summarize_context(
     memory and then provides a combined overview paragraph.
     """
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx)
+    storage, client_id = _auth(ctx, required_scope="memories:read")
 
     memories, _ = storage.list_memories_by_tag(topic, limit=500)
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -65,10 +65,16 @@ def _create_table(table_name: str = "hive-unit-api") -> None:
 
 @pytest.fixture()
 def client():
-    """TestClient with require_token overridden — no JWT needed."""
+    """TestClient with all auth dependencies overridden — no JWT needed."""
     with mock_aws():
         _create_table()
-        from hive.api._auth import require_token
+        from hive.api._auth import (
+            require_clients_read,
+            require_clients_write,
+            require_memories_read,
+            require_memories_write,
+            require_token,
+        )
         from hive.api.main import app
         from hive.models import OAuthClient
         from hive.storage import HiveStorage
@@ -80,7 +86,14 @@ def client():
         def _override():
             return (storage, oauth_client.client_id)
 
-        app.dependency_overrides[require_token] = _override
+        for dep in (
+            require_token,
+            require_memories_read,
+            require_memories_write,
+            require_clients_read,
+            require_clients_write,
+        ):
+            app.dependency_overrides[dep] = _override
         yield TestClient(app), storage, oauth_client.client_id
         app.dependency_overrides.clear()
 
@@ -379,7 +392,7 @@ class TestClientCreateErrors:
 
 class TestRequireTokenSuccessPath:
     def test_valid_jwt_reaches_endpoint(self):
-        """Covers _auth.py:31 — return storage, token.client_id on valid token."""
+        """Covers _auth.py require_scope — valid token reaches endpoint."""
         from datetime import datetime, timedelta, timezone
 
         from hive.auth.tokens import issue_jwt
@@ -400,7 +413,7 @@ class TestRequireTokenSuccessPath:
                 now = datetime.now(timezone.utc)
                 token = Token(
                     client_id=oauth_client.client_id,
-                    scope="memories:read memories:write",
+                    scope="memories:read memories:write clients:read clients:write",
                     issued_at=now,
                     expires_at=now + timedelta(hours=1),
                 )
@@ -421,6 +434,62 @@ class TestRequireTokenSuccessPath:
             else:
                 os.environ.pop("HIVE_TABLE_NAME", None)
 
+    async def test_require_token_valid_token(self):
+        """Covers _auth.py:28-33 — require_token returns (storage, client_id) on valid token."""
+        from datetime import datetime, timedelta, timezone
+
+        from fastapi.security import HTTPAuthorizationCredentials
+
+        from hive.api._auth import require_token
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.storage import HiveStorage
+
+        old_table = os.environ.get("HIVE_TABLE_NAME")
+        os.environ["HIVE_TABLE_NAME"] = "hive-unit-api"
+        try:
+            with mock_aws():
+                _create_table()
+                storage = HiveStorage(table_name="hive-unit-api", region="us-east-1")
+                oauth_client = OAuthClient(client_name="Direct Token Test")
+                storage.put_client(oauth_client)
+
+                now = datetime.now(timezone.utc)
+                token = Token(
+                    client_id=oauth_client.client_id,
+                    scope="memories:read",
+                    issued_at=now,
+                    expires_at=now + timedelta(hours=1),
+                )
+                storage.put_token(token)
+                jwt_str = issue_jwt(token)
+
+                creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=jwt_str)
+                result_storage, result_client_id = await require_token(
+                    credentials=creds, storage=storage
+                )
+                assert result_client_id == oauth_client.client_id
+        finally:
+            if old_table is not None:
+                os.environ["HIVE_TABLE_NAME"] = old_table
+            else:
+                os.environ.pop("HIVE_TABLE_NAME", None)
+
+    async def test_require_token_invalid_jwt_raises_401(self):
+        """Covers _auth.py:30-32 — invalid JWT raises HTTP 401."""
+        from unittest.mock import MagicMock
+
+        from fastapi import HTTPException
+        from fastapi.security import HTTPAuthorizationCredentials
+
+        from hive.api._auth import require_token
+
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="not-a-jwt")
+        storage = MagicMock()
+        with pytest.raises(HTTPException) as exc_info:
+            await require_token(credentials=creds, storage=storage)
+        assert exc_info.value.status_code == 401
+
 
 class TestMemoryUpsertOversized:
     def test_upsert_existing_oversized_returns_413(self, client):
@@ -435,3 +504,114 @@ class TestMemoryUpsertOversized:
         ):
             resp = tc.post("/api/memories", json={"key": "upsert-big", "value": "x" * 1000})
         assert resp.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# Scope enforcement — covers api/_auth.py require_scope
+# ---------------------------------------------------------------------------
+
+
+def _scoped_client_fixture(scope: str):
+    """Build a TestClient with a real token limited to the given scope."""
+    from datetime import datetime, timedelta, timezone
+
+    from hive.api.main import app
+    from hive.auth.tokens import issue_jwt
+    from hive.models import OAuthClient, Token
+    from hive.storage import HiveStorage
+
+    storage = HiveStorage(table_name="hive-unit-api", region="us-east-1")
+    oauth_client = OAuthClient(client_name="Scope Test Client", scope=scope)
+    storage.put_client(oauth_client)
+
+    now = datetime.now(timezone.utc)
+    token = Token(
+        client_id=oauth_client.client_id,
+        scope=scope,
+        issued_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    storage.put_token(token)
+    jwt = issue_jwt(token)
+
+    # Clear all dependency overrides so actual scope checks run
+    app.dependency_overrides.clear()
+    return TestClient(app, raise_server_exceptions=False), jwt
+
+
+class TestScopeEnforcement:
+    def test_read_scope_allows_get_memories(self):
+        with mock_aws():
+            _create_table()
+            old = os.environ.get("HIVE_TABLE_NAME")
+            os.environ["HIVE_TABLE_NAME"] = "hive-unit-api"
+            try:
+                tc, jwt = _scoped_client_fixture("memories:read")
+                resp = tc.get("/api/memories", headers={"Authorization": f"Bearer {jwt}"})
+                assert resp.status_code == 200
+            finally:
+                if old is not None:
+                    os.environ["HIVE_TABLE_NAME"] = old
+                else:
+                    os.environ.pop("HIVE_TABLE_NAME", None)
+                from hive.api.main import app
+
+                app.dependency_overrides.clear()
+
+    def test_read_scope_blocks_post_memories(self):
+        with mock_aws():
+            _create_table()
+            old = os.environ.get("HIVE_TABLE_NAME")
+            os.environ["HIVE_TABLE_NAME"] = "hive-unit-api"
+            try:
+                tc, jwt = _scoped_client_fixture("memories:read")
+                resp = tc.post(
+                    "/api/memories",
+                    json={"key": "k", "value": "v"},
+                    headers={"Authorization": f"Bearer {jwt}"},
+                )
+                assert resp.status_code == 403
+            finally:
+                if old is not None:
+                    os.environ["HIVE_TABLE_NAME"] = old
+                else:
+                    os.environ.pop("HIVE_TABLE_NAME", None)
+                from hive.api.main import app
+
+                app.dependency_overrides.clear()
+
+    def test_memories_scope_blocks_clients_endpoint(self):
+        with mock_aws():
+            _create_table()
+            old = os.environ.get("HIVE_TABLE_NAME")
+            os.environ["HIVE_TABLE_NAME"] = "hive-unit-api"
+            try:
+                tc, jwt = _scoped_client_fixture("memories:read memories:write")
+                resp = tc.get("/api/clients", headers={"Authorization": f"Bearer {jwt}"})
+                assert resp.status_code == 403
+            finally:
+                if old is not None:
+                    os.environ["HIVE_TABLE_NAME"] = old
+                else:
+                    os.environ.pop("HIVE_TABLE_NAME", None)
+                from hive.api.main import app
+
+                app.dependency_overrides.clear()
+
+    def test_clients_read_scope_allows_list_clients(self):
+        with mock_aws():
+            _create_table()
+            old = os.environ.get("HIVE_TABLE_NAME")
+            os.environ["HIVE_TABLE_NAME"] = "hive-unit-api"
+            try:
+                tc, jwt = _scoped_client_fixture("clients:read")
+                resp = tc.get("/api/clients", headers={"Authorization": f"Bearer {jwt}"})
+                assert resp.status_code == 200
+            finally:
+                if old is not None:
+                    os.environ["HIVE_TABLE_NAME"] = old
+                else:
+                    os.environ.pop("HIVE_TABLE_NAME", None)
+                from hive.api.main import app
+
+                app.dependency_overrides.clear()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -898,3 +898,223 @@ class TestValidateBearerMissingJti:
         storage = MagicMock()
         with pytest.raises(ValueError, match="missing jti"):
             validate_bearer_token(f"Bearer {token_str}", storage)
+
+
+# ---------------------------------------------------------------------------
+# DCR scope validation — covers dcr.py ALLOWED_SCOPES check
+# ---------------------------------------------------------------------------
+
+
+class TestDCRScopeValidation:
+    def test_unknown_scope_raises(self):
+        storage = MagicMock()
+        req = ClientRegistrationRequest(
+            client_name="Bad Scope App",
+            scope="memories:read unknown:scope",
+        )
+        with pytest.raises(ValueError, match="Unknown scope"):
+            register_client(req, storage)
+
+    def test_known_scopes_accepted(self):
+        storage = MagicMock()
+        req = ClientRegistrationRequest(
+            client_name="Read Only Agent",
+            redirect_uris=["http://localhost/cb"],
+            scope="memories:read",
+        )
+        resp = register_client(req, storage)
+        assert resp.scope == "memories:read"
+
+    def test_all_scopes_accepted(self):
+        storage = MagicMock()
+        req = ClientRegistrationRequest(
+            client_name="Admin App",
+            redirect_uris=["http://localhost/cb"],
+            scope="memories:read memories:write clients:read clients:write",
+        )
+        resp = register_client(req, storage)
+        assert "clients:write" in resp.scope
+
+
+# ---------------------------------------------------------------------------
+# Authorize scope restriction — covers oauth.py scope intersection
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorizeScopeRestriction:
+    def test_requested_scope_restricted_to_client_scope(self, oauth_client):
+        """Authorize restricts requested scope to client's registered scope."""
+        from hive.models import OAuthClient
+
+        tc, storage, _ = oauth_client
+
+        # Register a read-only client
+        readonly_client = OAuthClient(
+            client_name="Read Only",
+            redirect_uris=["https://app.example.com/cb"],
+            scope="memories:read",
+        )
+        storage.put_client(readonly_client)
+
+        _, challenge = _pkce_pair()
+        resp = tc.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": readonly_client.client_id,
+                "redirect_uri": "https://app.example.com/cb",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                # Request write scope — should be restricted to read-only
+                "scope": "memories:read memories:write",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        # Code was issued — verify stored scope is restricted to client's scope
+        location = resp.headers["location"]
+        code = location.split("code=")[1].split("&")[0]
+        auth_code = storage.get_auth_code(code)
+        assert auth_code is not None
+        assert "memories:write" not in auth_code.scope
+        assert "memories:read" in auth_code.scope
+
+    def test_scope_no_overlap_returns_400(self, oauth_client):
+        """Authorize returns 400 when requested scope has no overlap with client scope."""
+        from hive.models import OAuthClient
+
+        tc, storage, _ = oauth_client
+
+        readonly_client = OAuthClient(
+            client_name="Read Only 2",
+            redirect_uris=["https://app.example.com/cb"],
+            scope="memories:read",
+        )
+        storage.put_client(readonly_client)
+
+        _, challenge = _pkce_pair()
+        resp = tc.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": readonly_client.client_id,
+                "redirect_uri": "https://app.example.com/cb",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "scope": "clients:read clients:write",
+            },
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Token scope — scope in issued access token matches auth code scope
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTokenScopeNarrowing:
+    def test_refresh_intersects_scope_with_current_client_scope(self, oauth_client):
+        """Covers oauth.py scope re-intersection — refresh token scope narrows to client scope."""
+        from hive.auth.tokens import decode_jwt
+        from hive.models import OAuthClient
+
+        tc, storage, _ = oauth_client
+
+        # Register a client with write+read scope
+        wide_client = OAuthClient(
+            client_name="Wide Scope Client",
+            redirect_uris=["https://app.example.com/cb"],
+            scope="memories:read memories:write",
+        )
+        storage.put_client(wide_client)
+
+        verifier, challenge = _pkce_pair()
+        code_resp = tc.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": wide_client.client_id,
+                "redirect_uri": "https://app.example.com/cb",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "scope": "memories:read memories:write",
+            },
+            follow_redirects=False,
+        )
+        code = code_resp.headers["location"].split("code=")[1].split("&")[0]
+        token_resp = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": "https://app.example.com/cb",
+                "client_id": wide_client.client_id,
+                "code_verifier": verifier,
+            },
+        )
+        refresh_token = token_resp.json()["refresh_token"]
+
+        # Narrow the client's scope in storage
+        wide_client.scope = "memories:read"
+        storage.put_client(wide_client)
+
+        # Refresh should issue new tokens with narrowed scope
+        resp = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": wide_client.client_id,
+                "refresh_token": refresh_token,
+            },
+        )
+        assert resp.status_code == 200
+        claims = decode_jwt(resp.json()["access_token"])
+        assert "memories:write" not in claims["scope"]
+        assert "memories:read" in claims["scope"]
+
+
+class TestTokenScopeIntersection:
+    def test_access_token_carries_restricted_scope(self, oauth_client):
+        """Access token scope matches the effective scope from the auth code."""
+        from hive.auth.tokens import decode_jwt
+        from hive.models import OAuthClient
+
+        tc, storage, _ = oauth_client
+
+        readonly_client = OAuthClient(
+            client_name="Scope Test Client",
+            redirect_uris=["https://app.example.com/cb"],
+            scope="memories:read",
+        )
+        storage.put_client(readonly_client)
+
+        verifier, challenge = _pkce_pair()
+        code_resp = tc.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": readonly_client.client_id,
+                "redirect_uri": "https://app.example.com/cb",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "scope": "memories:read memories:write",  # request more than allowed
+            },
+            follow_redirects=False,
+        )
+        code = code_resp.headers["location"].split("code=")[1].split("&")[0]
+
+        token_resp = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": "https://app.example.com/cb",
+                "client_id": readonly_client.client_id,
+                "code_verifier": verifier,
+            },
+        )
+        assert token_resp.status_code == 200
+        data = token_resp.json()
+        claims = decode_jwt(data["access_token"])
+        assert claims["scope"] == "memories:read"
+        assert "memories:write" not in claims["scope"]

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -374,3 +374,83 @@ class TestListMemoriesPagination:
         result = await list_memories("pagtest", limit=1, ctx=ctx)
         assert result["has_more"] is True
         assert "next_cursor" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP tool scope enforcement — covers server.py _auth() required_scope check
+# ---------------------------------------------------------------------------
+
+
+def _make_limited_scope_jwt(storage, scope: str) -> str:
+    """Issue a JWT with a restricted scope and store it in `storage`."""
+    from hive.auth.tokens import issue_jwt
+    from hive.models import OAuthClient, Token
+
+    client = OAuthClient(client_name=f"Scope Test {scope}")
+    storage.put_client(client)
+    now = datetime.now(timezone.utc)
+    token = Token(
+        client_id=client.client_id,
+        scope=scope,
+        issued_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    storage.put_token(token)
+    return issue_jwt(token)
+
+
+class TestMcpToolScopeEnforcement:
+    async def test_remember_requires_write_scope(self, server_env):
+        """remember() raises ToolError when token only has memories:read."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        storage, _, _ = server_env
+        read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await remember("scope-k", "v", [], ctx=_make_ctx(read_only_jwt))
+
+    async def test_recall_requires_read_scope(self, server_env):
+        """recall() raises ToolError when token only has memories:write."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import recall
+
+        storage, _, _ = server_env
+        write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await recall("any-key", ctx=_make_ctx(write_only_jwt))
+
+    async def test_forget_requires_write_scope(self, server_env):
+        """forget() raises ToolError when token only has memories:read."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import forget
+
+        storage, _, _ = server_env
+        read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await forget("any-key", ctx=_make_ctx(read_only_jwt))
+
+    async def test_list_memories_requires_read_scope(self, server_env):
+        """list_memories() raises ToolError when token only has memories:write."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import list_memories
+
+        storage, _, _ = server_env
+        write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await list_memories("any-tag", ctx=_make_ctx(write_only_jwt))
+
+    async def test_summarize_context_requires_read_scope(self, server_env):
+        """summarize_context() raises ToolError when token only has memories:write."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import summarize_context
+
+        storage, _, _ = server_env
+        write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await summarize_context("any-topic", ctx=_make_ctx(write_only_jwt))


### PR DESCRIPTION
## Summary
- Adds `ALLOWED_SCOPES` validation in DCR — unknown scopes are rejected at registration time
- `authorize` endpoint restricts the requested scope to the intersection with the client's registered scope; no overlap → 400
- Refresh token flow re-intersects scope with the client's current registered scope (handles scope narrowing after issuance)
- `require_scope()` dependency factory in `api/_auth.py` with module-level instances for testability
- All API endpoints now require the appropriate scope: `memories:read`/`memories:write` for memory routes, `clients:read`/`clients:write` for client/stats routes
- MCP tools enforce scopes: `remember`/`forget` require `memories:write`; `recall`/`list_memories`/`summarize_context` require `memories:read`
- 100% unit test coverage maintained across all new paths

## Test plan
- [ ] `uv run inv pre-push` passes locally (160 unit tests, 86 frontend tests)
- [ ] CI passes on PR branch
- [ ] Token with `memories:read` scope returns 403 on write endpoints
- [ ] Token with `memories:read memories:write` scope returns 403 on `/api/clients`
- [ ] DCR rejects unknown scopes (e.g. `admin:all`)
- [ ] Authorize restricts scope to client's registered scope

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)