### PR TITLE
fix(e2e): split Dashboard Playwright tests into own file to fix asyncio conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,8 +529,13 @@ jobs:
         env:
           HIVE_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
           HIVE_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
-          HIVE_ADMIN_EMAIL: ${{ vars.HIVE_ADMIN_EMAIL }}
         run: uv run pytest tests/e2e/test_ui_e2e.py -v
+
+      - name: Run Dashboard e2e tests (Playwright)
+        env:
+          HIVE_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
+          HIVE_ADMIN_EMAIL: ${{ vars.HIVE_ADMIN_EMAIL }}
+        run: uv run pytest tests/e2e/test_dashboard_e2e.py -v
 
       - name: Issue synthetic token via PKCE bypass
         id: synth-token

--- a/tests/e2e/test_dashboard_e2e.py
+++ b/tests/e2e/test_dashboard_e2e.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Playwright E2E tests for the Hive Dashboard UI (admin-only).
+Must run in its own pytest invocation — mixing with async test files causes
+pytest-asyncio to start an event loop that blocks sync_playwright().
+Requires:
+  HIVE_UI_URL        — deployed UI URL (CloudFront)
+  HIVE_ADMIN_EMAIL   — admin email for Google auth bypass
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+UI_URL = os.environ.get("HIVE_UI_URL", "")
+ADMIN_EMAIL = os.environ.get("HIVE_ADMIN_EMAIL", "")
+
+pytestmark = pytest.mark.skipif(
+    not UI_URL,
+    reason="HIVE_UI_URL not set — skipping dashboard e2e tests",
+)
+
+
+@pytest.fixture(scope="module")
+def admin_browser_page():
+    """Browser page logged in as an admin user via the Google auth bypass."""
+    if not ADMIN_EMAIL:
+        pytest.skip("HIVE_ADMIN_EMAIL not set — skipping admin UI e2e tests")
+
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+
+        page.goto(
+            f"{UI_URL}/auth/login?test_email={ADMIN_EMAIL}",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
+
+        yield page
+        browser.close()
+
+
+class TestDashboardE2E:
+    def test_dashboard_tab_visible_for_admin(self, admin_browser_page):
+        page = admin_browser_page
+        page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
+        assert page.locator("nav button:has-text('Dashboard')").is_visible()
+
+    def test_dashboard_renders_without_error(self, admin_browser_page):
+        page = admin_browser_page
+        page.locator("nav button:has-text('Dashboard')").click()
+        page.wait_for_load_state("networkidle")
+        # No error banner should be present after metrics load
+        assert not page.locator("text=Failed to load metrics").is_visible()
+        assert not page.locator("text=Failed to load costs").is_visible()
+
+    def test_dashboard_period_selector(self, admin_browser_page):
+        page = admin_browser_page
+        page.locator("nav button:has-text('Dashboard')").click()
+        page.wait_for_load_state("networkidle")
+        # Switch through all period options — none should trigger an error banner
+        for period in ("1h", "7d", "24h"):
+            page.locator(f"button:has-text('{period}')").click()
+            page.wait_for_load_state("networkidle")
+            assert not page.locator("text=Failed to load metrics").is_visible(), (
+                f"Error banner appeared after switching to {period}"
+            )

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -14,7 +14,6 @@ import pytest
 
 UI_URL = os.environ.get("HIVE_UI_URL", "")
 API_URL = os.environ.get("HIVE_API_URL", "")
-ADMIN_EMAIL = os.environ.get("HIVE_ADMIN_EMAIL", "")
 
 pytestmark = pytest.mark.skipif(
     not UI_URL,
@@ -89,61 +88,3 @@ class TestUIE2E:
         page = browser_page
         page.locator("nav button:has-text('Activity Log')").click()
         assert page.locator("nav button:has-text('Activity Log')").is_visible()
-
-
-@pytest.fixture()
-async def admin_browser_page():
-    """Browser page logged in as an admin user via the Google auth bypass.
-
-    Uses the async Playwright API to avoid conflicts with pytest-asyncio's
-    event loop (sync_playwright() raises if a loop is already running).
-    """
-    if not ADMIN_EMAIL:
-        pytest.skip("HIVE_ADMIN_EMAIL not set — skipping admin UI e2e tests")
-
-    from playwright.async_api import async_playwright
-
-    # Use .start() instead of the context-manager form — async_playwright() as a
-    # context manager creates its own asyncio Runner, which raises when a loop
-    # is already running (pytest-asyncio asyncio_mode=auto keeps one live).
-    p = await async_playwright().start()
-    browser = await p.chromium.launch()
-    page = await browser.new_page()
-
-    await page.goto(
-        f"{UI_URL}/auth/login?test_email={ADMIN_EMAIL}",
-        timeout=30_000,
-        wait_until="networkidle",
-    )
-    await page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
-
-    yield page
-    await browser.close()
-    await p.stop()
-
-
-class TestDashboardE2E:
-    async def test_dashboard_tab_visible_for_admin(self, admin_browser_page):
-        page = admin_browser_page
-        await page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
-        assert await page.locator("nav button:has-text('Dashboard')").is_visible()
-
-    async def test_dashboard_renders_without_error(self, admin_browser_page):
-        page = admin_browser_page
-        await page.locator("nav button:has-text('Dashboard')").click()
-        await page.wait_for_load_state("networkidle")
-        # No error banner should be present after metrics load
-        assert not await page.locator("text=Failed to load metrics").is_visible()
-        assert not await page.locator("text=Failed to load costs").is_visible()
-
-    async def test_dashboard_period_selector(self, admin_browser_page):
-        page = admin_browser_page
-        await page.locator("nav button:has-text('Dashboard')").click()
-        await page.wait_for_load_state("networkidle")
-        # Switch through all period options — none should trigger an error banner
-        for period in ("1h", "7d", "24h"):
-            await page.locator(f"button:has-text('{period}')").click()
-            await page.wait_for_load_state("networkidle")
-            assert not await page.locator("text=Failed to load metrics").is_visible(), (
-                f"Error banner appeared after switching to {period}"
-            )


### PR DESCRIPTION
## Summary

- Moves `TestDashboardE2E` and its `admin_browser_page` fixture into a new `tests/e2e/test_dashboard_e2e.py` file
- Adds a dedicated **Run Dashboard e2e tests** CI step in `ci.yml`

## Changes

- `test_ui_e2e.py` — removed `TestDashboardE2E`, `admin_browser_page`, and `ADMIN_EMAIL`
- `test_dashboard_e2e.py` — new file with dashboard tests (sync Playwright, no async)
- `ci.yml` — adds separate step for `test_dashboard_e2e.py`; removes `HIVE_ADMIN_EMAIL` from UI step

## Root cause

`sync_playwright()` raises "Playwright Sync API inside asyncio loop" when called after `TestUIE2E` has already run in the same pytest session. `asyncio_mode=auto` starts an event loop mid-session that persists into subsequent fixture setups in the same process.

Running `TestDashboardE2E` in its own file means a fresh pytest session with no prior async infrastructure — `sync_playwright()` initialises cleanly.

**Verified locally:** all 7 tests pass (4 UI + 3 Dashboard).

## Test plan

- [x] `uv run inv pre-push` passes locally
- [x] Both test files verified green locally against dev stack
- [ ] CI e2e-dev passes green

## Checklist

- [x] PR title is descriptive
- [x] Closes #163