### PR TITLE
feat(multi-tenant): management auth — /auth/login, /auth/callback, management JWTs

### DIFF
--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -20,6 +20,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from hive.api.clients import router as clients_router
 from hive.api.memories import router as memories_router
 from hive.api.stats import router as stats_router
+from hive.auth.mgmt_auth import router as mgmt_auth_router
 from hive.auth.oauth import router as oauth_router
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 
@@ -112,6 +113,9 @@ async def _verify_origin_secret(request: Request, call_next):
 
 # OAuth 2.1 endpoints (unauthenticated)
 app.include_router(oauth_router)
+
+# Management UI auth endpoints (unauthenticated — issues mgmt JWTs)
+app.include_router(mgmt_auth_router)
 
 # Management API endpoints (Bearer token required)
 app.include_router(memories_router, prefix="/api")

--- a/src/hive/auth/google.py
+++ b/src/hive/auth/google.py
@@ -131,3 +131,12 @@ def is_email_allowed(email: str) -> bool:
     if not allowed:
         return True
     return email in allowed
+
+
+def is_admin_email(email: str) -> bool:
+    """Return True if this email gets the admin role.
+
+    Only emails explicitly listed in ALLOWED_EMAILS / ALLOWED_EMAILS_PARAM
+    receive admin.  An empty allowlist means no admins (not 'everyone is admin').
+    """
+    return email in _allowed_emails()

--- a/src/hive/auth/mgmt_auth.py
+++ b/src/hive/auth/mgmt_auth.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Management UI authentication — Google OAuth login flow for human users.
+
+This is a separate, lighter-weight flow from the MCP OAuth 2.1 flow.
+It issues short-lived management JWTs (typ=mgmt) stored in the browser's
+localStorage, not in DynamoDB.
+
+Routes:
+  GET /auth/login    — redirect to Google (or issue bypass JWT in non-prod)
+  GET /auth/callback — handle Google callback, upsert User, issue mgmt JWT
+"""
+
+from __future__ import annotations
+
+import html
+import os
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from hive.auth.google import (
+    exchange_google_code,
+    google_authorization_url,
+    is_admin_email,
+    verify_google_id_token,
+)
+from hive.auth.tokens import ISSUER, issue_mgmt_jwt
+from hive.logging_config import get_logger
+from hive.models import User
+from hive.storage import HiveStorage
+
+router = APIRouter(tags=["mgmt-auth"])
+logger = get_logger("hive.auth.mgmt_auth")
+
+_BYPASS = bool(os.environ.get("HIVE_BYPASS_GOOGLE_AUTH"))
+
+# Redirect target after successful login — the management UI root
+_UI_ROOT = "/"
+
+
+def _mgmt_callback_uri() -> str:
+    return f"{ISSUER}/auth/callback"
+
+
+def _html_redirect(jwt_token: str) -> HTMLResponse:
+    """Return a minimal HTML page that writes the JWT to localStorage and redirects."""
+    safe_token = html.escape(jwt_token, quote=True)
+    body = (
+        "<!DOCTYPE html><html><head><title>Logging in…</title></head><body>"
+        "<script>"
+        f"localStorage.setItem('hive_mgmt_token', '{safe_token}');"
+        f"location.replace('{_UI_ROOT}');"
+        "</script>"
+        "<noscript>JavaScript is required to complete login.</noscript>"
+        "</body></html>"
+    )
+    return HTMLResponse(content=body)
+
+
+@router.get("/auth/login", include_in_schema=False)
+async def mgmt_login(request: Request) -> RedirectResponse:
+    """Redirect the management UI user to Google for authentication.
+
+    In HIVE_BYPASS_GOOGLE_AUTH mode (non-prod), issue a synthetic JWT directly
+    for the test email so e2e tests can run without a real Google account.
+    """
+    if _BYPASS:
+        test_email = request.query_params.get("test_email", "test@example.com")
+        storage = HiveStorage()
+        user = _upsert_user(storage, test_email, test_email.split("@")[0], test_email)
+        token = issue_mgmt_jwt(user)
+        return _html_redirect(token)  # type: ignore[return-value]
+
+    storage = HiveStorage()
+    pending = storage.create_mgmt_pending_state()
+    url = google_authorization_url(pending.state, _mgmt_callback_uri())
+    return RedirectResponse(url, status_code=302)
+
+
+@router.get("/auth/callback", include_in_schema=False)
+async def mgmt_callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+) -> HTMLResponse:
+    """Handle the Google OAuth callback for the management UI.
+
+    Validates the nonce, exchanges the code, verifies the ID token,
+    upserts the User record, and returns an HTML page that writes the
+    management JWT to localStorage and redirects to the UI root.
+    """
+    if error:
+        raise HTTPException(status_code=400, detail=f"Google OAuth error: {error}")
+    if not code or not state:
+        raise HTTPException(status_code=400, detail="Missing code or state parameter")
+
+    storage = HiveStorage()
+
+    # Validate and consume the nonce
+    pending = storage.get_mgmt_pending_state(state)
+    if pending is None:
+        raise HTTPException(status_code=400, detail="Invalid or expired state")
+    if datetime.now(timezone.utc) >= pending.expires_at:
+        storage.delete_mgmt_pending_state(state)
+        raise HTTPException(status_code=400, detail="Login session expired, please try again")
+    storage.delete_mgmt_pending_state(state)
+
+    # Exchange code → ID token → claims
+    try:
+        id_token = await exchange_google_code(code, _mgmt_callback_uri())
+        claims = await verify_google_id_token(id_token)
+    except Exception as exc:
+        logger.warning("Google token exchange failed: %s", exc)
+        raise HTTPException(status_code=400, detail="Failed to verify Google identity") from exc
+
+    if not claims.get("email_verified"):
+        raise HTTPException(status_code=400, detail="Google email is not verified")
+
+    email: str = claims["email"]
+    display_name: str = claims.get("name", email.split("@")[0])
+
+    user = _upsert_user(storage, email, display_name, email)
+    token = issue_mgmt_jwt(user)
+    logger.info("Management login: %s (role=%s)", email, user.role)
+    return _html_redirect(token)
+
+
+def _upsert_user(storage: HiveStorage, email: str, display_name: str, _email: str) -> User:
+    """Create or update the User record for a given email."""
+    now = datetime.now(timezone.utc)
+    user = storage.get_user_by_email(email)
+    if user is None:
+        role = "admin" if is_admin_email(email) else "user"
+        user = User(email=email, display_name=display_name, role=role, created_at=now)
+        logger.info("New user registered: %s (role=%s)", email, role)
+    else:
+        user.display_name = display_name
+        # Re-evaluate admin status in case the allowlist was updated
+        user.role = "admin" if is_admin_email(email) else "user"
+    user.last_login_at = now
+    storage.put_user(user)
+    return user

--- a/src/hive/auth/tokens.py
+++ b/src/hive/auth/tokens.py
@@ -85,6 +85,43 @@ def _origin_verify_secret() -> str | None:
         return None
 
 
+MGMT_JWT_TTL_SECONDS = 28800  # 8 hours
+
+
+def issue_mgmt_jwt(user: Any) -> str:
+    """Issue a short-lived management session JWT for a human user.
+
+    Uses typ=mgmt to distinguish from MCP access tokens so neither can be
+    replayed as the other.
+    """
+    import time
+
+    now = int(time.time())
+    payload = {
+        "iss": ISSUER,
+        "sub": user.user_id,
+        "email": user.email,
+        "display_name": user.display_name,
+        "role": user.role,
+        "typ": "mgmt",
+        "iat": now,
+        "exp": now + MGMT_JWT_TTL_SECONDS,
+    }
+    return jwt.encode(payload, _jwt_secret(), algorithm=JWT_ALGORITHM)
+
+
+def decode_mgmt_jwt(token_str: str) -> dict[str, Any]:
+    """Decode a management JWT and enforce typ=mgmt.
+
+    Raises JWTError if the token is invalid, expired, or not a management token
+    (prevents MCP access tokens from being replayed on management endpoints).
+    """
+    claims = jwt.decode(token_str, _jwt_secret(), algorithms=[JWT_ALGORITHM], issuer=ISSUER)
+    if claims.get("typ") != "mgmt":
+        raise JWTError("Not a management token")
+    return claims
+
+
 def validate_bearer_token(authorization_header: str | None, storage: HiveStorage) -> Token:
     """
     Validate a Bearer token from an Authorization header.

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1286,3 +1286,252 @@ class TestOriginVerifySecret:
 
             result = _origin_verify_secret()
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Management JWT (issue_mgmt_jwt / decode_mgmt_jwt)
+# ---------------------------------------------------------------------------
+
+
+class TestMgmtJwt:
+    def _make_user(self):
+        from hive.models import User
+
+        return User(email="alice@example.com", display_name="Alice", role="admin")
+
+    def test_issue_and_decode(self):
+        from hive.auth.tokens import decode_mgmt_jwt, issue_mgmt_jwt
+
+        user = self._make_user()
+        token = issue_mgmt_jwt(user)
+        claims = decode_mgmt_jwt(token)
+        assert claims["sub"] == user.user_id
+        assert claims["email"] == user.email
+        assert claims["role"] == "admin"
+        assert claims["typ"] == "mgmt"
+
+    def test_mcp_token_rejected_as_mgmt(self):
+        """An MCP access token must not be accepted by decode_mgmt_jwt."""
+        from datetime import datetime, timedelta, timezone
+
+        from jose import JWTError
+
+        from hive.auth.tokens import decode_mgmt_jwt, issue_jwt
+        from hive.models import Token
+
+        now = datetime.now(timezone.utc)
+        mcp_token = Token(
+            client_id="c1",
+            scope="memories:read",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        jwt_str = issue_jwt(mcp_token)
+        with pytest.raises(JWTError, match="management token"):
+            decode_mgmt_jwt(jwt_str)
+
+    def test_is_admin_email(self, monkeypatch):
+        from hive.auth.google import _allowed_emails, is_admin_email
+
+        _allowed_emails.cache_clear()
+        monkeypatch.setenv("ALLOWED_EMAILS", '["admin@example.com"]')
+        _allowed_emails.cache_clear()
+        assert is_admin_email("admin@example.com") is True
+        assert is_admin_email("other@example.com") is False
+        _allowed_emails.cache_clear()
+
+    def test_is_admin_email_empty_list(self, monkeypatch):
+        from hive.auth.google import _allowed_emails, is_admin_email
+
+        _allowed_emails.cache_clear()
+        monkeypatch.setenv("ALLOWED_EMAILS", "[]")
+        _allowed_emails.cache_clear()
+        assert is_admin_email("anyone@example.com") is False
+        _allowed_emails.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Management auth routes (/auth/login, /auth/callback)
+# ---------------------------------------------------------------------------
+
+
+class TestMgmtAuthRoutes:
+    @pytest.fixture()
+    def mgmt_client(self):
+        with mock_aws():
+            _create_table()
+            old = os.environ.get("HIVE_TABLE_NAME")
+            os.environ["HIVE_TABLE_NAME"] = "hive-unit-auth"
+            try:
+                from fastapi.testclient import TestClient
+
+                from hive.api.main import app
+
+                yield TestClient(app, follow_redirects=False)
+            finally:
+                if old is not None:
+                    os.environ["HIVE_TABLE_NAME"] = old
+                else:
+                    os.environ.pop("HIVE_TABLE_NAME", None)
+
+    def test_login_bypass_issues_jwt(self, mgmt_client):
+        """In bypass mode, /auth/login returns HTML with a management JWT."""
+        from unittest.mock import patch
+
+        with patch("hive.auth.mgmt_auth._BYPASS", True):
+            resp = mgmt_client.get("/auth/login?test_email=dev@example.com")
+        assert resp.status_code == 200
+        assert "hive_mgmt_token" in resp.text
+
+    def test_login_redirects_to_google(self, mgmt_client):
+        """Without bypass, /auth/login redirects to Google."""
+        from unittest.mock import patch
+
+        with (
+            patch("hive.auth.mgmt_auth._BYPASS", False),
+            patch(
+                "hive.auth.mgmt_auth.google_authorization_url",
+                return_value="https://accounts.google.com/auth?state=x",
+            ),
+        ):
+            resp = mgmt_client.get("/auth/login")
+        assert resp.status_code == 302
+        assert "accounts.google.com" in resp.headers["location"]
+
+    def test_callback_error_param_returns_400(self, mgmt_client):
+        resp = mgmt_client.get("/auth/callback?error=access_denied")
+        assert resp.status_code == 400
+
+    def test_callback_missing_code_returns_400(self, mgmt_client):
+        resp = mgmt_client.get("/auth/callback?state=x")
+        assert resp.status_code == 400
+
+    def test_callback_invalid_state_returns_400(self, mgmt_client):
+        resp = mgmt_client.get("/auth/callback?code=c&state=no-such-state")
+        assert resp.status_code == 400
+
+    def test_callback_creates_user_and_issues_jwt(self, mgmt_client, monkeypatch):
+        """Full happy-path: valid state + Google exchange → HTML with JWT."""
+        monkeypatch.delenv("HIVE_BYPASS_GOOGLE_AUTH", raising=False)
+        from unittest.mock import AsyncMock, patch
+
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-auth", region="us-east-1")
+        pending = storage.create_mgmt_pending_state()
+
+        fake_claims = {
+            "email": "alice@example.com",
+            "email_verified": True,
+            "name": "Alice",
+            "sub": "google-uid-1",
+        }
+        with (
+            patch(
+                "hive.auth.mgmt_auth.exchange_google_code",
+                new_callable=AsyncMock,
+                return_value="fake-id-token",
+            ),
+            patch(
+                "hive.auth.mgmt_auth.verify_google_id_token",
+                new_callable=AsyncMock,
+                return_value=fake_claims,
+            ),
+        ):
+            resp = mgmt_client.get(f"/auth/callback?code=abc&state={pending.state}")
+
+        assert resp.status_code == 200
+        assert "hive_mgmt_token" in resp.text
+        # User should have been created
+        user = storage.get_user_by_email("alice@example.com")
+        assert user is not None
+        assert user.email == "alice@example.com"
+
+    def test_callback_unverified_email_returns_400(self, mgmt_client):
+        from unittest.mock import AsyncMock, patch
+
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-auth", region="us-east-1")
+        pending = storage.create_mgmt_pending_state()
+
+        fake_claims = {"email": "bad@example.com", "email_verified": False, "name": "Bad"}
+        with (
+            patch(
+                "hive.auth.mgmt_auth.exchange_google_code", new_callable=AsyncMock, return_value="t"
+            ),
+            patch(
+                "hive.auth.mgmt_auth.verify_google_id_token",
+                new_callable=AsyncMock,
+                return_value=fake_claims,
+            ),
+        ):
+            resp = mgmt_client.get(f"/auth/callback?code=c&state={pending.state}")
+        assert resp.status_code == 400
+
+    def test_callback_expired_state_returns_400(self, mgmt_client):
+        from datetime import datetime, timedelta, timezone
+        from unittest.mock import patch
+
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-auth", region="us-east-1")
+        pending = storage.create_mgmt_pending_state()
+
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        with patch("hive.auth.mgmt_auth.datetime") as mock_dt:
+            mock_dt.now.return_value = future
+            resp = mgmt_client.get(f"/auth/callback?code=c&state={pending.state}")
+        assert resp.status_code == 400
+
+    def test_callback_google_exchange_failure_returns_400(self, mgmt_client):
+        from unittest.mock import AsyncMock, patch
+
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-auth", region="us-east-1")
+        pending = storage.create_mgmt_pending_state()
+
+        with patch(
+            "hive.auth.mgmt_auth.exchange_google_code",
+            new_callable=AsyncMock,
+            side_effect=Exception("network error"),
+        ):
+            resp = mgmt_client.get(f"/auth/callback?code=c&state={pending.state}")
+        assert resp.status_code == 400
+
+    def test_callback_updates_existing_user(self, mgmt_client):
+        """Second login updates display_name and last_login_at."""
+        from unittest.mock import AsyncMock, patch
+
+        from hive.models import User
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-auth", region="us-east-1")
+        # Pre-create user
+        existing = User(email="bob@example.com", display_name="Bob Old", role="user")
+        storage.put_user(existing)
+
+        pending = storage.create_mgmt_pending_state()
+        fake_claims = {
+            "email": "bob@example.com",
+            "email_verified": True,
+            "name": "Bob New",
+            "sub": "google-uid-bob",
+        }
+        with (
+            patch(
+                "hive.auth.mgmt_auth.exchange_google_code", new_callable=AsyncMock, return_value="t"
+            ),
+            patch(
+                "hive.auth.mgmt_auth.verify_google_id_token",
+                new_callable=AsyncMock,
+                return_value=fake_claims,
+            ),
+        ):
+            resp = mgmt_client.get(f"/auth/callback?code=c&state={pending.state}")
+
+        assert resp.status_code == 200
+        user = storage.get_user_by_email("bob@example.com")
+        assert user is not None
+        assert user.display_name == "Bob New"


### PR DESCRIPTION
## Summary

- `issue_mgmt_jwt` / `decode_mgmt_jwt` in `tokens.py` — short-lived 8h JWTs with `typ=mgmt` claim that prevents MCP access tokens being replayed on management endpoints
- `is_admin_email()` in `google.py` — emails in `ALLOWED_EMAILS` get `admin` role; empty list means no admins
- New `src/hive/auth/mgmt_auth.py` router:
  - `GET /auth/login` — stores a nonce in DynamoDB, redirects to Google (bypass mode issues JWT directly for non-prod)
  - `GET /auth/callback` — validates nonce, exchanges Google code, verifies ID token, upserts `User` record, returns HTML page that writes management JWT to `localStorage` and redirects to `/`
- Registered in `api/main.py` alongside OAuth and management API routers
- 100% test coverage maintained

Closes #91
Part of #50

## Post-deploy note
After merging and deploying, add `{ISSUER}/auth/callback` as an authorized redirect URI in Google Cloud Console.

## Test plan
- [ ] CI passes
- [ ] `GET /auth/login` redirects to Google on prod
- [ ] After Google login, `localStorage.getItem('hive_mgmt_token')` is set in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)