### PR TITLE
fix(e2e): wait for network idle and POST response in create memory test

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -51,14 +51,20 @@ class TestUIE2E:
     def test_create_and_see_memory(self, browser_page):
         page = browser_page
         page.goto(UI_URL)
+        page.wait_for_load_state("networkidle")  # wait for initial memories load
 
         page.locator("button:has-text('+ New')").click()
         page.locator("input[placeholder='unique-key']").fill("ui-e2e-key")
         page.locator("textarea").fill("UI e2e test value")
         page.locator("input[placeholder='tag1, tag2']").fill("e2e")
-        page.locator("button:has-text('Save')").click()
 
-        page.wait_for_selector("text=ui-e2e-key")
+        with page.expect_response(
+            lambda r: "/api/memories" in r.url and r.request.method == "POST",
+            timeout=30_000,
+        ):
+            page.locator("button:has-text('Save')").click()
+
+        page.wait_for_selector("text=ui-e2e-key", timeout=30_000)
         assert page.locator("text=ui-e2e-key").first.is_visible()
 
     def test_clients_tab(self, browser_page):


### PR DESCRIPTION
## Summary

- Add `wait_for_load_state("networkidle")` after `page.goto` so the initial `GET /api/memories` settles before the test interacts with the form — prevents a race where the stale empty-list response from the initial load overwrites the newly created memory in React state
- Wrap the Save click in `expect_response` to explicitly wait for `POST /api/memories` to complete before asserting the memory appears in the list

Closes #100

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>