### PR TITLE
feat(docs): theme VitePress to match marketing site

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -11,9 +11,9 @@ export default defineConfig({
     logo: { src: "/logo.svg", alt: "Hive" },
     siteTitle: "Hive",
     nav: [
-      { text: "Home", link: "https://hive.warlordofmars.net" },
+      { text: "Home", link: "/" },
       { text: "Docs", link: "/docs/" },
-      { text: "App", link: "https://hive.warlordofmars.net/app" },
+      { text: "Sign in", link: "/app" },
     ],
 
     sidebar: [

--- a/docs-site/.vitepress/theme/index.js
+++ b/docs-site/.vitepress/theme/index.js
@@ -1,0 +1,4 @@
+import DefaultTheme from "vitepress/theme";
+import "./style.css";
+
+export default DefaultTheme;

--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -1,0 +1,120 @@
+/* ============================================================
+   Brand colour — orange, matching marketing site (#e8a020)
+   ============================================================ */
+:root {
+  --vp-c-brand-1: #e8a020;
+  --vp-c-brand-2: #f5a623;
+  --vp-c-brand-3: #d4891a;
+  --vp-c-brand-soft: rgba(232, 160, 32, 0.14);
+
+  --vp-button-brand-border: transparent;
+  --vp-button-brand-text: #fff;
+  --vp-button-brand-bg: #e8a020;
+  --vp-button-brand-hover-border: transparent;
+  --vp-button-brand-hover-text: #fff;
+  --vp-button-brand-hover-bg: #f5a623;
+  --vp-button-brand-active-border: transparent;
+  --vp-button-brand-active-text: #fff;
+  --vp-button-brand-active-bg: #d4891a;
+}
+
+.dark {
+  --vp-c-brand-1: #f5a623;
+  --vp-c-brand-2: #e8a020;
+  --vp-c-brand-3: #cc8010;
+  --vp-c-brand-soft: rgba(245, 166, 35, 0.16);
+}
+
+/* ============================================================
+   Navbar — always dark navy (#1a1a2e), matching marketing site
+   ============================================================ */
+.VPNavBar,
+.VPNavBar.has-sidebar,
+.VPNavBar.fill {
+  background-color: #1a1a2e !important;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08) !important;
+}
+
+/* Blur effect on scroll should also be dark */
+.VPNavBar::before {
+  background-color: #1a1a2e !important;
+}
+
+.VPNavBarTitle .title {
+  color: #fff !important;
+}
+
+.VPNavBarMenuLink {
+  color: rgba(255, 255, 255, 0.72) !important;
+}
+
+.VPNavBarMenuLink:hover,
+.VPNavBarMenuLink.active {
+  color: #fff !important;
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.VPNavBarSocialLinks .VPSocialLink {
+  color: rgba(255, 255, 255, 0.6) !important;
+}
+
+.VPNavBarSocialLinks .VPSocialLink:hover {
+  color: #fff !important;
+}
+
+/* Hamburger (mobile) */
+.VPNavBarHamburger .top,
+.VPNavBarHamburger .middle,
+.VPNavBarHamburger .bottom {
+  background-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+/* Local search button */
+.VPNavBarSearch .DocSearch-Button {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  border-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+.VPNavBarSearch .DocSearch-Button-Placeholder,
+.VPNavBarSearch .DocSearch-Button .DocSearch-Search-Icon {
+  color: rgba(255, 255, 255, 0.55) !important;
+}
+
+.VPNavBarSearch .DocSearch-Button-Keys .DocSearch-Button-Key {
+  color: rgba(255, 255, 255, 0.45) !important;
+  border-color: rgba(255, 255, 255, 0.2) !important;
+  box-shadow: none !important;
+}
+
+/* ============================================================
+   Home page hero — gradient matching marketing site
+   ============================================================ */
+.VPHero {
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%);
+  padding-bottom: 80px;
+}
+
+/* Hero name ("Hive") — plain white instead of default gradient */
+:root {
+  --vp-home-hero-name-color: #fff;
+  --vp-home-hero-name-background: none;
+}
+
+.VPHero .text {
+  color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.VPHero .tagline {
+  color: rgba(255, 255, 255, 0.62) !important;
+}
+
+/* ============================================================
+   Feature cards — rounded corners, brand icon colour
+   ============================================================ */
+.VPFeature {
+  border-radius: 12px !important;
+}
+
+.VPFeature .icon {
+  color: var(--vp-c-brand-1);
+}

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -14,16 +14,20 @@ hero:
       link: /tools/overview
 
 features:
-  - icon: 🧠
+  - icon:
+      svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M9 13a4.5 4.5 0 0 0 3-4"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M12 13h4"/><path d="M12 18h6a2 2 0 0 1 2 2v1"/><path d="M12 8h8"/><path d="M16 8V5a2 2 0 0 1 2-2"/><circle cx="16" cy="13" r=".5"/><circle cx="18" cy="3" r=".5"/><circle cx="20" cy="21" r=".5"/><circle cx="20" cy="8" r=".5"/></svg>'
     title: Memories that persist
     details: Everything your agent remembers survives the end of the conversation. Pick up exactly where you left off.
-  - icon: 🔌
+  - icon:
+      svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/></svg>'
     title: Works with any MCP client
     details: Claude Code, Claude Desktop, Cursor, Continue, claude.ai — if it supports MCP, it works with Hive.
-  - icon: 🔍
+  - icon:
+      svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>'
     title: Semantic search
     details: Find memories by meaning, not just by key or tag. Ask in plain language and Hive surfaces what's relevant.
-  - icon: 🔒
+  - icon:
+      svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg>'
     title: Your data, scoped to you
     details: Each OAuth client gets its own isolated memory space. Share only what you choose to share.
 ---


### PR DESCRIPTION
## Summary

- **Theme**: adds `.vitepress/theme/style.css` overriding VitePress defaults:
  - Navbar always dark navy `#1a1a2e` (both light and dark mode), matching the marketing page header
  - Brand/accent colour set to `#e8a020` / `#f5a623` orange throughout — links, active sidebar items, CTA buttons, feature icons
  - Home hero gets the same `linear-gradient(135deg, #1a1a2e → #16213e → #0f3460)` as the marketing page, with white hero text

- **Icons**: replaces 4 emoji feature icons (`🧠 🔌 🔍 🔒`) in `index.md` with inline Lucide SVGs — BrainCircuit, Plug, Search, ShieldCheck — the same icons used on the marketing page

- **Navigation**: changes nav links from absolute `https://hive.warlordofmars.net` URLs to root-relative `/` and `/app`. VitePress adds `target="_blank"` to external URLs; root-relative paths open same-tab for seamless movement between marketing site, docs, and app. "App" renamed to "Sign in" for consistency with the marketing page button.

## Test plan

- [ ] CI passes
- [ ] Docs site navbar is dark navy
- [ ] Feature card icons show orange Lucide icons (not emoji)
- [ ] Hero gradient matches marketing page
- [ ] "Home" and "Sign in" nav links open same tab

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)