### PR TITLE
fix(docs): fix navbar link double prefix and Sign in routing

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
     siteTitle: "Hive",
     nav: [
       { text: "Home", link: "/" },
-      { text: "Docs", link: "/docs/" },
+      { text: "Docs", link: "/" },
       { text: "Sign in", link: "/app" },
     ],
 

--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -16,6 +16,10 @@
   --vp-button-brand-active-border: transparent;
   --vp-button-brand-active-text: #fff;
   --vp-button-brand-active-bg: #d4891a;
+
+  /* Override nav background variable used by VitePress */
+  --vp-nav-bg-color: #1a1a2e;
+  --vp-nav-screen-bg-color: #1a1a2e;
 }
 
 .dark {
@@ -23,23 +27,57 @@
   --vp-c-brand-2: #e8a020;
   --vp-c-brand-3: #cc8010;
   --vp-c-brand-soft: rgba(245, 166, 35, 0.16);
+
+  --vp-nav-bg-color: #1a1a2e;
+  --vp-nav-screen-bg-color: #1a1a2e;
 }
 
 /* ============================================================
    Navbar — always dark navy (#1a1a2e), matching marketing site
+
+   VitePress navbar internals (1.6.x):
+   - Background is on .VPNavBar directly (not ::before)
+   - On desktop (>=960px), .VPNavBar:not(.home) becomes transparent,
+     and only .content-body gets var(--vp-nav-bg-color)
+   - .has-sidebar pages need .content-body overridden separately
+   - .home.top is transparent by design (hero shows through)
    ============================================================ */
-.VPNavBar,
-.VPNavBar.has-sidebar,
-.VPNavBar.fill {
+
+/* Base — covers mobile and all initial states */
+.VPNavBar {
   background-color: #1a1a2e !important;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08) !important;
 }
 
-/* Blur effect on scroll should also be dark */
-.VPNavBar::before {
+/* Explicitly cover every dynamic class combination */
+.VPNavBar.home,
+.VPNavBar.has-sidebar,
+.VPNavBar.home.top,
+.VPNavBar.screen-open {
   background-color: #1a1a2e !important;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08) !important;
 }
 
+/* Desktop — VitePress overrides to transparent; re-apply dark navy */
+@media (min-width: 960px) {
+  .VPNavBar,
+  .VPNavBar:not(.home),
+  .VPNavBar:not(.has-sidebar):not(.home.top),
+  .VPNavBar.home.top {
+    background-color: #1a1a2e !important;
+  }
+
+  /* content-body is the right-side container on desktop */
+  .VPNavBar .content-body {
+    background-color: #1a1a2e !important;
+  }
+
+  .VPNavBar:not(.has-sidebar):not(.home.top) .content-body {
+    background-color: #1a1a2e !important;
+  }
+}
+
+/* Navbar text and links */
 .VPNavBarTitle .title {
   color: #fff !important;
 }

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -633,6 +633,14 @@ function handler(event) {
         return request;
     }
 
+    // /docs/app → redirect to /app (Sign in link from docs nav)
+    if (uri === '/docs/app') {
+        return {
+            statusCode: 302,
+            headers: { location: { value: '/app' } }
+        };
+    }
+
     // Last path segment has a dot — treat as a static asset, pass through.
     var lastSegment = uri.split('/').pop();
     if (lastSegment.indexOf('.') !== -1) {

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -18,6 +18,12 @@ pytestmark = pytest.mark.skipif(
     reason="HIVE_UI_URL not set — skipping docs e2e tests",
 )
 
+# Expected navbar background — #1a1a2e in RGB
+_NAVBAR_BG = "rgb(26, 26, 46)"
+# Minimum luminance ratio considered "light enough" for white-on-dark text
+# rgb(255,255,255) on rgb(26,26,46) is ~12:1, well above 4.5:1 WCAG AA
+_MIN_ALPHA = 0.6  # channel value 0–1 for rgba text colours
+
 
 @pytest.fixture(scope="module")
 def docs_page():
@@ -30,18 +36,60 @@ def docs_page():
         browser.close()
 
 
-class TestDocsE2E:
+@pytest.fixture(scope="module")
+def docs_page_mobile():
+    """Separate page at 375×812 (iPhone viewport) for mobile tests."""
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page(viewport={"width": 375, "height": 812})
+        yield page
+        browser.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bg(page, selector: str) -> str:
+    return page.evaluate(
+        f"() => window.getComputedStyle(document.querySelector('{selector}')).backgroundColor"
+    )
+
+
+def _color(page, selector: str) -> str:
+    return page.evaluate(
+        f"() => window.getComputedStyle(document.querySelector('{selector}')).color"
+    )
+
+
+def _parse_rgb(css: str) -> tuple[int, int, int, float]:
+    """Parse rgb(...) or rgba(...) → (r, g, b, a)."""
+    import re
+
+    nums = [float(x) for x in re.findall(r"[\d.]+", css)]
+    r, g, b = int(nums[0]), int(nums[1]), int(nums[2])
+    a = float(nums[3]) if len(nums) > 3 else 1.0
+    return r, g, b, a
+
+
+# ---------------------------------------------------------------------------
+# General docs routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestDocsRouting:
     def test_docs_home_loads(self, docs_page):
         """GET /docs/ returns the VitePress home page, not the React app."""
         page = docs_page
         page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
-        # VitePress home has a hero heading; the React app has a Login button
         assert page.locator("text=Hive").first.is_visible()
-        # Must NOT be the React app (which has a Sign in / Sign out button)
         assert not page.locator("button:has-text('Sign in')").is_visible()
 
     def test_docs_home_title(self, docs_page):
-        """Page title contains 'Hive Docs'."""
+        """Page title contains 'Hive'."""
         page = docs_page
         page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
         assert "Hive" in page.title()
@@ -69,10 +117,7 @@ class TestDocsE2E:
         assert not page.locator("button:has-text('Sign in')").is_visible()
 
     def test_docs_logo_not_broken(self, docs_page):
-        """Logo image loads successfully (not a broken image).
-
-        Uses a doc page (not home) so the VitePress navbar logo is always rendered.
-        """
+        """Logo image loads successfully (not a broken image)."""
         page = docs_page
         page.goto(
             f"{UI_URL}/docs/getting-started/quick-start",
@@ -92,7 +137,6 @@ class TestDocsE2E:
             timeout=30_000,
             wait_until="networkidle",
         )
-        # Sidebar is only rendered on doc pages (not the home layout)
         assert page.locator(".VPSidebar").is_visible()
 
     def test_docs_search_present(self, docs_page):
@@ -103,3 +147,184 @@ class TestDocsE2E:
             page.locator("button.DocSearch").is_visible()
             or page.locator("[aria-label='Search']").is_visible()
         )
+
+
+# ---------------------------------------------------------------------------
+# Navbar appearance and behaviour tests
+# ---------------------------------------------------------------------------
+
+
+class TestDocsNavbar:
+    def test_navbar_dark_on_doc_page(self, docs_page):
+        """Navbar background is dark navy on a doc page (sidebar layout)."""
+        page = docs_page
+        page.goto(
+            f"{UI_URL}/docs/getting-started/quick-start",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        bg = _bg(page, ".VPNavBar")
+        assert bg == _NAVBAR_BG, (
+            f"Expected navbar bg {_NAVBAR_BG!r} on doc page, got {bg!r}. "
+            "Check .VPNavBar and .content-body CSS overrides."
+        )
+
+    def test_navbar_dark_on_home_page(self, docs_page):
+        """Navbar background is dark navy on the home page."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        bg = _bg(page, ".VPNavBar")
+        assert bg == _NAVBAR_BG, (
+            f"Expected navbar bg {_NAVBAR_BG!r} on home page, got {bg!r}. "
+            "Check .VPNavBar.home.top CSS override."
+        )
+
+    def test_navbar_dark_after_scroll(self, docs_page):
+        """Navbar stays dark navy after scrolling down on a doc page."""
+        page = docs_page
+        page.goto(
+            f"{UI_URL}/docs/getting-started/quick-start",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        page.evaluate("window.scrollBy(0, 300)")
+        page.wait_for_timeout(400)  # allow transition
+        bg = _bg(page, ".VPNavBar")
+        assert bg == _NAVBAR_BG, (
+            f"Navbar bg changed after scroll: {bg!r}. "
+            "Check .VPNavBar:not(.home) desktop media-query override."
+        )
+
+    def test_navbar_title_is_light(self, docs_page):
+        """Site title text is light (readable on dark navbar)."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        color = _color(page, ".VPNavBarTitle .title")
+        r, g, b, _ = _parse_rgb(color)
+        # All channels should be high (near white)
+        assert r > 200 and g > 200 and b > 200, (
+            f"Navbar title text {color!r} is too dark for dark background. "
+            "Check .VPNavBarTitle .title color override."
+        )
+
+    def test_nav_links_are_light(self, docs_page):
+        """Navigation menu links are light-coloured (readable on dark navbar)."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        # Get first nav menu link
+        link = page.locator(".VPNavBarMenuLink").first
+        if not link.is_visible():
+            pytest.skip("No nav menu links visible (may be mobile viewport)")
+        color = page.evaluate(
+            "el => window.getComputedStyle(el).color",
+            link.element_handle(),
+        )
+        r, g, b, a = _parse_rgb(color)
+        # Text should be at least 60% bright (alpha of rgba or high rgb values)
+        assert r > 150 and g > 150 and b > 150, (
+            f"Nav link color {color!r} is too dark for dark navbar. "
+            "Check .VPNavBarMenuLink color override."
+        )
+
+    def test_content_body_dark_on_sidebar_page(self, docs_page):
+        """The content-body (right navbar section) is dark on a sidebar page."""
+        page = docs_page
+        page.goto(
+            f"{UI_URL}/docs/getting-started/quick-start",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        content_body = page.locator(".VPNavBar .content-body")
+        if not content_body.is_visible():
+            pytest.skip(".content-body not visible (may be mobile viewport)")
+        bg = page.evaluate(
+            "el => window.getComputedStyle(el).backgroundColor",
+            content_body.element_handle(),
+        )
+        assert bg == _NAVBAR_BG, (
+            f"Expected .content-body bg {_NAVBAR_BG!r} on sidebar page, got {bg!r}. "
+            "Check .VPNavBar .content-body CSS override."
+        )
+
+    def test_docs_nav_link_no_double_prefix(self, docs_page):
+        """Docs nav link href is '/docs/' — VitePress base must not be double-applied.
+
+        config.mjs must use link: '/' (not '/docs/') so that VitePress prepends
+        the base once, producing '/docs/', not '/docs/docs/'.
+        """
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        docs_link = page.locator(".VPNavBarMenuLink", has_text="Docs")
+        if not docs_link.is_visible():
+            pytest.skip("Docs nav link not visible")
+        href = docs_link.get_attribute("href")
+        assert href == "/docs/", (
+            f"Docs nav link href {href!r} is not '/docs/'. "
+            "Check that config.mjs uses link: '/' — VitePress prepends the base automatically."
+        )
+        assert "/docs/docs" not in href, (
+            f"Docs nav link has double prefix: {href!r}. "
+            "Set link: '/' in config.mjs nav, not link: '/docs/'."
+        )
+
+    def test_docs_nav_link_click(self, docs_page):
+        """Clicking Docs nav link stays on /docs/ — no double redirect."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        docs_link = page.locator(".VPNavBarMenuLink", has_text="Docs")
+        if not docs_link.is_visible():
+            pytest.skip("Docs nav link not visible")
+        with page.expect_navigation(timeout=15_000):
+            docs_link.click()
+        assert "/docs/docs" not in page.url, (
+            f"Docs link navigated to {page.url!r} — double prefix detected."
+        )
+        assert page.url.rstrip("/").endswith("/docs"), (
+            f"Docs link navigated to {page.url!r} — expected to stay at '/docs/'."
+        )
+
+    def test_home_nav_link_click(self, docs_page):
+        """Clicking Home nav link stays within the site (no broken redirect)."""
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        home_link = page.locator(".VPNavBarMenuLink", has_text="Home")
+        if not home_link.is_visible():
+            pytest.skip("Home nav link not visible")
+        with page.expect_navigation(timeout=15_000):
+            home_link.click()
+        # Home link (link: '/') gets base prepended → /docs/ (docs home page)
+        assert UI_URL in page.url, f"Home link navigated outside the site: {page.url!r}."
+
+    def test_signin_nav_link_click(self, docs_page):
+        """Clicking Sign in nav link reaches the React app (/app).
+
+        The CloudFront Function redirects /docs/app → /app so the user lands
+        on the correct sign-in page, not a 404 or docs page.
+        """
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        signin_link = page.locator(".VPNavBarMenuLink", has_text="Sign in")
+        if not signin_link.is_visible():
+            pytest.skip("Sign in nav link not visible")
+        with page.expect_navigation(timeout=15_000):
+            signin_link.click()
+        assert page.url.rstrip("/").endswith("/app"), (
+            f"Sign in link navigated to {page.url!r} — expected URL ending in '/app'."
+        )
+
+    def test_navbar_hamburger_visible_mobile(self, docs_page_mobile):
+        """Hamburger menu button is visible on mobile viewport."""
+        page = docs_page_mobile
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        hamburger = page.locator(".VPNavBarHamburger")
+        assert hamburger.is_visible(), "Hamburger button not visible on mobile viewport"
+
+    def test_navbar_mobile_menu_toggle(self, docs_page_mobile):
+        """Clicking the hamburger opens the mobile nav screen."""
+        page = docs_page_mobile
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        hamburger = page.locator(".VPNavBarHamburger")
+        hamburger.click()
+        page.wait_for_timeout(300)
+        screen = page.locator(".VPNavScreen")
+        assert screen.is_visible(), "Mobile nav screen did not open after hamburger click"


### PR DESCRIPTION
## Summary

- Fix "Docs" nav link double prefix: `link: '/docs/'` with VitePress `base: '/docs/'` was producing `href="/docs/docs/"`. Changed to `link: '/'` so VitePress prepends base once → `/docs/`
- Fix "Sign in" routing: VitePress base prepends `/docs/` to `/app` → `/docs/app`, which fell through to a React 404. Added a CloudFront Function redirect `/docs/app → /app` so the Sign in button reaches the correct page
- Rewrite VitePress navbar CSS with correct VitePress 1.6.x selectors (direct `.VPNavBar` background, desktop `@media` override for `.content-body`, dark navy `--vp-nav-bg-color` variable)
- Replace style-check navbar e2e tests with click-based tests that verify each button's `href` attribute and actual navigation destination

Closes #168

## Test plan

- [ ] Docs nav link `href` is `/docs/` (not `/docs/docs/`)
- [ ] Clicking Docs stays at `/docs/`
- [ ] Clicking Sign in navigates to `/app` (via CloudFront redirect)
- [ ] Clicking Home stays within the site
- [ ] Navbar appearance tests (dark navy, light text) still pass
- [ ] Mobile hamburger / nav screen tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)