### PR TITLE
fix(docs): expand docs navbar to match marketing site

### DIFF
--- a/docs-site/.vitepress/theme/index.js
+++ b/docs-site/.vitepress/theme/index.js
@@ -5,19 +5,20 @@ import "./style.css";
 export default {
   ...DefaultTheme,
 
-  // Inject Docs and Sign in as plain <a> elements via nav-bar-content-after so
-  // they render at the far right of the navbar (after search/social), in the
-  // correct order, without Vue Router involvement.
+  // Inject nav links as plain <a> elements via nav-bar-content-after so
+  // they render at the far right of the navbar, matching the marketing site:
+  // Use cases · Clients · Pricing · FAQ · Docs | Sign in
   //
   // VitePress .content-body flex order:
   //   [nav-bar-content-before] Search Menu Appearance Social [nav-bar-content-after]
-  //
-  // Using nav-bar-content-after puts our links at the rightmost position, which
-  // matches the marketing site layout: ... Docs | Sign in (at right edge).
   Layout() {
     return h(DefaultTheme.Layout, null, {
       "nav-bar-content-after": () =>
         h("div", { class: "docs-nav-group" }, [
+          h("a", { href: "/use-cases", class: "docs-nav-link" }, "Use cases"),
+          h("a", { href: "/clients", class: "docs-nav-link" }, "Clients"),
+          h("a", { href: "/pricing", class: "docs-nav-link" }, "Pricing"),
+          h("a", { href: "/faq", class: "docs-nav-link" }, "FAQ"),
           h(
             "a",
             { href: "/docs/getting-started/what-is-hive", class: "docs-nav-link" },
@@ -28,6 +29,10 @@ export default {
       // Mobile expanded menu
       "nav-screen-content-after": () =>
         h("div", { class: "docs-screen-group" }, [
+          h("a", { href: "/use-cases", class: "docs-screen-nav-link" }, "Use cases"),
+          h("a", { href: "/clients", class: "docs-screen-nav-link" }, "Clients"),
+          h("a", { href: "/pricing", class: "docs-screen-nav-link" }, "Pricing"),
+          h("a", { href: "/faq", class: "docs-screen-nav-link" }, "FAQ"),
           h(
             "a",
             { href: "/docs/getting-started/what-is-hive", class: "docs-screen-nav-link" },
@@ -53,6 +58,17 @@ export default {
             e.stopImmediatePropagation();
             window.location.href = "/";
             return;
+          }
+          // Marketing site links (outside /docs/) → full-page navigation
+          const navLink = e.target.closest(".docs-nav-link, .docs-screen-nav-link");
+          if (navLink) {
+            const href = navLink.getAttribute("href");
+            if (href && !href.startsWith("/docs/")) {
+              e.preventDefault();
+              e.stopImmediatePropagation();
+              window.location.href = href;
+              return;
+            }
           }
           // Sign in → /app
           const signin = e.target.closest(".docs-signin-btn, .docs-signin-screen-btn");


### PR DESCRIPTION
## Summary
- Adds Use cases, Clients, Pricing, and FAQ links to the docs site navbar (both desktop and mobile) to match the marketing site navigation
- Adds a click interceptor for the new marketing-site links so Vue Router doesn't swallow them (same pattern as the existing Sign in interceptor)
- `LoginPage.jsx` card border is already correct (`var(--border)`) — no change needed

Closes #251

## Test plan
- [x] `uv run inv pre-push` — 286 JS tests pass
- [ ] Verify docs navbar shows all 6 links in dev deployment
- [ ] Verify clicking Use cases / Pricing / etc. navigates to the marketing site (full page nav, not Vue Router)

🤖 Generated with [Claude Code](https://claude.com/claude-code)