### PR TITLE
fix(docs): intercept Sign in click to bypass VitePress SPA routing

### DIFF
--- a/docs-site/.vitepress/theme/index.js
+++ b/docs-site/.vitepress/theme/index.js
@@ -6,18 +6,30 @@ export default {
 
   enhanceApp({ router }) {
     // VitePress's Vue Router intercepts ALL root-relative link clicks, including
-    // the logo link (href="/"). That keeps the user in the VitePress SPA instead
-    // of navigating to the marketing page. Intercept the click in the capture
-    // phase (before Vue Router) and force a full page navigation for href="/".
+    // links that should navigate outside the docs (logo → "/", Sign in → "/app").
+    // Intercept those clicks in the capture phase (before Vue Router) and call
+    // window.location.href directly to force a real full-page navigation.
     if (typeof window !== "undefined") {
       document.addEventListener(
         "click",
         (e) => {
-          const a = e.target.closest(".VPNavBarTitle .title");
-          if (a && a.getAttribute("href") === "/") {
+          // Logo → marketing page root
+          const title = e.target.closest(".VPNavBarTitle .title");
+          if (title && title.getAttribute("href") === "/") {
             e.preventDefault();
             e.stopImmediatePropagation();
             window.location.href = "/";
+            return;
+          }
+
+          // Sign in nav link → /app
+          // VitePress base prepends /docs/ making the href /docs/app, which Vue
+          // Router would handle as a client-side route. Navigate directly to /app.
+          const navLink = e.target.closest(".VPNavBarMenuLink");
+          if (navLink && navLink.getAttribute("href") === "/docs/app") {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            window.location.href = "/app";
           }
         },
         true, // capture phase — fires before Vue Router's link handler

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -325,10 +325,11 @@ class TestDocsNavbar:
         )
 
     def test_signin_nav_link_click(self, docs_page):
-        """Clicking Sign in nav link loads the React login page.
+        """Clicking Sign in nav link loads the React login page at /app.
 
-        The CloudFront Function redirects /docs/app → /app (302) so the user
-        lands on the correct sign-in page, not a 404.
+        VitePress's Vue Router would intercept href='/docs/app' as a client-side
+        route. The theme's enhanceApp override intercepts the click and calls
+        window.location.href='/app' directly to force a real page load.
         """
         page = docs_page
         page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
@@ -338,10 +339,9 @@ class TestDocsNavbar:
         with page.expect_navigation(timeout=15_000):
             signin_link.click()
         # Wait for the React app to fully mount — VPNavBar must be gone
-        page.locator(".VPNavBar").wait_for(state="hidden", timeout=10_000)
+        page.locator(".VPNavBar").wait_for(state="hidden", timeout=15_000)
         assert page.url.rstrip("/").endswith("/app"), (
-            f"Sign in link navigated to {page.url!r} — expected URL ending in '/app'. "
-            "Check CloudFront Function redirect: /docs/app → /app."
+            f"Sign in link navigated to {page.url!r} — expected URL ending in '/app'."
         )
 
     def test_navbar_hamburger_visible_mobile(self, docs_page_mobile):


### PR DESCRIPTION
## Summary

Sign in nav link (`href="/docs/app"`) is under the VitePress base path `/docs/`, so Vue Router intercepts the click as a client-side route rather than a full page load. The CloudFront redirect `/docs/app → /app` never fires, and the user stays in the VitePress shell.

Extended the `enhanceApp` click interceptor (same pattern as the logo fix in #213) to also match `.VPNavBarMenuLink[href="/docs/app"]` and call `window.location.href = "/app"` directly in the capture phase.

Also bumped the e2e test's `.VPNavBar` hidden wait from 10 s → 15 s.

Closes #214

## Test plan

- [ ] `test_signin_nav_link_click` passes — URL ends in `/app`, `.VPNavBar` gone
- [ ] All 19 docs e2e tests green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)