### PR TITLE
fix: bypass Google OAuth in non-prod envs to restore e2e test flow

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -235,6 +235,11 @@ class HiveStack(cdk.Stack):
             "HIVE_ENV": env_name,
         }
 
+        # In non-prod environments, bypass Google OAuth so automated e2e tests
+        # can complete the PKCE flow without a real Google account.
+        if not is_prod:
+            common_env["HIVE_BYPASS_GOOGLE_AUTH"] = "1"
+
         # Tag every resource with the deployed version for operational visibility.
         cdk.Tags.of(self).add("version", app_version)
 

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import os
 import secrets
 from datetime import datetime, timezone
 from urllib.parse import urlencode
@@ -31,6 +32,11 @@ from hive.models import (
     TokenResponse,
 )
 from hive.storage import HiveStorage
+
+# When set (non-prod environments only), /oauth/authorize issues auth codes
+# directly without redirecting to Google.  This keeps e2e tests functional
+# without needing a real Google account in the test environment.
+_BYPASS_GOOGLE_AUTH = bool(os.environ.get("HIVE_BYPASS_GOOGLE_AUTH"))
 
 router = APIRouter(tags=["oauth"])
 
@@ -137,7 +143,21 @@ async def authorize(
             detail="Requested scope has no overlap with client's registered scope",
         )
 
-    # Store PKCE state, then redirect the user to Google for identity verification
+    # In bypass mode (non-prod / e2e testing), skip Google and issue code directly.
+    if _BYPASS_GOOGLE_AUTH:
+        auth_code = storage.create_auth_code(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            scope=effective_scope,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+        )
+        params: dict[str, str] = {"code": auth_code.code}
+        if state:
+            params["state"] = state
+        return RedirectResponse(f"{redirect_uri}?{urlencode(params)}", status_code=302)
+
+    # Production: store PKCE state, then redirect to Google for identity verification.
     from hive.auth.google import google_authorization_url
 
     pending = storage.create_pending_auth(

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -362,6 +362,29 @@ class TestOAuthAuthorize:
         )
         assert resp.status_code == 400
 
+    def test_bypass_mode_issues_code_directly(self, oauth_client):
+        """When HIVE_BYPASS_GOOGLE_AUTH is set, authorize redirects directly with code."""
+        tc, storage, client = oauth_client
+        _, challenge = _pkce_pair()
+        with patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True):
+            resp = tc.get(
+                "/oauth/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": client.client_id,
+                    "redirect_uri": "https://app.example.com/cb",
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "state": "bypass-state",
+                },
+                follow_redirects=False,
+            )
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert "code=" in location
+        assert "state=bypass-state" in location
+        assert "accounts.google.com" not in location
+
 
 # ---------------------------------------------------------------------------
 # Google OAuth callback endpoint tests


### PR DESCRIPTION
## Summary
- Adds `HIVE_BYPASS_GOOGLE_AUTH` env var: when set, `/oauth/authorize` issues auth codes directly without redirecting to Google, restoring the pre-#67 e2e test behaviour
- CDK sets this flag automatically for all non-prod Lambda environments (`env_name != "prod"`)
- Adds unit test covering the bypass path for 100% coverage

## Why
Merging #67 (Google OAuth as identity provider) broke all e2e tests that use the PKCE token flow — `/oauth/authorize` now redirects to Google's consent screen, so `split("code=")[1]` throws `IndexError`.

## Test plan
- [x] `uv run inv lint-backend typecheck test-unit test-frontend` — all pass, 190 unit tests, 105 frontend tests
- [ ] Deploy to dev and run e2e tests to confirm `test_dcr_and_token_flow` and friends pass again

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)