### PR TITLE
release: Trivy scanning + cdk-nag compliance (#81, #82)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -71,6 +74,38 @@ jobs:
       - name: npm audit
         working-directory: ui
         run: npm audit --audit-level=high
+
+      - name: Trivy — dependency scan (table, for log visibility)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+          ignore-unfixed: true
+          scanners: vuln
+          trivyignores: .trivyignore
+
+      - name: Trivy — dependency scan
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-deps.sarif
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          ignore-unfixed: true
+          scanners: vuln
+          trivyignores: .trivyignore
+
+      - name: Upload Trivy dependency results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@f94817b9f0deeb3871261446912ae8f854d1b675 # codeql-bundle-v2.25.1
+        with:
+          sarif_file: trivy-deps.sarif
+          category: trivy-deps
 
   unit-tests:
     name: Unit Tests
@@ -338,6 +373,9 @@ jobs:
   infra-synth:
     name: Infra Synth
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -362,6 +400,36 @@ jobs:
       - name: Synth dev stack
         working-directory: infra
         run: cdk synth HiveStack-dev --no-staging -c env=dev -c hosted_zone_id=${{ vars.HOSTED_ZONE_ID }}
+
+      - name: Trivy — IaC scan (table, for log visibility)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: config
+          scan-ref: infra/cdk.out/
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+          trivyignores: .trivyignore
+
+      - name: Trivy — IaC scan (CloudFormation templates)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: config
+          scan-ref: infra/cdk.out/
+          format: sarif
+          output: trivy-iac.sarif
+          severity: HIGH,CRITICAL
+          # cdk-nag is the hard gate for IaC security (fails synth on violations).
+          # Trivy IaC is informational — findings go to the Security tab.
+          exit-code: "0"
+          trivyignores: .trivyignore
+
+      - name: Upload Trivy IaC results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@f94817b9f0deeb3871261446912ae8f854d1b675 # codeql-bundle-v2.25.1
+        with:
+          sarif_file: trivy-iac.sarif
+          category: trivy-iac
 
 # ── Deploy to dev (push to development) ───────────────────────────────────────
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+# Weekly Trivy security scan — catches newly disclosed CVEs against the
+# current codebase even when no PRs are open.
+name: Security Scan (weekly)
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: read
+  security-events: write
+  issues: write
+
+jobs:
+  trivy-weekly:
+    name: Trivy Full Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Trivy — dependency scan
+        id: trivy-deps
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-deps.sarif
+          severity: HIGH,CRITICAL
+          exit-code: "0" # Don't fail — report findings via issue instead
+          ignore-unfixed: true
+
+      - name: Upload dependency scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@f94817b9f0deeb3871261446912ae8f854d1b675 # codeql-bundle-v2.25.1
+        with:
+          sarif_file: trivy-deps.sarif
+          category: trivy-deps-weekly
+
+      - name: Check for new HIGH/CRITICAL findings
+        id: check
+        run: |
+          COUNT=$(python3 -c "
+          import json, sys
+          with open('trivy-deps.sarif') as f:
+              data = json.load(f)
+          runs = data.get('runs', [])
+          total = sum(len(r.get('results', [])) for r in runs)
+          print(total)
+          ")
+          echo "finding_count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Open issue if new findings detected
+        if: steps.check.outputs.finding_count != '0'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const count = '${{ steps.check.outputs.finding_count }}';
+            const run_url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security',
+            });
+            const existing = issues.find(i => i.title.includes('Trivy: HIGH/CRITICAL vulnerabilities detected'));
+            if (!existing) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Trivy: HIGH/CRITICAL vulnerabilities detected',
+                body: `## Security Alert\n\nTrivy detected **${count}** HIGH or CRITICAL vulnerability finding(s) in the weekly scan.\n\nSee the [Security tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/security/code-scanning) for details.\n\n[Workflow run](${run_url})`,
+                labels: ['security'],
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Weekly scan still detecting **${count}** finding(s). [Run](${run_url})`,
+              });
+            }

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,9 @@
+# Trivy ignore file — accepted-risk findings
+# Format: CVE-YYYY-NNNNN  # reason
+#
+# Add entries here for findings that have been reviewed and accepted,
+# e.g. because a fix is not yet available or the finding is not exploitable
+# in our deployment context.
+#
+# Example:
+# CVE-2023-12345  # Not exploitable: we don't use the affected code path

--- a/infra/app.py
+++ b/infra/app.py
@@ -3,6 +3,7 @@
 """CDK app entry point for Hive infrastructure."""
 
 import aws_cdk as cdk
+from cdk_nag import AwsSolutionsChecks
 from stacks.hive_stack import HiveStack
 
 app = cdk.App()
@@ -24,6 +25,8 @@ env = cdk.Environment(
 # In CI this is injected from the HOSTED_ZONE_ID Actions variable.
 hosted_zone_id = app.node.try_get_context("hosted_zone_id") or ""
 
-HiveStack(app, stack_id, env_name=env_name, hosted_zone_id=hosted_zone_id, env=env)
+stack = HiveStack(app, stack_id, env_name=env_name, hosted_zone_id=hosted_zone_id, env=env)
+
+cdk.Aspects.of(stack).add(AwsSolutionsChecks(verbose=True))
 
 app.synth()

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 
 import aws_cdk as cdk
+from cdk_nag import NagPackSuppression, NagSuppressions
 from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_cloudfront as cloudfront
 from aws_cdk import aws_cloudfront_origins as origins
@@ -367,6 +368,7 @@ class HiveStack(cdk.Stack):
             removal_policy=data_removal,
             auto_delete_objects=not is_prod,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            enforce_ssl=True,
         )
 
         # API origin — strip "https://" prefix and trailing "/" from the function URL
@@ -1174,4 +1176,79 @@ class HiveStack(cdk.Stack):
             "DashboardUrl",
             value=f"https://{self.region}.console.aws.amazon.com/cloudwatch/home#dashboards:name={dashboard_name}",
             description="CloudWatch dashboard URL",
+        )
+
+        # ----------------------------------------------------------------
+        # cdk-nag suppressions
+        # ----------------------------------------------------------------
+        NagSuppressions.add_stack_suppressions(
+            self,
+            [
+                # AWSLambdaBasicExecutionRole is the standard minimal Lambda
+                # execution role recommended by AWS. Using a more restrictive
+                # custom policy would require duplicating its managed policy
+                # contents, adding maintenance burden with no security benefit.
+                NagPackSuppression(
+                    id="AwsSolutions-IAM4",
+                    reason="AWSLambdaBasicExecutionRole is the standard least-privilege Lambda execution role.",
+                ),
+                # CloudWatch GetMetricData and Cost Explorer GetCostAndUsage
+                # do not support resource-level permissions — AWS requires '*'.
+                # The WAF log delivery condition ARN also requires a wildcard
+                # resource in the resource policy. All DynamoDB grants use
+                # table-scoped ARNs; the '*' finding applies only to the above.
+                NagPackSuppression(
+                    id="AwsSolutions-IAM5",
+                    reason="CloudWatch GetMetricData and ce:GetCostAndUsage require resource '*' per AWS docs. WAF log delivery policy requires wildcard resource condition.",
+                ),
+                # PYTHON_3_12 is the latest stable Lambda runtime available
+                # in aws-cdk-lib at the time of writing. We track the latest
+                # available runtime and will upgrade when 3.13 is GA in CDK.
+                NagPackSuppression(
+                    id="AwsSolutions-L1",
+                    reason="PYTHON_3_12 is the latest stable Lambda runtime available in CDK. Will upgrade to 3.13 when available.",
+                ),
+                # S3 server-access logging would write to another S3 bucket,
+                # creating a circular dependency and cost. CloudFront access
+                # logs (via CloudWatch metrics) provide sufficient visibility
+                # into access patterns for this SaaS product.
+                NagPackSuppression(
+                    id="AwsSolutions-S1",
+                    reason="CloudFront metrics provide sufficient access visibility. S3 server-access logging adds cost and bucket management overhead.",
+                ),
+                # CloudFront access logging is expensive and produces high
+                # volumes of data. We use CloudWatch metrics (via EMF) and
+                # CloudWatch alarms for operational visibility instead.
+                NagPackSuppression(
+                    id="AwsSolutions-CFR3",
+                    reason="CloudWatch metrics and alarms provide operational visibility. CloudFront access logging not required for this use case.",
+                ),
+                # Geo-restriction is intentionally not applied — Hive is a
+                # public SaaS product available to users worldwide.
+                NagPackSuppression(
+                    id="AwsSolutions-CFR1",
+                    reason="Hive is a globally available SaaS product. Geo-restriction is not appropriate.",
+                ),
+                # Lambda Function URLs are used instead of API Gateway.
+                # They are public by design — the origin-verify secret and
+                # JWT auth in the application layer enforce access control.
+                NagPackSuppression(
+                    id="AwsSolutions-FAS1",
+                    reason="Function URL auth=NONE is intentional; origin-verify header + JWT auth in the application layer enforce access control.",
+                ),
+                # SNS topic encryption with KMS would add per-message costs
+                # for alarm notifications. The topic carries no sensitive
+                # payload — only alarm state change notifications.
+                NagPackSuppression(
+                    id="AwsSolutions-SNS2",
+                    reason="SNS topic carries only CloudWatch alarm notifications (no sensitive data). KMS encryption adds cost without meaningful security benefit.",
+                ),
+                # Enforcing SSL-only on the alarm SNS topic would require a
+                # resource policy that restricts all AWS services, which can
+                # break CloudWatch alarm delivery in some regions.
+                NagPackSuppression(
+                    id="AwsSolutions-SNS3",
+                    reason="SSL-only policy on alarm SNS topic can break CloudWatch alarm delivery. Alarms carry no sensitive data.",
+                ),
+            ],
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 ]
 infra = [
     "aws-cdk-lib>=2.245.0",
+    "cdk-nag>=2.28.0",
     "constructs>=10.6.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -451,6 +451,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cdk-nag"
+version = "2.37.55"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-cdk-lib" },
+    { name = "constructs" },
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e0/b0e6b23a8efccb0970006a0e9bfa2953b6faa280598a1d1fd4ded7bf354a/cdk_nag-2.37.55.tar.gz", hash = "sha256:e9dc517070ef5a19deef95e79731e5624bd86cd07b56d210380408ea1314e47b", size = 761495, upload-time = "2025-10-17T00:18:46.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/ad/7cf42fe81acf6f40016bc8359fe28efad002a7accb7cb535186a449c4c3a/cdk_nag-2.37.55-py3-none-any.whl", hash = "sha256:bf83bcdeb98ac20bb813cac291af121d91c5a296fa815e01f93886b4f8b38845", size = 755391, upload-time = "2025-10-17T00:18:45.135Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -1243,6 +1259,7 @@ dev = [
 ]
 infra = [
     { name = "aws-cdk-lib" },
+    { name = "cdk-nag" },
     { name = "constructs" },
 ]
 
@@ -1275,6 +1292,7 @@ dev = [
 ]
 infra = [
     { name = "aws-cdk-lib", specifier = ">=2.245.0" },
+    { name = "cdk-nag", specifier = ">=2.28.0" },
     { name = "constructs", specifier = ">=10.6.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Trivy dependency scan (HIGH/CRITICAL CVEs) integrated into CI audit job and weekly security workflow
- Trivy IaC scan (CloudFormation templates) added to infra-synth job — findings go to GitHub Security tab; cdk-nag is the hard gate
- cdk-nag `AwsSolutionsChecks` aspect applied to CDK stack at synth time with suppressions for accepted intentional design choices
- Weekly security scan workflow (`security.yml`) opens/updates a GitHub issue when findings are detected
- `enforce_ssl=True` added to UiBucket (satisfies `AwsSolutions-S10`)
- `.trivyignore` placeholder file added for future accepted-risk suppressions

Closes #81
Closes #82