### PR TITLE
fix(e2e): navigate directly to /app after bypass login

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -35,8 +35,10 @@ def browser_page():
         # write it to localStorage as hive_mgmt_token, and redirect to /.
         page.goto(f"{UI_URL}/auth/login", timeout=30_000, wait_until="networkidle")
 
-        # Should now be at UI_URL root with hive_mgmt_token in localStorage.
-        page.wait_for_url(f"{UI_URL}**", timeout=10_000)
+        # Token is now in localStorage. Navigate directly to /app — the
+        # HomeRoute would also redirect there, but client-side redirects can
+        # race with wait_for_url so we go straight to the destination.
+        page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
 
         yield page
         browser.close()


### PR DESCRIPTION
## Summary
- With react-router, `/` now does a client-side `<Navigate to="/app" replace />` after a valid token is found
- The old `wait_for_url(f"{UI_URL}**")` races with this redirect and times out (10 s) because the navigation already completed by the time the call is made
- Fix: after bypass login sets the token, navigate directly to `{UI_URL}/app` instead of relying on the redirect chain

## Test plan
- [x] E2E fixture now lands on `/app` reliably without a race condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)