### PR TITLE
feat: make Google auth bypass conditional on test_email param

### DIFF
--- a/src/hive/auth/mgmt_auth.py
+++ b/src/hive/auth/mgmt_auth.py
@@ -64,10 +64,12 @@ async def mgmt_login(request: Request) -> RedirectResponse:
     """Redirect the management UI user to Google for authentication.
 
     In HIVE_BYPASS_GOOGLE_AUTH mode (non-prod), issue a synthetic JWT directly
-    for the test email so e2e tests can run without a real Google account.
+    when a test_email query parameter is provided, so e2e tests can run without
+    a real Google account.  Omitting test_email falls through to the real Google
+    OAuth flow, allowing developers to log in with their actual identity in dev.
     """
-    if _BYPASS:
-        test_email = request.query_params.get("test_email", "test@example.com")
+    test_email = request.query_params.get("test_email")
+    if _BYPASS and test_email:
         storage = HiveStorage()
         user = _upsert_user(storage, test_email, test_email.split("@")[0], test_email)
         token = issue_mgmt_jwt(user)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1383,6 +1383,21 @@ class TestMgmtAuthRoutes:
         assert resp.status_code == 200
         assert "hive_mgmt_token" in resp.text
 
+    def test_login_bypass_without_test_email_redirects_to_google(self, mgmt_client):
+        """In bypass mode, /auth/login without test_email falls through to Google."""
+        from unittest.mock import patch
+
+        with (
+            patch("hive.auth.mgmt_auth._BYPASS", True),
+            patch(
+                "hive.auth.mgmt_auth.google_authorization_url",
+                return_value="https://accounts.google.com/auth?state=x",
+            ),
+        ):
+            resp = mgmt_client.get("/auth/login")
+        assert resp.status_code == 302
+        assert "accounts.google.com" in resp.headers["location"]
+
     def test_login_redirects_to_google(self, mgmt_client):
         """Without bypass, /auth/login redirects to Google."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary

When `HIVE_BYPASS_GOOGLE_AUTH=true`, only trigger the bypass when `test_email` is explicitly present in the query string. Without it, fall through to the real Google OAuth flow.

## Changes

- `src/hive/auth/mgmt_auth.py` — change bypass condition from `if _BYPASS:` to `if _BYPASS and test_email:`
- `tests/unit/test_auth.py` — add test for bypass mode without `test_email` redirecting to Google

## Test plan

- [x] `uv run inv pre-push` passes locally (261 Python + 172 JS)
- [x] Existing bypass test (`test_login_bypass_issues_jwt`) still passes — always supplies `test_email`
- [x] New test `test_login_bypass_without_test_email_redirects_to_google` covers the new path
- [x] Coverage remains at 100%

## Checklist

- [x] PR title is descriptive
- [x] Closes #140