### PR TITLE
release: fix Google ID token at_hash validation error

### DIFF
--- a/src/hive/auth/google.py
+++ b/src/hive/auth/google.py
@@ -117,6 +117,7 @@ async def verify_google_id_token(id_token: str) -> dict[str, Any]:
         algorithms=["RS256"],
         audience=_google_client_id(),
         issuer=GOOGLE_ISSUER,
+        options={"verify_at_hash": False},
     )
     return claims
 


### PR DESCRIPTION
## Summary
- fix: skip at_hash validation in Google ID token verification (#78)

Fixes `Google token verification failed: No access_token provided to compare against at_hash claim` — python-jose was trying to validate the at_hash claim but we never pass the access token since we only need the email for identity.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)