### PR TITLE
feat: user onboarding Setup tab in management UI

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -5,12 +5,15 @@ import AuthCallback from "./components/AuthCallback.jsx";
 import ClientManager from "./components/ClientManager.jsx";
 import LoginPage from "./components/LoginPage.jsx";
 import MemoryBrowser from "./components/MemoryBrowser.jsx";
+import SetupPanel from "./components/SetupPanel.jsx";
 import UsersPanel from "./components/UsersPanel.jsx";
+import { api } from "./api.js";
 
 const BASE_TABS = [
   { id: "memories", label: "Memories" },
   { id: "clients", label: "OAuth Clients" },
   { id: "activity", label: "Activity Log" },
+  { id: "setup", label: "Setup" },
 ];
 const ADMIN_TABS = [...BASE_TABS, { id: "users", label: "Users" }];
 
@@ -58,6 +61,14 @@ export default function App() {
     fetch("/health")
       .then((r) => r.json())
       .then((data) => setVersion(data.version ?? null))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    api.listClients()
+      .then((data) => {
+        if (data && data.items.length === 0) setTab("setup");
+      })
       .catch(() => {});
   }, []);
 
@@ -119,6 +130,7 @@ export default function App() {
         {tab === "clients" && <ClientManager />}
         {tab === "activity" && <ActivityLog />}
         {tab === "users" && isAdmin && <UsersPanel />}
+        {tab === "setup" && <SetupPanel />}
       </main>
 
       {version && (

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -21,12 +21,33 @@ vi.mock("./components/AuthCallback.jsx", () => ({
 vi.mock("./components/UsersPanel.jsx", () => ({
   default: () => <div data-testid="users-panel" />,
 }));
+vi.mock("./components/SetupPanel.jsx", () => ({
+  default: () => <div data-testid="setup-panel" />,
+}));
 
 /** Build a syntactically-valid mgmt JWT with given claims. */
 function makeToken({ expOffsetSeconds = 3600, role = "user", email = "u@example.com" } = {}) {
   const exp = Math.floor(Date.now() / 1000) + expOffsetSeconds;
   const payload = btoa(JSON.stringify({ exp, sub: "test-user", role, email }));
   return `eyJhbGciOiJIUzI1NiJ9.${payload}.sig`;
+}
+
+/** URL-aware fetch mock: /api/clients returns items, everything else returns health. */
+function makeFetch({ clients = [{ client_id: "c1" }] } = {}) {
+  return vi.fn().mockImplementation((url) => {
+    if (String(url).includes("/api/clients")) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ items: clients }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ status: "ok", version: "1.2.3" }),
+    });
+  });
 }
 
 describe("App", () => {
@@ -43,14 +64,7 @@ describe("App", () => {
         delete _storage[k];
       },
     });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ status: "ok", version: "1.2.3" }),
-      }),
-    );
+    vi.stubGlobal("fetch", makeFetch());
     // Most tests need a valid token — set it by default
     _storage["hive_mgmt_token"] = makeToken();
   });
@@ -64,11 +78,12 @@ describe("App", () => {
     expect(screen.getByText("Hive")).toBeTruthy();
   });
 
-  it("renders the three base tab buttons for non-admin", async () => {
+  it("renders the base tab buttons for non-admin (including Setup)", async () => {
     await act(async () => render(<App />));
     expect(screen.getByText("Memories")).toBeTruthy();
     expect(screen.getByText("OAuth Clients")).toBeTruthy();
     expect(screen.getByText("Activity Log")).toBeTruthy();
+    expect(screen.getByText("Setup")).toBeTruthy();
     expect(screen.queryByText("Users")).toBeNull();
   });
 
@@ -78,11 +93,55 @@ describe("App", () => {
     expect(screen.getByText("Users")).toBeTruthy();
   });
 
-  it("shows MemoryBrowser on initial render", async () => {
+  it("shows MemoryBrowser on initial render when clients exist", async () => {
     await act(async () => render(<App />));
-    expect(screen.getByTestId("memory-browser")).toBeTruthy();
+    await waitFor(() => expect(screen.getByTestId("memory-browser")).toBeTruthy());
     expect(screen.queryByTestId("client-manager")).toBeNull();
     expect(screen.queryByTestId("activity-log")).toBeNull();
+    expect(screen.queryByTestId("setup-panel")).toBeNull();
+  });
+
+  it("defaults to Setup tab on first load when no clients registered", async () => {
+    vi.stubGlobal("fetch", makeFetch({ clients: [] }));
+    await act(async () => render(<App />));
+    await waitFor(() => expect(screen.getByTestId("setup-panel")).toBeTruthy());
+    expect(screen.queryByTestId("memory-browser")).toBeNull();
+  });
+
+  it("does not switch to Setup when listClients returns null", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url) => {
+        if (String(url).includes("/api/clients")) {
+          return Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve() });
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok", version: "1.2.3" }),
+        });
+      }),
+    );
+    await act(async () => render(<App />));
+    expect(screen.getByText("Memories")).toBeTruthy();
+  });
+
+  it("does not crash when listClients fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url) => {
+        if (String(url).includes("/api/clients")) {
+          return Promise.reject(new Error("Network error"));
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok", version: "1.2.3" }),
+        });
+      }),
+    );
+    await act(async () => render(<App />));
+    expect(screen.getByText("Memories")).toBeTruthy();
   });
 
   it("switches to ClientManager when OAuth Clients tab is clicked", async () => {
@@ -96,6 +155,13 @@ describe("App", () => {
     await act(async () => render(<App />));
     fireEvent.click(screen.getByText("Activity Log"));
     expect(screen.getByTestId("activity-log")).toBeTruthy();
+    expect(screen.queryByTestId("memory-browser")).toBeNull();
+  });
+
+  it("switches to SetupPanel when Setup tab is clicked", async () => {
+    await act(async () => render(<App />));
+    fireEvent.click(screen.getByText("Setup"));
+    expect(screen.getByTestId("setup-panel")).toBeTruthy();
     expect(screen.queryByTestId("memory-browser")).toBeNull();
   });
 
@@ -162,10 +228,19 @@ describe("App", () => {
   it("hides footer when health check returns no version", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ status: "ok" }),
+      vi.fn().mockImplementation((url) => {
+        if (String(url).includes("/api/clients")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ items: [{ client_id: "c1" }] }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "ok" }),
+        });
       }),
     );
     await act(async () => render(<App />));
@@ -174,7 +249,19 @@ describe("App", () => {
   });
 
   it("does not crash when health check fails", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url) => {
+        if (String(url).includes("/api/clients")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ items: [{ client_id: "c1" }] }),
+          });
+        }
+        return Promise.reject(new Error("Network error"));
+      }),
+    );
     await act(async () => render(<App />));
     expect(screen.getByText("Memories")).toBeTruthy();
     expect(screen.queryByText(/Hive \d/)).toBeNull();

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useState } from "react";
+import { api } from "../api.js";
+
+export default function SetupPanel() {
+  const mcpUrl = import.meta.env.VITE_MCP_BASE ?? `${window.location.origin}/mcp`;
+  const [clientName, setClientName] = useState("");
+  const [clientId, setClientId] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  async function handleRegister(e) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      const data = await api.createClient({ client_name: clientName });
+      setClientId(data.client_id);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const configSnippet = JSON.stringify(
+    { mcpServers: { hive: { type: "http", url: mcpUrl } } },
+    null,
+    2,
+  );
+
+  function handleCopy() {
+    navigator.clipboard.writeText(configSnippet);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <h2 style={{ marginBottom: 24 }}>Set up Hive</h2>
+
+      <section style={{ marginBottom: 32 }}>
+        <h3 style={{ marginBottom: 12 }}>Step 1 — Register a client</h3>
+        <p style={{ marginBottom: 12, color: "#555" }}>
+          Give your MCP client a name (e.g. &ldquo;Claude Code&rdquo; or &ldquo;My Agent&rdquo;).
+        </p>
+        {!clientId ? (
+          <form onSubmit={handleRegister}>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input
+                required
+                placeholder="Client name"
+                value={clientName}
+                onChange={(e) => setClientName(e.target.value)}
+              />
+              <button className="primary" type="submit" disabled={loading}>
+                {loading ? "Registering\u2026" : "Register"}
+              </button>
+            </div>
+            {error && <p style={{ color: "#d00", marginTop: 8 }}>{error}</p>}
+          </form>
+        ) : (
+          <p style={{ color: "#1a7340" }}>
+            ✓ Client registered. Your client ID: <code>{clientId}</code>
+          </p>
+        )}
+      </section>
+
+      <section style={{ marginBottom: 32 }}>
+        <h3 style={{ marginBottom: 12 }}>Step 2 — Add Hive to Claude Code</h3>
+        <p style={{ marginBottom: 8, color: "#555" }}>
+          Add the following to your <code>~/.claude/settings.json</code>:
+        </p>
+        <pre
+          style={{
+            background: "#f5f5f5",
+            border: "1px solid #e0e0e0",
+            borderRadius: 6,
+            padding: "12px 16px",
+            fontSize: 13,
+            overflowX: "auto",
+          }}
+        >
+          {configSnippet}
+        </pre>
+        <button className="secondary" onClick={handleCopy} style={{ marginTop: 8 }}>
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </section>
+
+      <section>
+        <h3 style={{ marginBottom: 12 }}>Step 3 — Connect</h3>
+        <p style={{ color: "#555" }}>
+          Open Claude Code. The next time you use a Hive memory tool, it will prompt you to
+          authorise access via your browser. Complete the flow and you&apos;re done.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api.js", () => ({
+  api: {
+    createClient: vi.fn(),
+  },
+}));
+
+import { api } from "../api.js";
+import SetupPanel from "./SetupPanel.jsx";
+
+describe("SetupPanel", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("renders all three step headings", async () => {
+    await act(async () => render(<SetupPanel />));
+    expect(screen.getByText(/Step 1/)).toBeTruthy();
+    expect(screen.getByText(/Step 2/)).toBeTruthy();
+    expect(screen.getByText(/Step 3/)).toBeTruthy();
+  });
+
+  it("renders the registration form initially", async () => {
+    await act(async () => render(<SetupPanel />));
+    expect(screen.getByPlaceholderText("Client name")).toBeTruthy();
+    expect(screen.getByText("Register")).toBeTruthy();
+    expect(screen.queryByText(/client ID/)).toBeNull();
+  });
+
+  it("shows Registering\u2026 during submit", async () => {
+    let resolve;
+    api.createClient.mockReturnValue(new Promise((r) => { resolve = r; }));
+    await act(async () => render(<SetupPanel />));
+    fireEvent.change(screen.getByPlaceholderText("Client name"), {
+      target: { value: "My Client" },
+    });
+    act(() => {
+      fireEvent.submit(screen.getByPlaceholderText("Client name").closest("form"));
+    });
+    expect(screen.getByText("Registering\u2026")).toBeTruthy();
+    await act(async () => resolve({ client_id: "c1" }));
+  });
+
+  it("shows client_id on successful registration", async () => {
+    api.createClient.mockResolvedValue({ client_id: "test-id-123" });
+    await act(async () => render(<SetupPanel />));
+    fireEvent.change(screen.getByPlaceholderText("Client name"), {
+      target: { value: "My Client" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("Client name").closest("form")),
+    );
+    await waitFor(() => expect(screen.getByText(/test-id-123/)).toBeTruthy());
+    expect(screen.queryByPlaceholderText("Client name")).toBeNull();
+  });
+
+  it("shows error when registration fails", async () => {
+    api.createClient.mockRejectedValue(new Error("Name already taken"));
+    await act(async () => render(<SetupPanel />));
+    fireEvent.change(screen.getByPlaceholderText("Client name"), {
+      target: { value: "Bad" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("Client name").closest("form")),
+    );
+    await waitFor(() => expect(screen.getByText("Name already taken")).toBeTruthy());
+    expect(screen.getByPlaceholderText("Client name")).toBeTruthy();
+  });
+
+  it("shows Copy button initially", async () => {
+    await act(async () => render(<SetupPanel />));
+    expect(screen.getByText("Copy")).toBeTruthy();
+  });
+
+  it("shows Copied! after click and reverts after 2s", async () => {
+    vi.useFakeTimers();
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Copy"));
+    expect(screen.getByText("Copied!")).toBeTruthy();
+    act(() => vi.runAllTimers());
+    expect(screen.getByText("Copy")).toBeTruthy();
+    vi.useRealTimers();
+  });
+
+  it("uses VITE_MCP_BASE when set", async () => {
+    vi.stubEnv("VITE_MCP_BASE", "https://custom.example.com/mcp");
+    await act(async () => render(<SetupPanel />));
+    expect(document.body.textContent).toContain("custom.example.com/mcp");
+  });
+
+  it("falls back to window.location.origin + /mcp when VITE_MCP_BASE not set", async () => {
+    await act(async () => render(<SetupPanel />));
+    expect(document.body.textContent).toContain("localhost");
+    expect(document.body.textContent).toContain("/mcp");
+  });
+});

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -7,7 +7,9 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api": "http://localhost:8001",
+      "/auth": "http://localhost:8001",
       "/oauth": "http://localhost:8001",
+      "/mcp": "http://localhost:8000",
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- New **Setup tab** in the management UI nav bar with a three-step onboarding flow:
  - **Step 1** — Register an OAuth client (just a name, calls DCR endpoint, shows `client_id` on success)
  - **Step 2** — Copy Claude Code MCP config snippet to clipboard (`~/.claude/settings.json` format)
  - **Step 3** — Instructions: MCP client will prompt for OAuth authorization on first use
- First-run detection: on app load, if no clients are registered, automatically switches to the Setup tab
- `VITE_MCP_BASE` env var configures the MCP server URL; falls back to `window.location.origin + "/mcp"` (correct for same-origin CloudFront routing)
- `/auth` and `/mcp` added to Vite dev server proxy for local development parity with production

## Test plan
- [ ] CI passes with 100% branch coverage (132 tests)
- [ ] New user sees Setup tab automatically on first login
- [ ] Returning user with existing clients lands on Memories tab

Closes #47

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>