### PR TITLE
fix: skip at_hash validation in Google ID token verification

### DIFF
--- a/src/hive/auth/google.py
+++ b/src/hive/auth/google.py
@@ -117,6 +117,7 @@ async def verify_google_id_token(id_token: str) -> dict[str, Any]:
         algorithms=["RS256"],
         audience=_google_client_id(),
         issuer=GOOGLE_ISSUER,
+        options={"verify_at_hash": False},
     )
     return claims
 


### PR DESCRIPTION
## Summary
- `python-jose` was raising `No access_token provided to compare against at_hash claim` when decoding Google ID tokens
- Google includes `at_hash` in the ID token (a hash of the access token), but we never pass the access token to the decoder since we only need the email claim for identity
- Fix: set `options={"verify_at_hash": False}` — safe because we still verify signature, audience, issuer, and expiry

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)