### PR TITLE
fix(e2e): skip token flow tests when Google OAuth redirect is required

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -45,7 +45,10 @@ async def live_token() -> str:
             },
             follow_redirects=False,
         )
-        code = auth.headers["location"].split("code=")[1].split("&")[0]
+        location = auth.headers.get("location", "")
+        if "accounts.google.com" in location:
+            pytest.skip("Google OAuth required — cannot complete token flow in CI without bypass")
+        code = location.split("code=")[1].split("&")[0]
 
         token_resp = await http.post(
             "/oauth/token",
@@ -88,7 +91,10 @@ def issue_token_sync() -> str:
                 "code_challenge_method": "S256",
             },
         )
-        code = auth.headers["location"].split("code=")[1].split("&")[0]
+        location = auth.headers.get("location", "")
+        if "accounts.google.com" in location:
+            pytest.skip("Google OAuth required — cannot complete token flow in CI without bypass")
+        code = location.split("code=")[1].split("&")[0]
 
         token_resp = http.post(
             "/oauth/token",

--- a/tests/e2e/test_auth_e2e.py
+++ b/tests/e2e/test_auth_e2e.py
@@ -65,7 +65,12 @@ class TestOAuthE2E:
                 },
             )
             assert auth.status_code == 302
-            code = auth.headers["location"].split("code=")[1].split("&")[0]
+            location = auth.headers.get("location", "")
+            if "accounts.google.com" in location:
+                pytest.skip(
+                    "Google OAuth required — cannot complete token flow in CI without bypass"
+                )
+            code = location.split("code=")[1].split("&")[0]
 
             # Exchange
             token = await http.post(


### PR DESCRIPTION
## Summary
- Prod e2e tests were crashing with `IndexError` because `/oauth/authorize` in prod correctly redirects to Google instead of returning a code directly
- Now checks the redirect location — if it points to `accounts.google.com`, skips gracefully instead of crashing
- Same fix applied to `conftest.py` (`live_token` fixture and `issue_token_sync`) and `test_auth_e2e.py`

## Why
Prod does not set `HIVE_BYPASS_GOOGLE_AUTH`, so the full token flow can't be automated in CI without a real Google account. The bypass only exists in dev/non-prod environments.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)