### PR TITLE
chore: update CHANGELOG for v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,25 @@ All notable changes to Hive are documented here. Releases correspond to GitHub t
 
 See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) for full release notes generated from merged PRs.
 
-## Unreleased
+## v0.13.0 — 2026-04-06
 
 ### Added
-- Scheduled synthetic traffic workflow generating real CloudWatch metrics every 15 minutes (#141)
-- E2E tests for CloudWatch metrics dashboard, including admin API and UI validation (#143)
-- Dark mode support with OS preference detection and manual toggle (#155)
-- Migrate UI to Tailwind CSS v4 with CSS custom property colour tokens (#156)
+
+- Scheduled synthetic traffic workflow generating real CloudWatch metrics every 15 minutes (#154)
+- E2E tests for CloudWatch metrics dashboard, including admin API and UI validation (#157)
+- Dark mode support with OS preference detection and manual toggle; CSS design tokens via Tailwind v4 (#175)
+- Visual identity — logo, favicon, and social preview image (#173)
+- Make Google auth bypass conditional on `test_email` param for safer e2e testing (#170, #171)
+
+### Fixed
+
+- MCP client setup instructions for Claude Desktop and Claude Code (#169)
+- Marketing page layout: logo, wordmark, 2×2 feature grid, consistent 1100px content width (#178–#181)
+- Dark mode applied to all routes (LoginPage, HomePage) via `useTheme` at App root (#182, #183)
+
+### Changed
+
+- Broadened messaging from Claude-specific to MCP-compatible; added Cursor and Continue setup docs and onboarding snippets (#184)
 
 ## Earlier releases
 


### PR DESCRIPTION
Fills in the Unreleased section with the v0.13.0 changes ahead of the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)