### PR TITLE
fix(ui): guard api.listClients() in AppShell against unauthenticated renders

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -63,6 +63,9 @@ function AppShell() {
   const navigate = useNavigate();
   const { theme, toggle } = useTheme();
 
+  const token = localStorage.getItem("hive_mgmt_token") ?? "";
+  const authenticated = isTokenValid(token);
+
   useEffect(() => {
     fetch("/health")
       .then((r) => r.json())
@@ -71,12 +74,13 @@ function AppShell() {
   }, []);
 
   useEffect(() => {
+    if (!authenticated) return;
     api.listClients()
       .then((data) => {
         if (data && data.items.length === 0) setTab("setup");
       })
       .catch(() => {});
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     function onSwitchTab(e) { switchTab(e.detail); }
@@ -84,9 +88,7 @@ function AppShell() {
     return () => window.removeEventListener("hive:switch-tab", onSwitchTab);
   }, []);
 
-  const token = localStorage.getItem("hive_mgmt_token") ?? "";
-
-  if (!isTokenValid(token)) {
+  if (!authenticated) {
     return <LoginPage />;
   }
 


### PR DESCRIPTION
## Summary

Regression introduced by #285 (hooks rules fix): moving `useEffect` calls above the early return caused `api.listClients()` to fire on every render of `AppShell`, including when there is no valid token. `api.js` responds to any 401 with `window.location.replace("/")`, which immediately bounced unauthenticated users back to the home page before `<LoginPage />` could render — making the Sign In button appear broken.

Fix: derive `authenticated` from the token before the effects and skip the `listClients` call when not authenticated. Using `authenticated` as the effect dependency also means the call fires correctly once the user has a valid session.

## Test plan
- [x] `uv run inv pre-push` passes (304 JS tests, 291 Python unit tests, lint, mypy)
- [ ] Clicking Sign In on the home page now stays on the login screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)