### PR TITLE
fix(ui): align all page content to navbar's 1100px container

### DIFF
--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -149,8 +149,6 @@ export default function HomePage() {
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-            maxWidth: 640,
-            margin: "0 auto",
             gap: 32,
           }}
         >
@@ -176,7 +174,7 @@ export default function HomePage() {
 
       {/* How it works */}
       <section style={{ background: "#f8f9fa", padding: "80px 32px" }}>
-        <div style={{ maxWidth: 640, margin: "0 auto" }}>
+        <div style={{ maxWidth: 1100, margin: "0 auto" }}>
           <h2
             style={{
               textAlign: "center",


### PR DESCRIPTION
## Summary

Removes the inner `maxWidth: 640` overrides on the features grid and how-it-works section so all content fills to the same `1100px` as the navbar — left and right edges now line up at every scroll position.

## Test plan

- [x] 183 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)