### PR TITLE
fix(docs): e2e fixture conflict + logo navigates to marketing page

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -10,8 +10,10 @@ export default defineConfig({
   themeConfig: {
     logo: { src: "/logo.svg", alt: "Hive" },
     siteTitle: "Hive",
+    // logoLink is used directly (no withBase() applied), so "/" goes to the
+    // marketing page root, not /docs/.
+    logoLink: "/",
     nav: [
-      { text: "Home", link: "/" },
       { text: "Docs", link: "/" },
       { text: "Sign in", link: "/app" },
     ],

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -300,24 +300,20 @@ class TestDocsNavbar:
             f"Docs link navigated to {page.url!r} — expected '/docs/'."
         )
 
-    def test_home_nav_link_click(self, docs_page):
-        """Clicking Home nav link stays within the site (no broken redirect).
+    def test_logo_click_navigates_to_marketing(self, docs_page):
+        """Clicking the Hive logo navigates to the marketing page root (/).
 
-        Start from a subpage for the same reason as test_docs_nav_link_click.
+        VitePress logoLink is used directly without withBase(), so logoLink: '/'
+        produces href='/' which goes to the marketing site, not /docs/.
         """
         page = docs_page
-        page.goto(
-            f"{UI_URL}/docs/getting-started/quick-start",
-            timeout=30_000,
-            wait_until="networkidle",
-        )
-        home_link = page.locator(".VPNavBarMenuLink", has_text="Home")
-        if not home_link.is_visible():
-            pytest.skip("Home nav link not visible")
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        logo = page.locator(".VPNavBarTitle .title")
         with page.expect_navigation(timeout=15_000):
-            home_link.click()
-        # Home link (link: '/') gets base prepended → /docs/ (docs home)
-        assert UI_URL in page.url, f"Home link navigated outside the site: {page.url!r}."
+            logo.click()
+        assert page.url.rstrip("/") == UI_URL.rstrip("/"), (
+            f"Logo click navigated to {page.url!r} — expected marketing page '{UI_URL}'."
+        )
 
     def test_signin_nav_link_click(self, docs_page):
         """Clicking Sign in nav link reaches the React app (/app).


### PR DESCRIPTION
## Summary

- Fix e2e fixture conflict: two `sync_playwright()` instances in the same process conflict over the asyncio event loop when both are active simultaneously (module-scoped fixtures). Refactored to share a single `_browser` fixture
- Fix click-nav test timeouts: VitePress SPA routing doesn't trigger `expect_navigation` when clicking a link to the already-active page — tests now navigate to a subpage first
- Remove redundant "Home" nav link — logo already links to docs home, and having three links to `/docs/` is confusing
- Set `logoLink: "/"` so the Hive logo navigates to the marketing page root (VitePress applies `logoLink` directly without `withBase()`, so `"/"` → `href="/"` not `"/docs/"`)
- Add `test_logo_click_navigates_to_marketing` test

Closes #210

## Test plan

- [ ] All 19 docs e2e tests pass in CI
- [ ] Clicking logo navigates to marketing page (`/`)
- [ ] Docs nav link has `href="/docs/"` (no double prefix)
- [ ] Sign in navigates to `/app` via CloudFront redirect (already deployed in #209)
- [ ] Mobile hamburger and nav screen open correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)