### PR TITLE
docs: broaden messaging from Claude-specific to MCP-compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,33 +29,18 @@
 <!-- MCP -->
 [![MCP](https://img.shields.io/badge/MCP-compatible-blueviolet)](https://modelcontextprotocol.io/)
 
-Shared persistent memory for Claude agents — free hosted service, no AWS account required.
+Shared persistent memory for AI agents — works with any MCP-compatible client. Free hosted service, no AWS account required.
 
-Hive is an MCP server that gives Claude agents durable, shared memory across conversations. Connect any number of Claude clients, store and retrieve memories by key or tag, and manage everything through a web UI.
+Hive is an MCP server that gives AI agents durable, shared memory across conversations. Connect any MCP-compatible client — Claude Code, Claude Desktop, Cursor, Continue, or custom agents — store and retrieve memories by key or tag, and manage everything through a web UI.
 
 **Hosted at [hive.warlordofmars.net](https://hive.warlordofmars.net) — sign in with Google, no setup required.**
 
 ## Getting started
 
 1. **Sign in** at [hive.warlordofmars.net](https://hive.warlordofmars.net) with your Google account
-2. **Connect Claude** using the config for your client below — OAuth is handled automatically on first use
+2. **Connect your MCP client** using the config for your client below — OAuth is handled automatically on first use
 
-**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "hive": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://hive.warlordofmars.net/mcp"]
-    }
-  }
-}
-```
-
-Claude Desktop doesn't support HTTP MCP servers directly — [`mcp-remote`](https://github.com/geelen/mcp-remote) proxies the connection and handles the OAuth flow automatically on first run.
-
-**Claude Code** (`~/.claude/settings.json`):
+**Claude Code** (`~/.claude/settings.json`) / **Cursor** (`~/.cursor/mcp.json`):
 
 ```json
 {
@@ -68,13 +53,24 @@ Claude Desktop doesn't support HTTP MCP servers directly — [`mcp-remote`](http
 }
 ```
 
-Claude Code supports HTTP MCP servers natively and handles the OAuth flow automatically.
+**Claude Desktop / any stdio-based client** — use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy:
 
-For detailed setup instructions see [docs/mcp-setup.md](docs/mcp-setup.md).
+```json
+{
+  "mcpServers": {
+    "hive": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://hive.warlordofmars.net/mcp"]
+    }
+  }
+}
+```
+
+OAuth is handled automatically on first use for all of the above. For detailed setup instructions see [docs/mcp-setup.md](docs/mcp-setup.md).
 
 ## What it does
 
-Claude agents are stateless — every new conversation starts blank. Hive gives them a persistent, shared memory store:
+AI agents are stateless — every new conversation starts blank. Hive gives them a persistent, shared memory store:
 
 | Tool | Description |
 |---|---|
@@ -91,7 +87,7 @@ Multiple agents or team members connect with their own OAuth clients, so you can
 Hive is a serverless, AWS-native stack deployed on Lambda + DynamoDB behind CloudFront:
 
 ```
-Claude (MCP client)
+MCP client (Claude Code, Cursor, …)
       │  MCP / Streamable HTTP
       ▼
 ┌──────────────────────────────────────────────┐
@@ -126,7 +122,7 @@ Claude (MCP client)
 
 | Doc | Description |
 |---|---|
-| [docs/mcp-setup.md](docs/mcp-setup.md) | Connecting Claude Desktop, claude.ai, and SDK to Hive |
+| [docs/mcp-setup.md](docs/mcp-setup.md) | Connecting MCP clients (Claude Code, Claude Desktop, Cursor, and more) to Hive |
 | [docs/admin-ui.md](docs/admin-ui.md) | Using the management UI |
 | [docs/api-reference.md](docs/api-reference.md) | REST API reference |
 | [docs/oauth.md](docs/oauth.md) | OAuth 2.1 implementation details |

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -48,6 +48,44 @@ Restart Claude Desktop. On first use `mcp-remote` will open a browser window to 
 
 ---
 
+## Cursor
+
+Cursor supports HTTP MCP servers natively with built-in OAuth 2.1 + DCR — the same config format as Claude Code.
+
+Add to `~/.cursor/mcp.json` (create the file if it doesn't exist):
+
+```json
+{
+  "mcpServers": {
+    "hive": {
+      "type": "http",
+      "url": "https://hive.warlordofmars.net/mcp"
+    }
+  }
+}
+```
+
+Restart Cursor. On first use it will open a browser window to complete the OAuth flow.
+
+---
+
+## Continue
+
+Continue supports MCP servers via `mcp-remote`. Add to `.continue/config.yaml` in your project or home directory:
+
+```yaml
+mcpServers:
+  - name: hive
+    command: npx
+    args:
+      - mcp-remote
+      - https://hive.warlordofmars.net/mcp
+```
+
+On first use `mcp-remote` will open a browser window to complete the OAuth flow.
+
+---
+
 ## claude.ai (web)
 
 In your claude.ai account settings, navigate to **Integrations → Add MCP server**:

--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -7,12 +7,12 @@ const FEATURES = [
   {
     icon: BrainCircuit,
     title: "Persistent memory across sessions",
-    body: "Store facts, context, and decisions once. Every Claude session picks up exactly where the last one left off.",
+    body: "Store facts, context, and decisions once. Every session picks up exactly where the last one left off.",
   },
   {
     icon: Plug,
     title: "Works with any MCP client",
-    body: "Plug in to Claude Code, Claude Desktop, or any agent that speaks the Model Context Protocol.",
+    body: "Plug in to Claude Code, Claude Desktop, Cursor, Continue, or any client that speaks the Model Context Protocol.",
   },
   {
     icon: Users,
@@ -35,12 +35,12 @@ const HOW_IT_WORKS = [
   {
     step: "2",
     title: "Register an MCP client",
-    body: "Give your agent a name and copy the one-line config snippet into Claude Code.",
+    body: "Give your agent a name and copy the one-line config snippet into your MCP client.",
   },
   {
     step: "3",
     title: "Start remembering",
-    body: 'Tell Claude to "remember" something. Hive stores it. Every future session can recall it.',
+    body: 'Ask your agent to "remember" something. Hive stores it. Every future session can recall it.',
   },
 ];
 
@@ -102,7 +102,7 @@ export default function HomePage() {
         >
           Persistent memory
           <br />
-          for Claude agents
+          for AI agents
         </h1>
         <p
           style={{
@@ -113,8 +113,8 @@ export default function HomePage() {
             lineHeight: 1.6,
           }}
         >
-          Hive gives your Claude agents a shared, durable memory store via the Model Context
-          Protocol — so context survives across sessions, tools, and team members.
+          Hive gives your AI agents a shared, durable memory store via the Model Context
+          Protocol — works with Claude Code, Cursor, Continue, and any MCP-compatible client.
         </p>
         <button
           onClick={() => navigate("/app")}

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -6,17 +6,20 @@ export default function SetupPanel() {
   const [activeTab, setActiveTab] = useState("code");
   const [copied, setCopied] = useState(false);
 
+  const httpConfig = JSON.stringify(
+    { mcpServers: { hive: { type: "http", url: mcpUrl } } },
+    null,
+    2,
+  );
+  const mrConfig = JSON.stringify(
+    { mcpServers: { hive: { command: "npx", args: ["mcp-remote", mcpUrl] } } },
+    null,
+    2,
+  );
   const configs = {
-    code: JSON.stringify(
-      { mcpServers: { hive: { type: "http", url: mcpUrl } } },
-      null,
-      2,
-    ),
-    desktop: JSON.stringify(
-      { mcpServers: { hive: { command: "npx", args: ["mcp-remote", mcpUrl] } } },
-      null,
-      2,
-    ),
+    code: httpConfig,
+    cursor: httpConfig,
+    desktop: mrConfig,
   };
 
   function handleCopy() {
@@ -51,6 +54,9 @@ export default function SetupPanel() {
           <button style={tabStyle("code")} onClick={() => setActiveTab("code")}>
             Claude Code
           </button>
+          <button style={tabStyle("cursor")} onClick={() => setActiveTab("cursor")}>
+            Cursor
+          </button>
           <button style={tabStyle("desktop")} onClick={() => setActiveTab("desktop")}>
             Claude Desktop
           </button>
@@ -67,6 +73,11 @@ export default function SetupPanel() {
           {activeTab === "code" && (
             <p style={{ margin: "0 0 8px", color: "#555", fontSize: 13 }}>
               Add to <code>~/.claude/settings.json</code>:
+            </p>
+          )}
+          {activeTab === "cursor" && (
+            <p style={{ margin: "0 0 8px", color: "#555", fontSize: 13 }}>
+              Add to <code>~/.cursor/mcp.json</code> (create it if it doesn't exist):
             </p>
           )}
           {activeTab === "desktop" && (
@@ -101,6 +112,8 @@ export default function SetupPanel() {
         <p style={{ color: "#555" }}>
           {activeTab === "code"
             ? "Open Claude Code. The next time you use a Hive memory tool, it will prompt you to authorise access via your browser. Complete the flow and you're done."
+            : activeTab === "cursor"
+            ? "Restart Cursor. On first use it will open a browser window to complete the OAuth flow. After authorising, the connection is maintained automatically."
             : "Restart Claude Desktop. On first use it will open a browser window to complete the OAuth flow. After authorising, the connection is maintained automatically."}
         </p>
       </section>

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -24,9 +24,10 @@ describe("SetupPanel", () => {
     expect(screen.getByText(/Step 2/)).toBeTruthy();
   });
 
-  it("renders Claude Code and Claude Desktop tabs", async () => {
+  it("renders Claude Code, Cursor, and Claude Desktop tabs", async () => {
     await act(async () => render(<SetupPanel />));
     expect(screen.getByText("Claude Code")).toBeTruthy();
+    expect(screen.getByText("Cursor")).toBeTruthy();
     expect(screen.getByText("Claude Desktop")).toBeTruthy();
   });
 
@@ -81,5 +82,18 @@ describe("SetupPanel", () => {
     fireEvent.click(screen.getByText("Claude Desktop"));
     fireEvent.click(screen.getByText("Claude Code"));
     expect(document.body.textContent).toContain('"type": "http"');
+  });
+
+  it("switches to Cursor tab and shows http config", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Cursor"));
+    expect(document.body.textContent).toContain('"type": "http"');
+    expect(document.body.textContent).toContain("~/.cursor/mcp.json");
+  });
+
+  it("step 2 text updates when switching to Cursor tab", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Cursor"));
+    expect(document.body.textContent).toContain("Restart Cursor");
   });
 });


### PR DESCRIPTION
## Summary

- **README**: reframe lead copy, getting started, architecture diagram, and docs table — Hive is an MCP-compatible service with Claude as a prominent example, not the only client
- **HomePage**: update hero heading/subtitle (`for Claude agents` → `for AI agents`) and feature/step copy to be client-agnostic; expand "Works with any MCP client" feature to list Claude Code, Cursor, Continue explicitly
- **docs/mcp-setup.md**: add Cursor and Continue setup sections
- **SetupPanel**: add Cursor tab alongside Claude Code and Claude Desktop (same native HTTP MCP config format, placed in `~/.cursor/mcp.json`)

## Test plan

- [ ] 185 frontend tests pass, SetupPanel at 100% coverage
- [ ] New Cursor tab renders correct config and step 2 text
- [ ] Marketing page hero reads "Persistent memory for AI agents"

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)