### PR TITLE
fix: route /auth/* through CloudFront for management login

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -548,6 +548,7 @@ class HiveStack(cdk.Stack):
             ),
             additional_behaviors={
                 "/api/*": api_behavior,
+                "/auth/*": api_behavior,
                 "/oauth/*": api_behavior,
                 "/.well-known/*": cloudfront.BehaviorOptions(
                     origin=api_cf_origin,

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -29,12 +29,13 @@ def browser_page():
         browser = p.chromium.launch()
         page = browser.new_page()
 
-        # Navigate to the bypass login endpoint.  In non-prod deployments,
+        # Navigate to the bypass login endpoint via CloudFront (same origin as
+        # the UI) so the mgmt JWT lands in the correct localStorage origin.
         # HIVE_BYPASS_GOOGLE_AUTH=1 causes /auth/login to issue a mgmt JWT,
         # write it to localStorage as hive_mgmt_token, and redirect to /.
-        page.goto(f"{API_URL}auth/login", timeout=30_000, wait_until="networkidle")
+        page.goto(f"{UI_URL}auth/login", timeout=30_000, wait_until="networkidle")
 
-        # Should now be at UI_URL with hive_mgmt_token in localStorage.
+        # Should now be at UI_URL root with hive_mgmt_token in localStorage.
         page.wait_for_url(f"{UI_URL}**", timeout=10_000)
 
         yield page


### PR DESCRIPTION
## Summary

- Add `/auth/*` → `api_behavior` CloudFront behavior — without this, `/auth/login` and `/auth/callback` were served from S3 (returning the React SPA) instead of being proxied to the API Lambda
- Update Playwright e2e fixture to use `UI_URL` (CloudFront) instead of `API_URL` (Lambda direct) for the bypass login so the mgmt JWT is written to the correct localStorage origin

## Root cause

The `/auth/login` and `/auth/callback` endpoints existed only on the Lambda Function URL, not accessible via CloudFront. This broke:
1. The "Sign in with Google" button (`/auth/login` relative URL resolved to CloudFront, which returned `index.html`)
2. The Playwright bypass login (token was set on the Lambda URL's localStorage origin, not CloudFront's; `location.replace('/')` redirected to the Lambda root, not the UI)

## Test plan
- [ ] CI passes including `Infra Synth` (validates CDK change)
- [ ] E2E Tests (dev) pass — Playwright bypass login reaches the UI

Closes #100

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>