### PR TITLE
fix(ci): add npm cache to deploy jobs to prevent lightningcss miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/package.json
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
@@ -662,6 +664,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/package.json
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/package.json
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4


### PR DESCRIPTION
## Summary

- Deploy jobs were missing `cache: "npm"` on `setup-node`, causing optional platform-specific packages (`lightningcss-linux-x64-gnu`) to be silently skipped when the npm registry has a transient failure
- The `frontend` CI job already had this cache configured; this PR aligns all deploy jobs to match
- Affected: `Deploy (dev)`, `Deploy (prod)` in `ci.yml` and `deploy-dev.yml`

**Root cause**: `lightningcss` lists its native binaries as `optional: true`. When npm fails to download an optional package (e.g., registry timeout), it silently skips it. With the npm cache warm from a previous run, the binary is already present and the build succeeds — explaining why this was intermittent.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)