### PR TITLE
feat: e2e tests for CloudWatch metrics dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,10 +519,17 @@ jobs:
           HIVE_MCP_URL: ${{ needs.deploy-dev.outputs.mcp_url }}
         run: uv run pytest tests/e2e/test_auth_e2e.py tests/e2e/test_mcp_e2e.py -v
 
+      - name: Run admin metrics e2e tests
+        env:
+          HIVE_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
+          HIVE_ADMIN_EMAIL: ${{ vars.HIVE_ADMIN_EMAIL }}
+        run: uv run pytest tests/e2e/test_admin_e2e.py -v
+
       - name: Run UI e2e tests (Playwright)
         env:
           HIVE_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
           HIVE_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
+          HIVE_ADMIN_EMAIL: ${{ vars.HIVE_ADMIN_EMAIL }}
         run: uv run pytest tests/e2e/test_ui_e2e.py -v
 
       - name: Issue synthetic token via PKCE bypass

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,13 +7,16 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import html as html_lib
 import os
+import re
 import secrets
 
 import httpx
 import pytest
 
 API_URL = os.environ.get("HIVE_API_URL", "")
+ADMIN_EMAIL = os.environ.get("HIVE_ADMIN_EMAIL", "")
 
 
 @pytest.fixture(scope="session")
@@ -108,3 +111,27 @@ def issue_token_sync() -> str:
         )
         token_resp.raise_for_status()
         return token_resp.json()["access_token"]
+
+
+@pytest.fixture(scope="session")
+async def live_admin_token() -> str:
+    """Issue a management JWT with admin role via the Google auth bypass.
+
+    Hits /auth/login?test_email=<HIVE_ADMIN_EMAIL> and parses the JWT from
+    the HTML response.  Skips if the env var is not set or if the server
+    redirects to Google (bypass not enabled).
+    """
+    if not API_URL:
+        pytest.skip("HIVE_API_URL not set")
+    if not ADMIN_EMAIL:
+        pytest.skip("HIVE_ADMIN_EMAIL not set")
+
+    async with httpx.AsyncClient(base_url=API_URL, follow_redirects=False) as http:
+        resp = await http.get("/auth/login", params={"test_email": ADMIN_EMAIL})
+        if resp.status_code in (301, 302, 307, 308):
+            pytest.skip("Google OAuth redirect — HIVE_BYPASS_GOOGLE_AUTH not enabled")
+        resp.raise_for_status()
+        m = re.search(r"localStorage\.setItem\('hive_mgmt_token',\s*'([^']+)'\)", resp.text)
+        if not m:
+            pytest.fail("Could not extract mgmt token from bypass login response")
+        return html_lib.unescape(m.group(1))

--- a/tests/e2e/test_admin_e2e.py
+++ b/tests/e2e/test_admin_e2e.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+E2E tests for the admin-only CloudWatch metrics and cost endpoints.
+Requires:
+  HIVE_API_URL       — deployed management API URL
+  HIVE_ADMIN_EMAIL   — admin email address (resolved against allowed-emails list)
+
+These tests verify structure only — they do not assert specific metric values,
+since CloudWatch data may lag or be sparse depending on recent traffic.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+API_URL = os.environ.get("HIVE_API_URL", "")
+
+pytestmark = pytest.mark.skipif(
+    not API_URL,
+    reason="HIVE_API_URL not set — skipping admin e2e tests",
+)
+
+_EXPECTED_TOOLS = ["remember", "recall", "forget", "listmemories", "summarizecontext"]
+_EXPECTED_METRIC_PREFIXES = ["inv_", "err_", "p99_"]
+
+
+def _assert_metric_structure(data: dict) -> None:
+    """Assert that a metrics response has the expected shape."""
+    assert "period" in data
+    assert "environment" in data
+    assert "metrics" in data
+    metrics = data["metrics"]
+    assert isinstance(metrics, dict)
+
+    for tool in _EXPECTED_TOOLS:
+        for prefix in _EXPECTED_METRIC_PREFIXES:
+            key = f"{prefix}{tool}"
+            assert key in metrics, f"Missing metric key: {key}"
+            entry = metrics[key]
+            assert "timestamps" in entry
+            assert "values" in entry
+            assert isinstance(entry["timestamps"], list)
+            assert isinstance(entry["values"], list)
+
+    assert "tokens_issued" in metrics
+    assert "token_failures" in metrics
+
+
+@pytest.mark.asyncio
+class TestAdminMetricsE2E:
+    async def test_metrics_1h(self, live_admin_token):
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/metrics",
+                params={"period": "1h"},
+                headers={"Authorization": f"Bearer {live_admin_token}"},
+            )
+            assert resp.status_code == 200, resp.text
+            _assert_metric_structure(resp.json())
+
+    async def test_metrics_24h(self, live_admin_token):
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/metrics",
+                params={"period": "24h"},
+                headers={"Authorization": f"Bearer {live_admin_token}"},
+            )
+            assert resp.status_code == 200, resp.text
+            data = resp.json()
+            _assert_metric_structure(data)
+            assert data["period"] == "24h"
+
+    async def test_metrics_7d(self, live_admin_token):
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/metrics",
+                params={"period": "7d"},
+                headers={"Authorization": f"Bearer {live_admin_token}"},
+            )
+            assert resp.status_code == 200, resp.text
+            _assert_metric_structure(resp.json())
+
+    async def test_metrics_invalid_period(self, live_admin_token):
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/metrics",
+                params={"period": "99y"},
+                headers={"Authorization": f"Bearer {live_admin_token}"},
+            )
+            assert resp.status_code == 422
+
+    async def test_metrics_requires_admin(self, live_token):
+        """MCP access tokens must not grant access to admin endpoints."""
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/metrics",
+                headers={"Authorization": f"Bearer {live_token}"},
+            )
+            assert resp.status_code == 401
+
+    async def test_metrics_has_data_after_synthetic_traffic(self, live_admin_token):
+        """After synthetic traffic has run, the 7d window should have invocation data."""
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/metrics",
+                params={"period": "7d"},
+                headers={"Authorization": f"Bearer {live_admin_token}"},
+            )
+            assert resp.status_code == 200
+            metrics = resp.json()["metrics"]
+            # At least one tool should have invocation data points
+            total_invocations = sum(
+                sum(metrics[f"inv_{t}"]["values"])
+                for t in _EXPECTED_TOOLS
+                if metrics.get(f"inv_{t}", {}).get("values")
+            )
+            assert total_invocations > 0, (
+                "No invocation data found in 7d window — synthetic traffic may not have run yet"
+            )

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -14,6 +14,7 @@ import pytest
 
 UI_URL = os.environ.get("HIVE_UI_URL", "")
 API_URL = os.environ.get("HIVE_API_URL", "")
+ADMIN_EMAIL = os.environ.get("HIVE_ADMIN_EMAIL", "")
 
 pytestmark = pytest.mark.skipif(
     not UI_URL,
@@ -88,3 +89,53 @@ class TestUIE2E:
         page = browser_page
         page.locator("nav button:has-text('Activity Log')").click()
         assert page.locator("nav button:has-text('Activity Log')").is_visible()
+
+
+@pytest.fixture(scope="module")
+def admin_browser_page():
+    """Browser page logged in as an admin user via the Google auth bypass."""
+    if not ADMIN_EMAIL:
+        pytest.skip("HIVE_ADMIN_EMAIL not set — skipping admin UI e2e tests")
+
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+
+        page.goto(
+            f"{UI_URL}/auth/login?test_email={ADMIN_EMAIL}",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
+
+        yield page
+        browser.close()
+
+
+class TestDashboardE2E:
+    def test_dashboard_tab_visible_for_admin(self, admin_browser_page):
+        page = admin_browser_page
+        page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
+        assert page.locator("nav button:has-text('Dashboard')").is_visible()
+
+    def test_dashboard_renders_without_error(self, admin_browser_page):
+        page = admin_browser_page
+        page.locator("nav button:has-text('Dashboard')").click()
+        page.wait_for_load_state("networkidle")
+        # No error banner should be present after metrics load
+        assert not page.locator("text=Failed to load metrics").is_visible()
+        assert not page.locator("text=Failed to load costs").is_visible()
+
+    def test_dashboard_period_selector(self, admin_browser_page):
+        page = admin_browser_page
+        page.locator("nav button:has-text('Dashboard')").click()
+        page.wait_for_load_state("networkidle")
+        # Switch through all period options — none should trigger an error banner
+        for period in ("1h", "7d", "24h"):
+            page.locator(f"button:has-text('{period}')").click()
+            page.wait_for_load_state("networkidle")
+            assert not page.locator("text=Failed to load metrics").is_visible(), (
+                f"Error banner appeared after switching to {period}"
+            )


### PR DESCRIPTION
## Summary

- **`tests/e2e/test_admin_e2e.py`** (new) — API-level tests for `/api/admin/metrics`:
  - All three periods (`1h`, `24h`, `7d`) return 200 with correct structure
  - All expected metric keys present (`inv_`/`err_`/`p99_` per tool + `tokens_issued` / `token_failures`)
  - Invalid period returns 422
  - MCP access token rejected with 401 (auth boundary check)
  - 7-day window has `> 0` invocation data after synthetic traffic has run

- **`tests/e2e/test_ui_e2e.py`** — adds `TestDashboardE2E`:
  - `admin_browser_page` fixture logs in via bypass with `HIVE_ADMIN_EMAIL`
  - Dashboard tab visible for admin users
  - Charts render without error banners
  - Period selector (`1h` / `24h` / `7d`) switches cleanly

- **`tests/e2e/conftest.py`** — adds `live_admin_token` fixture (parses mgmt JWT from `/auth/login?test_email=` HTML response)

- **`.github/workflows/ci.yml`** — new "Run admin metrics e2e tests" step with `HIVE_ADMIN_EMAIL: ${{ vars.HIVE_ADMIN_EMAIL }}`; also passes `HIVE_ADMIN_EMAIL` to the existing UI test step

## Test plan

- [ ] Merge and watch `e2e-dev` job after next deploy to `development` — confirm all admin e2e tests pass
- [ ] Confirm `test_metrics_has_data_after_synthetic_traffic` passes (requires at least one synthetic traffic run on dev since deploy)

Closes #143