### PR TITLE
fix(e2e): explicitly navigate to Memories tab before create-memory test

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -58,6 +58,9 @@ class TestUIE2E:
 
         page.goto(UI_URL)
         page.wait_for_load_state("networkidle")  # wait for initial memories load
+        # Ensure we're on Memories tab regardless of first-run redirect
+        page.locator("nav button:has-text('Memories')").click()
+        page.wait_for_load_state("networkidle")
 
         page.locator("button:has-text('+ New')").click()
         page.locator("input[placeholder='unique-key']").fill(memory_key)


### PR DESCRIPTION
## Summary

The Setup tab is now the default for users with no registered clients (#47). The e2e bypass user in dev may have no clients, so the app lands on Setup instead of Memories — making the `+ New` button invisible and timing out.

**Fix:** explicitly click the Memories nav tab after page load before interacting with MemoryBrowser.

Closes #100

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>