### PR TITLE
feat: integrate Google Analytics 4 on marketing site and UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,8 @@ jobs:
 
       - name: Build React UI
         working-directory: ui
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: npm install && npm run build
 
       - name: Build docs site
@@ -673,6 +675,8 @@ jobs:
 
       - name: Build React UI
         working-directory: ui
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: npm install && npm run build
 
       - name: Build docs site

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Build React UI
         working-directory: ui
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: npm install && npm run build
 
       - name: Build docs site

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,22 @@
     <meta property="og:title" content="Hive — Shared Memory for Claude Agents" />
     <meta property="og:description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
     <meta property="og:image" content="https://hive.warlordofmars.net/social-preview.png" />
+    <!-- Google Analytics 4 — only injected when VITE_GA_MEASUREMENT_ID is set at build time -->
+    <script>
+      (function () {
+        var id = "%VITE_GA_MEASUREMENT_ID%";
+        if (!id) return;
+        var s = document.createElement("script");
+        s.src = "https://www.googletagmanager.com/gtag/js?id=" + id;
+        s.async = true;
+        document.head.appendChild(s);
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { window.dataLayer.push(arguments); }
+        window.gtag = gtag;
+        gtag("js", new Date());
+        gtag("config", id, { send_page_view: false });
+      })();
+    </script>
     <!-- Set theme before first paint to prevent flash of wrong background colour -->
     <script>
       (function () {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useEffect, useState } from "react";
-import { BrowserRouter, Navigate, Route, Routes, useNavigate } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { trackEvent, trackPageView } from "./analytics.js";
 import { api } from "./api.js";
 import ActivityLog from "./components/ActivityLog.jsx";
 import AuthCallback from "./components/AuthCallback.jsx";
@@ -52,6 +53,11 @@ function signOut() {
 
 function AppShell() {
   const [tab, setTab] = useState("memories");
+
+  function switchTab(id) {
+    setTab(id);
+    trackEvent("tab_view", { tab_name: id });
+  }
   const [version, setVersion] = useState(null);
   const navigate = useNavigate();
   const { theme, toggle } = useTheme();
@@ -107,7 +113,7 @@ function AppShell() {
           {tabs.map((t) => (
             <button
               key={t.id}
-              onClick={() => setTab(t.id)}
+              onClick={() => switchTab(t.id)}
               style={{
                 background: tab === t.id ? "rgba(255,255,255,.15)" : "transparent",
                 color: "#fff",
@@ -198,10 +204,19 @@ function HomeRoute() {
   return <HomePage />;
 }
 
+function RouteTracker() {
+  const location = useLocation();
+  useEffect(() => {
+    trackPageView(location.pathname);
+  }, [location.pathname]);
+  return null;
+}
+
 export default function App() {
   useTheme(); // apply data-theme to <html> for all routes
   return (
     <BrowserRouter>
+      <RouteTracker />
       <Routes>
         <Route path="/" element={<HomeRoute />} />
         <Route path="/pricing" element={<PricingPage />} />

--- a/ui/src/analytics.js
+++ b/ui/src/analytics.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+
+/**
+ * Thin wrapper around gtag. All functions are no-ops when:
+ *   - running in local dev (import.meta.env.DEV)
+ *   - VITE_GA_MEASUREMENT_ID is not set
+ */
+
+const ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
+const enabled = !import.meta.env.DEV && !!ID;
+
+export function trackPageView(path) {
+  if (!enabled) return;
+  window.gtag?.("event", "page_view", {
+    page_path: path,
+    send_to: ID,
+  });
+}
+
+export function trackEvent(name, params = {}) {
+  if (!enabled) return;
+  window.gtag?.("event", name, { ...params, send_to: ID });
+}

--- a/ui/src/analytics.test.js
+++ b/ui/src/analytics.test.js
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We need to re-import the module with different env conditions, so we use
+// vi.doMock / vi.importActual patterns with module resetting.
+
+describe("analytics (GA disabled — DEV mode or no ID)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.gtag = vi.fn();
+  });
+
+  afterEach(() => {
+    delete window.gtag;
+  });
+
+  it("trackPageView is a no-op when DEV=true", async () => {
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    const { trackPageView } = await import("./analytics.js");
+    trackPageView("/test");
+    expect(window.gtag).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it("trackEvent is a no-op when DEV=true", async () => {
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    const { trackEvent } = await import("./analytics.js");
+    trackEvent("cta_click", { cta_location: "hero" });
+    expect(window.gtag).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it("trackPageView is a no-op when no measurement ID", async () => {
+    vi.stubEnv("DEV", false);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "");
+    const { trackPageView } = await import("./analytics.js");
+    trackPageView("/test");
+    expect(window.gtag).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it("trackEvent is a no-op when no measurement ID", async () => {
+    vi.stubEnv("DEV", false);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "");
+    const { trackEvent } = await import("./analytics.js");
+    trackEvent("tab_view", { tab_name: "memories" });
+    expect(window.gtag).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("analytics (GA enabled — production with ID)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("DEV", false);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    window.gtag = vi.fn();
+  });
+
+  afterEach(() => {
+    delete window.gtag;
+    vi.unstubAllEnvs();
+  });
+
+  it("trackPageView calls gtag with page_view event", async () => {
+    const { trackPageView } = await import("./analytics.js");
+    trackPageView("/pricing");
+    expect(window.gtag).toHaveBeenCalledWith("event", "page_view", {
+      page_path: "/pricing",
+      send_to: "G-TEST123",
+    });
+  });
+
+  it("trackEvent calls gtag with the given event name and params", async () => {
+    const { trackEvent } = await import("./analytics.js");
+    trackEvent("cta_click", { cta_location: "hero" });
+    expect(window.gtag).toHaveBeenCalledWith("event", "cta_click", {
+      cta_location: "hero",
+      send_to: "G-TEST123",
+    });
+  });
+
+  it("trackEvent works with no params", async () => {
+    const { trackEvent } = await import("./analytics.js");
+    trackEvent("tab_view");
+    expect(window.gtag).toHaveBeenCalledWith("event", "tab_view", {
+      send_to: "G-TEST123",
+    });
+  });
+
+  it("trackPageView is a no-op when window.gtag is not defined", async () => {
+    delete window.gtag;
+    const { trackPageView } = await import("./analytics.js");
+    expect(() => trackPageView("/test")).not.toThrow();
+  });
+
+  it("trackEvent is a no-op when window.gtag is not defined", async () => {
+    delete window.gtag;
+    const { trackEvent } = await import("./analytics.js");
+    expect(() => trackEvent("cta_click")).not.toThrow();
+  });
+});

--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -4,6 +4,7 @@ import { BrainCircuit, Plug, ShieldCheck, Users } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import PageLayout from "@/components/PageLayout";
+import { trackEvent } from "@/analytics.js";
 
 const FEATURES = [
   {
@@ -49,6 +50,11 @@ const HOW_IT_WORKS = [
 export default function HomePage() {
   const navigate = useNavigate();
 
+  function handleCta(location) {
+    trackEvent("cta_click", { cta_location: location });
+    navigate("/app");
+  }
+
   return (
     <PageLayout>
       {/* Hero */}
@@ -67,7 +73,7 @@ export default function HomePage() {
           Hive gives your AI agents a shared, durable memory store via the Model Context
           Protocol — works with Claude Code, Cursor, Continue, and any MCP-compatible client.
         </p>
-        <Button variant="brand" size="lg" onClick={() => navigate("/app")}>
+        <Button variant="brand" size="lg" onClick={() => handleCta("hero")}>
           Get started free →
         </Button>
         <p className="mt-4 text-white/45 text-[13px]">No credit card required</p>
@@ -116,7 +122,7 @@ export default function HomePage() {
             ))}
           </div>
           <div className="text-center mt-14">
-            <Button variant="brand" size="lg" onClick={() => navigate("/app")}>
+            <Button variant="brand" size="lg" onClick={() => handleCta("how_it_works")}>
               Get started free →
             </Button>
           </div>


### PR DESCRIPTION
## Summary

- `analytics.js` — thin gtag wrapper; all calls are no-ops in dev (`import.meta.env.DEV`) or when `VITE_GA_MEASUREMENT_ID` is unset
- `index.html` — lazily appends the gtag script tag only when the ID is injected at build time; no script loaded in dev
- `App.jsx` — `RouteTracker` component fires `page_view` on every SPA route change; `AppShell` fires `tab_view` on tab switches via `switchTab()`
- `HomePage.jsx` — fires `cta_click` (`cta_location: hero` / `how_it_works`) on "Get started" button clicks
- CI/CD — `VITE_GA_MEASUREMENT_ID` secret passed to all deploy-time React UI build steps (dev + prod)
- `VITE_GA_MEASUREMENT_ID` repo secret set in GitHub

## Test plan

- [x] 265 JS tests, 100% coverage
- [x] Pre-push hook passed
- [ ] Verify GA4 events appear in Google Analytics realtime report after deploy

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)