### PR TITLE
fix(infra): redirect CloudFront 403 to index.html for SPA routing (closes #137)

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -584,6 +584,13 @@ class HiveStack(cdk.Stack):
             certificate=certificate,
             default_root_object="index.html",
             error_responses=[
+                # S3 with OAC returns 403 (not 404) for missing paths.
+                # Both must redirect to index.html so React Router handles routing.
+                cloudfront.ErrorResponse(
+                    http_status=403,
+                    response_page_path="/index.html",
+                    response_http_status=200,
+                ),
                 cloudfront.ErrorResponse(
                     http_status=404,
                     response_page_path="/index.html",


### PR DESCRIPTION
## Summary

Reloading the admin app on any route (e.g. `/app`) returned a raw S3 `AccessDenied` XML error. S3 with OAC returns **403** (not 404) for paths that don't exist as S3 objects. The CloudFront distribution only had a 404 → `index.html` error response, so 403s fell through.

Adds a matching 403 error response so React Router handles all deep-link and reload navigation correctly.

Closes #137