### PR TITLE
fix(ui): apply theme globally; fix LoginPage dark mode colours

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -186,6 +186,7 @@ function HomeRoute() {
 }
 
 export default function App() {
+  useTheme(); // apply data-theme to <html> for all routes
   return (
     <BrowserRouter>
       <Routes>

--- a/ui/src/components/LoginPage.jsx
+++ b/ui/src/components/LoginPage.jsx
@@ -9,12 +9,13 @@ export default function LoginPage() {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "#f5f5f5",
+        background: "var(--bg)",
       }}
     >
       <div
         style={{
-          background: "#fff",
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
           borderRadius: 12,
           padding: 48,
           textAlign: "center",
@@ -23,10 +24,10 @@ export default function LoginPage() {
           width: "100%",
         }}
       >
-        <h1 style={{ fontSize: 28, fontWeight: 700, marginBottom: 8, color: "#1a1a2e" }}>
+        <h1 style={{ fontSize: 28, fontWeight: 700, marginBottom: 8, color: "var(--text)" }}>
           Hive
         </h1>
-        <p style={{ color: "#666", marginBottom: 32 }}>
+        <p style={{ color: "var(--text-muted)", marginBottom: 32 }}>
           Shared persistent memory for Claude agents
         </p>
         <button
@@ -36,11 +37,12 @@ export default function LoginPage() {
           style={{
             width: "100%",
             padding: "12px 0",
-            background: "#fff",
-            border: "1px solid #ddd",
+            background: "var(--bg)",
+            border: "1px solid var(--border)",
             borderRadius: 8,
             cursor: "pointer",
             fontSize: 15,
+            color: "var(--text)",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",


### PR DESCRIPTION
## Summary

**Root cause:** `useTheme()` was called inside `AppShell` only, so `data-theme` was never set on `<html>` for unauthenticated routes — `LoginPage`, `HomePage`, and `AuthCallback` always rendered with `:root` (light) CSS variables regardless of OS setting.

**Fixes:**
- Move `useTheme()` call to the `App` root so the theme is applied on every route from first render
- Replace hardcoded colours in `LoginPage` (`#f5f5f5`, `#fff`, `#666`) with CSS variables (`--bg`, `--surface`, `--border`, `--text`, `--text-muted`) so it adapts to both light and dark mode

## Test plan

- [x] 183 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)