### PR TITLE
release: v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Hive are documented here. Releases correspond to GitHub t
 
 See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) for full release notes generated from merged PRs.
 
+## v0.16.0 — 2026-04-08
+
+### Added
+
+- Marketing site expanded with Pricing, FAQ, Use Cases, MCP Client Compatibility, Changelog, and Status pages (#231, #232, #234)
+- Shared `PageLayout` component with consistent header/footer nav across all marketing pages (#231)
+- `ChangelogPage` parses `CHANGELOG.md` at build time and renders versioned sections with color-coded change groups (#234)
+- `StatusPage` performs a live health check against `GET /health` with refresh and checked-at time display (#234)
+- shadcn/ui component foundation with Tailwind v4 design tokens matching VitePress docs site branding (#228)
+
+### Fixed
+
+- Tailwind utility classes (`mx-auto`) overridden by unlayered CSS reset — moved reset into `@layer base` (#229)
+- Flash of light background on dark-mode page load — synchronous inline theme script applied before first paint (#230)
+- E2e mobile menu toggle test replaced fixed 300ms wait with condition-based `wait_for` (#235)
+
 ## v0.15.0 — 2026-04-07
 
 ### Added

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -361,15 +361,18 @@ class TestDocsNavbar:
             f"Sign in button navigated to {page.url!r} — expected URL ending in '/app'."
         )
 
-    def test_signin_back_button_returns_to_docs(self, docs_page):
+    def test_signin_back_button_returns_to_docs(self, _browser):
         """Pressing Back after Sign in returns to the docs page — not a /docs/app 404.
 
         The old approach used a RouterLink (href=/docs/app) with a JS click
         interceptor.  Vue Router pushed /docs/app onto the history stack before
         the interceptor fired, so Back landed on /docs/app (404).  The fix is
         a plain <a href="/app"> that Vue Router never sees.
+
+        Uses a fresh page (not the module-scoped docs_page) so that accumulated
+        history from prior tests doesn't affect the go_back() destination.
         """
-        page = docs_page
+        page = _browser.new_page()
         origin_url = f"{UI_URL}/docs/getting-started/what-is-hive"
         page.goto(origin_url, timeout=30_000, wait_until="networkidle")
         signin_btn = page.locator(".docs-signin-btn")
@@ -388,6 +391,7 @@ class TestDocsNavbar:
         assert page.locator(".VPNavBar").is_visible(), (
             f"Back button left the docs site entirely ({page.url!r})."
         )
+        page.close()
 
     def test_signin_link_has_button_style(self, docs_page):
         """Sign in button styling matches the marketing site header button exactly.

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -468,6 +468,6 @@ class TestDocsNavbar:
         page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
         hamburger = page.locator(".VPNavBarHamburger")
         hamburger.click()
-        page.wait_for_timeout(300)
         screen = page.locator(".VPNavScreen")
+        screen.wait_for(state="visible", timeout=5_000)
         assert screen.is_visible(), "Mobile nav screen did not open after hamburger click"

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/ui/components.json
+++ b/ui/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": false,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,19 @@
     <meta property="og:title" content="Hive — Shared Memory for Claude Agents" />
     <meta property="og:description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
     <meta property="og:image" content="https://hive.warlordofmars.net/social-preview.png" />
+    <!-- Set theme before first paint to prevent flash of wrong background colour -->
+    <script>
+      (function () {
+        var stored = localStorage.getItem("hive_theme");
+        var theme =
+          stored === "dark" || stored === "light"
+            ? stored
+            : window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+        document.documentElement.setAttribute("data-theme", theme);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,8 +6,10 @@ import ActivityLog from "./components/ActivityLog.jsx";
 import AuthCallback from "./components/AuthCallback.jsx";
 import ClientManager from "./components/ClientManager.jsx";
 import Dashboard from "./components/Dashboard.jsx";
+import FaqPage from "./components/FaqPage.jsx";
 import HomePage from "./components/HomePage.jsx";
 import LoginPage from "./components/LoginPage.jsx";
+import PricingPage from "./components/PricingPage.jsx";
 import MemoryBrowser from "./components/MemoryBrowser.jsx";
 import SetupPanel from "./components/SetupPanel.jsx";
 import UsersPanel from "./components/UsersPanel.jsx";
@@ -198,6 +200,8 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<HomeRoute />} />
+        <Route path="/pricing" element={<PricingPage />} />
+        <Route path="/faq" element={<FaqPage />} />
         <Route path="/app" element={<AppShell />} />
         <Route path="/oauth/callback" element={<AuthCallback />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,11 +6,13 @@ import ActivityLog from "./components/ActivityLog.jsx";
 import AuthCallback from "./components/AuthCallback.jsx";
 import ClientManager from "./components/ClientManager.jsx";
 import Dashboard from "./components/Dashboard.jsx";
+import ChangelogPage from "./components/ChangelogPage.jsx";
 import FaqPage from "./components/FaqPage.jsx";
 import HomePage from "./components/HomePage.jsx";
 import LoginPage from "./components/LoginPage.jsx";
 import McpClientsPage from "./components/McpClientsPage.jsx";
 import PricingPage from "./components/PricingPage.jsx";
+import StatusPage from "./components/StatusPage.jsx";
 import UseCasesPage from "./components/UseCasesPage.jsx";
 import MemoryBrowser from "./components/MemoryBrowser.jsx";
 import SetupPanel from "./components/SetupPanel.jsx";
@@ -206,6 +208,8 @@ export default function App() {
         <Route path="/faq" element={<FaqPage />} />
         <Route path="/use-cases" element={<UseCasesPage />} />
         <Route path="/clients" element={<McpClientsPage />} />
+        <Route path="/changelog" element={<ChangelogPage />} />
+        <Route path="/status" element={<StatusPage />} />
         <Route path="/app" element={<AppShell />} />
         <Route path="/oauth/callback" element={<AuthCallback />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -9,7 +9,9 @@ import Dashboard from "./components/Dashboard.jsx";
 import FaqPage from "./components/FaqPage.jsx";
 import HomePage from "./components/HomePage.jsx";
 import LoginPage from "./components/LoginPage.jsx";
+import McpClientsPage from "./components/McpClientsPage.jsx";
 import PricingPage from "./components/PricingPage.jsx";
+import UseCasesPage from "./components/UseCasesPage.jsx";
 import MemoryBrowser from "./components/MemoryBrowser.jsx";
 import SetupPanel from "./components/SetupPanel.jsx";
 import UsersPanel from "./components/UsersPanel.jsx";
@@ -202,6 +204,8 @@ export default function App() {
         <Route path="/" element={<HomeRoute />} />
         <Route path="/pricing" element={<PricingPage />} />
         <Route path="/faq" element={<FaqPage />} />
+        <Route path="/use-cases" element={<UseCasesPage />} />
+        <Route path="/clients" element={<McpClientsPage />} />
         <Route path="/app" element={<AppShell />} />
         <Route path="/oauth/callback" element={<AuthCallback />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/ui/src/components/ChangelogPage.jsx
+++ b/ui/src/components/ChangelogPage.jsx
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import changelogRaw from "../../CHANGELOG.md?raw";
+import PageLayout from "@/components/PageLayout";
+
+/**
+ * Parse the CHANGELOG.md into sections.
+ * Each section starts with "## vX.Y.Z — YYYY-MM-DD" and contains ### subsections.
+ * Returns an array of { version, date, groups: [{ heading, items }] }
+ */
+export function parseChangelog(raw) {
+  const sections = [];
+  let current = null;
+  let currentGroup = null;
+
+  for (const line of raw.split("\n")) {
+    const versionMatch = line.match(/^## (v[\d.]+(?:-[\w.]+)?) — (\d{4}-\d{2}-\d{2})/);
+    if (versionMatch) {
+      if (current) sections.push(current);
+      current = { version: versionMatch[1], date: versionMatch[2], groups: [] };
+      currentGroup = null;
+      continue;
+    }
+
+    if (!current) continue;
+
+    // Stop at "## Earlier releases" or similar non-version headings
+    if (line.startsWith("## ")) {
+      sections.push(current);
+      current = null;
+      break;
+    }
+
+    const groupMatch = line.match(/^### (.+)/);
+    if (groupMatch) {
+      currentGroup = { heading: groupMatch[1], items: [] };
+      current.groups.push(currentGroup);
+      continue;
+    }
+
+    const itemMatch = line.match(/^- (.+)/);
+    if (itemMatch && currentGroup) {
+      // Strip PR refs like (#123, #456) from item text
+      currentGroup.items.push(itemMatch[1].replace(/\s*\(#[\d, #]+\)/g, "").trim());
+    }
+  }
+
+  if (current) sections.push(current);
+  return sections;
+}
+
+const GROUP_COLORS = {
+  Added: "text-green-600 dark:text-green-400",
+  Fixed: "text-amber-600 dark:text-amber-400",
+  Changed: "text-blue-600 dark:text-blue-400",
+  Removed: "text-red-600 dark:text-red-400",
+};
+
+function ChangelogSection({ version, date, groups }) {
+  return (
+    <div className="border-b border-[var(--border)] pb-10 mb-10 last:border-0 last:mb-0 last:pb-0">
+      <div className="flex items-baseline gap-4 mb-6">
+        <h2 className="text-xl font-bold">{version}</h2>
+        <span className="text-sm text-[var(--text-muted)]">{date}</span>
+      </div>
+      {groups.map((g) => (
+        <div key={g.heading} className="mb-4 last:mb-0">
+          <h3 className={`text-xs font-semibold uppercase tracking-widest mb-2 ${GROUP_COLORS[g.heading] ?? "text-[var(--text-muted)]"}`}>
+            {g.heading}
+          </h3>
+          <ul className="flex flex-col gap-1.5">
+            {g.items.map((item, i) => (
+              <li key={i} className="text-sm text-[var(--text)] leading-relaxed flex gap-2">
+                <span className="text-[var(--text-muted)] shrink-0">—</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ChangelogPage() {
+  const sections = parseChangelog(changelogRaw);
+
+  return (
+    <PageLayout>
+      {/* Header */}
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">Changelog</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[480px] mx-auto leading-relaxed">
+            Notable changes in each release of Hive.
+          </p>
+        </div>
+      </section>
+
+      {/* Entries */}
+      <section className="py-16 px-8">
+        <div className="max-w-[720px] mx-auto">
+          {sections.map((s) => (
+            <ChangelogSection key={s.version} {...s} />
+          ))}
+          <p className="text-sm text-[var(--text-muted)] mt-8">
+            Older releases are on the{" "}
+            <a
+              href="https://github.com/warlordofmars/hive/releases"
+              className="text-brand no-underline hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub releases page
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/ChangelogPage.test.jsx
+++ b/ui/src/components/ChangelogPage.test.jsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import ChangelogPage from "./ChangelogPage.jsx";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+// Mock the raw CHANGELOG import
+vi.mock("../../CHANGELOG.md?raw", () => ({
+  default: `# Changelog
+
+## v1.2.0 — 2026-01-02
+
+### Added
+
+- New feature one (#1)
+- New feature two (#2)
+
+### Fixed
+
+- Bug fix one (#3)
+
+### Deprecated
+
+- Old thing
+
+## v1.1.0 — 2026-01-01
+
+### Added
+
+- Initial feature (#0)
+
+## Earlier releases
+
+See GitHub.
+`,
+}));
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("ChangelogPage", () => {
+  it("renders the heading", async () => {
+    await act(async () => renderInRouter(<ChangelogPage />));
+    expect(screen.getAllByText("Changelog").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders parsed version headings", async () => {
+    await act(async () => renderInRouter(<ChangelogPage />));
+    expect(screen.getByText("v1.2.0")).toBeTruthy();
+    expect(screen.getByText("v1.1.0")).toBeTruthy();
+  });
+
+  it("renders release dates", async () => {
+    await act(async () => renderInRouter(<ChangelogPage />));
+    expect(screen.getByText("2026-01-02")).toBeTruthy();
+    expect(screen.getByText("2026-01-01")).toBeTruthy();
+  });
+
+  it("renders group headings (Added, Fixed)", async () => {
+    await act(async () => renderInRouter(<ChangelogPage />));
+    expect(screen.getAllByText("Added").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Fixed")).toBeTruthy();
+  });
+
+  it("renders changelog items with PR refs stripped", async () => {
+    await act(async () => renderInRouter(<ChangelogPage />));
+    expect(screen.getByText("New feature one")).toBeTruthy();
+    expect(screen.getByText("Bug fix one")).toBeTruthy();
+  });
+
+  it("renders an unknown group heading with fallback style", async () => {
+    await act(async () => renderInRouter(<ChangelogPage />));
+    expect(screen.getByText("Deprecated")).toBeTruthy();
+  });
+
+  it("parseChangelog pushes trailing section when no Earlier-releases terminator", async () => {
+    const { parseChangelog } = await import("./ChangelogPage.jsx");
+    const result = parseChangelog("## v2.0.0 — 2026-06-01\n\n### Added\n\n- Something\n");
+    expect(result.length).toBe(1);
+    expect(result[0].version).toBe("v2.0.0");
+  });
+
+  it("renders GitHub releases link", async () => {
+    await act(async () => renderInRouter(<ChangelogPage />));
+    expect(screen.getByText("GitHub releases page")).toBeTruthy();
+  });
+});

--- a/ui/src/components/FaqPage.jsx
+++ b/ui/src/components/FaqPage.jsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+
+const FAQS = [
+  {
+    q: "Is my data private? Who can see my memories?",
+    a: "Your memories are scoped to your account. Only you can read, write, or delete them. Admins of the Hive service can access data for operational purposes (e.g. debugging, compliance), but no data is shared with third parties or used for training.",
+  },
+  {
+    q: "What are the usage limits?",
+    a: "There are no hard limits on the number of memories or API calls during the free period. We reserve the right to introduce fair-use limits in future to ensure service quality for all users — we'll give plenty of notice before doing so.",
+  },
+  {
+    q: "Which MCP clients are supported?",
+    a: "Any client that implements the Model Context Protocol works with Hive. Tested clients include Claude Code, Claude Desktop, Cursor, and Continue. If your client supports MCP, it will work.",
+  },
+  {
+    q: "How do I delete my account or data?",
+    a: "You can delete individual memories at any time from the Memory Browser in the management UI. To delete your account and all associated data, sign in and use the account settings, or contact us and we will remove everything within 30 days.",
+  },
+  {
+    q: "What happens if the service goes down?",
+    a: "Hive is hosted on AWS with Lambda and DynamoDB, both of which have high availability SLAs. If the service is unavailable, your MCP client will receive an error and can degrade gracefully. Memories are not lost during downtime.",
+  },
+  {
+    q: "Is this free forever?",
+    a: "The current free tier will remain free. If paid plans are introduced in the future, existing free-tier accounts will keep their current access. We will communicate any changes well in advance.",
+  },
+  {
+    q: "How do I connect my MCP client?",
+    a: "Sign in, register a client in the management UI, and copy the one-line config snippet into your MCP client's configuration file. Full step-by-step instructions are in the docs.",
+  },
+  {
+    q: "Does Hive work offline or self-hosted?",
+    a: "The hosted service requires an internet connection. Self-hosting is not officially supported at this time, though the project is open source and you are welcome to deploy your own instance.",
+  },
+];
+
+function FaqItem({ q, a }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="border-b border-[var(--border)]">
+      <button
+        className="w-full flex items-center justify-between py-5 text-left gap-4 bg-transparent hover:opacity-80 transition-opacity"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className="font-medium text-base">{q}</span>
+        <ChevronDown
+          size={18}
+          className="shrink-0 text-[var(--text-muted)] transition-transform duration-200"
+          style={{ transform: open ? "rotate(180deg)" : "rotate(0deg)" }}
+        />
+      </button>
+      {open && (
+        <p className="pb-5 text-sm text-[var(--text-muted)] leading-relaxed">{a}</p>
+      )}
+    </div>
+  );
+}
+
+export default function FaqPage() {
+  return (
+    <PageLayout>
+      {/* Header */}
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">Frequently asked questions</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[480px] mx-auto leading-relaxed">
+            Everything you need to know before getting started.
+          </p>
+        </div>
+      </section>
+
+      {/* Accordion */}
+      <section className="py-16 px-8">
+        <div className="max-w-[720px] mx-auto">
+          {FAQS.map((item) => (
+            <FaqItem key={item.q} q={item.q} a={item.a} />
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+        <p className="text-[var(--text-muted)] text-sm">
+          Still have questions?{" "}
+          <a href="/docs/" className="text-brand no-underline hover:underline">
+            Read the docs →
+          </a>
+        </p>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/FaqPage.test.jsx
+++ b/ui/src/components/FaqPage.test.jsx
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import FaqPage from "./FaqPage.jsx";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("FaqPage", () => {
+  it("renders the heading", async () => {
+    await act(async () => renderInRouter(<FaqPage />));
+    expect(screen.getByText(/Frequently asked questions/)).toBeTruthy();
+  });
+
+  it("renders all FAQ questions", async () => {
+    await act(async () => renderInRouter(<FaqPage />));
+    expect(screen.getByText(/Is my data private/)).toBeTruthy();
+    expect(screen.getByText(/What are the usage limits/)).toBeTruthy();
+    expect(screen.getByText(/Which MCP clients are supported/)).toBeTruthy();
+    expect(screen.getByText(/How do I delete my account/)).toBeTruthy();
+    expect(screen.getByText(/What happens if the service goes down/)).toBeTruthy();
+    expect(screen.getByText(/Is this free forever/)).toBeTruthy();
+    expect(screen.getByText(/How do I connect my MCP client/)).toBeTruthy();
+    expect(screen.getByText(/Does Hive work offline/)).toBeTruthy();
+  });
+
+  it("answers are hidden by default", async () => {
+    await act(async () => renderInRouter(<FaqPage />));
+    expect(screen.queryByText(/Your memories are scoped to your account/)).toBeFalsy();
+  });
+
+  it("clicking a question reveals the answer", async () => {
+    await act(async () => renderInRouter(<FaqPage />));
+    fireEvent.click(screen.getByText(/Is my data private/));
+    expect(screen.getByText(/Your memories are scoped to your account/)).toBeTruthy();
+  });
+
+  it("clicking an open question hides the answer again", async () => {
+    await act(async () => renderInRouter(<FaqPage />));
+    const btn = screen.getByText(/Is my data private/).closest("button");
+    fireEvent.click(btn);
+    expect(screen.getByText(/Your memories are scoped to your account/)).toBeTruthy();
+    fireEvent.click(btn);
+    expect(screen.queryByText(/Your memories are scoped to your account/)).toBeFalsy();
+  });
+
+  it("multiple questions can be open simultaneously", async () => {
+    await act(async () => renderInRouter(<FaqPage />));
+    fireEvent.click(screen.getByText(/Is my data private/));
+    fireEvent.click(screen.getByText(/What are the usage limits/));
+    expect(screen.getByText(/Your memories are scoped to your account/)).toBeTruthy();
+    expect(screen.getByText(/no hard limits/)).toBeTruthy();
+  });
+
+  it("renders docs link", async () => {
+    await act(async () => renderInRouter(<FaqPage />));
+    expect(screen.getByText(/Read the docs/)).toBeTruthy();
+  });
+});

--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { BrainCircuit, Plug, ShieldCheck, Users } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 
 const FEATURES = [
   {
@@ -48,216 +49,103 @@ export default function HomePage() {
   const navigate = useNavigate();
 
   return (
-    <div style={{ fontFamily: "system-ui, sans-serif", color: "var(--text)" }}>
+    <div className="font-[system-ui,sans-serif] text-[var(--text)]">
       {/* Nav */}
-      <header style={{ background: "#1a1a2e", color: "#fff" }}>
-        <div
-          style={{
-            maxWidth: 1100,
-            margin: "0 auto",
-            padding: "0 32px",
-            height: 56,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-          }}
-        >
-          <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <img src="/logo.svg" alt="Hive" style={{ height: 28 }} />
-            <span style={{ fontWeight: 700, fontSize: 20, letterSpacing: 1 }}>Hive</span>
+      <header className="bg-navy text-white">
+        <div className="max-w-[1100px] mx-auto px-8 h-14 flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            <img src="/logo.svg" alt="Hive" className="h-7 w-auto" />
+            <span className="font-bold text-xl tracking-[1px]">Hive</span>
           </span>
-          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div className="flex items-center gap-3">
             <a
               href="/docs/"
-              style={{
-                color: "rgba(255,255,255,.75)",
-                fontSize: 14,
-                textDecoration: "none",
-              }}
+              className="text-white/75 text-sm no-underline hover:text-white transition-colors"
             >
               Docs
             </a>
-            <button
-              onClick={() => navigate("/app")}
-              style={{
-                background: "transparent",
-                color: "rgba(255,255,255,.8)",
-                border: "1px solid rgba(255,255,255,.3)",
-                borderRadius: 6,
-                padding: "6px 16px",
-                fontSize: 14,
-                cursor: "pointer",
-              }}
-            >
+            <Button variant="outline" size="sm" onClick={() => navigate("/app")}>
               Sign in
-            </button>
+            </Button>
           </div>
         </div>
       </header>
 
       {/* Hero */}
       <section
+        className="text-white py-24 px-8 text-center"
         style={{
           background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%)",
-          color: "#fff",
-          padding: "96px 32px",
-          textAlign: "center",
         }}
       >
-        <h1
-          style={{
-            fontSize: "clamp(2rem, 5vw, 3.5rem)",
-            fontWeight: 800,
-            marginBottom: 24,
-            lineHeight: 1.15,
-          }}
-        >
+        <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-extrabold mb-6 leading-[1.15]">
           Persistent memory
           <br />
           for AI agents
         </h1>
-        <p
-          style={{
-            fontSize: "clamp(1rem, 2vw, 1.25rem)",
-            color: "rgba(255,255,255,.75)",
-            maxWidth: 560,
-            margin: "0 auto 40px",
-            lineHeight: 1.6,
-          }}
-        >
+        <p className="text-[clamp(1rem,2vw,1.25rem)] text-white/75 max-w-[560px] mx-auto mb-10 leading-relaxed">
           Hive gives your AI agents a shared, durable memory store via the Model Context
           Protocol — works with Claude Code, Cursor, Continue, and any MCP-compatible client.
         </p>
-        <button
-          onClick={() => navigate("/app")}
-          style={{
-            background: "#e8a020",
-            color: "#fff",
-            border: "none",
-            borderRadius: 8,
-            padding: "14px 36px",
-            fontSize: 17,
-            fontWeight: 600,
-            cursor: "pointer",
-            letterSpacing: 0.3,
-          }}
-        >
+        <Button variant="brand" size="lg" onClick={() => navigate("/app")}>
           Get started free →
-        </button>
-        <p style={{ marginTop: 16, color: "rgba(255,255,255,.45)", fontSize: 13 }}>
-          No credit card required
-        </p>
+        </Button>
+        <p className="mt-4 text-white/45 text-[13px]">No credit card required</p>
       </section>
 
       {/* Features */}
-      <section style={{ padding: "80px 32px" }}>
-        <div style={{ maxWidth: 1100, margin: "0 auto" }}>
-        <h2
-          style={{ textAlign: "center", fontSize: "1.75rem", fontWeight: 700, marginBottom: 56 }}
-        >
-          Everything your agents need to remember
-        </h2>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-            gap: 32,
-          }}
-        >
-          {FEATURES.map((f) => (
-            <div
-              key={f.title}
-              style={{
-                background: "var(--surface)",
-                border: "1px solid var(--border)",
-                borderRadius: 12,
-                padding: 28,
-                boxShadow: "0 2px 8px rgba(0,0,0,.04)",
-              }}
-            >
-              <div style={{ marginBottom: 12 }}><f.icon size={32} color="#e8a020" /></div>
-              <h3 style={{ fontSize: "1rem", fontWeight: 700, marginBottom: 8 }}>{f.title}</h3>
-              <p style={{ color: "var(--text-muted)", fontSize: 14, lineHeight: 1.6 }}>{f.body}</p>
-            </div>
-          ))}
-        </div>
+      <section className="py-20 px-8">
+        <div className="max-w-[1100px] mx-auto">
+          <h2 className="text-center text-[1.75rem] font-bold mb-14">
+            Everything your agents need to remember
+          </h2>
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-8">
+            {FEATURES.map((f) => (
+              <div
+                key={f.title}
+                className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-7 shadow-sm"
+              >
+                <div className="mb-3">
+                  <f.icon size={32} color="#e8a020" />
+                </div>
+                <h3 className="text-base font-bold mb-2">{f.title}</h3>
+                <p className="text-[var(--text-muted)] text-sm leading-relaxed">{f.body}</p>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
 
       {/* How it works */}
-      <section style={{ background: "var(--surface)", padding: "80px 32px" }}>
-        <div style={{ maxWidth: 1100, margin: "0 auto" }}>
-          <h2
-            style={{
-              textAlign: "center",
-              fontSize: "1.75rem",
-              fontWeight: 700,
-              marginBottom: 56,
-            }}
-          >
+      <section className="bg-[var(--surface)] py-20 px-8">
+        <div className="max-w-[1100px] mx-auto">
+          <h2 className="text-center text-[1.75rem] font-bold mb-14">
             Up and running in minutes
           </h2>
-          <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+          <div className="flex flex-col gap-8">
             {HOW_IT_WORKS.map((s) => (
-              <div key={s.step} style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
-                <div
-                  style={{
-                    width: 40,
-                    height: 40,
-                    borderRadius: "50%",
-                    background: "var(--accent)",
-                    color: "var(--accent-fg)",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    fontWeight: 700,
-                    fontSize: 16,
-                    flexShrink: 0,
-                  }}
-                >
+              <div key={s.step} className="flex gap-6 items-start">
+                <div className="size-10 rounded-full bg-[var(--accent)] text-[var(--accent-fg)] flex items-center justify-center font-bold text-base shrink-0">
                   {s.step}
                 </div>
                 <div>
-                  <h3 style={{ fontSize: "1rem", fontWeight: 700, marginBottom: 6 }}>
-                    {s.title}
-                  </h3>
-                  <p style={{ color: "var(--text-muted)", fontSize: 14, lineHeight: 1.6 }}>{s.body}</p>
+                  <h3 className="text-base font-bold mb-1.5">{s.title}</h3>
+                  <p className="text-[var(--text-muted)] text-sm leading-relaxed">{s.body}</p>
                 </div>
               </div>
             ))}
           </div>
-          <div style={{ textAlign: "center", marginTop: 56 }}>
-            <button
-              onClick={() => navigate("/app")}
-              style={{
-                background: "var(--accent)",
-                color: "var(--accent-fg)",
-                border: "none",
-                borderRadius: 8,
-                padding: "14px 36px",
-                fontSize: 16,
-                fontWeight: 600,
-                cursor: "pointer",
-              }}
-            >
+          <div className="text-center mt-14">
+            <Button variant="brand" size="lg" onClick={() => navigate("/app")}>
               Get started free →
-            </button>
+            </Button>
           </div>
         </div>
       </section>
 
       {/* Footer */}
-      <footer style={{ borderTop: "1px solid var(--border)" }}>
-        <div
-          style={{
-            maxWidth: 1100,
-            margin: "0 auto",
-            padding: "32px",
-            textAlign: "center",
-            fontSize: 13,
-            color: "var(--text-muted)",
-          }}
-        >
+      <footer className="border-t border-[var(--border)]">
+        <div className="max-w-[1100px] mx-auto px-8 py-8 text-center text-[13px] text-[var(--text-muted)]">
           © 2026 Hive. Free to use.
         </div>
       </footer>

--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import { BrainCircuit, Plug, ShieldCheck, Users } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import PageLayout from "@/components/PageLayout";
 
 const FEATURES = [
   {
@@ -49,28 +50,7 @@ export default function HomePage() {
   const navigate = useNavigate();
 
   return (
-    <div className="font-[system-ui,sans-serif] text-[var(--text)]">
-      {/* Nav */}
-      <header className="bg-navy text-white">
-        <div className="max-w-[1100px] mx-auto px-8 h-14 flex items-center justify-between">
-          <span className="flex items-center gap-2">
-            <img src="/logo.svg" alt="Hive" className="h-7 w-auto" />
-            <span className="font-bold text-xl tracking-[1px]">Hive</span>
-          </span>
-          <div className="flex items-center gap-3">
-            <a
-              href="/docs/"
-              className="text-white/75 text-sm no-underline hover:text-white transition-colors"
-            >
-              Docs
-            </a>
-            <Button variant="outline" size="sm" onClick={() => navigate("/app")}>
-              Sign in
-            </Button>
-          </div>
-        </div>
-      </header>
-
+    <PageLayout>
       {/* Hero */}
       <section
         className="text-white py-24 px-8 text-center"
@@ -142,13 +122,6 @@ export default function HomePage() {
           </div>
         </div>
       </section>
-
-      {/* Footer */}
-      <footer className="border-t border-[var(--border)]">
-        <div className="max-w-[1100px] mx-auto px-8 py-8 text-center text-[13px] text-[var(--text-muted)]">
-          © 2026 Hive. Free to use.
-        </div>
-      </footer>
-    </div>
+    </PageLayout>
   );
 }

--- a/ui/src/components/McpClientsPage.jsx
+++ b/ui/src/components/McpClientsPage.jsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+
+const CLIENTS = [
+  {
+    name: "Claude Code",
+    description: "Anthropic's official CLI for Claude. Add Hive as an MCP server in your project or global config.",
+    config: `{
+  "mcpServers": {
+    "hive": {
+      "type": "http",
+      "url": "https://hive.warlordofmars.net/mcp"
+    }
+  }
+}`,
+    configFile: "~/.claude/claude_desktop_config.json or .mcp.json",
+  },
+  {
+    name: "Claude Desktop",
+    description: "The Claude desktop app on Mac and Windows. Add Hive to your MCP server list in settings.",
+    config: `{
+  "mcpServers": {
+    "hive": {
+      "type": "http",
+      "url": "https://hive.warlordofmars.net/mcp"
+    }
+  }
+}`,
+    configFile: "Claude Desktop → Settings → MCP Servers",
+  },
+  {
+    name: "Cursor",
+    description: "The AI-first code editor. Add Hive as an MCP server in your Cursor settings.",
+    config: `{
+  "mcpServers": {
+    "hive": {
+      "type": "http",
+      "url": "https://hive.warlordofmars.net/mcp"
+    }
+  }
+}`,
+    configFile: "~/.cursor/mcp.json",
+  },
+  {
+    name: "Continue",
+    description: "The open-source AI code assistant for VS Code and JetBrains. Add Hive in your Continue config.",
+    config: `{
+  "experimental": {
+    "modelContextProtocolServers": [
+      {
+        "transport": {
+          "type": "http",
+          "url": "https://hive.warlordofmars.net/mcp"
+        }
+      }
+    ]
+  }
+}`,
+    configFile: "~/.continue/config.json",
+  },
+];
+
+function CopyButton({ text }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="flex items-center gap-1.5 text-xs text-white/60 hover:text-white/90 transition-colors bg-transparent"
+      aria-label="Copy config"
+    >
+      {copied ? <Check size={13} /> : <Copy size={13} />}
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}
+
+function ClientCard({ name, description, config, configFile }) {
+  return (
+    <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-6">
+      <h2 className="text-base font-bold mb-2">{name}</h2>
+      <p className="text-[var(--text-muted)] text-sm leading-relaxed mb-4">{description}</p>
+      <div className="rounded-lg bg-navy overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-white/10">
+          <span className="text-white/40 text-xs">{configFile}</span>
+          <CopyButton text={config} />
+        </div>
+        <pre className="text-white/85 text-xs leading-relaxed p-4 overflow-x-auto">
+          <code>{config}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+export default function McpClientsPage() {
+  return (
+    <PageLayout>
+      {/* Header */}
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">MCP client compatibility</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[560px] mx-auto leading-relaxed">
+            Hive works with any client that speaks the Model Context Protocol.
+            Copy the config snippet for your tool below.
+          </p>
+        </div>
+      </section>
+
+      {/* Client cards */}
+      <section className="py-20 px-8">
+        <div className="max-w-[1100px] mx-auto grid grid-cols-[repeat(auto-fit,minmax(460px,1fr))] gap-6">
+          {CLIENTS.map((c) => (
+            <ClientCard key={c.name} {...c} />
+          ))}
+        </div>
+      </section>
+
+      {/* Footer note */}
+      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+        <p className="text-[var(--text-muted)] text-sm max-w-[560px] mx-auto leading-relaxed">
+          Any MCP-compatible client works with Hive — these are the most commonly used ones.
+          See the{" "}
+          <a href="/docs/" className="text-brand no-underline hover:underline">
+            docs
+          </a>{" "}
+          for full setup instructions including authentication.
+        </p>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/McpClientsPage.test.jsx
+++ b/ui/src/components/McpClientsPage.test.jsx
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import McpClientsPage from "./McpClientsPage.jsx";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+// jsdom doesn't implement clipboard API
+Object.assign(navigator, {
+  clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+});
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("McpClientsPage", () => {
+  it("renders the heading", async () => {
+    await act(async () => renderInRouter(<McpClientsPage />));
+    expect(screen.getByText(/MCP client compatibility/)).toBeTruthy();
+  });
+
+  it("renders all client cards", async () => {
+    await act(async () => renderInRouter(<McpClientsPage />));
+    expect(screen.getByText("Claude Code")).toBeTruthy();
+    expect(screen.getByText("Claude Desktop")).toBeTruthy();
+    expect(screen.getByText("Cursor")).toBeTruthy();
+    expect(screen.getByText("Continue")).toBeTruthy();
+  });
+
+  it("renders config snippets for each client", async () => {
+    const { container } = await act(async () => renderInRouter(<McpClientsPage />));
+    const snippets = container.querySelectorAll("pre");
+    expect(snippets.length).toBe(4);
+  });
+
+  it("renders Copy buttons", async () => {
+    await act(async () => renderInRouter(<McpClientsPage />));
+    const copyBtns = screen.getAllByText("Copy");
+    expect(copyBtns.length).toBe(4);
+  });
+
+  it("clicking Copy calls clipboard and shows Copied!", async () => {
+    await act(async () => renderInRouter(<McpClientsPage />));
+    const copyBtn = screen.getAllByText("Copy")[0];
+    await act(async () => fireEvent.click(copyBtn));
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(screen.getAllByText("Copied!").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders docs link", async () => {
+    await act(async () => renderInRouter(<McpClientsPage />));
+    expect(screen.getByText("docs")).toBeTruthy();
+  });
+});

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -44,12 +44,14 @@ export default function PageLayout({ children }) {
               <img src="/logo.svg" alt="Hive" className="h-5 w-auto opacity-60" />
               <span className="font-bold text-sm tracking-[1px] text-[var(--text-muted)]">Hive</span>
             </div>
-            <div className="flex gap-8 text-sm text-[var(--text-muted)]">
+            <div className="flex flex-wrap gap-x-8 gap-y-2 text-sm text-[var(--text-muted)]">
               <a href="/use-cases" className="no-underline hover:text-[var(--text)] transition-colors">Use cases</a>
               <a href="/clients" className="no-underline hover:text-[var(--text)] transition-colors">Clients</a>
               <a href="/pricing" className="no-underline hover:text-[var(--text)] transition-colors">Pricing</a>
               <a href="/faq" className="no-underline hover:text-[var(--text)] transition-colors">FAQ</a>
               <a href="/docs/" className="no-underline hover:text-[var(--text)] transition-colors">Docs</a>
+              <a href="/changelog" className="no-underline hover:text-[var(--text)] transition-colors">Changelog</a>
+              <a href="/status" className="no-underline hover:text-[var(--text)] transition-colors">Status</a>
             </div>
           </div>
           <p className="mt-6 text-[13px] text-[var(--text-muted)]">© 2026 Hive. Free to use.</p>

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -19,6 +19,8 @@ export default function PageLayout({ children }) {
             <span className="font-bold text-xl tracking-[1px]">Hive</span>
           </span>
           <div className="flex items-center gap-6">
+            <a href="/use-cases" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Use cases</a>
+            <a href="/clients" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Clients</a>
             <a href="/pricing" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Pricing</a>
             <a href="/faq" className="text-white/75 text-sm no-underline hover:text-white transition-colors">FAQ</a>
             <a href="/docs/" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Docs</a>
@@ -43,6 +45,8 @@ export default function PageLayout({ children }) {
               <span className="font-bold text-sm tracking-[1px] text-[var(--text-muted)]">Hive</span>
             </div>
             <div className="flex gap-8 text-sm text-[var(--text-muted)]">
+              <a href="/use-cases" className="no-underline hover:text-[var(--text)] transition-colors">Use cases</a>
+              <a href="/clients" className="no-underline hover:text-[var(--text)] transition-colors">Clients</a>
               <a href="/pricing" className="no-underline hover:text-[var(--text)] transition-colors">Pricing</a>
               <a href="/faq" className="no-underline hover:text-[var(--text)] transition-colors">FAQ</a>
               <a href="/docs/" className="no-underline hover:text-[var(--text)] transition-colors">Docs</a>

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+export default function PageLayout({ children }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="font-[system-ui,sans-serif] text-[var(--text)] flex flex-col min-h-screen">
+      {/* Nav */}
+      <header className="bg-navy text-white">
+        <div className="max-w-[1100px] mx-auto px-8 h-14 flex items-center justify-between">
+          <span
+            className="flex items-center gap-2 cursor-pointer"
+            onClick={() => navigate("/")}
+          >
+            <img src="/logo.svg" alt="Hive" className="h-7 w-auto" />
+            <span className="font-bold text-xl tracking-[1px]">Hive</span>
+          </span>
+          <div className="flex items-center gap-6">
+            <a href="/pricing" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Pricing</a>
+            <a href="/faq" className="text-white/75 text-sm no-underline hover:text-white transition-colors">FAQ</a>
+            <a href="/docs/" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Docs</a>
+            <Button variant="outline" size="sm" onClick={() => navigate("/app")}>
+              Sign in
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {/* Page content */}
+      <main className="flex-1">
+        {children}
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-[var(--border)]">
+        <div className="max-w-[1100px] mx-auto px-8 py-8">
+          <div className="flex flex-col gap-6 sm:flex-row sm:justify-between sm:items-start">
+            <div className="flex items-center gap-2">
+              <img src="/logo.svg" alt="Hive" className="h-5 w-auto opacity-60" />
+              <span className="font-bold text-sm tracking-[1px] text-[var(--text-muted)]">Hive</span>
+            </div>
+            <div className="flex gap-8 text-sm text-[var(--text-muted)]">
+              <a href="/pricing" className="no-underline hover:text-[var(--text)] transition-colors">Pricing</a>
+              <a href="/faq" className="no-underline hover:text-[var(--text)] transition-colors">FAQ</a>
+              <a href="/docs/" className="no-underline hover:text-[var(--text)] transition-colors">Docs</a>
+            </div>
+          </div>
+          <p className="mt-6 text-[13px] text-[var(--text-muted)]">© 2026 Hive. Free to use.</p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -34,6 +34,8 @@ describe("PageLayout", () => {
     await act(async () =>
       renderInRouter(<PageLayout><span /></PageLayout>)
     );
+    expect(screen.getAllByText("Use cases").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Clients").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("Pricing").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("FAQ").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("Docs").length).toBeGreaterThanOrEqual(1);
@@ -74,9 +76,9 @@ describe("PageLayout", () => {
     await act(async () =>
       renderInRouter(<PageLayout><span /></PageLayout>)
     );
-    const pricingLinks = screen.getAllByText("Pricing");
-    expect(pricingLinks.length).toBeGreaterThanOrEqual(1);
-    const faqLinks = screen.getAllByText("FAQ");
-    expect(faqLinks.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Pricing").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("FAQ").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Use cases").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Clients").length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PageLayout from "./PageLayout.jsx";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("PageLayout", () => {
+  it("renders children", async () => {
+    await act(async () =>
+      renderInRouter(<PageLayout><p>test content</p></PageLayout>)
+    );
+    expect(screen.getByText("test content")).toBeTruthy();
+  });
+
+  it("renders nav with logo and wordmark", async () => {
+    const { container } = await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    expect(container.querySelector('img[alt="Hive"]')).toBeTruthy();
+    expect(screen.getAllByText("Hive").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders nav links: Pricing, FAQ, Docs", async () => {
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    expect(screen.getAllByText("Pricing").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("FAQ").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Docs").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders Sign in button", async () => {
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    expect(screen.getByText("Sign in")).toBeTruthy();
+  });
+
+  it("Sign in navigates to /app", async () => {
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    fireEvent.click(screen.getByText("Sign in"));
+    expect(mockNavigate).toHaveBeenCalledWith("/app");
+  });
+
+  it("clicking logo navigates to /", async () => {
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    const logo = screen.getAllByText("Hive")[0].closest("span");
+    fireEvent.click(logo);
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+
+  it("renders footer with copyright", async () => {
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    expect(screen.getByText(/© 2026 Hive/)).toBeTruthy();
+  });
+
+  it("renders footer links: Pricing, FAQ, Docs", async () => {
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    const pricingLinks = screen.getAllByText("Pricing");
+    expect(pricingLinks.length).toBeGreaterThanOrEqual(1);
+    const faqLinks = screen.getAllByText("FAQ");
+    expect(faqLinks.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/ui/src/components/PricingPage.jsx
+++ b/ui/src/components/PricingPage.jsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import { Check } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import PageLayout from "@/components/PageLayout";
+
+const INCLUDED = [
+  "Unlimited memories",
+  "Semantic search across all memories",
+  "Works with Claude Code, Claude Desktop, Cursor, Continue, and any MCP client",
+  "Multiple OAuth clients per account",
+  "Activity log and memory browser UI",
+  "OAuth 2.1 with PKCE — no shared secrets",
+  "No credit card required",
+];
+
+export default function PricingPage() {
+  const navigate = useNavigate();
+
+  return (
+    <PageLayout>
+      {/* Header */}
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">Simple, honest pricing</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[480px] mx-auto leading-relaxed">
+            Hive is free to use. No tiers, no credit card, no catch.
+          </p>
+        </div>
+      </section>
+
+      {/* Pricing card */}
+      <section className="py-20 px-8">
+        <div className="max-w-[420px] mx-auto">
+          <div className="bg-[var(--surface)] border border-[var(--border)] rounded-2xl p-8 shadow-sm">
+            <div className="mb-6">
+              <span className="inline-block bg-brand/10 text-brand text-xs font-semibold px-3 py-1 rounded-full mb-4">
+                Free
+              </span>
+              <div className="flex items-baseline gap-1">
+                <span className="text-[3rem] font-extrabold leading-none">$0</span>
+                <span className="text-[var(--text-muted)] text-sm">/ forever</span>
+              </div>
+            </div>
+
+            <ul className="flex flex-col gap-3 mb-8">
+              {INCLUDED.map((item) => (
+                <li key={item} className="flex items-start gap-3 text-sm">
+                  <Check size={16} className="text-brand shrink-0 mt-0.5" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+
+            <Button variant="brand" size="lg" className="w-full" onClick={() => navigate("/app")}>
+              Get started free →
+            </Button>
+            <p className="text-center text-[13px] text-[var(--text-muted)] mt-3">
+              No credit card required
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ nudge */}
+      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+        <p className="text-[var(--text-muted)] text-sm">
+          Questions about limits or data?{" "}
+          <a href="/faq" className="text-brand no-underline hover:underline">
+            See the FAQ →
+          </a>
+        </p>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/PricingPage.test.jsx
+++ b/ui/src/components/PricingPage.test.jsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PricingPage from "./PricingPage.jsx";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("PricingPage", () => {
+  it("renders the heading", async () => {
+    await act(async () => renderInRouter(<PricingPage />));
+    expect(screen.getByText(/Simple, honest pricing/)).toBeTruthy();
+  });
+
+  it("renders the Free badge", async () => {
+    await act(async () => renderInRouter(<PricingPage />));
+    expect(screen.getByText("Free")).toBeTruthy();
+  });
+
+  it("renders $0 price", async () => {
+    await act(async () => renderInRouter(<PricingPage />));
+    expect(screen.getByText("$0")).toBeTruthy();
+  });
+
+  it("renders all included features", async () => {
+    await act(async () => renderInRouter(<PricingPage />));
+    expect(screen.getByText(/Unlimited memories/)).toBeTruthy();
+    expect(screen.getByText(/Semantic search/)).toBeTruthy();
+    expect(screen.getAllByText(/No credit card required/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders Get started free CTA", async () => {
+    await act(async () => renderInRouter(<PricingPage />));
+    expect(screen.getAllByText(/Get started free/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("CTA navigates to /app", async () => {
+    await act(async () => renderInRouter(<PricingPage />));
+    fireEvent.click(screen.getByText(/Get started free →/));
+    expect(mockNavigate).toHaveBeenCalledWith("/app");
+  });
+
+  it("renders FAQ link", async () => {
+    await act(async () => renderInRouter(<PricingPage />));
+    expect(screen.getByText(/See the FAQ/)).toBeTruthy();
+  });
+});

--- a/ui/src/components/StatusPage.jsx
+++ b/ui/src/components/StatusPage.jsx
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useEffect, useState } from "react";
+import { CheckCircle, AlertCircle, RefreshCw } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+
+const CHECK_URL = "/health";
+
+function useHealthCheck() {
+  const [status, setStatus] = useState("loading"); // "loading" | "ok" | "error"
+  const [version, setVersion] = useState(null);
+  const [checkedAt, setCheckedAt] = useState(null);
+
+  function check() {
+    setStatus("loading");
+    fetch(CHECK_URL)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data) => {
+        setVersion(data.version ?? null);
+        setStatus("ok");
+        setCheckedAt(new Date());
+      })
+      .catch(() => {
+        setStatus("error");
+        setCheckedAt(new Date());
+      });
+  }
+
+  useEffect(() => {
+    check();
+  }, []);
+
+  return { status, version, checkedAt, check };
+}
+
+export default function StatusPage() {
+  const { status, version, checkedAt, check } = useHealthCheck();
+
+  const isOk = status === "ok";
+  const isLoading = status === "loading";
+
+  return (
+    <PageLayout>
+      {/* Header */}
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">Service status</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[480px] mx-auto leading-relaxed">
+            Current status of the Hive API.
+          </p>
+        </div>
+      </section>
+
+      {/* Status card */}
+      <section className="py-16 px-8">
+        <div className="max-w-[480px] mx-auto">
+          <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-8">
+            <div className="flex items-center gap-4 mb-6">
+              {isLoading ? (
+                <RefreshCw size={32} className="text-[var(--text-muted)] animate-spin" />
+              ) : isOk ? (
+                <CheckCircle size={32} className="text-green-500" />
+              ) : (
+                <AlertCircle size={32} className="text-red-500" />
+              )}
+              <div>
+                <p className="font-bold text-lg">
+                  {isLoading ? "Checking…" : isOk ? "All systems operational" : "Service unavailable"}
+                </p>
+                {version && (
+                  <p className="text-sm text-[var(--text-muted)]">Version {version}</p>
+                )}
+              </div>
+            </div>
+
+            <div className="border-t border-[var(--border)] pt-4 flex items-center justify-between">
+              {checkedAt ? (
+                <p className="text-xs text-[var(--text-muted)]">
+                  Checked at {checkedAt.toLocaleTimeString()}
+                </p>
+              ) : (
+                <span />
+              )}
+              <button
+                onClick={check}
+                disabled={isLoading}
+                className="flex items-center gap-1.5 text-xs text-brand hover:opacity-80 transition-opacity bg-transparent disabled:opacity-40"
+              >
+                <RefreshCw size={12} />
+                Refresh
+              </button>
+            </div>
+          </div>
+
+          <p className="text-center text-xs text-[var(--text-muted)] mt-6">
+            This page checks the Hive API in real time. For incident history, see our{" "}
+            <a
+              href="https://github.com/warlordofmars/hive/issues"
+              className="text-brand no-underline hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub issues
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/StatusPage.test.jsx
+++ b/ui/src/components/StatusPage.test.jsx
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import StatusPage from "./StatusPage.jsx";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("StatusPage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("renders the heading", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: "ok", version: "1.0.0" }),
+    });
+    await act(async () => renderInRouter(<StatusPage />));
+    expect(screen.getByText("Service status")).toBeTruthy();
+  });
+
+  it("shows operational status when health check passes", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: "ok", version: "1.2.3" }),
+    });
+    await act(async () => renderInRouter(<StatusPage />));
+    await waitFor(() =>
+      expect(screen.getByText("All systems operational")).toBeTruthy()
+    );
+    expect(screen.getByText("Version 1.2.3")).toBeTruthy();
+  });
+
+  it("shows error status when health check fails", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    await act(async () => renderInRouter(<StatusPage />));
+    await waitFor(() =>
+      expect(screen.getByText("Service unavailable")).toBeTruthy()
+    );
+  });
+
+  it("shows error status when health returns non-ok HTTP status", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    });
+    await act(async () => renderInRouter(<StatusPage />));
+    await waitFor(() =>
+      expect(screen.getByText("Service unavailable")).toBeTruthy()
+    );
+  });
+
+  it("shows checked-at time after check completes", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: "ok", version: "1.0.0" }),
+    });
+    await act(async () => renderInRouter(<StatusPage />));
+    await waitFor(() => expect(screen.getByText(/Checked at/)).toBeTruthy());
+  });
+
+  it("refresh button triggers a new health check", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: "ok", version: "1.0.0" }),
+    });
+    await act(async () => renderInRouter(<StatusPage />));
+    await waitFor(() => expect(screen.getByText("Refresh")).toBeTruthy());
+    await act(async () => fireEvent.click(screen.getByText("Refresh")));
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders GitHub issues link", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: "ok" }),
+    });
+    await act(async () => renderInRouter(<StatusPage />));
+    expect(screen.getByText("GitHub issues")).toBeTruthy();
+  });
+});

--- a/ui/src/components/UseCasesPage.jsx
+++ b/ui/src/components/UseCasesPage.jsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import { BookOpen, Bot, Share2, Workflow } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import PageLayout from "@/components/PageLayout";
+
+const USE_CASES = [
+  {
+    icon: BookOpen,
+    title: "Remember project context across sessions",
+    body: "Store architecture decisions, conventions, and open questions once. Every new Claude session picks up exactly where you left off — no more re-explaining the same context.",
+    snippet: `remember("auth uses JWT, tokens stored in DynamoDB with 24h TTL")
+remember("all API routes require Bearer token, except /health")`,
+  },
+  {
+    icon: Share2,
+    title: "Share team knowledge with AI agents",
+    body: "One Hive, many agents. Store shared conventions, runbooks, and team decisions so every team member's AI assistant draws from the same pool of knowledge.",
+    snippet: `remember("deploy via 'uv run inv deploy', never push directly to main")
+remember("on-call rotation: Mon–Wed Alice, Thu–Fri Bob")`,
+  },
+  {
+    icon: Bot,
+    title: "Persistent preferences and instructions",
+    body: "Store how you like to work — preferred code style, tone, output format — and every session with every MCP-compatible client respects those preferences automatically.",
+    snippet: `remember("always use TypeScript strict mode")
+remember("responses should be concise, no preamble")`,
+  },
+  {
+    icon: Workflow,
+    title: "Cross-tool memory for automated workflows",
+    body: "Connect multiple AI tools to the same memory store. A workflow running in Cursor can leave context that a Claude Code session picks up — seamless handoffs across tools.",
+    snippet: `remember("migration v42 is pending, run after PR #108 merges")
+recall("pending migrations")`,
+  },
+];
+
+function CodeSnippet({ code }) {
+  return (
+    <pre className="mt-4 rounded-lg bg-navy text-white/85 text-xs leading-relaxed p-4 overflow-x-auto">
+      <code>{code}</code>
+    </pre>
+  );
+}
+
+export default function UseCasesPage() {
+  const navigate = useNavigate();
+
+  return (
+    <PageLayout>
+      {/* Header */}
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">What can you do with Hive?</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[560px] mx-auto leading-relaxed">
+            Persistent memory unlocks a new class of AI workflows. Here are a few ways teams are using it today.
+          </p>
+        </div>
+      </section>
+
+      {/* Use cases */}
+      <section className="py-20 px-8">
+        <div className="max-w-[1100px] mx-auto flex flex-col gap-16">
+          {USE_CASES.map((uc) => (
+            <div key={uc.title} className="grid grid-cols-1 gap-8 md:grid-cols-2 md:gap-16 items-start">
+              <div>
+                <div className="mb-4">
+                  <uc.icon size={32} color="#e8a020" />
+                </div>
+                <h2 className="text-xl font-bold mb-3">{uc.title}</h2>
+                <p className="text-[var(--text-muted)] text-sm leading-relaxed">{uc.body}</p>
+              </div>
+              <CodeSnippet code={uc.snippet} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 px-8 text-center border-t border-[var(--border)]">
+        <div className="max-w-[480px] mx-auto">
+          <h2 className="text-2xl font-bold mb-4">Ready to give your agents a memory?</h2>
+          <p className="text-[var(--text-muted)] text-sm mb-8 leading-relaxed">
+            Free to use. No credit card. Works with any MCP-compatible client.
+          </p>
+          <Button variant="brand" size="lg" onClick={() => navigate("/app")}>
+            Get started free →
+          </Button>
+        </div>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/UseCasesPage.test.jsx
+++ b/ui/src/components/UseCasesPage.test.jsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import UseCasesPage from "./UseCasesPage.jsx";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("UseCasesPage", () => {
+  it("renders the heading", async () => {
+    await act(async () => renderInRouter(<UseCasesPage />));
+    expect(screen.getByText(/What can you do with Hive/)).toBeTruthy();
+  });
+
+  it("renders all use case titles", async () => {
+    await act(async () => renderInRouter(<UseCasesPage />));
+    expect(screen.getByText(/Remember project context/)).toBeTruthy();
+    expect(screen.getByText(/Share team knowledge/)).toBeTruthy();
+    expect(screen.getByText(/Persistent preferences/)).toBeTruthy();
+    expect(screen.getByText(/Cross-tool memory/)).toBeTruthy();
+  });
+
+  it("renders code snippets", async () => {
+    const { container } = await act(async () => renderInRouter(<UseCasesPage />));
+    const snippets = container.querySelectorAll("pre");
+    expect(snippets.length).toBe(4);
+  });
+
+  it("renders CTA button", async () => {
+    await act(async () => renderInRouter(<UseCasesPage />));
+    expect(screen.getByText(/Get started free/)).toBeTruthy();
+  });
+
+  it("CTA navigates to /app", async () => {
+    await act(async () => renderInRouter(<UseCasesPage />));
+    fireEvent.click(screen.getByText(/Get started free →/));
+    expect(mockNavigate).toHaveBeenCalledWith("/app");
+  });
+});

--- a/ui/src/components/ui/button.jsx
+++ b/ui/src/components/ui/button.jsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-navy text-white hover:opacity-90",
+        brand:
+          "bg-brand text-white hover:bg-brand-light",
+        outline:
+          "border border-white/30 bg-transparent text-white/80 hover:text-white hover:border-white/50",
+        ghost:
+          "bg-transparent hover:bg-white/10 text-white/75 hover:text-white",
+        danger:
+          "bg-red-600 text-white hover:opacity-90",
+        secondary:
+          "border border-[var(--border)] bg-transparent text-[var(--text)] hover:bg-[var(--surface)]",
+      },
+      size: {
+        default: "px-4 py-2",
+        sm:      "px-3 py-1.5 text-xs",
+        lg:      "px-9 py-3.5 text-base font-semibold rounded-lg",
+        icon:    "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+function Button({ className, variant, size, asChild = false, ...props }) {
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/ui/src/components/ui/button.test.jsx
+++ b/ui/src/components/ui/button.test.jsx
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Button } from "./button";
+
+describe("Button", () => {
+  it("renders children", () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByText("Click me")).toBeTruthy();
+  });
+
+  it("calls onClick when clicked", () => {
+    const handler = vi.fn();
+    render(<Button onClick={handler}>Go</Button>);
+    fireEvent.click(screen.getByText("Go"));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("is disabled when disabled prop set", () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByText("Disabled").closest("button")).toBeDisabled();
+  });
+
+  it("renders as Slot when asChild is true", () => {
+    render(
+      <Button asChild>
+        <a href="/test">Link button</a>
+      </Button>
+    );
+    const link = screen.getByText("Link button");
+    expect(link.tagName.toLowerCase()).toBe("a");
+  });
+
+  it("applies variant classes", () => {
+    const { container } = render(<Button variant="brand">Brand</Button>);
+    expect(container.firstChild.className).toContain("bg-brand");
+  });
+
+  it("applies size classes", () => {
+    const { container } = render(<Button size="lg">Large</Button>);
+    expect(container.firstChild.className).toContain("px-9");
+  });
+
+  it("merges custom className", () => {
+    const { container } = render(<Button className="custom-class">Custom</Button>);
+    expect(container.firstChild.className).toContain("custom-class");
+  });
+
+  it("renders all variants without error", () => {
+    const variants = ["default", "brand", "outline", "ghost", "danger", "secondary"];
+    variants.forEach((variant) => {
+      const { unmount } = render(<Button variant={variant}>{variant}</Button>);
+      expect(screen.getByText(variant)).toBeTruthy();
+      unmount();
+    });
+  });
+
+  it("renders all sizes without error", () => {
+    const sizes = ["default", "sm", "lg", "icon"];
+    sizes.forEach((size) => {
+      const { unmount } = render(<Button size={size}>{size}</Button>);
+      expect(screen.getByText(size)).toBeTruthy();
+      unmount();
+    });
+  });
+});

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,5 +1,20 @@
 @import "tailwindcss";
 
+/* ============================================================
+   Brand colour tokens — match VitePress docs theme exactly
+   ============================================================ */
+@theme {
+  /* Orange — #e8a020 primary, matching docs site --vp-c-brand-1 */
+  --color-brand:       #e8a020;
+  --color-brand-light: #f5a623;
+  --color-brand-dark:  #d4891a;
+
+  /* Navy — #1a1a2e, matching docs site navbar */
+  --color-navy:      #1a1a2e;
+  --color-navy-mid:  #16213e;
+  --color-navy-deep: #0f3460;
+}
+
 :root {
   --bg: #ffffff;
   --surface: #f9f9f9;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -43,7 +43,9 @@
   --radius: 6px;
 }
 
-* { box-sizing: border-box; margin: 0; padding: 0; }
+/* box-sizing / margin / padding reset is handled by Tailwind's @layer base preflight.
+   Duplicating it here as unlayered CSS overrides @layer utilities (CSS Cascade Level 5),
+   breaking mx-auto, padding utilities, and margin utilities across the app. */
 
 body {
   background: var(--bg);

--- a/ui/src/lib/utils.js
+++ b/ui/src/lib/utils.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}

--- a/ui/src/lib/utils.test.js
+++ b/ui/src/lib/utils.test.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { describe, expect, it } from "vitest";
+import { cn } from "./utils";
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("handles conditional classes", () => {
+    expect(cn("foo", false && "bar", "baz")).toBe("foo baz");
+  });
+
+  it("merges conflicting Tailwind classes, keeping last", () => {
+    expect(cn("bg-red-500", "bg-blue-500")).toBe("bg-blue-500");
+  });
+
+  it("handles undefined and null gracefully", () => {
+    expect(cn("foo", undefined, null)).toBe("foo");
+  });
+});

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,9 +1,15 @@
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import path from "path";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   server: {
     port: 5173,
     proxy: {

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -2,12 +2,28 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import fs from "fs";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/** Vite plugin that resolves ?raw imports for files outside the project root. */
+function rawOutsideRoot() {
+  return {
+    name: "raw-outside-root",
+    load(id) {
+      if (!id.endsWith("?raw")) return;
+      const filePath = id.slice(0, -4); // strip ?raw
+      if (fs.existsSync(filePath)) {
+        const content = fs.readFileSync(filePath, "utf-8");
+        return `export default ${JSON.stringify(content)}`;
+      }
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [rawOutsideRoot(), react(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -2,6 +2,9 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],


### PR DESCRIPTION
## v0.16.0

### Added

- Marketing site expanded with Pricing, FAQ, Use Cases, MCP Client Compatibility, Changelog, and Status pages (#231, #232, #234)
- Shared `PageLayout` component with consistent header/footer nav across all marketing pages (#231)
- `ChangelogPage` parses `CHANGELOG.md` at build time and renders versioned sections with color-coded change groups (#234)
- `StatusPage` performs a live health check against `GET /health` with refresh and checked-at time display (#234)
- shadcn/ui component foundation with Tailwind v4 design tokens matching VitePress docs site branding (#228)

### Fixed

- Tailwind utility classes (`mx-auto`) overridden by unlayered CSS reset — moved reset into `@layer base` (#229)
- Flash of light background on dark-mode page load — synchronous inline theme script applied before first paint (#230)
- E2e mobile menu toggle test replaced fixed 300ms wait with condition-based `wait_for` (#235)

🤖 Generated with [Claude Code](https://claude.com/claude-code)