### PR TITLE
feat: Dashboard tab with CloudWatch metrics and cost data (#95, #37)

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -323,6 +323,18 @@ class HiveStack(cdk.Stack):
         google_client_secret_param.grant_read(api_role)
         allowed_emails_param.grant_read(api_role)
         origin_verify_param.grant_read(api_role)
+        api_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["cloudwatch:GetMetricData"],
+                resources=["*"],
+            )
+        )
+        api_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["ce:GetCostAndUsage"],
+                resources=["*"],
+            )
+        )
 
         api_fn = lambda_.Function(
             self,

--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Admin-only endpoints for CloudWatch metrics and AWS Cost Explorer data.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import boto3
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from hive.api._auth import require_admin
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+NAMESPACE = "Hive"
+ENVIRONMENT = os.environ.get("HIVE_ENV", os.environ.get("ENV", "local"))
+
+# Seconds of CloudWatch data to fetch per period label
+_PERIOD_SECONDS = {
+    "1h": 3600,
+    "24h": 86400,
+    "7d": 7 * 86400,
+}
+# CloudWatch resolution per period (stat window size in seconds)
+_STAT_PERIOD = {
+    "1h": 300,  # 5-min buckets
+    "24h": 3600,  # 1-hour buckets
+    "7d": 86400,  # 1-day buckets
+}
+
+# Cost cache: store results in a module-level dict keyed by env to avoid
+# hammering the Cost Explorer API ($0.01/request). TTL = 24 h.
+_cost_cache: dict[str, tuple[float, Any]] = {}
+_COST_CACHE_TTL = 86400  # 24 hours
+
+
+def _cloudwatch_client():  # pragma: no cover
+    return boto3.client("cloudwatch", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+
+
+def _ce_client():  # pragma: no cover
+    return boto3.client("ce", region_name="us-east-1")
+
+
+def _build_metric_queries(period_label: str) -> list[dict[str, Any]]:
+    """Return GetMetricData queries for all tracked metrics."""
+    stat_period = _STAT_PERIOD[period_label]
+    tools = ["remember", "recall", "forget", "list_memories", "summarize_context"]
+    queries: list[dict[str, Any]] = []
+
+    for tool in tools:
+        safe_id = tool.replace("_", "")
+        queries.append(
+            {
+                "Id": f"inv_{safe_id}",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": NAMESPACE,
+                        "MetricName": "ToolInvocations",
+                        "Dimensions": [
+                            {"Name": "Environment", "Value": ENVIRONMENT},
+                            {"Name": "operation", "Value": tool},
+                        ],
+                    },
+                    "Period": stat_period,
+                    "Stat": "Sum",
+                },
+            }
+        )
+        queries.append(
+            {
+                "Id": f"err_{safe_id}",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": NAMESPACE,
+                        "MetricName": "ToolErrors",
+                        "Dimensions": [
+                            {"Name": "Environment", "Value": ENVIRONMENT},
+                            {"Name": "operation", "Value": tool},
+                        ],
+                    },
+                    "Period": stat_period,
+                    "Stat": "Sum",
+                },
+            }
+        )
+        queries.append(
+            {
+                "Id": f"p99_{safe_id}",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": NAMESPACE,
+                        "MetricName": "StorageLatencyMs",
+                        "Dimensions": [
+                            {"Name": "Environment", "Value": ENVIRONMENT},
+                            {"Name": "operation", "Value": tool},
+                        ],
+                    },
+                    "Period": stat_period,
+                    "Stat": "p99",
+                },
+            }
+        )
+
+    queries.append(
+        {
+            "Id": "tokens_issued",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": NAMESPACE,
+                    "MetricName": "TokensIssued",
+                    "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+                },
+                "Period": stat_period,
+                "Stat": "Sum",
+            },
+        }
+    )
+    queries.append(
+        {
+            "Id": "token_failures",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": NAMESPACE,
+                    "MetricName": "TokenValidationFailures",
+                    "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+                },
+                "Period": stat_period,
+                "Stat": "Sum",
+            },
+        }
+    )
+
+    return queries
+
+
+def _get_cloudwatch_metrics(period_label: str) -> dict[str, Any]:
+    """Fetch metric data from CloudWatch and return structured results."""
+    import datetime
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    start = now - datetime.timedelta(seconds=_PERIOD_SECONDS[period_label])
+    queries = _build_metric_queries(period_label)
+    cw = _cloudwatch_client()
+
+    try:
+        resp = cw.get_metric_data(
+            MetricDataQueries=queries,
+            StartTime=start,
+            EndTime=now,
+        )
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=502, detail=f"CloudWatch error: {exc}") from exc
+
+    results: dict[str, Any] = {}
+    for r in resp.get("MetricDataResults", []):
+        results[r["Id"]] = {
+            "timestamps": [t.isoformat() for t in r.get("Timestamps", [])],
+            "values": r.get("Values", []),
+        }
+    return results
+
+
+def _get_cost_data() -> dict[str, Any]:
+    """Fetch cost data from Cost Explorer, cached for 24 h."""
+    import datetime
+
+    cached = _cost_cache.get(ENVIRONMENT)
+    if cached and time.time() - cached[0] < _COST_CACHE_TTL:
+        return cached[1]
+
+    ce = _ce_client()
+    today = datetime.date.today()
+    # Last 6 full months + current month
+    start_date = (today.replace(day=1) - datetime.timedelta(days=6 * 30)).replace(day=1)
+
+    try:
+        resp = ce.get_cost_and_usage(
+            TimePeriod={
+                "Start": start_date.isoformat(),
+                "End": today.isoformat(),
+            },
+            Granularity="MONTHLY",
+            Filter={
+                "Tags": {
+                    "Key": "project",
+                    "Values": ["hive"],
+                    "MatchOptions": ["EQUALS"],
+                }
+            },
+            GroupBy=[{"Type": "DIMENSION", "Key": "SERVICE"}],
+            Metrics=["UnblendedCost"],
+        )
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=502, detail=f"Cost Explorer error: {exc}") from exc
+
+    monthly: list[dict[str, Any]] = []
+    for result in resp.get("ResultsByTime", []):
+        period = result["TimePeriod"]["Start"]
+        by_service = {
+            g["Keys"][0]: float(g["Metrics"]["UnblendedCost"]["Amount"])
+            for g in result.get("Groups", [])
+        }
+        total = sum(by_service.values())
+        monthly.append({"period": period, "total": round(total, 4), "by_service": by_service})
+
+    data: dict[str, Any] = {
+        "environment": ENVIRONMENT,
+        "monthly": monthly,
+        "currency": "USD",
+        "note": "Cost data lags ~24 h. Cached for 24 h.",
+    }
+    _cost_cache[ENVIRONMENT] = (time.time(), data)
+    return data
+
+
+@router.get("/metrics")
+async def get_metrics(
+    period: str = Query("24h", pattern="^(1h|24h|7d)$"),
+    _claims: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Return CloudWatch metric time-series for the current environment.
+
+    Admin-only. Period: 1h | 24h | 7d.
+    """
+    return {
+        "period": period,
+        "environment": ENVIRONMENT,
+        "metrics": _get_cloudwatch_metrics(period),
+    }
+
+
+@router.get("/costs")
+async def get_costs(
+    _claims: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Return AWS Cost Explorer monthly spend breakdown.
+
+    Admin-only. Results cached for 24 h.
+    """
+    return _get_cost_data()

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -17,6 +17,7 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
+from hive.api.admin import router as admin_router
 from hive.api.clients import router as clients_router
 from hive.api.memories import router as memories_router
 from hive.api.stats import router as stats_router
@@ -123,6 +124,7 @@ app.include_router(memories_router, prefix="/api")
 app.include_router(clients_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
+app.include_router(admin_router, prefix="/api")
 
 
 @app.get("/health", include_in_schema=False)

--- a/tests/unit/test_admin_api.py
+++ b/tests/unit/test_admin_api.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for /admin/metrics and /admin/costs endpoints.
+
+CloudWatch and Cost Explorer boto3 calls are mocked via unittest.mock so
+tests run without any AWS credentials.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-unit-admin")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+os.environ.pop("DYNAMODB_ENDPOINT", None)
+
+_ADMIN_CLAIMS = {"sub": "admin-001", "role": "admin", "email": "admin@example.com"}
+_USER_CLAIMS = {"sub": "user-001", "role": "user", "email": "user@example.com"}
+
+
+def _create_table() -> None:
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName="hive-unit-admin",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "UserEmailIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _make_cw_response(metric_ids: list[str]) -> dict:
+    """Build a minimal CloudWatch GetMetricData response."""
+    ts = datetime.datetime(2026, 4, 1, 12, 0, tzinfo=datetime.timezone.utc)
+    return {
+        "MetricDataResults": [
+            {"Id": mid, "Timestamps": [ts], "Values": [1.0]} for mid in metric_ids
+        ]
+    }
+
+
+def _make_ce_response() -> dict:
+    """Build a minimal Cost Explorer GetCostAndUsage response."""
+    return {
+        "ResultsByTime": [
+            {
+                "TimePeriod": {"Start": "2026-03-01", "End": "2026-04-01"},
+                "Groups": [
+                    {
+                        "Keys": ["AWS Lambda"],
+                        "Metrics": {"UnblendedCost": {"Amount": "0.5000", "Unit": "USD"}},
+                    },
+                    {
+                        "Keys": ["Amazon DynamoDB"],
+                        "Metrics": {"UnblendedCost": {"Amount": "0.1200", "Unit": "USD"}},
+                    },
+                ],
+            }
+        ]
+    }
+
+
+@pytest.fixture()
+def admin_tc():
+    """TestClient authenticated as admin, with CW/CE boto3 calls mocked."""
+    with mock_aws():
+        _create_table()
+        from hive.api import _auth as auth_mod
+        from hive.api.main import app
+
+        app.dependency_overrides[auth_mod.require_mgmt_user] = lambda: _ADMIN_CLAIMS
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def user_tc():
+    """TestClient authenticated as a non-admin user."""
+    with mock_aws():
+        _create_table()
+        from hive.api import _auth as auth_mod
+        from hive.api.main import app
+
+        app.dependency_overrides[auth_mod.require_mgmt_user] = lambda: _USER_CLAIMS
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# /admin/metrics
+# ---------------------------------------------------------------------------
+
+
+class TestAdminMetrics:
+    def test_returns_metrics_for_24h(self, admin_tc):
+        metric_ids = [
+            "inv_remember",
+            "err_remember",
+            "p99_remember",
+            "inv_recall",
+            "err_recall",
+            "p99_recall",
+            "inv_forget",
+            "err_forget",
+            "p99_forget",
+            "inv_listmemories",
+            "err_listmemories",
+            "p99_listmemories",
+            "inv_summarizecontext",
+            "err_summarizecontext",
+            "p99_summarizecontext",
+            "tokens_issued",
+            "token_failures",
+        ]
+        cw_resp = _make_cw_response(metric_ids)
+        with patch("hive.api.admin._cloudwatch_client") as mock_cw_factory:
+            mock_cw = MagicMock()
+            mock_cw.get_metric_data.return_value = cw_resp
+            mock_cw_factory.return_value = mock_cw
+
+            resp = admin_tc.get("/api/admin/metrics?period=24h")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["period"] == "24h"
+        assert "metrics" in body
+        assert "inv_remember" in body["metrics"]
+        assert body["metrics"]["inv_remember"]["values"] == [1.0]
+
+    def test_returns_metrics_for_1h(self, admin_tc):
+        with patch("hive.api.admin._cloudwatch_client") as mock_cw_factory:
+            mock_cw = MagicMock()
+            mock_cw.get_metric_data.return_value = {"MetricDataResults": []}
+            mock_cw_factory.return_value = mock_cw
+
+            resp = admin_tc.get("/api/admin/metrics?period=1h")
+
+        assert resp.status_code == 200
+        assert resp.json()["period"] == "1h"
+
+    def test_returns_metrics_for_7d(self, admin_tc):
+        with patch("hive.api.admin._cloudwatch_client") as mock_cw_factory:
+            mock_cw = MagicMock()
+            mock_cw.get_metric_data.return_value = {"MetricDataResults": []}
+            mock_cw_factory.return_value = mock_cw
+
+            resp = admin_tc.get("/api/admin/metrics?period=7d")
+
+        assert resp.status_code == 200
+        assert resp.json()["period"] == "7d"
+
+    def test_invalid_period_returns_422(self, admin_tc):
+        resp = admin_tc.get("/api/admin/metrics?period=99d")
+        assert resp.status_code == 422
+
+    def test_non_admin_gets_403(self, user_tc):
+        resp = user_tc.get("/api/admin/metrics?period=24h")
+        assert resp.status_code == 403
+
+    def test_environment_in_response(self, admin_tc):
+        with patch("hive.api.admin._cloudwatch_client") as mock_cw_factory:
+            mock_cw = MagicMock()
+            mock_cw.get_metric_data.return_value = {"MetricDataResults": []}
+            mock_cw_factory.return_value = mock_cw
+
+            resp = admin_tc.get("/api/admin/metrics?period=24h")
+
+        assert "environment" in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# /admin/costs
+# ---------------------------------------------------------------------------
+
+
+class TestAdminCosts:
+    def setup_method(self):
+        # Clear the module-level cache before each test
+        import hive.api.admin as admin_mod
+
+        admin_mod._cost_cache.clear()
+
+    def test_returns_cost_data(self, admin_tc):
+        with patch("hive.api.admin._ce_client") as mock_ce_factory:
+            mock_ce = MagicMock()
+            mock_ce.get_cost_and_usage.return_value = _make_ce_response()
+            mock_ce_factory.return_value = mock_ce
+
+            resp = admin_tc.get("/api/admin/costs")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["currency"] == "USD"
+        assert len(body["monthly"]) == 1
+        assert body["monthly"][0]["period"] == "2026-03-01"
+        assert body["monthly"][0]["total"] == pytest.approx(0.62, abs=0.01)
+        assert "AWS Lambda" in body["monthly"][0]["by_service"]
+
+    def test_non_admin_gets_403(self, user_tc):
+        resp = user_tc.get("/api/admin/costs")
+        assert resp.status_code == 403
+
+    def test_cache_is_used_on_second_call(self, admin_tc):
+        with patch("hive.api.admin._ce_client") as mock_ce_factory:
+            mock_ce = MagicMock()
+            mock_ce.get_cost_and_usage.return_value = _make_ce_response()
+            mock_ce_factory.return_value = mock_ce
+
+            admin_tc.get("/api/admin/costs")
+            admin_tc.get("/api/admin/costs")
+
+            # CE should only be called once — second hit uses cache
+            assert mock_ce.get_cost_and_usage.call_count == 1
+
+    def test_cache_expires_after_ttl(self, admin_tc):
+        with patch("hive.api.admin._ce_client") as mock_ce_factory:
+            mock_ce = MagicMock()
+            mock_ce.get_cost_and_usage.return_value = _make_ce_response()
+            mock_ce_factory.return_value = mock_ce
+
+            admin_tc.get("/api/admin/costs")
+
+            # Backdate the cache entry so it appears expired
+            import hive.api.admin as admin_mod
+
+            env = admin_mod.ENVIRONMENT
+            ts, data = admin_mod._cost_cache[env]
+            admin_mod._cost_cache[env] = (ts - admin_mod._COST_CACHE_TTL - 1, data)
+
+            admin_tc.get("/api/admin/costs")
+            assert mock_ce.get_cost_and_usage.call_count == 2
+
+    def test_note_and_environment_in_response(self, admin_tc):
+        with patch("hive.api.admin._ce_client") as mock_ce_factory:
+            mock_ce = MagicMock()
+            mock_ce.get_cost_and_usage.return_value = _make_ce_response()
+            mock_ce_factory.return_value = mock_ce
+
+            resp = admin_tc.get("/api/admin/costs")
+
+        body = resp.json()
+        assert "note" in body
+        assert "environment" in body

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.30.3"
+        "react-router-dom": "^6.30.3",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.6",
@@ -1084,6 +1085,42 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1496,6 +1533,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1639,11 +1688,80 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -2367,6 +2485,15 @@
         "node": "*"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2464,6 +2591,127 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -2555,6 +2803,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -2877,6 +3131,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -3145,6 +3409,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -3712,6 +3982,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3781,6 +4061,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5239,9 +5528,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5285,6 +5596,36 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5297,6 +5638,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5348,6 +5704,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -6013,6 +6375,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6269,6 +6637,37 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.3"
+    "react-router-dom": "^6.30.3",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.6",

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -5,6 +5,7 @@ import { api } from "./api.js";
 import ActivityLog from "./components/ActivityLog.jsx";
 import AuthCallback from "./components/AuthCallback.jsx";
 import ClientManager from "./components/ClientManager.jsx";
+import Dashboard from "./components/Dashboard.jsx";
 import HomePage from "./components/HomePage.jsx";
 import LoginPage from "./components/LoginPage.jsx";
 import MemoryBrowser from "./components/MemoryBrowser.jsx";
@@ -17,7 +18,11 @@ const BASE_TABS = [
   { id: "activity", label: "Activity Log" },
   { id: "setup", label: "Setup" },
 ];
-const ADMIN_TABS = [...BASE_TABS, { id: "users", label: "Users" }];
+const ADMIN_TABS = [
+  ...BASE_TABS,
+  { id: "users", label: "Users" },
+  { id: "dashboard", label: "Dashboard" },
+];
 
 function parseToken(token) {
   if (!token) return null;
@@ -133,6 +138,7 @@ function AppShell() {
         {tab === "activity" && <ActivityLog />}
         {tab === "users" && isAdmin && <UsersPanel />}
         {tab === "setup" && <SetupPanel />}
+        {tab === "dashboard" && isAdmin && <Dashboard />}
       </main>
 
       {version && (

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -27,6 +27,9 @@ vi.mock("./components/SetupPanel.jsx", () => ({
 vi.mock("./components/HomePage.jsx", () => ({
   default: () => <div data-testid="home-page" />,
 }));
+vi.mock("./components/Dashboard.jsx", () => ({
+  default: () => <div data-testid="dashboard" />,
+}));
 
 /** Build a syntactically-valid mgmt JWT with given claims. */
 function makeToken({ expOffsetSeconds = 3600, role = "user", email = "u@example.com" } = {}) {
@@ -131,10 +134,11 @@ describe("AppShell", () => {
     expect(screen.queryByText("Users")).toBeNull();
   });
 
-  it("renders Users tab for admin", async () => {
+  it("renders Users and Dashboard tabs for admin", async () => {
     _storage["hive_mgmt_token"] = makeToken({ role: "admin" });
     await act(async () => render(<App />));
     expect(screen.getByText("Users")).toBeTruthy();
+    expect(screen.getByText("Dashboard")).toBeTruthy();
   });
 
   it("shows MemoryBrowser on initial render when clients exist", async () => {
@@ -212,6 +216,14 @@ describe("AppShell", () => {
     await act(async () => render(<App />));
     fireEvent.click(screen.getByText("Users"));
     expect(screen.getByTestId("users-panel")).toBeTruthy();
+    expect(screen.queryByTestId("memory-browser")).toBeNull();
+  });
+
+  it("switches to Dashboard when Dashboard tab is clicked (admin only)", async () => {
+    _storage["hive_mgmt_token"] = makeToken({ role: "admin" });
+    await act(async () => render(<App />));
+    fireEvent.click(screen.getByText("Dashboard"));
+    expect(screen.getByTestId("dashboard")).toBeTruthy();
     expect(screen.queryByTestId("memory-browser")).toBeNull();
   });
 

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -65,6 +65,10 @@ export const api = {
   getActivity: (days = 7, { limit = 100 } = {}) =>
     request("GET", `/api/activity?days=${days}&limit=${limit}`),
 
+  // Admin
+  getMetrics: (period = "24h") => request("GET", `/api/admin/metrics?period=${period}`),
+  getCosts: () => request("GET", "/api/admin/costs"),
+
   // Users
   getMe: () => request("GET", "/api/users/me"),
   listUsers: ({ limit = 50, cursor } = {}) => {

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -250,6 +250,28 @@ describe("api", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Admin
+  // ---------------------------------------------------------------------------
+
+  it("getMetrics calls GET /api/admin/metrics with default period", async () => {
+    mockOk({ period: "24h", metrics: {} });
+    await api.getMetrics();
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/admin/metrics?period=24h");
+  });
+
+  it("getMetrics passes custom period", async () => {
+    mockOk({ period: "7d", metrics: {} });
+    await api.getMetrics("7d");
+    expect(fetchMock.mock.calls[0][0]).toContain("period=7d");
+  });
+
+  it("getCosts calls GET /api/admin/costs", async () => {
+    mockOk({ monthly: [] });
+    await api.getCosts();
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/admin/costs");
+  });
+
+  // ---------------------------------------------------------------------------
   // 401 handling — clears token and redirects
   // ---------------------------------------------------------------------------
 

--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -1,0 +1,352 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { api } from "../api.js";
+
+const TOOL_COLORS = {
+  remember: "#1a73e8",
+  recall: "#34a853",
+  forget: "#d93025",
+  list_memories: "#fbbc04",
+  summarize_context: "#9334e8",
+};
+
+const PERIOD_OPTIONS = ["1h", "24h", "7d"];
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+/** Merge per-tool CloudWatch time-series into [{timestamp, tool, value}] rows. */
+function buildInvocationSeries(metrics, tools) {
+  const byTs = {};
+  for (const tool of tools) {
+    const safe = tool.replace("_", "");
+    const series = metrics[`inv_${safe}`] ?? { timestamps: [], values: [] };
+    series.timestamps.forEach((ts, i) => {
+      const label = ts.slice(0, 16).replace("T", " ");
+      if (!byTs[label]) byTs[label] = { ts: label };
+      byTs[label][tool] = (byTs[label][tool] ?? 0) + (series.values[i] ?? 0);
+    });
+  }
+  return Object.values(byTs).sort((a, b) => a.ts.localeCompare(b.ts));
+}
+
+/** Build [{ts, p99_remember, p99_recall, ...}] for latency chart. */
+function buildLatencySeries(metrics, tools) {
+  const byTs = {};
+  for (const tool of tools) {
+    const safe = tool.replace("_", "");
+    const series = metrics[`p99_${safe}`] ?? { timestamps: [], values: [] };
+    series.timestamps.forEach((ts, i) => {
+      const label = ts.slice(0, 16).replace("T", " ");
+      if (!byTs[label]) byTs[label] = { ts: label };
+      byTs[label][tool] = Math.round(series.values[i] ?? 0);
+    });
+  }
+  return Object.values(byTs).sort((a, b) => a.ts.localeCompare(b.ts));
+}
+
+/** Build [{month, ...services}] for cost bar chart. */
+function buildCostSeries(monthly) {
+  return monthly.map((m) => ({ month: m.period.slice(0, 7), ...m.by_service }));
+}
+
+/** Collect all unique AWS service names across months. */
+function collectServices(monthly) {
+  const set = new Set();
+  for (const m of monthly) Object.keys(m.by_service).forEach((s) => set.add(s));
+  return [...set];
+}
+
+export function formatCostTick(v) {
+  return `$${v.toFixed(2)}`;
+}
+
+export function formatCostTooltip(v) {
+  return `$${Number(v).toFixed(4)}`;
+}
+
+const SERVICE_COLORS = [
+  "#1a73e8", "#34a853", "#fbbc04", "#d93025",
+  "#9334e8", "#00897b", "#e65100", "#0277bd",
+];
+
+// ------------------------------------------------------------------
+// Sub-components
+// ------------------------------------------------------------------
+
+function StatCard({ label, value }) {
+  return (
+    <div
+      style={{
+        background: "#fff",
+        border: "1px solid #e8e8e8",
+        borderRadius: 10,
+        padding: "18px 24px",
+        flex: 1,
+        minWidth: 120,
+        boxShadow: "0 1px 4px rgba(0,0,0,.04)",
+      }}
+    >
+      <div style={{ fontSize: 28, fontWeight: 700, color: "#1a1a2e" }}>{value ?? "—"}</div>
+      <div style={{ fontSize: 13, color: "#666", marginTop: 4 }}>{label}</div>
+    </div>
+  );
+}
+
+function SectionHeader({ title }) {
+  return (
+    <h3
+      style={{
+        fontSize: 15,
+        fontWeight: 700,
+        color: "#1a1a2e",
+        margin: "32px 0 16px",
+        borderBottom: "1px solid #eee",
+        paddingBottom: 8,
+      }}
+    >
+      {title}
+    </h3>
+  );
+}
+
+function ErrorBanner({ msg }) {
+  if (!msg) return null;
+  return (
+    <div
+      style={{
+        background: "#fff3f3",
+        border: "1px solid #fcc",
+        borderRadius: 6,
+        padding: "8px 14px",
+        color: "#c00",
+        fontSize: 13,
+        marginBottom: 12,
+      }}
+    >
+      {msg}
+    </div>
+  );
+}
+
+// ------------------------------------------------------------------
+// Main component
+// ------------------------------------------------------------------
+
+export default function Dashboard() {
+  const [period, setPeriod] = useState("24h");
+  const [stats, setStats] = useState(null);
+  const [metrics, setMetrics] = useState(null);
+  const [costs, setCosts] = useState(null);
+  const [metricsError, setMetricsError] = useState("");
+  const [costsError, setCostsError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const intervalRef = useRef(null);
+
+  const TOOLS = ["remember", "recall", "forget", "list_memories", "summarize_context"];
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    setMetricsError("");
+    setCostsError("");
+
+    const [statsRes, metricsRes, costsRes] = await Promise.allSettled([
+      api.getStats(),
+      api.getMetrics(period),
+      api.getCosts(),
+    ]);
+
+    if (statsRes.status === "fulfilled") setStats(statsRes.value);
+    if (metricsRes.status === "fulfilled") setMetrics(metricsRes.value);
+    else setMetricsError(metricsRes.reason?.message ?? "Failed to load metrics");
+    if (costsRes.status === "fulfilled") setCosts(costsRes.value);
+    else setCostsError(costsRes.reason?.message ?? "Failed to load costs");
+
+    setLoading(false);
+  }, [period]);
+
+  useEffect(() => {
+    loadAll();
+    intervalRef.current = setInterval(loadAll, 60_000);
+    return () => clearInterval(intervalRef.current);
+  }, [loadAll]);
+
+  const invData = metrics ? buildInvocationSeries(metrics.metrics ?? {}, TOOLS) : [];
+  const latData = metrics ? buildLatencySeries(metrics.metrics ?? {}, TOOLS) : [];
+  const costData = costs ? buildCostSeries(costs.monthly ?? []) : [];
+  const services = costs ? collectServices(costs.monthly ?? []) : [];
+
+  const authData = metrics
+    ? [
+        {
+          name: "Tokens Issued",
+          value: (metrics.metrics?.tokens_issued?.values ?? []).reduce((s, v) => s + v, 0),
+        },
+        {
+          name: "Validation Failures",
+          value: (metrics.metrics?.token_failures?.values ?? []).reduce((s, v) => s + v, 0),
+        },
+      ]
+    : [];
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 20 }}>
+        <h2 style={{ fontSize: 18, margin: 0 }}>Dashboard</h2>
+        <div style={{ display: "flex", gap: 4 }}>
+          {PERIOD_OPTIONS.map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              style={{
+                background: period === p ? "#1a1a2e" : "#f0f0f0",
+                color: period === p ? "#fff" : "#333",
+                border: "none",
+                borderRadius: 6,
+                padding: "4px 12px",
+                fontSize: 13,
+                cursor: "pointer",
+              }}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+        {loading && (
+          <span style={{ fontSize: 12, color: "#999" }}>Loading…</span>
+        )}
+        <button
+          onClick={loadAll}
+          style={{
+            marginLeft: "auto",
+            background: "transparent",
+            border: "1px solid #ddd",
+            borderRadius: 6,
+            padding: "4px 12px",
+            fontSize: 13,
+            cursor: "pointer",
+          }}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {/* Summary stats */}
+      {stats && (
+        <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+          <StatCard label="Total Memories" value={stats.total_memories} />
+          <StatCard label="Total Clients" value={stats.total_clients} />
+          <StatCard label="Events Today" value={stats.events_today} />
+          <StatCard label="Events (7d)" value={stats.events_last_7_days} />
+        </div>
+      )}
+
+      {/* CloudWatch metrics */}
+      <SectionHeader title="Tool Invocations" />
+      <ErrorBanner msg={metricsError} />
+      {invData.length > 0 && (
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={invData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="ts" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11 }} />
+            <Tooltip />
+            <Legend />
+            {TOOLS.map((t) => (
+              <Line
+                key={t}
+                type="monotone"
+                dataKey={t}
+                stroke={TOOL_COLORS[t]}
+                dot={false}
+                strokeWidth={2}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+      {invData.length === 0 && !metricsError && !loading && (
+        <div style={{ color: "#999", fontSize: 13 }}>No invocation data for this period.</div>
+      )}
+
+      <SectionHeader title="Storage Latency p99 (ms)" />
+      {latData.length > 0 && (
+        <ResponsiveContainer width="100%" height={220}>
+          <LineChart data={latData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="ts" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11 }} />
+            <Tooltip />
+            <Legend />
+            {TOOLS.map((t) => (
+              <Line
+                key={t}
+                type="monotone"
+                dataKey={t}
+                stroke={TOOL_COLORS[t]}
+                dot={false}
+                strokeWidth={2}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+      {latData.length === 0 && !metricsError && !loading && (
+        <div style={{ color: "#999", fontSize: 13 }}>No latency data for this period.</div>
+      )}
+
+      <SectionHeader title="Auth Events" />
+      {authData.length > 0 && (
+        <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+          {authData.map((d) => (
+            <StatCard key={d.name} label={d.name} value={d.value} />
+          ))}
+        </div>
+      )}
+
+      {/* Cost data */}
+      <SectionHeader title="Monthly AWS Spend" />
+      <ErrorBanner msg={costsError} />
+      {costs && (
+        <p style={{ fontSize: 12, color: "#999", margin: "0 0 12px" }}>
+          {costs.note}
+        </p>
+      )}
+      {costData.length > 0 && (
+        <ResponsiveContainer width="100%" height={260}>
+          <BarChart data={costData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11 }} tickFormatter={formatCostTick} />
+            <Tooltip formatter={formatCostTooltip} />
+            <Legend />
+            {services.map((svc, i) => (
+              <Bar
+                key={svc}
+                dataKey={svc}
+                stackId="cost"
+                fill={SERVICE_COLORS[i % SERVICE_COLORS.length]}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+      {costData.length === 0 && !costsError && !loading && (
+        <div style={{ color: "#999", fontSize: 13 }}>No cost data available yet.</div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/Dashboard.test.jsx
+++ b/ui/src/components/Dashboard.test.jsx
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Dashboard from "./Dashboard.jsx";
+
+// Recharts renders SVG; jsdom doesn't support ResizeObserver
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+vi.mock("../api.js", () => ({
+  api: {
+    getStats: vi.fn(),
+    getMetrics: vi.fn(),
+    getCosts: vi.fn(),
+  },
+}));
+
+import { api } from "../api.js";
+import { formatCostTick, formatCostTooltip } from "./Dashboard.jsx";
+
+const STATS = {
+  total_memories: 42,
+  total_clients: 3,
+  events_today: 10,
+  events_last_7_days: 88,
+};
+
+const METRICS = {
+  period: "24h",
+  environment: "test",
+  metrics: {
+    inv_remember: { timestamps: ["2026-04-01T12:00:00Z"], values: [5] },
+    err_remember: { timestamps: ["2026-04-01T12:00:00Z"], values: [1] },
+    p99_remember: { timestamps: ["2026-04-01T12:00:00Z"], values: [120] },
+    inv_recall: { timestamps: [], values: [] },
+    err_recall: { timestamps: [], values: [] },
+    p99_recall: { timestamps: [], values: [] },
+    inv_forget: { timestamps: [], values: [] },
+    err_forget: { timestamps: [], values: [] },
+    p99_forget: { timestamps: [], values: [] },
+    inv_listmemories: { timestamps: [], values: [] },
+    err_listmemories: { timestamps: [], values: [] },
+    p99_listmemories: { timestamps: [], values: [] },
+    inv_summarizecontext: { timestamps: [], values: [] },
+    err_summarizecontext: { timestamps: [], values: [] },
+    p99_summarizecontext: { timestamps: [], values: [] },
+    tokens_issued: { timestamps: ["2026-04-01T12:00:00Z"], values: [7] },
+    token_failures: { timestamps: ["2026-04-01T12:00:00Z"], values: [2] },
+  },
+};
+
+const COSTS = {
+  environment: "dev",
+  currency: "USD",
+  note: "Cost data lags ~24 h. Cached for 24 h.",
+  monthly: [
+    {
+      period: "2026-03-01",
+      total: 0.62,
+      by_service: { "AWS Lambda": 0.5, "Amazon DynamoDB": 0.12 },
+    },
+  ],
+};
+
+describe("formatters", () => {
+  it("formatCostTick formats to 2 decimal places with $", () => {
+    expect(formatCostTick(1.5)).toBe("$1.50");
+    expect(formatCostTick(0)).toBe("$0.00");
+  });
+
+  it("formatCostTooltip formats to 4 decimal places with $", () => {
+    expect(formatCostTooltip(0.1234)).toBe("$0.1234");
+    expect(formatCostTooltip("0.5")).toBe("$0.5000");
+  });
+});
+
+describe("Dashboard", () => {
+  beforeEach(() => {
+    api.getStats.mockResolvedValue(STATS);
+    api.getMetrics.mockResolvedValue(METRICS);
+    api.getCosts.mockResolvedValue(COSTS);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the Dashboard heading", async () => {
+    await act(async () => render(<Dashboard />));
+    expect(screen.getByText("Dashboard")).toBeTruthy();
+  });
+
+  it("renders period selector buttons", async () => {
+    await act(async () => render(<Dashboard />));
+    expect(screen.getByText("1h")).toBeTruthy();
+    expect(screen.getByText("24h")).toBeTruthy();
+    expect(screen.getByText("7d")).toBeTruthy();
+  });
+
+  it("renders summary stat cards after load", async () => {
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("42")).toBeTruthy());
+    expect(screen.getByText("Total Memories")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("Total Clients")).toBeTruthy();
+    expect(screen.getByText("10")).toBeTruthy();
+    expect(screen.getByText("Events Today")).toBeTruthy();
+    expect(screen.getByText("88")).toBeTruthy();
+    expect(screen.getByText("Events (7d)")).toBeTruthy();
+  });
+
+  it("renders section headers", async () => {
+    await act(async () => render(<Dashboard />));
+    expect(screen.getByText("Tool Invocations")).toBeTruthy();
+    expect(screen.getByText("Storage Latency p99 (ms)")).toBeTruthy();
+    expect(screen.getByText("Auth Events")).toBeTruthy();
+    expect(screen.getByText("Monthly AWS Spend")).toBeTruthy();
+  });
+
+  it("renders auth stat cards from metric data", async () => {
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("Tokens Issued")).toBeTruthy());
+    expect(screen.getByText("Validation Failures")).toBeTruthy();
+  });
+
+  it("renders cost note", async () => {
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText(/Cost data lags/)).toBeTruthy());
+  });
+
+  it("switches period when a period button is clicked", async () => {
+    await act(async () => render(<Dashboard />));
+    fireEvent.click(screen.getByText("1h"));
+    await waitFor(() => expect(api.getMetrics).toHaveBeenCalledWith("1h"));
+  });
+
+  it("clicking 7d calls getMetrics with 7d", async () => {
+    await act(async () => render(<Dashboard />));
+    fireEvent.click(screen.getByText("7d"));
+    await waitFor(() => expect(api.getMetrics).toHaveBeenCalledWith("7d"));
+  });
+
+  it("clicking Refresh reloads all data", async () => {
+    await act(async () => render(<Dashboard />));
+    const count = api.getStats.mock.calls.length;
+    fireEvent.click(screen.getByText("Refresh"));
+    await waitFor(() => expect(api.getStats.mock.calls.length).toBeGreaterThan(count));
+  });
+
+  it("auto-refreshes after 60 seconds", async () => {
+    vi.useFakeTimers();
+    await act(async () => render(<Dashboard />));
+    const count = api.getStats.mock.calls.length;
+    await act(async () => vi.advanceTimersByTime(60_000));
+    expect(api.getStats.mock.calls.length).toBeGreaterThan(count);
+    vi.useRealTimers();
+  });
+
+  it("shows empty state when no invocation data", async () => {
+    api.getMetrics.mockResolvedValue({
+      period: "24h",
+      environment: "test",
+      metrics: {},
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("No invocation data for this period.")).toBeTruthy()
+    );
+    expect(screen.getByText("No latency data for this period.")).toBeTruthy();
+  });
+
+  it("shows empty state when no cost data", async () => {
+    api.getCosts.mockResolvedValue({
+      environment: "dev",
+      currency: "USD",
+      note: "Cost data lags ~24 h.",
+      monthly: [],
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("No cost data available yet.")).toBeTruthy()
+    );
+  });
+
+  it("shows metrics error banner when getMetrics rejects", async () => {
+    api.getMetrics.mockRejectedValue(new Error("CloudWatch unavailable"));
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("CloudWatch unavailable")).toBeTruthy()
+    );
+  });
+
+  it("shows costs error banner when getCosts rejects", async () => {
+    api.getCosts.mockRejectedValue(new Error("Cost Explorer unavailable"));
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("Cost Explorer unavailable")).toBeTruthy()
+    );
+  });
+
+  it("handles getMetrics rejection with no message", async () => {
+    api.getMetrics.mockRejectedValue({});
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load metrics")).toBeTruthy()
+    );
+  });
+
+  it("handles getCosts rejection with no message", async () => {
+    api.getCosts.mockRejectedValue({});
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load costs")).toBeTruthy()
+    );
+  });
+
+  it("renders loading indicator during fetch", async () => {
+    let resolve;
+    api.getStats.mockReturnValue(new Promise((r) => { resolve = r; }));
+    api.getMetrics.mockReturnValue(new Promise(() => {}));
+    api.getCosts.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => render(<Dashboard />));
+    expect(screen.getByText("Loading…")).toBeTruthy();
+    // resolve to allow cleanup
+    resolve(STATS);
+  });
+
+  it("renders dash for undefined StatCard value", async () => {
+    // getStats returns data with a null field to hit the value ?? "—" branch
+    api.getStats.mockResolvedValue({
+      total_memories: null,
+      total_clients: 3,
+      events_today: 10,
+      events_last_7_days: 88,
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("—")).toBeTruthy());
+  });
+
+  it("handles metrics response missing metrics key", async () => {
+    // metrics.metrics is undefined — hits ?? {} branch on lines 179-180
+    api.getMetrics.mockResolvedValue({ period: "24h", environment: "test" });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("No invocation data for this period.")).toBeTruthy()
+    );
+  });
+
+  it("handles costs response missing monthly key", async () => {
+    // costs.monthly is undefined — hits ?? [] branch on lines 181-182
+    api.getCosts.mockResolvedValue({
+      environment: "dev",
+      currency: "USD",
+      note: "Cost data lags ~24 h.",
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("No cost data available yet.")).toBeTruthy()
+    );
+  });
+
+  it("handles sparse values array (values[i] undefined)", async () => {
+    // timestamps has more entries than values — hits ?? 0 on lines 40 and 55
+    api.getMetrics.mockResolvedValue({
+      period: "24h",
+      environment: "test",
+      metrics: {
+        inv_remember: { timestamps: ["2026-04-01T12:00:00Z", "2026-04-01T13:00:00Z"], values: [5] },
+        p99_remember: { timestamps: ["2026-04-01T12:00:00Z", "2026-04-01T13:00:00Z"], values: [120] },
+        tokens_issued: { timestamps: [], values: [] },
+        token_failures: { timestamps: [], values: [] },
+      },
+    });
+    await act(async () => render(<Dashboard />));
+    // Just assert no crash — the sparse-values path is exercised
+    expect(screen.getByText("Tool Invocations")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- New `/admin/metrics?period=1h|24h|7d` endpoint — queries CloudWatch `GetMetricData` for all MCP tool invocations, errors, p99 storage latency, tokens issued/validation failures (admin-only)
- New `/admin/costs` endpoint — queries Cost Explorer monthly spend grouped by service, cached 24 h to keep API costs minimal (admin-only)
- IAM: `cloudwatch:GetMetricData` + `ce:GetCostAndUsage` added to API Lambda role in CDK
- `Dashboard.jsx` — new admin-only tab in the management UI with:
  - Summary stats row (memories, clients, events today, events 7d)
  - Tool invocations line chart (per-tool colours, all 5 MCP tools)
  - Storage latency p99 line chart
  - Auth events stat cards (tokens issued / validation failures)
  - Monthly AWS spend stacked bar chart by service
  - Period selector (1h / 24h / 7d) + 60-second auto-refresh + manual Refresh button
- Recharts added as UI dependency

## Test plan
- [x] Backend: 11 unit tests — all endpoints, admin gate, cache hit/expiry, period validation
- [x] Frontend: 31 tests — all render states, period switching, auto-refresh, empty states, error banners, edge cases
- [x] 100% branch + function coverage maintained throughout

Closes #95
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)