### PR TITLE
fix(e2e): missing slash in UI_URL/auth/login path

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -33,7 +33,7 @@ def browser_page():
         # the UI) so the mgmt JWT lands in the correct localStorage origin.
         # HIVE_BYPASS_GOOGLE_AUTH=1 causes /auth/login to issue a mgmt JWT,
         # write it to localStorage as hive_mgmt_token, and redirect to /.
-        page.goto(f"{UI_URL}auth/login", timeout=30_000, wait_until="networkidle")
+        page.goto(f"{UI_URL}/auth/login", timeout=30_000, wait_until="networkidle")
 
         # Should now be at UI_URL root with hive_mgmt_token in localStorage.
         page.wait_for_url(f"{UI_URL}**", timeout=10_000)


### PR DESCRIPTION
## Summary

`UI_URL` has no trailing slash (`https://hive-dev.warlordofmars.net`) so `f"{UI_URL}auth/login"` produced `https://hive-dev.warlordofmars.netauth/login` — `net::ERR_NAME_NOT_RESOLVED`.

Fix: `f"{UI_URL}/auth/login"`.

The previous `API_URL` form worked because Lambda Function URLs always include a trailing slash.

Closes #100

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>