### PR TITLE
fix(infra): fix /docs 403 (shared S3 OAC origin) + docs e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,11 @@ jobs:
           HIVE_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
         run: uv run pytest tests/e2e/test_ui_e2e.py -v
 
+      - name: Run docs e2e tests (Playwright)
+        env:
+          HIVE_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
+        run: uv run pytest tests/e2e/test_docs_e2e.py -v
+
       - name: Run Dashboard e2e tests (Playwright)
         env:
           HIVE_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -640,8 +640,13 @@ function handler(event) {
             runtime=cloudfront.FunctionRuntime.JS_2_0,
         )
 
+        # Single S3 origin shared by default + docs behaviors — two separate
+        # with_origin_access_control() calls would create distinct OACs and the
+        # second one would not receive a bucket policy grant, causing 403s.
+        ui_s3_origin = origins.S3BucketOrigin.with_origin_access_control(ui_bucket)
+
         docs_behavior = cloudfront.BehaviorOptions(
-            origin=origins.S3BucketOrigin.with_origin_access_control(ui_bucket),
+            origin=ui_s3_origin,
             viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             cache_policy=cloudfront.CachePolicy.CACHING_OPTIMIZED,
             function_associations=[
@@ -656,7 +661,7 @@ function handler(event) {
             self,
             "UiDistribution",
             default_behavior=cloudfront.BehaviorOptions(
-                origin=origins.S3BucketOrigin.with_origin_access_control(ui_bucket),
+                origin=ui_s3_origin,
                 viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                 cache_policy=cloudfront.CachePolicy.CACHING_OPTIMIZED,
             ),

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Playwright E2E tests for the Hive VitePress docs site.
+Requires:
+  HIVE_UI_URL — deployed UI URL (CloudFront), e.g. https://hive.warlordofmars.net
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+UI_URL = os.environ.get("HIVE_UI_URL", "")
+
+pytestmark = pytest.mark.skipif(
+    not UI_URL,
+    reason="HIVE_UI_URL not set — skipping docs e2e tests",
+)
+
+
+@pytest.fixture(scope="module")
+def docs_page():
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        yield page
+        browser.close()
+
+
+class TestDocsE2E:
+    def test_docs_home_loads(self, docs_page):
+        """GET /docs/ returns the VitePress home page, not the React app."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        # VitePress home has a hero heading; the React app has a Login button
+        assert page.locator("text=Hive").first.is_visible()
+        # Must NOT be the React app (which has a Sign in / Sign out button)
+        assert not page.locator("button:has-text('Sign in')").is_visible()
+
+    def test_docs_home_title(self, docs_page):
+        """Page title contains 'Hive Docs'."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        assert "Hive" in page.title()
+
+    def test_docs_subpage_loads(self, docs_page):
+        """A nested doc page loads without redirecting to the React app."""
+        page = docs_page
+        page.goto(
+            f"{UI_URL}/docs/getting-started/quick-start",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        assert page.locator("h1").first.is_visible()
+        assert not page.locator("button:has-text('Sign in')").is_visible()
+
+    def test_docs_directory_path_loads(self, docs_page):
+        """Trailing-slash directory path resolves to the right page (CloudFront Function)."""
+        page = docs_page
+        page.goto(
+            f"{UI_URL}/docs/getting-started/",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        assert page.locator("h1").first.is_visible()
+        assert not page.locator("button:has-text('Sign in')").is_visible()
+
+    def test_docs_logo_not_broken(self, docs_page):
+        """Logo image loads successfully (not a broken image)."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        logo = page.locator("img.VPImage")
+        assert logo.is_visible()
+        natural_width = page.evaluate("el => el.naturalWidth", logo.element_handle())
+        assert natural_width > 0, "Logo image failed to load (naturalWidth == 0)"
+
+    def test_docs_sidebar_navigation(self, docs_page):
+        """Sidebar links are visible and navigable."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        assert page.locator(".VPSidebarItem").first.is_visible()
+
+    def test_docs_search_present(self, docs_page):
+        """Local search button is present."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        assert (
+            page.locator("button.DocSearch").is_visible()
+            or page.locator("[aria-label='Search']").is_visible()
+        )


### PR DESCRIPTION
## Summary

- **Root cause of `/docs` redirect**: Two separate `S3BucketOrigin.with_origin_access_control(ui_bucket)` calls created distinct OACs. Only the first (default behavior) received a bucket policy grant — the docs behavior's OAC had no `s3:GetObject` permission, so S3 returned 403, which CloudFront's error response mapped back to `/index.html` (the React app). Fix: extract a single `ui_s3_origin` and reuse it in both behaviors.
- **Docs e2e tests**: New `tests/e2e/test_docs_e2e.py` (7 Playwright tests) covering home page content, page title, subpage loads, trailing-slash directory path resolution (CloudFront Function), logo `naturalWidth > 0`, sidebar visibility, and search button presence. Added as a step in the `e2e-dev` CI job.

## Test plan

- [ ] CI passes
- [ ] After dev deploy, `/docs/` loads the VitePress home — not the React app
- [ ] `/docs/getting-started/` and `/docs/getting-started/quick-start` both load correctly
- [ ] Logo is visible in the VitePress navbar
- [ ] Docs e2e step passes in the dev e2e job

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)