### PR TITLE
feat(ui): app shell polish — Lucide icons, orange tab indicator, changelog footer link

### DIFF
--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -180,20 +180,21 @@ def _get_cost_data() -> dict[str, Any]:
     # Last 6 full months + current month
     start_date = (today.replace(day=1) - datetime.timedelta(days=6 * 30)).replace(day=1)
 
+    _tag_filter = {"Tags": {"Key": "project", "Values": ["hive"], "MatchOptions": ["EQUALS"]}}
+
     try:
-        resp = ce.get_cost_and_usage(
-            TimePeriod={
-                "Start": start_date.isoformat(),
-                "End": today.isoformat(),
-            },
+        monthly_resp = ce.get_cost_and_usage(
+            TimePeriod={"Start": start_date.isoformat(), "End": today.isoformat()},
             Granularity="MONTHLY",
-            Filter={
-                "Tags": {
-                    "Key": "project",
-                    "Values": ["hive"],
-                    "MatchOptions": ["EQUALS"],
-                }
-            },
+            Filter=_tag_filter,
+            GroupBy=[{"Type": "DIMENSION", "Key": "SERVICE"}],
+            Metrics=["UnblendedCost"],
+        )
+        daily_start = (today - datetime.timedelta(days=30)).isoformat()
+        daily_resp = ce.get_cost_and_usage(
+            TimePeriod={"Start": daily_start, "End": today.isoformat()},
+            Granularity="DAILY",
+            Filter=_tag_filter,
             GroupBy=[{"Type": "DIMENSION", "Key": "SERVICE"}],
             Metrics=["UnblendedCost"],
         )
@@ -201,7 +202,7 @@ def _get_cost_data() -> dict[str, Any]:
         raise HTTPException(status_code=502, detail=f"Cost Explorer error: {exc}") from exc
 
     monthly: list[dict[str, Any]] = []
-    for result in resp.get("ResultsByTime", []):
+    for result in monthly_resp.get("ResultsByTime", []):
         period = result["TimePeriod"]["Start"]
         by_service = {
             g["Keys"][0]: float(g["Metrics"]["UnblendedCost"]["Amount"])
@@ -210,9 +211,19 @@ def _get_cost_data() -> dict[str, Any]:
         total = sum(by_service.values())
         monthly.append({"period": period, "total": round(total, 4), "by_service": by_service})
 
+    daily: list[dict[str, Any]] = []
+    for result in daily_resp.get("ResultsByTime", []):
+        day = result["TimePeriod"]["Start"]
+        total = sum(
+            float(g["Metrics"]["UnblendedCost"]["Amount"]) for g in result.get("Groups", [])
+        )
+        if total > 0:
+            daily.append({"date": day, "total": round(total, 6)})
+
     data: dict[str, Any] = {
         "environment": ENVIRONMENT,
         "monthly": monthly,
+        "daily": daily,
         "currency": "USD",
         "note": "Cost data lags ~24 h. Cached for 24 h.",
     }

--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -36,9 +36,11 @@ async def get_stats(
     events_today = storage.get_events_for_date(today.isoformat())
     events_7 = storage.get_events_for_dates(last_7, limit=10000)
 
+    is_admin = claims.get("role") == "admin"
     return StatsResponse(
         total_memories=storage.count_memories(owner_user_id=owner_user_id),
         total_clients=storage.count_clients(owner_user_id=owner_user_id),
+        total_users=storage.count_users() if is_admin else None,
         events_today=len(events_today),
         events_last_7_days=len(events_7),
     )

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -545,6 +545,7 @@ class TokenResponse(BaseModel):
 class StatsResponse(BaseModel):
     total_memories: int
     total_clients: int
+    total_users: int | None = None  # admin only
     events_today: int
     events_last_7_days: int
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -561,6 +561,14 @@ class HiveStorage:
         )
         return resp.get("Count", 0)
 
+    def count_users(self) -> int:
+        resp = self.table.scan(
+            Select="COUNT",
+            FilterExpression="SK = :sk AND begins_with(PK, :prefix)",
+            ExpressionAttributeValues={":sk": "META", ":prefix": "USER#"},
+        )
+        return resp.get("Count", 0)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/tests/unit/test_admin_api.py
+++ b/tests/unit/test_admin_api.py
@@ -84,8 +84,8 @@ def _make_cw_response(metric_ids: list[str]) -> dict:
     }
 
 
-def _make_ce_response() -> dict:
-    """Build a minimal Cost Explorer GetCostAndUsage response."""
+def _make_ce_monthly_response() -> dict:
+    """Build a minimal Cost Explorer monthly GetCostAndUsage response."""
     return {
         "ResultsByTime": [
             {
@@ -103,6 +103,28 @@ def _make_ce_response() -> dict:
             }
         ]
     }
+
+
+def _make_ce_daily_response() -> dict:
+    """Build a minimal Cost Explorer daily GetCostAndUsage response."""
+    return {
+        "ResultsByTime": [
+            {
+                "TimePeriod": {"Start": "2026-04-01", "End": "2026-04-02"},
+                "Groups": [
+                    {
+                        "Keys": ["AWS Lambda"],
+                        "Metrics": {"UnblendedCost": {"Amount": "0.0200", "Unit": "USD"}},
+                    },
+                ],
+            }
+        ]
+    }
+
+
+def _make_ce_response() -> dict:
+    """Back-compat alias — returns monthly response (used by CW tests that don't check costs)."""
+    return _make_ce_monthly_response()
 
 
 @pytest.fixture()
@@ -236,10 +258,18 @@ class TestAdminCosts:
 
         admin_mod._cost_cache.clear()
 
+    def _mock_ce(self, mock_ce, repeats=1):
+        """Set side_effect to return monthly then daily responses, repeated N times."""
+        responses = []
+        for _ in range(repeats):
+            responses.append(_make_ce_monthly_response())
+            responses.append(_make_ce_daily_response())
+        mock_ce.get_cost_and_usage.side_effect = responses
+
     def test_returns_cost_data(self, admin_tc):
         with patch("hive.api.admin._ce_client") as mock_ce_factory:
             mock_ce = MagicMock()
-            mock_ce.get_cost_and_usage.return_value = _make_ce_response()
+            self._mock_ce(mock_ce)
             mock_ce_factory.return_value = mock_ce
 
             resp = admin_tc.get("/api/admin/costs")
@@ -251,6 +281,10 @@ class TestAdminCosts:
         assert body["monthly"][0]["period"] == "2026-03-01"
         assert body["monthly"][0]["total"] == pytest.approx(0.62, abs=0.01)
         assert "AWS Lambda" in body["monthly"][0]["by_service"]
+        assert "daily" in body
+        assert len(body["daily"]) == 1
+        assert body["daily"][0]["date"] == "2026-04-01"
+        assert body["daily"][0]["total"] == pytest.approx(0.02, abs=0.001)
 
     def test_non_admin_gets_403(self, user_tc):
         resp = user_tc.get("/api/admin/costs")
@@ -259,19 +293,19 @@ class TestAdminCosts:
     def test_cache_is_used_on_second_call(self, admin_tc):
         with patch("hive.api.admin._ce_client") as mock_ce_factory:
             mock_ce = MagicMock()
-            mock_ce.get_cost_and_usage.return_value = _make_ce_response()
+            self._mock_ce(mock_ce)
             mock_ce_factory.return_value = mock_ce
 
             admin_tc.get("/api/admin/costs")
             admin_tc.get("/api/admin/costs")
 
-            # CE should only be called once — second hit uses cache
-            assert mock_ce.get_cost_and_usage.call_count == 1
+            # CE makes 2 calls (monthly + daily) on first request; second uses cache
+            assert mock_ce.get_cost_and_usage.call_count == 2
 
     def test_cache_expires_after_ttl(self, admin_tc):
         with patch("hive.api.admin._ce_client") as mock_ce_factory:
             mock_ce = MagicMock()
-            mock_ce.get_cost_and_usage.return_value = _make_ce_response()
+            self._mock_ce(mock_ce, repeats=2)
             mock_ce_factory.return_value = mock_ce
 
             admin_tc.get("/api/admin/costs")
@@ -284,12 +318,13 @@ class TestAdminCosts:
             admin_mod._cost_cache[env] = (ts - admin_mod._COST_CACHE_TTL - 1, data)
 
             admin_tc.get("/api/admin/costs")
-            assert mock_ce.get_cost_and_usage.call_count == 2
+            # 2 CE calls per request × 2 requests = 4
+            assert mock_ce.get_cost_and_usage.call_count == 4
 
     def test_note_and_environment_in_response(self, admin_tc):
         with patch("hive.api.admin._ce_client") as mock_ce_factory:
             mock_ce = MagicMock()
-            mock_ce.get_cost_and_usage.return_value = _make_ce_response()
+            self._mock_ce(mock_ce)
             mock_ce_factory.return_value = mock_ce
 
             resp = admin_tc.get("/api/admin/costs")

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -444,7 +444,10 @@ class TestStats:
         tc, *_ = admin_client
         resp = tc.get("/api/stats")
         assert resp.status_code == 200
-        assert "total_memories" in resp.json()
+        data = resp.json()
+        assert "total_memories" in data
+        assert "total_users" in data
+        assert isinstance(data["total_users"], int)
 
     def test_get_activity_default(self, client):
         tc, *_ = client

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -341,6 +341,14 @@ class TestListAllAndCounts:
         storage.put_client(OAuthClient(client_name="B"))
         assert storage.count_clients() == 2
 
+    def test_count_users(self, storage):
+        assert storage.count_users() == 0
+        from hive.models import User
+
+        storage.put_user(User(email="a@x.com", display_name="A"))
+        storage.put_user(User(email="b@x.com", display_name="B"))
+        assert storage.count_users() == 2
+
 
 # ---------------------------------------------------------------------------
 # Pagination

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useEffect, useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { Moon, Sun } from "lucide-react";
 import { trackEvent, trackPageView } from "./analytics.js";
 import { api } from "./api.js";
 import ActivityLog from "./components/ActivityLog.jsx";
@@ -115,11 +116,12 @@ function AppShell() {
               key={t.id}
               onClick={() => switchTab(t.id)}
               style={{
-                background: tab === t.id ? "rgba(255,255,255,.15)" : "transparent",
+                background: "transparent",
                 color: "#fff",
                 borderRadius: 6,
                 padding: "6px 14px",
                 fontSize: 14,
+                borderBottom: tab === t.id ? "2px solid #e8a020" : "2px solid transparent",
               }}
             >
               {t.label}
@@ -166,7 +168,7 @@ function AppShell() {
           }}
           aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
         >
-          {theme === "dark" ? "☀" : "☾"}
+          {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
         </button>
       </header>
 
@@ -189,7 +191,14 @@ function AppShell() {
             borderTop: "1px solid #eee",
           }}
         >
-          Hive {version}
+          <a
+            href="/changelog"
+            style={{ color: "inherit", textDecoration: "none" }}
+            onMouseOver={(e) => (e.target.style.textDecoration = "underline")}
+            onMouseOut={(e) => (e.target.style.textDecoration = "none")}
+          >
+            Hive {version}
+          </a>
         </footer>
       )}
     </div>

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -333,14 +333,28 @@ describe("AppShell", () => {
     await act(async () => render(<App />));
     const toggle = screen.getByRole("button", { name: /switch to dark mode/i });
     expect(toggle).toBeTruthy();
-    expect(toggle.textContent).toBe("☾");
+    // icon is now a Lucide SVG — no text content
+    expect(toggle.querySelector("svg")).toBeTruthy();
   });
 
-  it("clicking dark mode toggle changes aria-label and icon", async () => {
+  it("clicking dark mode toggle changes aria-label", async () => {
     await act(async () => render(<App />));
     const toggle = screen.getByRole("button", { name: /switch to dark mode/i });
     fireEvent.click(toggle);
-    const toggled = screen.getByRole("button", { name: /switch to light mode/i });
-    expect(toggled.textContent).toBe("☀");
+    expect(screen.getByRole("button", { name: /switch to light mode/i })).toBeTruthy();
+  });
+
+  it("active tab has orange bottom border", async () => {
+    await act(async () => render(<App />));
+    const memoriesBtn = screen.getByText("Memories");
+    expect(memoriesBtn.style.borderBottom).toContain("rgb(232, 160, 32)");
+  });
+
+  it("version in footer links to /changelog", async () => {
+    await act(async () => render(<App />));
+    await waitFor(() => expect(screen.getByText("Hive 1.2.3")).toBeTruthy());
+    const link = screen.getByText("Hive 1.2.3").closest("a");
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("href")).toBe("/changelog");
   });
 });

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -357,4 +357,14 @@ describe("AppShell", () => {
     expect(link).toBeTruthy();
     expect(link.getAttribute("href")).toBe("/changelog");
   });
+
+  it("footer changelog link underlines on hover and resets on mouse out", async () => {
+    await act(async () => render(<App />));
+    await waitFor(() => expect(screen.getByText("Hive 1.2.3")).toBeTruthy());
+    const link = screen.getByText("Hive 1.2.3").closest("a");
+    fireEvent.mouseOver(link);
+    expect(link.style.textDecoration).toBe("underline");
+    fireEvent.mouseOut(link);
+    expect(link.style.textDecoration).toBe("none");
+  });
 });

--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -71,7 +71,7 @@ function buildCostSeries(monthly) {
 }
 
 function buildDailyCostSeries(daily) {
-  return (daily ?? []).map((d) => ({ date: d.date, total: d.total }));
+  return daily.map((d) => ({ date: d.date, total: d.total }));
 }
 
 function collectServices(monthly) {
@@ -114,6 +114,16 @@ export function CustomTooltip({ active, payload, label }) {
           <span style={{ fontWeight: 600 }}>{p.value}</span>
         </div>
       ))}
+    </div>
+  );
+}
+
+export function CustomDailyCostTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 8, padding: "10px 14px", fontSize: 12, color: "var(--text)" }}>
+      <div style={{ fontWeight: 600, marginBottom: 4, color: "var(--text-muted)" }}>{label}</div>
+      <div style={{ fontWeight: 600 }}>{formatCostTooltip(payload[0].value)}</div>
     </div>
   );
 }
@@ -499,17 +509,7 @@ export default function Dashboard() {
               height={40}
             />
             <YAxis tick={{ fontSize: 11, fill: "var(--text-muted)" }} tickFormatter={formatCostTick} />
-            <Tooltip
-              content={({ active, payload, label }) => {
-                if (!active || !payload?.length) return null;
-                return (
-                  <div style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 8, padding: "10px 14px", fontSize: 12, color: "var(--text)" }}>
-                    <div style={{ fontWeight: 600, marginBottom: 4, color: "var(--text-muted)" }}>{label}</div>
-                    <div style={{ fontWeight: 600 }}>{formatCostTooltip(payload[0].value)}</div>
-                  </div>
-                );
-              }}
-            />
+            <Tooltip content={<CustomDailyCostTooltip />} />
             <Area
               type="monotone"
               dataKey="total"

--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -70,6 +70,10 @@ function buildCostSeries(monthly) {
   return monthly.map((m) => ({ month: m.period.slice(0, 7), ...m.by_service }));
 }
 
+function buildDailyCostSeries(daily) {
+  return (daily ?? []).map((d) => ({ date: d.date, total: d.total }));
+}
+
 function collectServices(monthly) {
   const set = new Set();
   for (const m of monthly) Object.keys(m.by_service).forEach((s) => set.add(s));
@@ -85,7 +89,7 @@ export function formatCostTooltip(v) {
 }
 
 // ------------------------------------------------------------------
-// Custom Tooltip
+// Custom Tooltips
 // ------------------------------------------------------------------
 
 export function CustomTooltip({ active, payload, label }) {
@@ -242,7 +246,6 @@ export default function Dashboard() {
   const [stats, setStats] = useState(null);
   const [metrics, setMetrics] = useState(null);
   const [costs, setCosts] = useState(null);
-  const [userCount, setUserCount] = useState(null);
   const [metricsError, setMetricsError] = useState("");
   const [costsError, setCostsError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -256,11 +259,10 @@ export default function Dashboard() {
     setMetricsError("");
     setCostsError("");
 
-    const [statsRes, metricsRes, costsRes, usersRes] = await Promise.allSettled([
+    const [statsRes, metricsRes, costsRes] = await Promise.allSettled([
       api.getStats(),
       api.getMetrics(period),
       api.getCosts(),
-      api.listUsers({ limit: 1 }),
     ]);
 
     if (statsRes.status === "fulfilled") setStats(statsRes.value);
@@ -268,7 +270,6 @@ export default function Dashboard() {
     else setMetricsError(metricsRes.reason?.message ?? "Failed to load metrics");
     if (costsRes.status === "fulfilled") setCosts(costsRes.value);
     else setCostsError(costsRes.reason?.message ?? "Failed to load costs");
-    if (usersRes.status === "fulfilled") setUserCount(usersRes.value?.total ?? null);
 
     setLastRefreshed(new Date());
     setLoading(false);
@@ -283,6 +284,7 @@ export default function Dashboard() {
   const invData = metrics ? buildInvocationSeries(metrics.metrics ?? {}, TOOLS) : [];
   const latData = metrics ? buildLatencySeries(metrics.metrics ?? {}, TOOLS) : [];
   const costData = costs ? buildCostSeries(costs.monthly ?? []) : [];
+  const dailyCostData = costs ? buildDailyCostSeries(costs.daily ?? []) : [];
   const services = costs ? collectServices(costs.monthly ?? []) : [];
 
   const mtdCost = costs?.monthly?.length
@@ -323,12 +325,13 @@ export default function Dashboard() {
               key={p}
               onClick={() => setPeriod(p)}
               style={{
-                background: period === p ? "#1a1a2e" : "var(--surface)",
-                color: period === p ? "#fff" : "var(--text)",
-                border: "1px solid var(--border)",
+                background: period === p ? "#e8a020" : "var(--surface)",
+                color: period === p ? "#1a1a2e" : "var(--text)",
+                border: period === p ? "1px solid #e8a020" : "1px solid var(--border)",
                 borderRadius: 6,
                 padding: "4px 12px",
                 fontSize: 13,
+                fontWeight: period === p ? 700 : 400,
                 cursor: "pointer",
               }}
             >
@@ -374,7 +377,7 @@ export default function Dashboard() {
         <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
           <StatCard label="Total Memories" value={stats.total_memories} />
           <StatCard label="Total Clients" value={stats.total_clients} />
-          <StatCard label="Total Users" value={userCount} />
+          <StatCard label="Total Users" value={stats.total_users} />
           <StatCard label="Events Today" value={stats.events_today} />
           <StatCard label="Events (7d)" value={stats.events_last_7_days} />
           {mtdCost !== null && (
@@ -390,45 +393,12 @@ export default function Dashboard() {
         <SkeletonBlock height={260} />
       ) : invData.length > 0 ? (
         <ResponsiveContainer width="100%" height={260}>
-          <LineChart data={invData} margin={{ bottom: 10 }}>
-            <defs>
-              <CartesianGrid strokeDasharray="" vertical={false} stroke="var(--border)" />
-            </defs>
-            <CartesianGrid strokeDasharray="" vertical={false} stroke="var(--border)" />
-            <XAxis {...xAxisProps} />
-            <YAxis tick={{ fontSize: 11, fill: "var(--text-muted)" }} />
-            <Tooltip content={<CustomTooltip />} />
-            <Legend wrapperStyle={{ fontSize: 12, color: "var(--text-muted)" }} />
-            {TOOLS.map((t) => (
-              <Line
-                key={t}
-                type="monotone"
-                dataKey={t}
-                stroke={TOOL_COLORS[t]}
-                dot={false}
-                strokeWidth={2}
-                animationDuration={400}
-                activeDot={{ r: 5, strokeWidth: 2 }}
-              />
-            ))}
-          </LineChart>
-        </ResponsiveContainer>
-      ) : !metricsError && (
-        <EmptyState icon={TrendingUp} message="No invocation data for this period." />
-      )}
-
-      {/* Tool Latency p99 */}
-      <SectionHeader title="Tool Latency p99 (ms)" />
-      {loading && !metrics ? (
-        <SkeletonBlock height={220} />
-      ) : latData.length > 0 ? (
-        <ResponsiveContainer width="100%" height={220}>
-          <AreaChart data={latData} margin={{ bottom: 10 }}>
+          <AreaChart data={invData} margin={{ bottom: 10 }}>
             <defs>
               {TOOLS.map((t) => (
-                <linearGradient key={t} id={`grad_${t}`} x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor={TOOL_COLORS[t]} stopOpacity={0.2} />
-                  <stop offset="95%" stopColor={TOOL_COLORS[t]} stopOpacity={0} />
+                <linearGradient key={t} id={`inv_grad_${t}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={TOOL_COLORS[t]} stopOpacity={0.4} />
+                  <stop offset="95%" stopColor={TOOL_COLORS[t]} stopOpacity={0.04} />
                 </linearGradient>
               ))}
             </defs>
@@ -443,7 +413,46 @@ export default function Dashboard() {
                 type="monotone"
                 dataKey={t}
                 stroke={TOOL_COLORS[t]}
-                fill={`url(#grad_${t})`}
+                fill={`url(#inv_grad_${t})`}
+                strokeWidth={2}
+                dot={false}
+                animationDuration={400}
+                activeDot={{ r: 5, strokeWidth: 2 }}
+              />
+            ))}
+          </AreaChart>
+        </ResponsiveContainer>
+      ) : !metricsError && (
+        <EmptyState icon={TrendingUp} message="No invocation data for this period." />
+      )}
+
+      {/* Tool Latency p99 */}
+      <SectionHeader title="Tool Latency p99 (ms)" />
+      {loading && !metrics ? (
+        <SkeletonBlock height={220} />
+      ) : latData.length > 0 ? (
+        <ResponsiveContainer width="100%" height={220}>
+          <AreaChart data={latData} margin={{ bottom: 10 }}>
+            <defs>
+              {TOOLS.map((t) => (
+                <linearGradient key={t} id={`lat_grad_${t}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={TOOL_COLORS[t]} stopOpacity={0.4} />
+                  <stop offset="95%" stopColor={TOOL_COLORS[t]} stopOpacity={0.04} />
+                </linearGradient>
+              ))}
+            </defs>
+            <CartesianGrid strokeDasharray="" vertical={false} stroke="var(--border)" />
+            <XAxis {...xAxisProps} />
+            <YAxis tick={{ fontSize: 11, fill: "var(--text-muted)" }} />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend wrapperStyle={{ fontSize: 12, color: "var(--text-muted)" }} />
+            {TOOLS.map((t) => (
+              <Area
+                key={t}
+                type="monotone"
+                dataKey={t}
+                stroke={TOOL_COLORS[t]}
+                fill={`url(#lat_grad_${t})`}
                 strokeWidth={2}
                 dot={false}
                 animationDuration={400}
@@ -466,9 +475,58 @@ export default function Dashboard() {
         </div>
       )}
 
+      {/* Daily AWS Spend */}
+      <SectionHeader title="Daily AWS Spend (Last 30 Days)" />
+      <ErrorBanner msg={costsError} />
+      {loading && !costs ? (
+        <SkeletonBlock height={200} />
+      ) : dailyCostData.length > 0 ? (
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart data={dailyCostData} margin={{ bottom: 10 }}>
+            <defs>
+              <linearGradient id="daily_cost_grad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#e8a020" stopOpacity={0.4} />
+                <stop offset="95%" stopColor="#e8a020" stopOpacity={0.04} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="" vertical={false} stroke="var(--border)" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 11, fill: "var(--text-muted)" }}
+              interval="preserveStartEnd"
+              angle={-25}
+              textAnchor="end"
+              height={40}
+            />
+            <YAxis tick={{ fontSize: 11, fill: "var(--text-muted)" }} tickFormatter={formatCostTick} />
+            <Tooltip
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null;
+                return (
+                  <div style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 8, padding: "10px 14px", fontSize: 12, color: "var(--text)" }}>
+                    <div style={{ fontWeight: 600, marginBottom: 4, color: "var(--text-muted)" }}>{label}</div>
+                    <div style={{ fontWeight: 600 }}>{formatCostTooltip(payload[0].value)}</div>
+                  </div>
+                );
+              }}
+            />
+            <Area
+              type="monotone"
+              dataKey="total"
+              stroke="#e8a020"
+              fill="url(#daily_cost_grad)"
+              strokeWidth={2}
+              dot={false}
+              animationDuration={400}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      ) : !costsError && (
+        <EmptyState icon={BarChart2} message="No daily cost data available yet." />
+      )}
+
       {/* Monthly AWS Spend */}
       <SectionHeader title="Monthly AWS Spend" />
-      <ErrorBanner msg={costsError} />
       {costs && (
         <p style={{ fontSize: 12, color: "var(--text-muted)", margin: "0 0 12px" }}>
           {costs.note}

--- a/ui/src/components/Dashboard.test.jsx
+++ b/ui/src/components/Dashboard.test.jsx
@@ -15,7 +15,6 @@ vi.mock("../api.js", () => ({
     getStats: vi.fn(),
     getMetrics: vi.fn(),
     getCosts: vi.fn(),
-    listUsers: vi.fn(),
   },
 }));
 
@@ -25,6 +24,7 @@ import { formatCostTick, formatCostTooltip, CustomTooltip, CustomCostTooltip } f
 const STATS = {
   total_memories: 42,
   total_clients: 3,
+  total_users: 7,
   events_today: 10,
   events_last_7_days: 88,
 };
@@ -67,9 +67,11 @@ const COSTS = {
       by_service: { "AWS Lambda": 0.5, "Amazon DynamoDB": 0.12 },
     },
   ],
+  daily: [
+    { date: "2026-04-01", total: 0.02 },
+    { date: "2026-04-02", total: 0.03 },
+  ],
 };
-
-const USERS = { total: 7, items: [], next_cursor: null };
 
 describe("CustomTooltip", () => {
   it("returns null when not active", () => {
@@ -128,7 +130,6 @@ describe("Dashboard", () => {
     api.getStats.mockResolvedValue(STATS);
     api.getMetrics.mockResolvedValue(METRICS);
     api.getCosts.mockResolvedValue(COSTS);
-    api.listUsers.mockResolvedValue(USERS);
   });
 
   afterEach(() => {
@@ -148,6 +149,12 @@ describe("Dashboard", () => {
     expect(screen.getByText("30d")).toBeTruthy();
   });
 
+  it("selected period button has orange background", async () => {
+    await act(async () => render(<Dashboard />));
+    const btn = screen.getByText("24h");
+    expect(btn.style.background).toBe("rgb(232, 160, 32)");
+  });
+
   it("renders summary stat cards after load", async () => {
     await act(async () => render(<Dashboard />));
     await waitFor(() => expect(screen.getByText("42")).toBeTruthy());
@@ -160,9 +167,18 @@ describe("Dashboard", () => {
     expect(screen.getByText("Events (7d)")).toBeTruthy();
   });
 
-  it("renders Total Users stat card", async () => {
+  it("renders Total Users stat card from stats.total_users", async () => {
     await act(async () => render(<Dashboard />));
     await waitFor(() => expect(screen.getByText("Total Users")).toBeTruthy());
+    // total_users = 7 appears multiple times (also tokens_issued); confirm at least one
+    expect(screen.getAllByText("7").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders — for Total Users when total_users is null", async () => {
+    api.getStats.mockResolvedValue({ ...STATS, total_users: null });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("Total Users")).toBeTruthy());
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders MTD cost stat card", async () => {
@@ -172,16 +188,17 @@ describe("Dashboard", () => {
   });
 
   it("does not render MTD cost card when no cost data", async () => {
-    api.getCosts.mockResolvedValue({ environment: "dev", currency: "USD", note: "x", monthly: [] });
+    api.getCosts.mockResolvedValue({ environment: "dev", currency: "USD", note: "x", monthly: [], daily: [] });
     await act(async () => render(<Dashboard />));
     await waitFor(() => expect(screen.queryByText("AWS Cost (MTD)")).toBeFalsy());
   });
 
-  it("renders section headers with renamed latency title", async () => {
+  it("renders section headers", async () => {
     await act(async () => render(<Dashboard />));
     expect(screen.getByText("Tool Invocations")).toBeTruthy();
     expect(screen.getByText("Tool Latency p99 (ms)")).toBeTruthy();
     expect(screen.getByText("Auth Events")).toBeTruthy();
+    expect(screen.getByText("Daily AWS Spend (Last 30 Days)")).toBeTruthy();
     expect(screen.getByText("Monthly AWS Spend")).toBeTruthy();
   });
 
@@ -244,16 +261,31 @@ describe("Dashboard", () => {
     expect(screen.getByText("No latency data for this period.")).toBeTruthy();
   });
 
-  it("shows empty state when no cost data", async () => {
+  it("shows empty state when no monthly cost data", async () => {
     api.getCosts.mockResolvedValue({
       environment: "dev",
       currency: "USD",
       note: "Cost data lags ~24 h.",
       monthly: [],
+      daily: [],
     });
     await act(async () => render(<Dashboard />));
     await waitFor(() =>
       expect(screen.getByText("No cost data available yet.")).toBeTruthy()
+    );
+  });
+
+  it("shows empty state when no daily cost data", async () => {
+    api.getCosts.mockResolvedValue({
+      environment: "dev",
+      currency: "USD",
+      note: "Cost data lags ~24 h.",
+      monthly: [{ period: "2026-03-01", total: 0.62, by_service: { "AWS Lambda": 0.62 } }],
+      daily: [],
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("No daily cost data available yet.")).toBeTruthy()
     );
   });
 
@@ -294,7 +326,6 @@ describe("Dashboard", () => {
     api.getStats.mockReturnValue(new Promise((r) => { resolve = r; }));
     api.getMetrics.mockReturnValue(new Promise(() => {}));
     api.getCosts.mockReturnValue(new Promise(() => {}));
-    api.listUsers.mockReturnValue(new Promise(() => {}));
 
     await act(async () => render(<Dashboard />));
     expect(screen.getByText("Loading…")).toBeTruthy();
@@ -305,11 +336,12 @@ describe("Dashboard", () => {
     api.getStats.mockResolvedValue({
       total_memories: null,
       total_clients: 3,
+      total_users: null,
       events_today: 10,
       events_last_7_days: 88,
     });
     await act(async () => render(<Dashboard />));
-    await waitFor(() => expect(screen.getByText("—")).toBeTruthy());
+    await waitFor(() => expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1));
   });
 
   it("handles metrics response missing metrics key", async () => {
@@ -328,6 +360,19 @@ describe("Dashboard", () => {
     );
   });
 
+  it("handles costs response missing daily key", async () => {
+    api.getCosts.mockResolvedValue({
+      environment: "dev",
+      currency: "USD",
+      note: "Cost data lags ~24 h.",
+      monthly: [{ period: "2026-03-01", total: 0.62, by_service: { "AWS Lambda": 0.62 } }],
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() =>
+      expect(screen.getByText("No daily cost data available yet.")).toBeTruthy()
+    );
+  });
+
   it("handles sparse values array (values[i] undefined)", async () => {
     api.getMetrics.mockResolvedValue({
       period: "24h",
@@ -341,20 +386,5 @@ describe("Dashboard", () => {
     });
     await act(async () => render(<Dashboard />));
     expect(screen.getByText("Tool Invocations")).toBeTruthy();
-  });
-
-  it("handles listUsers rejection gracefully", async () => {
-    api.listUsers.mockRejectedValue(new Error("forbidden"));
-    await act(async () => render(<Dashboard />));
-    await waitFor(() => expect(screen.getByText("Total Users")).toBeTruthy());
-    // value should be — when listUsers fails
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
-  });
-
-  it("handles listUsers response missing total field", async () => {
-    api.listUsers.mockResolvedValue({ items: [] });
-    await act(async () => render(<Dashboard />));
-    await waitFor(() => expect(screen.getByText("Total Users")).toBeTruthy());
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/ui/src/components/Dashboard.test.jsx
+++ b/ui/src/components/Dashboard.test.jsx
@@ -19,7 +19,7 @@ vi.mock("../api.js", () => ({
 }));
 
 import { api } from "../api.js";
-import { formatCostTick, formatCostTooltip, CustomTooltip, CustomCostTooltip } from "./Dashboard.jsx";
+import { formatCostTick, formatCostTooltip, CustomTooltip, CustomCostTooltip, CustomDailyCostTooltip } from "./Dashboard.jsx";
 
 const STATS = {
   total_memories: 42,
@@ -90,6 +90,25 @@ describe("CustomTooltip", () => {
     expect(screen.getByText("2026-04-01 12:00")).toBeTruthy();
     expect(screen.getByText("remember:")).toBeTruthy();
     expect(screen.getByText("5")).toBeTruthy();
+  });
+});
+
+describe("CustomDailyCostTooltip", () => {
+  it("returns null when not active", () => {
+    const { container } = render(<CustomDailyCostTooltip active={false} payload={[]} label="x" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when payload is empty", () => {
+    const { container } = render(<CustomDailyCostTooltip active={true} payload={[]} label="x" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders date and formatted cost when active", () => {
+    const payload = [{ value: 0.02 }];
+    render(<CustomDailyCostTooltip active={true} payload={payload} label="2026-04-01" />);
+    expect(screen.getByText("2026-04-01")).toBeTruthy();
+    expect(screen.getByText("$0.0200")).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary
- Replaces emoji ☾/☀ on dark mode toggle with Lucide `Moon`/`Sun` icons (#253)
- Active tab now shows a 2px orange (`#e8a020`) bottom border instead of a filled background highlight (#254)
- Footer version string is now a link to `/changelog` (hover underline) (#256)

Closes #253
Closes #254
Closes #256

## Test plan
- [x] `uv run inv pre-push` — all 291 Python + 285 JS tests pass
- [ ] Verify dark mode toggle renders SVG icon in browser
- [ ] Verify active tab shows orange underline (not background fill)
- [ ] Verify footer version is clickable and goes to `/changelog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)