### PR TITLE
release: v0.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,8 @@ jobs:
         run: npm install && npm run build
 
       - name: Deploy dev stack
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: uv run inv deploy --env dev
 
       - name: Export stack URLs
@@ -686,6 +688,7 @@ jobs:
       - name: Deploy prod stack
         env:
           APP_VERSION: ${{ needs.release.outputs.version }}
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: uv run inv deploy --env prod
 
       - name: Export stack URLs

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,4 +46,6 @@ jobs:
         run: npm install && npm run build
 
       - name: Deploy
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: uv run inv deploy --env dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Hive are documented here. Releases correspond to GitHub t
 
 See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) for full release notes generated from merged PRs.
 
+## v0.17.1 — 2026-04-10
+
+### Fixed
+
+- Pass `VITE_GA_MEASUREMENT_ID` to `inv deploy` steps so GA4 tag is correctly substituted in deployed `index.html` (#243)
+
 ## v0.17.0 — 2026-04-09
 
 ### Added


### PR DESCRIPTION
## v0.17.1

### Fixed

- Pass `VITE_GA_MEASUREMENT_ID` to `inv deploy` steps so GA4 tag is correctly substituted in deployed `index.html` (#243)

🤖 Generated with [Claude Code](https://claude.com/claude-code)