### PR TITLE
fix(ui): update LoginPage tagline to be MCP-agnostic

### DIFF
--- a/ui/src/components/LoginPage.jsx
+++ b/ui/src/components/LoginPage.jsx
@@ -28,7 +28,7 @@ export default function LoginPage() {
           Hive
         </h1>
         <p style={{ color: "var(--text-muted)", marginBottom: 32 }}>
-          Shared persistent memory for Claude agents
+          Shared persistent memory for AI agents
         </p>
         <button
           onClick={() => {


### PR DESCRIPTION
Missed in #184 — login page tagline still said "for Claude agents".

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)