### PR TITLE
fix(docs): fix logo double-base-path and sidebar e2e test

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
   head: [["link", { rel: "icon", type: "image/svg+xml", href: "/docs/favicon.svg" }]],
 
   themeConfig: {
-    logo: { src: "/docs/logo.svg", alt: "Hive" },
+    logo: { src: "/logo.svg", alt: "Hive" },
     siteTitle: "Hive",
     nav: [
       { text: "Home", link: "https://hive.warlordofmars.net" },

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -69,19 +69,31 @@ class TestDocsE2E:
         assert not page.locator("button:has-text('Sign in')").is_visible()
 
     def test_docs_logo_not_broken(self, docs_page):
-        """Logo image loads successfully (not a broken image)."""
+        """Logo image loads successfully (not a broken image).
+
+        Uses a doc page (not home) so the VitePress navbar logo is always rendered.
+        """
         page = docs_page
-        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        page.goto(
+            f"{UI_URL}/docs/getting-started/quick-start",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
         logo = page.locator("img[alt='Hive']")
         assert logo.is_visible()
         natural_width = page.evaluate("el => el.naturalWidth", logo.element_handle())
         assert natural_width > 0, "Logo image failed to load (naturalWidth == 0)"
 
     def test_docs_sidebar_navigation(self, docs_page):
-        """Sidebar section headings are visible."""
+        """Sidebar section headings are visible on a doc page."""
         page = docs_page
-        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
-        assert page.locator("text=Getting started").first.is_visible()
+        page.goto(
+            f"{UI_URL}/docs/getting-started/quick-start",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        # Sidebar is only rendered on doc pages (not the home layout)
+        assert page.locator(".VPSidebar").is_visible()
 
     def test_docs_search_present(self, docs_page):
         """Local search button is present."""


### PR DESCRIPTION
## Summary

- **Logo broken image**: VitePress calls `withBase()` on `logo.src` at render time, so `"/docs/logo.svg"` became `"/docs/docs/logo.svg"` in the output HTML. Fix: use `"/logo.svg"` — VitePress prepends the base to produce the correct `"/docs/logo.svg"`.
- **Sidebar e2e test**: VitePress home layout (`layout: home`) renders no sidebar, so `text=Getting started` only appeared inside a JSON `<script>` blob, not as visible DOM. Updated test navigates to a doc page (`/docs/getting-started/quick-start`) and asserts `.VPSidebar` is visible.

## Test plan

- [ ] CI passes
- [ ] After dev deploy, logo displays correctly in VitePress navbar
- [ ] All 7 docs e2e tests pass

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)