### PR TITLE
feat: Route53 custom domain + ACM cert + MCP via CloudFront

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,11 +357,11 @@ jobs:
 
       - name: Synth prod stack
         working-directory: infra
-        run: cdk synth HiveStack --no-staging -c env=prod
+        run: cdk synth HiveStack --no-staging -c env=prod -c hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}
 
       - name: Synth dev stack
         working-directory: infra
-        run: cdk synth HiveStack-dev --no-staging -c env=dev
+        run: cdk synth HiveStack-dev --no-staging -c env=dev -c hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}
 
 # ── Deploy to dev (push to development) ───────────────────────────────────────
 

--- a/infra/app.py
+++ b/infra/app.py
@@ -19,6 +19,11 @@ env = cdk.Environment(
     region=app.node.try_get_context("region") or "us-east-1",
 )
 
-HiveStack(app, stack_id, env_name=env_name, env=env)
+# hosted_zone_id is required for Route53 hosted zone lookup without live AWS credentials.
+# Pass at synth/deploy time: cdk deploy -c hosted_zone_id=Z1234567890ABC
+# In CI this is injected from the HOSTED_ZONE_ID Actions variable.
+hosted_zone_id = app.node.try_get_context("hosted_zone_id") or ""
+
+HiveStack(app, stack_id, env_name=env_name, hosted_zone_id=hosted_zone_id, env=env)
 
 app.synth()

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 
 import aws_cdk as cdk
+from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_cloudfront as cloudfront
 from aws_cdk import aws_cloudfront_origins as origins
 from aws_cdk import aws_cloudwatch as cw
@@ -31,6 +32,8 @@ from aws_cdk import aws_dynamodb as dynamodb
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_logs as logs
+from aws_cdk import aws_route53 as route53
+from aws_cdk import aws_route53_targets as route53_targets
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_s3_deployment as s3deploy
 from aws_cdk import aws_sns as sns
@@ -40,12 +43,16 @@ from constructs import Construct
 GITHUB_REPO = "warlordofmars/hive"
 
 
+HOSTED_ZONE_NAME = "warlordofmars.net"
+
+
 class HiveStack(cdk.Stack):
     def __init__(
         self,
         scope: Construct,
         construct_id: str,
         env_name: str = "prod",
+        hosted_zone_id: str = "",
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -154,10 +161,34 @@ class HiveStack(cdk.Stack):
 
         # JWT issuer URL embedded in tokens — must be unique per environment.
         issuer_host = "hive" if is_prod else f"hive-{env_name}"
+        custom_domain = f"{issuer_host}.{HOSTED_ZONE_NAME}"
+
+        # ----------------------------------------------------------------
+        # Route53 hosted zone + ACM certificate
+        # ----------------------------------------------------------------
+        # hosted_zone_id is passed as CDK context (-c hosted_zone_id=...) so that
+        # the synth step in CI works without live AWS credentials.
+        hosted_zone = route53.HostedZone.from_hosted_zone_attributes(
+            self,
+            "HostedZone",
+            hosted_zone_id=hosted_zone_id,
+            zone_name=HOSTED_ZONE_NAME,
+        )
+
+        # ACM certificate must be in us-east-1 for CloudFront — this stack
+        # deploys to us-east-1 by default, so no cross-region cert needed.
+        certificate = acm.Certificate(
+            self,
+            "Certificate",
+            domain_name=custom_domain,
+            validation=acm.CertificateValidation.from_dns(hosted_zone),
+        )
+
         app_version = os.environ.get("APP_VERSION", "dev")
         common_env = {
             "HIVE_TABLE_NAME": table.table_name,
-            "HIVE_ISSUER": f"https://{issuer_host}.{self.account}.{self.region}.on.aws",
+            # Custom domain is the canonical issuer URL for all environments.
+            "HIVE_ISSUER": f"https://{custom_domain}",
             # Tell both Lambdas which SSM parameter holds the JWT secret.
             "HIVE_JWT_SECRET_PARAM": ssm_param_name,
             # APP_VERSION is injected at deploy time via the APP_VERSION env var.
@@ -259,15 +290,28 @@ class HiveStack(cdk.Stack):
 
         # API origin — strip "https://" prefix and trailing "/" from the function URL
         api_origin_domain = cdk.Fn.select(2, cdk.Fn.split("/", api_url.url))
+        mcp_origin_domain = cdk.Fn.select(2, cdk.Fn.split("/", mcp_url.url))
 
         api_cf_origin = origins.HttpOrigin(
             api_origin_domain,
             protocol_policy=cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
             origin_ssl_protocols=[cloudfront.OriginSslPolicy.TLS_V1_2],
         )
+        mcp_cf_origin = origins.HttpOrigin(
+            mcp_origin_domain,
+            protocol_policy=cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+            origin_ssl_protocols=[cloudfront.OriginSslPolicy.TLS_V1_2],
+        )
 
         api_behavior = cloudfront.BehaviorOptions(
             origin=api_cf_origin,
+            viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
+            origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+            allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
+        )
+        mcp_behavior = cloudfront.BehaviorOptions(
+            origin=mcp_cf_origin,
             viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
             origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
@@ -297,7 +341,10 @@ class HiveStack(cdk.Stack):
                     cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
                     origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
                 ),
+                "/mcp*": mcp_behavior,
             },
+            domain_names=[custom_domain],
+            certificate=certificate,
             default_root_object="index.html",
             error_responses=[
                 cloudfront.ErrorResponse(
@@ -319,6 +366,27 @@ class HiveStack(cdk.Stack):
                 distribution=distribution,
                 distribution_paths=["/*"],
             )
+
+        # ----------------------------------------------------------------
+        # Route53 alias records — A + AAAA → CloudFront distribution
+        # ----------------------------------------------------------------
+        cf_alias_target = route53.RecordTarget.from_alias(
+            route53_targets.CloudFrontTarget(distribution)
+        )
+        route53.ARecord(
+            self,
+            "AliasRecord",
+            zone=hosted_zone,
+            record_name=issuer_host,
+            target=cf_alias_target,
+        )
+        route53.AaaaRecord(
+            self,
+            "AliasRecordAAAA",
+            zone=hosted_zone,
+            record_name=issuer_host,
+            target=cf_alias_target,
+        )
 
         # ----------------------------------------------------------------
         # GitHub Actions OIDC deploy role
@@ -821,14 +889,26 @@ class HiveStack(cdk.Stack):
         # ----------------------------------------------------------------
         # Outputs
         # ----------------------------------------------------------------
-        cdk.CfnOutput(self, "McpFunctionUrl", value=mcp_url.url, description="MCP server URL")
-        cdk.CfnOutput(self, "ApiFunctionUrl", value=api_url.url, description="Management API URL")
+        cdk.CfnOutput(self, "McpFunctionUrl", value=mcp_url.url, description="MCP Lambda URL (direct)")
+        cdk.CfnOutput(self, "ApiFunctionUrl", value=api_url.url, description="API Lambda URL (direct)")
         cdk.CfnOutput(self, "TableName", value=table.table_name, description="DynamoDB table name")
         cdk.CfnOutput(
             self,
+            "HiveUrl",
+            value=f"https://{custom_domain}",
+            description="Hive base URL (custom domain)",
+        )
+        cdk.CfnOutput(
+            self,
+            "McpUrl",
+            value=f"https://{custom_domain}/mcp",
+            description="MCP server URL — use this in MCP client config",
+        )
+        cdk.CfnOutput(
+            self,
             "UiUrl",
-            value=f"https://{distribution.domain_name}",
-            description="Management UI URL (CloudFront)",
+            value=f"https://{custom_domain}",
+            description="Management UI URL",
         )
         cdk.CfnOutput(
             self,

--- a/tasks.py
+++ b/tasks.py
@@ -89,6 +89,20 @@ def _aws_account(ctx) -> str:
     ).stdout.strip()
 
 
+def _hosted_zone_id(ctx, zone_name: str = "warlordofmars.net") -> str:
+    """Resolve the Route53 hosted zone ID.
+
+    Checks HOSTED_ZONE_ID env var first; falls back to a Route53 API lookup.
+    """
+    if zone_id := os.environ.get("HOSTED_ZONE_ID"):
+        return zone_id
+    return ctx.run(
+        f"aws route53 list-hosted-zones-by-name --dns-name {zone_name}"
+        " --query 'HostedZones[0].Id' --output text",
+        hide=True,
+    ).stdout.strip().split("/")[-1]
+
+
 def _cfn_output(ctx, key, env="prod"):
     stack = _stack_name(env)
     return ctx.run(
@@ -404,10 +418,12 @@ def seed(ctx, env=None, token=None, reset=False):
 def synth(ctx, env="prod"):
     """Synthesize CDK template locally (skips Docker bundling). Use --env dev for dev stack."""
     account = _aws_account(ctx)
+    zone_id = _hosted_zone_id(ctx)
     stack = _stack_name(env)
     with ctx.cd(INFRA):
         ctx.run(
-            f"uv run cdk synth {stack} --no-staging -c account={account} -c env={env}",
+            f"uv run cdk synth {stack} --no-staging"
+            f" -c account={account} -c env={env} -c hosted_zone_id={zone_id}",
             pty=True,
         )
 
@@ -416,15 +432,21 @@ def synth(ctx, env="prod"):
 def diff(ctx, env="prod"):
     """Show CDK diff against the deployed stack. Use --env dev for dev stack."""
     account = _aws_account(ctx)
+    zone_id = _hosted_zone_id(ctx)
     stack = _stack_name(env)
     with ctx.cd(INFRA):
-        ctx.run(f"uv run cdk diff {stack} -c account={account} -c env={env}", pty=True)
+        ctx.run(
+            f"uv run cdk diff {stack}"
+            f" -c account={account} -c env={env} -c hosted_zone_id={zone_id}",
+            pty=True,
+        )
 
 
 @task
 def deploy(ctx, env="prod"):
     """Deploy CDK stack to AWS. Use --env dev for dev stack."""
     account = _aws_account(ctx)
+    zone_id = _hosted_zone_id(ctx)
     stack = _stack_name(env)
     if env == "prod":
         # In CI, APP_VERSION is set by the release job. Locally, infer from commits.
@@ -441,7 +463,8 @@ def deploy(ctx, env="prod"):
 
     with ctx.cd(INFRA):
         ctx.run(
-            f"uv run cdk deploy {stack} --require-approval never -c account={account} -c env={env}",
+            f"uv run cdk deploy {stack} --require-approval never"
+            f" -c account={account} -c env={env} -c hosted_zone_id={zone_id}",
             env={"APP_VERSION": app_version},
             pty=True,
         )


### PR DESCRIPTION
Closes #8

## Summary

- **Route53**: A + AAAA alias records pointing `hive.warlordofmars.net` (prod) / `hive-{env}.warlordofmars.net` (non-prod) at the CloudFront distribution
- **ACM certificate**: DNS-validated cert for the custom domain (stack is us-east-1 so no cross-region cert needed)
- **MCP behavior**: adds `/mcp*` CloudFront behavior routing to the MCP Lambda — MCP client config URL is now `https://hive.warlordofmars.net/mcp`
- **`HIVE_ISSUER`**: updated from raw Lambda Function URL to custom domain (note: this invalidates existing tokens on first deploy — users will need to re-auth)
- **Stack outputs**: `HiveUrl`, `McpUrl` added; `UiUrl` updated to custom domain

## CI / local synth

`from_hosted_zone_attributes` is used instead of `from_lookup` so synth works without live AWS credentials. The hosted zone ID is threaded as CDK context:

- **CI**: reads from `vars.HOSTED_ZONE_ID` Actions repository variable (needs to be created — see below)
- **Local**: `inv synth/diff/deploy` auto-resolve via `aws route53 list-hosted-zones-by-name`, or set `HOSTED_ZONE_ID` env var to skip the lookup

## Before merging / deploying

- [ ] Create GitHub Actions repository variable: **`HOSTED_ZONE_ID`** = your Route53 hosted zone ID (Settings → Secrets and variables → Actions → Variables)
- [ ] Complete Google Cloud Console setup per #68 before first login attempt

## Test plan

- [ ] `uv run inv diff --env dev` — verify Route53 + ACM + CloudFront changes look correct
- [ ] Deploy to dev, confirm `https://hive-dev.warlordofmars.net` resolves and cert is valid
- [ ] Hit `https://hive-dev.warlordofmars.net/mcp` — confirm MCP Lambda responds
- [ ] Hit `https://hive-dev.warlordofmars.net/health` — confirm API Lambda responds
- [ ] Deploy to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)