### PR TITLE
fix: pass VITE_GA_MEASUREMENT_ID to inv deploy steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,8 @@ jobs:
         run: npm install && npm run build
 
       - name: Deploy dev stack
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: uv run inv deploy --env dev
 
       - name: Export stack URLs
@@ -686,6 +688,7 @@ jobs:
       - name: Deploy prod stack
         env:
           APP_VERSION: ${{ needs.release.outputs.version }}
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: uv run inv deploy --env prod
 
       - name: Export stack URLs

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,4 +46,6 @@ jobs:
         run: npm install && npm run build
 
       - name: Deploy
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: uv run inv deploy --env dev


### PR DESCRIPTION
## Summary

The `inv deploy` task rebuilds the React UI itself before running CDK deploy. The separate "Build React UI" CI step runs with the env var but that build is discarded — `inv deploy` rebuilds from scratch without the var, so `%VITE_GA_MEASUREMENT_ID%` was never substituted in the deployed `index.html`.

Fix: add `VITE_GA_MEASUREMENT_ID` to the env of the deploy steps (not just the build steps) in both `ci.yml` and `deploy-dev.yml`.

## Test plan

- [x] Pre-push hook passed
- [ ] Verify `G-NH1PX6TW4E` appears in deployed `index.html` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)