### PR TITLE
feat(ui): empty state illustrations in admin UI

### DIFF
--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -294,7 +294,7 @@ class TestDocsNavbar:
             timeout=30_000,
             wait_until="networkidle",
         )
-        docs_link = page.locator(".docs-nav-link")
+        docs_link = page.locator(".docs-nav-link", has_text="Docs")
         if not docs_link.is_visible():
             pytest.skip("Docs nav link not visible")
         href = docs_link.get_attribute("href")
@@ -313,7 +313,7 @@ class TestDocsNavbar:
             timeout=30_000,
             wait_until="networkidle",
         )
-        docs_link = page.locator(".docs-nav-link")
+        docs_link = page.locator(".docs-nav-link", has_text="Docs")
         if not docs_link.is_visible():
             pytest.skip("Docs nav link not visible")
         with page.expect_navigation(timeout=15_000):
@@ -440,7 +440,7 @@ class TestDocsNavbar:
         """Docs nav link color and font-size match the marketing site header."""
         page = docs_page
         page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
-        docs_link = page.locator(".docs-nav-link")
+        docs_link = page.locator(".docs-nav-link").first
         if not docs_link.is_visible():
             pytest.skip("Docs nav link not visible (may be mobile viewport)")
 

--- a/ui/src/components/ActivityLog.jsx
+++ b/ui/src/components/ActivityLog.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useState } from "react";
 import { api } from "../api.js";
+import EmptyState from "./EmptyState.jsx";
 
 const EVENT_COLORS = {
   memory_created: "#34a853",
@@ -100,8 +101,12 @@ export default function ActivityLog() {
           <tbody>
             {events.length === 0 && !loading && (
               <tr>
-                <td colSpan={4} style={{ textAlign: "center", color: "var(--text-muted)", padding: 30 }}>
-                  No activity in this period.
+                <td colSpan={4} style={{ padding: 0 }}>
+                  <EmptyState
+                    variant="activity"
+                    title="No activity in this period"
+                    description="Events will appear here as your MCP clients use Hive tools."
+                  />
                 </td>
               </tr>
             )}

--- a/ui/src/components/ActivityLog.test.jsx
+++ b/ui/src/components/ActivityLog.test.jsx
@@ -49,7 +49,7 @@ describe("ActivityLog", () => {
 
   it("shows empty state when no events", async () => {
     await act(async () => render(<ActivityLog />));
-    await waitFor(() => expect(screen.getByText("No activity in this period.")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("No activity in this period")).toBeTruthy());
   });
 
   it("renders event rows", async () => {

--- a/ui/src/components/ClientManager.jsx
+++ b/ui/src/components/ClientManager.jsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { api } from "../api.js";
+import EmptyState from "./EmptyState.jsx";
 
 export default function ClientManager() {
   const [clients, setClients] = useState([]);
@@ -158,8 +159,12 @@ export default function ClientManager() {
           <tbody>
             {clients.length === 0 && !loading && (
               <tr>
-                <td colSpan={6} style={{ textAlign: "center", color: "var(--text-muted)", padding: 30 }}>
-                  No clients registered.
+                <td colSpan={6} style={{ padding: 0 }}>
+                  <EmptyState
+                    variant="clients"
+                    title="No clients registered"
+                    description="Register an OAuth client to connect your MCP agent to Hive."
+                  />
                 </td>
               </tr>
             )}

--- a/ui/src/components/ClientManager.test.jsx
+++ b/ui/src/components/ClientManager.test.jsx
@@ -41,7 +41,7 @@ describe("ClientManager", () => {
 
   it("shows empty state when no clients", async () => {
     await act(async () => render(<ClientManager />));
-    await waitFor(() => expect(screen.getByText("No clients registered.")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("No clients registered")).toBeTruthy());
   });
 
   it("renders loaded clients in table", async () => {
@@ -161,7 +161,7 @@ describe("ClientManager", () => {
   it("handles API returning no items key gracefully", async () => {
     api.listClients.mockResolvedValue({});
     await act(async () => render(<ClientManager />));
-    await waitFor(() => expect(screen.getByText("No clients registered.")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("No clients registered")).toBeTruthy());
   });
 
   it("shows error when createClient fails", async () => {

--- a/ui/src/components/EmptyState.jsx
+++ b/ui/src/components/EmptyState.jsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+
+const ILLUSTRATIONS = {
+  memories: (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" aria-hidden="true">
+      <rect x="12" y="20" width="56" height="44" rx="6" stroke="currentColor" strokeWidth="2.5" />
+      <rect x="20" y="30" width="24" height="3" rx="1.5" fill="currentColor" opacity=".4" />
+      <rect x="20" y="37" width="40" height="3" rx="1.5" fill="currentColor" opacity=".25" />
+      <rect x="20" y="44" width="32" height="3" rx="1.5" fill="currentColor" opacity=".25" />
+      <circle cx="58" cy="22" r="10" fill="var(--accent)" opacity=".15" />
+      <path d="M54 22h8M58 18v8" stroke="var(--accent)" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  ),
+  clients: (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" aria-hidden="true">
+      <rect x="10" y="28" width="36" height="28" rx="5" stroke="currentColor" strokeWidth="2.5" />
+      <rect x="18" y="36" width="20" height="3" rx="1.5" fill="currentColor" opacity=".4" />
+      <rect x="18" y="43" width="14" height="3" rx="1.5" fill="currentColor" opacity=".25" />
+      <path d="M46 42h8M54 42l-4-4M54 42l-4 4" stroke="var(--accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      <rect x="54" y="28" width="16" height="28" rx="5" stroke="var(--accent)" strokeWidth="2" opacity=".5" />
+      <rect x="57" y="36" width="10" height="2.5" rx="1.25" fill="var(--accent)" opacity=".5" />
+      <rect x="57" y="42" width="7" height="2.5" rx="1.25" fill="var(--accent)" opacity=".35" />
+    </svg>
+  ),
+  activity: (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" aria-hidden="true">
+      <circle cx="40" cy="40" r="22" stroke="currentColor" strokeWidth="2.5" />
+      <path d="M40 28v13l8 5" stroke="var(--accent)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx="40" cy="40" r="2" fill="currentColor" opacity=".3" />
+    </svg>
+  ),
+  users: (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" aria-hidden="true">
+      <circle cx="35" cy="30" r="10" stroke="currentColor" strokeWidth="2.5" />
+      <path d="M15 62c0-11 9-18 20-18s20 7 20 18" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+      <circle cx="57" cy="32" r="7" stroke="var(--accent)" strokeWidth="2" opacity=".6" />
+      <path d="M44 58c0-7 6-12 13-12" stroke="var(--accent)" strokeWidth="2" strokeLinecap="round" opacity=".6" />
+    </svg>
+  ),
+};
+
+export default function EmptyState({ variant, title, description, action }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        textAlign: "center",
+        padding: "48px 24px",
+        color: "var(--text-muted)",
+      }}
+    >
+      <div style={{ marginBottom: 16, opacity: 0.6 }}>
+        {ILLUSTRATIONS[variant] ?? ILLUSTRATIONS.memories}
+      </div>
+      <p style={{ fontWeight: 600, fontSize: 15, color: "var(--text)", marginBottom: 6 }}>
+        {title}
+      </p>
+      {description && (
+        <p style={{ fontSize: 13, maxWidth: 320, lineHeight: 1.5 }}>{description}</p>
+      )}
+      {action && <div style={{ marginTop: 16 }}>{action}</div>}
+    </div>
+  );
+}

--- a/ui/src/components/EmptyState.test.jsx
+++ b/ui/src/components/EmptyState.test.jsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EmptyState from "./EmptyState.jsx";
+
+describe("EmptyState", () => {
+  it("renders title", () => {
+    render(<EmptyState variant="memories" title="No memories yet" />);
+    expect(screen.getByText("No memories yet")).toBeTruthy();
+  });
+
+  it("renders description when provided", () => {
+    render(<EmptyState variant="clients" title="No clients" description="Register one to get started." />);
+    expect(screen.getByText("Register one to get started.")).toBeTruthy();
+  });
+
+  it("does not render description when omitted", () => {
+    const { container } = render(<EmptyState variant="activity" title="No activity" />);
+    expect(container.querySelectorAll("p").length).toBe(1); // only title
+  });
+
+  it("renders action when provided", () => {
+    render(<EmptyState variant="users" title="No users" action={<button>Add</button>} />);
+    expect(screen.getByText("Add")).toBeTruthy();
+  });
+
+  it("renders all four variants without error", () => {
+    for (const variant of ["memories", "clients", "activity", "users"]) {
+      const { unmount } = render(<EmptyState variant={variant} title="Test" />);
+      unmount();
+    }
+  });
+
+  it("falls back to memories illustration for unknown variant", () => {
+    const { container } = render(<EmptyState variant="unknown" title="Test" />);
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+});

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../api.js";
+import EmptyState from "./EmptyState.jsx";
 
 export default function MemoryBrowser() {
   const [memories, setMemories] = useState([]);
@@ -178,8 +179,13 @@ export default function MemoryBrowser() {
         {loading && <p style={{ color: "var(--text-muted)" }}>Loading…</p>}
 
         {!loading && memories.length === 0 && (
-          <div className="card" style={{ textAlign: "center", color: "var(--text-muted)", padding: 40 }}>
-            No memories found.
+          <div className="card" style={{ padding: 0 }}>
+            <EmptyState
+              variant="memories"
+              title="No memories yet"
+              description="Use the remember tool in your MCP client to store your first memory."
+              action={<button className="primary" onClick={openCreate}>+ New Memory</button>}
+            />
           </div>
         )}
 

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -47,7 +47,7 @@ describe("MemoryBrowser", () => {
 
   it("renders empty state after load", async () => {
     await act(async () => render(<MemoryBrowser />));
-    await waitFor(() => expect(screen.getByText("No memories found.")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("No memories yet")).toBeTruthy());
   });
 
   it("renders loaded memories", async () => {

--- a/ui/src/components/UsersPanel.jsx
+++ b/ui/src/components/UsersPanel.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useState } from "react";
 import { api } from "../api.js";
+import EmptyState from "./EmptyState.jsx";
 
 export default function UsersPanel() {
   const [users, setUsers] = useState([]);
@@ -41,7 +42,11 @@ export default function UsersPanel() {
     <div>
       <h2 style={{ marginBottom: 16 }}>Users</h2>
       {users.length === 0 ? (
-        <p style={{ color: "var(--text-muted)" }}>No users found.</p>
+        <EmptyState
+          variant="users"
+          title="No users found"
+          description="Users appear here after they sign in for the first time via Google OAuth."
+        />
       ) : (
         <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
           <thead>

--- a/ui/src/components/UsersPanel.test.jsx
+++ b/ui/src/components/UsersPanel.test.jsx
@@ -55,7 +55,7 @@ describe("UsersPanel", () => {
   it("shows empty state when no users", async () => {
     api.listUsers.mockResolvedValue({ items: [] });
     await act(async () => render(<UsersPanel />));
-    expect(screen.getByText("No users found.")).toBeTruthy();
+    expect(screen.getByText("No users found")).toBeTruthy();
   });
 
   it("shows error when listUsers fails", async () => {
@@ -108,6 +108,6 @@ describe("UsersPanel", () => {
   it("shows empty state when listUsers returns null", async () => {
     api.listUsers.mockResolvedValue(null);
     await act(async () => render(<UsersPanel />));
-    expect(screen.getByText("No users found.")).toBeTruthy();
+    expect(screen.getByText("No users found")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- New shared `EmptyState` component with inline SVG spot illustrations, title, description, and optional CTA
- Four variants: `memories`, `clients`, `activity`, `users` — each with a minimal brand-aligned SVG (navy/orange, CSS-var aware for dark mode)
- Wired into `MemoryBrowser`, `ClientManager`, `ActivityLog`, `UsersPanel` replacing plain text empty states

| Component | Title | CTA |
|---|---|---|
| MemoryBrowser | "No memories yet" | + New Memory |
| ClientManager | "No clients registered" | — (Register button already in header) |
| ActivityLog | "No activity in this period" | — |
| UsersPanel | "No users found" | — |

Closes #263

## Test plan
- [x] `uv run inv pre-push` — 291 Python + 304 JS tests pass, 100% coverage
- [ ] Verify each empty state renders correctly in light and dark mode in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)