### PR TITLE
docs(claude): update CLAUDE.md with docs site, UI conventions, and e2e patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,33 +30,43 @@ hive/
 │           └── stats.py       # Usage stats + activity log endpoints
 ├── ui/
 │   ├── src/
-│   │   ├── App.jsx
+│   │   ├── App.jsx            # Router, AppShell, tab nav
+│   │   ├── api.js             # API client (fetch wrappers)
 │   │   └── components/
 │   │       ├── MemoryBrowser.jsx
 │   │       ├── ClientManager.jsx
-│   │       └── ActivityLog.jsx
+│   │       ├── ActivityLog.jsx
+│   │       ├── Dashboard.jsx
+│   │       ├── UsersPanel.jsx
+│   │       ├── SetupPanel.jsx
+│   │       ├── EmptyState.jsx # Shared empty-state illustrations
+│   │       ├── HomePage.jsx   # Marketing landing page
+│   │       └── ...            # Other marketing pages
 │   └── package.json
+├── docs-site/                 # VitePress documentation site
+│   ├── .vitepress/
+│   │   ├── config.mjs         # base: "/docs/", nav, sidebar
+│   │   └── theme/
+│   │       ├── index.js       # Custom Layout (nav-bar-content-after slot)
+│   │       └── style.css      # Dark navy navbar, brand colours
+│   └── getting-started/       # Markdown content
 ├── infra/
 │   ├── app.py                 # CDK app entry point
 │   └── stacks/
-│       └── hive_stack.py      # Lambda + DynamoDB + Function URLs + IAM
+│       └── hive_stack.py      # Lambda + DynamoDB + CloudFront + IAM
 ├── tests/
 │   ├── unit/                  # Pure logic, no AWS deps
-│   │   ├── test_models.py
-│   │   ├── test_auth.py
-│   │   └── test_storage.py
-│   ├── integration/           # Tests against local DynamoDB
-│   │   ├── test_mcp_tools.py
-│   │   ├── test_api.py
-│   │   └── test_oauth.py
-│   └── e2e/                   # Tests against deployed AWS environment
+│   ├── integration/           # Tests against DynamoDB Local
+│   └── e2e/                   # Playwright tests against deployed env
 │       ├── test_mcp_e2e.py
 │       ├── test_auth_e2e.py
-│       └── test_ui_e2e.py     # Playwright
+│       ├── test_ui_e2e.py     # Admin UI (Playwright)
+│       ├── test_docs_e2e.py   # VitePress docs site (Playwright)
+│       └── test_dashboard_e2e.py
 ├── .github/
 │   └── workflows/
-│       ├── ci.yml             # Run all tests on PR
-│       └── deploy.yml         # Deploy to AWS on merge to main
+│       ├── ci.yml             # CI on every PR + deploy to dev on push to development
+│       └── deploy-dev.yml     # Manual dev deploy (workflow_dispatch)
 ├── pyproject.toml
 └── README.md
 
@@ -87,26 +97,45 @@ hive/
 - Communicates with FastAPI management API on port 8001
 - Features: browse/search/create/edit/delete memories,
   manage OAuth clients (DCR), usage stats, activity log
+- Auth: Google OAuth via `/auth/login`; token stored in localStorage as `hive_mgmt_token`
+
+## Docs site
+- VitePress with `base: "/docs/"` — served at `<domain>/docs/`
+- CloudFront Function rewrites clean URLs (no extension → `.html`)
+- Nav links injected via `nav-bar-content-after` layout slot as plain `<a>` elements
+  (not Vue Router links) so Vue Router never intercepts marketing-site clicks
+- Deployed to S3 prefix `docs/` alongside the React SPA in the same bucket
+- `DeployUi` CDK construct uses `prune=False` — never delete docs assets
+- `DeployDocs` depends on `DeployUi` so docs always win on final write order
 
 ## Testing
+
 - pytest for all Python tests (unit, integration, e2e)
 - DynamoDB Local (Docker) for integration tests
 - Playwright for UI e2e tests
 - Unit tests: no AWS deps, fully mocked
 - Integration tests: run against DynamoDB Local
-- E2e tests: run against deployed AWS staging environment
+- E2e tests: run against deployed AWS dev environment
+- **100% coverage required** — both Python (pytest-cov) and JS (vitest v8); CI fails below 100%
+- Every new UI component needs a co-located `*.test.jsx` file
+
+### E2e test conventions
+
+- Use a unique tag per test run (e.g. `e2e-{timestamp}`) when creating test data, then
+  filter by that tag to assert — avoids pagination issues from accumulated test data
+- When selecting one element among many sharing a class, use Playwright `has_text=`
+  (e.g. `page.locator(".docs-nav-link", has_text="Docs")`) to avoid strict-mode violations
 
 ## CI/CD (GitHub Actions)
-- ci.yml triggers on all PRs:
-  - Lint (ruff) + type check (mypy)
-  - Unit tests
-  - Integration tests (spin up DynamoDB Local via Docker)
-  - Frontend tests (vitest) + build
-- deploy.yml triggers on merge to main:
-  - Run full test suite
-  - CDK deploy to AWS
-  - Run e2e tests against deployed environment
-  - Playwright e2e against deployed UI
+
+- `ci.yml` runs on every PR and push to `development` or `main`:
+  - Lint (ruff) + type check (mypy) + copyright headers
+  - Unit tests, integration tests (DynamoDB Local), frontend tests (vitest) + build
+  - Docs site build, infra synth + Trivy IaC scan
+  - On push to `development`: deploy to dev + run all e2e tests
+  - On push to `main`: release + deploy to prod + back-merge to development
+- `deploy-dev.yml` — manual dev deploy via `workflow_dispatch`
+- Deploy order: React SPA → docs site (docs depend on SPA deployment completing first)
 
 ## Conventions
 - Use uv for all dependency management — never pip or requirements.txt
@@ -115,6 +144,18 @@ hive/
 - All config via environment variables
 - Never hardcode credentials or secrets
 - AWS credentials in GitHub Actions via OIDC (no long-lived access keys)
+
+## UI conventions
+
+- **CSS variables only** — never hardcode colours; use `var(--text-muted)`, `var(--border)`,
+  `var(--accent)`, `var(--danger)`, `var(--success)`, etc. for dark-mode compatibility
+- **Lucide icons** — use `lucide-react` for all icons; never use emojis as UI elements
+- **jsdom colour normalisation** — in vitest, jsdom converts hex to `rgb(r, g, b)`;
+  assert `"rgb(232, 160, 32)"` not `"#e8a020"`
+- **Anonymous inline functions** — vitest v8 counts uncovered anonymous functions;
+  extract or name handlers that must be tested (e.g. event listeners in `useEffect`)
+- **`vi.useFakeTimers()`** — activate only *after* the initial async render completes
+  (`await waitFor(...)`) otherwise fake timers block promise resolution
 
 ## Pre-PR checklist (required before every push)
 


### PR DESCRIPTION
## Summary

- Documents the VitePress docs site setup (base path, CloudFront rewrite, nav slot, `prune=False` requirement)
- Adds UI conventions section: CSS variables, Lucide icons over emojis, jsdom hex normalization, `vi.useFakeTimers()` ordering, anonymous function coverage
- Documents e2e test conventions: unique tags per run, Playwright `has_text=` strict-mode pattern
- Updates CI/CD section to reflect actual workflow filenames (`ci.yml` + `deploy-dev.yml`)
- Updates structure tree to include `docs-site/`, `EmptyState.jsx`, and co-located test files
- Adds 100% coverage requirement and co-located `*.test.jsx` pattern

## Test plan
- [ ] No code changes — docs only
- [ ] Markdown lints cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)