### PR TITLE
fix: DynamoDB Scan Limit causes list_all_memories to miss items

### DIFF
--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -165,27 +165,42 @@ class HiveStorage:
         """Scan for all META memory items (optionally filtered by owner_client_id).
 
         Returns (memories, next_cursor). Use sparingly — prefer tag-based queries.
-        """
-        kwargs: dict[str, Any] = {
-            "FilterExpression": "SK = :sk AND begins_with(PK, :pk_prefix)",
-            "ExpressionAttributeValues": {":sk": "META", ":pk_prefix": "MEMORY#"},
-            "Limit": limit,
-        }
-        if client_id:
-            kwargs["FilterExpression"] += " AND owner_client_id = :cid"
-            kwargs["ExpressionAttributeValues"][":cid"] = client_id
-        if cursor:
-            kwargs["ExclusiveStartKey"] = _decode_cursor(cursor)
 
-        resp = self.table.scan(**kwargs)
-        memories = [
-            Memory.from_dynamo(i)
-            for i in resp.get("Items", [])
-            if i["SK"] == "META" and i["PK"].startswith("MEMORY#")
-        ]
-        lek = resp.get("LastEvaluatedKey")
-        next_cursor = _encode_cursor(lek) if lek else None
-        return memories, next_cursor
+        Iterates DynamoDB scan pages until *limit* matching items are collected,
+        avoiding the "Limit evaluates N items before filter" footgun that causes
+        misses in single-table designs with mixed item types.
+        """
+        filter_expr = "SK = :sk AND begins_with(PK, :pk_prefix)"
+        expr_vals: dict[str, Any] = {":sk": "META", ":pk_prefix": "MEMORY#"}
+        if client_id:
+            filter_expr += " AND owner_client_id = :cid"
+            expr_vals[":cid"] = client_id
+
+        start_key = _decode_cursor(cursor) if cursor else None
+        memories: list[Memory] = []
+
+        while True:
+            kwargs: dict[str, Any] = {
+                "FilterExpression": filter_expr,
+                "ExpressionAttributeValues": expr_vals,
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+
+            resp = self.table.scan(**kwargs)
+            for item in resp.get("Items", []):
+                memories.append(Memory.from_dynamo(item))
+                if len(memories) >= limit:
+                    break
+
+            lek = resp.get("LastEvaluatedKey")
+            if len(memories) >= limit:
+                last = memories[limit - 1]
+                next_key = {"PK": f"MEMORY#{last.memory_id}", "SK": "META"}
+                return memories[:limit], _encode_cursor(next_key)
+            if lek is None:
+                return memories, None
+            start_key = lek
 
     # ------------------------------------------------------------------
     # OAuth Client management
@@ -211,19 +226,34 @@ class HiveStorage:
         limit: int = 50,
         cursor: str | None = None,
     ) -> tuple[list[OAuthClient], str | None]:
-        kwargs: dict[str, Any] = {
-            "FilterExpression": "begins_with(PK, :prefix) AND SK = :sk",
-            "ExpressionAttributeValues": {":prefix": "CLIENT#", ":sk": "META"},
-            "Limit": limit,
-        }
-        if cursor:
-            kwargs["ExclusiveStartKey"] = _decode_cursor(cursor)
+        filter_expr = "begins_with(PK, :prefix) AND SK = :sk"
+        expr_vals: dict[str, Any] = {":prefix": "CLIENT#", ":sk": "META"}
 
-        resp = self.table.scan(**kwargs)
-        clients = [OAuthClient.from_dynamo(i) for i in resp.get("Items", [])]
-        lek = resp.get("LastEvaluatedKey")
-        next_cursor = _encode_cursor(lek) if lek else None
-        return clients, next_cursor
+        start_key = _decode_cursor(cursor) if cursor else None
+        clients: list[OAuthClient] = []
+
+        while True:
+            kwargs: dict[str, Any] = {
+                "FilterExpression": filter_expr,
+                "ExpressionAttributeValues": expr_vals,
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+
+            resp = self.table.scan(**kwargs)
+            for item in resp.get("Items", []):
+                clients.append(OAuthClient.from_dynamo(item))
+                if len(clients) >= limit:
+                    break
+
+            lek = resp.get("LastEvaluatedKey")
+            if len(clients) >= limit:
+                last = clients[limit - 1]
+                next_key = {"PK": f"CLIENT#{last.client_id}", "SK": "META"}
+                return clients[:limit], _encode_cursor(next_key)
+            if lek is None:
+                return clients, None
+            start_key = lek
 
     # ------------------------------------------------------------------
     # Authorization codes

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -369,6 +369,56 @@ class TestPagination:
         with pytest.raises(ValueError, match="Invalid pagination cursor"):
             storage.list_all_memories(cursor="not-valid-base64!!!")
 
+    def test_list_all_memories_follows_scan_pages(self, storage):
+        """Covers the scan-loop continuation path when DynamoDB returns LastEvaluatedKey."""
+        from unittest.mock import patch
+
+        mems = [Memory(key=f"paged-{i}", value="v", owner_client_id="c1") for i in range(3)]
+        for m in mems:
+            storage.put_memory(m)
+
+        fake_lek = {"PK": f"MEMORY#{mems[0].memory_id}", "SK": "META"}
+        page1_items = [mems[0].to_dynamo_meta()]
+        page2_items = [mems[1].to_dynamo_meta(), mems[2].to_dynamo_meta()]
+        responses = iter(
+            [
+                {"Items": page1_items, "LastEvaluatedKey": fake_lek},
+                {"Items": page2_items},
+            ]
+        )
+
+        with patch.object(storage.table, "scan", side_effect=lambda **_kw: next(responses)):
+            result, cursor = storage.list_all_memories(limit=5)
+
+        assert len(result) == 3
+        assert cursor is None
+
+    def test_list_clients_follows_scan_pages(self, storage):
+        """Covers the scan-loop continuation path in list_clients."""
+        from unittest.mock import patch
+
+        from hive.models import OAuthClient
+
+        clients = [OAuthClient(client_name=f"C{i}") for i in range(3)]
+        for c in clients:
+            storage.put_client(c)
+
+        fake_lek = {"PK": f"CLIENT#{clients[0].client_id}", "SK": "META"}
+        page1_items = [clients[0].to_dynamo()]
+        page2_items = [clients[1].to_dynamo(), clients[2].to_dynamo()]
+        responses = iter(
+            [
+                {"Items": page1_items, "LastEvaluatedKey": fake_lek},
+                {"Items": page2_items},
+            ]
+        )
+
+        with patch.object(storage.table, "scan", side_effect=lambda **_kw: next(responses)):
+            result, cursor = storage.list_clients(limit=5)
+
+        assert len(result) == 3
+        assert cursor is None
+
     def test_activity_limit_respected(self, storage):
         from datetime import date
 


### PR DESCRIPTION
## Summary

- `list_all_memories` and `list_clients` passed `Limit=N` to DynamoDB Scan, but Scan's `Limit` limits items *evaluated* before filtering — not items *returned*
- In the single-table design with TOKEN#, CLIENT#, and LOG# items mixed alongside MEMORY# items, `Limit=50` evaluates 50 non-MEMORY items and returns zero results
- This caused `test_create_and_see_memory` to time out: the POST succeeded, but the subsequent `GET /api/memories` returned an empty list because the new memory fell outside the evaluated window
- Both functions now loop through DynamoDB scan pages until the requested number of *matching* items is collected; the next-page cursor is encoded from the last returned item's primary key

Closes #70

## Test plan

- [x] `uv run inv lint-backend typecheck test-unit test-frontend` passes locally
- [x] Two new tests added: `test_list_all_memories_follows_scan_pages` and `test_list_clients_follows_scan_pages` — cover the multi-page scan loop path with a mocked scan
- [ ] Deploy to dev and verify `test_create_and_see_memory` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)