### PR TITLE
fix(ui): add logo to HomePage header and constrain features to 2×2 grid

### DIFF
--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -61,7 +61,7 @@ export default function HomePage() {
           justifyContent: "space-between",
         }}
       >
-        <span style={{ fontWeight: 700, fontSize: 20, letterSpacing: 1 }}>Hive</span>
+        <img src="/logo.svg" alt="Hive" style={{ height: 28 }} />
         <button
           onClick={() => navigate("/app")}
           style={{
@@ -142,7 +142,9 @@ export default function HomePage() {
         <div
           style={{
             display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+            maxWidth: 640,
+            margin: "0 auto",
             gap: 32,
           }}
         >

--- a/ui/src/components/HomePage.test.jsx
+++ b/ui/src/components/HomePage.test.jsx
@@ -48,6 +48,13 @@ describe("HomePage", () => {
     expect(screen.getByText(/Start remembering/)).toBeTruthy();
   });
 
+  it("renders the logo in the nav header", async () => {
+    const { container } = await act(async () => renderInRouter(<HomePage />));
+    const logo = container.querySelector('img[alt="Hive"]');
+    expect(logo).toBeTruthy();
+    expect(logo.getAttribute("src")).toBe("/logo.svg");
+  });
+
   it("renders the nav Sign in button", async () => {
     await act(async () => renderInRouter(<HomePage />));
     expect(screen.getByText("Sign in")).toBeTruthy();


### PR DESCRIPTION
## Summary

- Replace plain text "Hive" wordmark in `HomePage` nav with `<img src="/logo.svg">` — consistent with the admin UI header (#176)
- Constrain features grid to 2×2 layout using `minmax(280px, 1fr)` with `maxWidth: 640` — collapses to 1 column on mobile without a media query (#177)

## Test plan

- [x] Logo renders in nav header (`img[alt="Hive"]` test added)
- [x] 183 frontend tests pass
- [x] Logo is visible against dark `#1a1a2e` header (amber on navy — same as admin UI)

Closes #176
Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)