### PR TITLE
fix: use async Playwright for admin Dashboard e2e tests

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -91,51 +91,55 @@ class TestUIE2E:
         assert page.locator("nav button:has-text('Activity Log')").is_visible()
 
 
-@pytest.fixture(scope="module")
-def admin_browser_page():
-    """Browser page logged in as an admin user via the Google auth bypass."""
+@pytest.fixture()
+async def admin_browser_page():
+    """Browser page logged in as an admin user via the Google auth bypass.
+
+    Uses the async Playwright API to avoid conflicts with pytest-asyncio's
+    event loop (sync_playwright() raises if a loop is already running).
+    """
     if not ADMIN_EMAIL:
         pytest.skip("HIVE_ADMIN_EMAIL not set — skipping admin UI e2e tests")
 
-    from playwright.sync_api import sync_playwright
+    from playwright.async_api import async_playwright
 
-    with sync_playwright() as p:
-        browser = p.chromium.launch()
-        page = browser.new_page()
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
 
-        page.goto(
+        await page.goto(
             f"{UI_URL}/auth/login?test_email={ADMIN_EMAIL}",
             timeout=30_000,
             wait_until="networkidle",
         )
-        page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
+        await page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
 
         yield page
-        browser.close()
+        await browser.close()
 
 
 class TestDashboardE2E:
-    def test_dashboard_tab_visible_for_admin(self, admin_browser_page):
+    async def test_dashboard_tab_visible_for_admin(self, admin_browser_page):
         page = admin_browser_page
-        page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
-        assert page.locator("nav button:has-text('Dashboard')").is_visible()
+        await page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
+        assert await page.locator("nav button:has-text('Dashboard')").is_visible()
 
-    def test_dashboard_renders_without_error(self, admin_browser_page):
+    async def test_dashboard_renders_without_error(self, admin_browser_page):
         page = admin_browser_page
-        page.locator("nav button:has-text('Dashboard')").click()
-        page.wait_for_load_state("networkidle")
+        await page.locator("nav button:has-text('Dashboard')").click()
+        await page.wait_for_load_state("networkidle")
         # No error banner should be present after metrics load
-        assert not page.locator("text=Failed to load metrics").is_visible()
-        assert not page.locator("text=Failed to load costs").is_visible()
+        assert not await page.locator("text=Failed to load metrics").is_visible()
+        assert not await page.locator("text=Failed to load costs").is_visible()
 
-    def test_dashboard_period_selector(self, admin_browser_page):
+    async def test_dashboard_period_selector(self, admin_browser_page):
         page = admin_browser_page
-        page.locator("nav button:has-text('Dashboard')").click()
-        page.wait_for_load_state("networkidle")
+        await page.locator("nav button:has-text('Dashboard')").click()
+        await page.wait_for_load_state("networkidle")
         # Switch through all period options — none should trigger an error banner
         for period in ("1h", "7d", "24h"):
-            page.locator(f"button:has-text('{period}')").click()
-            page.wait_for_load_state("networkidle")
-            assert not page.locator("text=Failed to load metrics").is_visible(), (
+            await page.locator(f"button:has-text('{period}')").click()
+            await page.wait_for_load_state("networkidle")
+            assert not await page.locator("text=Failed to load metrics").is_visible(), (
                 f"Error banner appeared after switching to {period}"
             )


### PR DESCRIPTION
## Summary

Fixes the `admin_browser_page` fixture that was failing in CI with:
```
playwright._impl._errors.Error: It looks like you are using Playwright Sync API inside the asyncio loop.
```

**Root cause:** `asyncio_mode = "auto"` in pyproject.toml causes pytest-asyncio to create a session-scoped event loop as soon as any async fixture is discovered in conftest.py. When `admin_browser_page` runs after that setup, `sync_playwright()` sees a running loop and raises.

**Fix:** Switch `admin_browser_page` to `async_playwright()` (async Playwright API) and make `TestDashboardE2E` tests `async def`. The existing `browser_page` / `TestUIE2E` are unaffected.

## Test plan

- [ ] Watch `e2e-dev` after merge — confirm `TestDashboardE2E` passes

Closes #143