### PR TITLE
fix(infra): suppress Lambda X-Ray alert for CDK custom resource handlers

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -47,3 +47,8 @@ AVD-AWS-0017
 # DynamoDB PITR is intentionally disabled in the dev stack to reduce cost.
 # It is enabled in the prod stack where data durability is required.
 AVD-AWS-0024
+
+# X-Ray tracing is enabled (ACTIVE) on all application Lambda functions (MCP
+# and API). The dev stack also contains CDK-managed custom resource Lambdas
+# (e.g. AutoDeleteObjects for UiBucket) whose tracing cannot be configured.
+AVD-AWS-0066


### PR DESCRIPTION
## Summary

Adds `AVD-AWS-0066` to `.trivyignore` to clear the one remaining open code scanning alert.

X-Ray tracing is already enabled (`ACTIVE`) on all application Lambda functions (MCP and API). The alert persists because the dev stack includes a CDK-managed `AutoDeleteObjects` custom resource Lambda (created by `auto_delete_objects=True` on `UiBucket`) whose tracing cannot be configured externally.

Closes #126