### PR TITLE
fix(ui): add Hive wordmark next to logo in nav; align section widths

### DIFF
--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -62,7 +62,10 @@ export default function HomePage() {
             justifyContent: "space-between",
           }}
         >
-          <img src="/logo.svg" alt="Hive" style={{ height: 28 }} />
+          <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <img src="/logo.svg" alt="Hive" style={{ height: 28 }} />
+            <span style={{ fontWeight: 700, fontSize: 20, letterSpacing: 1 }}>Hive</span>
+          </span>
           <button
             onClick={() => navigate("/app")}
             style={{
@@ -173,7 +176,7 @@ export default function HomePage() {
 
       {/* How it works */}
       <section style={{ background: "#f8f9fa", padding: "80px 32px" }}>
-        <div style={{ maxWidth: 1100, margin: "0 auto" }}>
+        <div style={{ maxWidth: 640, margin: "0 auto" }}>
           <h2
             style={{
               textAlign: "center",

--- a/ui/src/components/HomePage.test.jsx
+++ b/ui/src/components/HomePage.test.jsx
@@ -48,11 +48,13 @@ describe("HomePage", () => {
     expect(screen.getByText(/Start remembering/)).toBeTruthy();
   });
 
-  it("renders the logo in the nav header", async () => {
+  it("renders the logo and wordmark in the nav header", async () => {
     const { container } = await act(async () => renderInRouter(<HomePage />));
     const logo = container.querySelector('img[alt="Hive"]');
     expect(logo).toBeTruthy();
     expect(logo.getAttribute("src")).toBe("/logo.svg");
+    // "Hive" wordmark text appears alongside logo
+    expect(screen.getAllByText("Hive").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders the nav Sign in button", async () => {


### PR DESCRIPTION
## Summary

- Nav header now shows logo + "Hive" text together (matches admin UI in `App.jsx`)
- "Up and running in minutes" section content constrained to `640px` to match the features grid — previously it spread to `1100px` making it visually wider than the cards above it

## Test plan

- [x] Logo + wordmark renders in nav header (test updated)
- [x] 183 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)