### PR TITLE
fix(docs): unify docs site visual design with marketing site

### DIFF
--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -1,6 +1,23 @@
 /* ============================================================
    Brand colour — orange, matching marketing site (#e8a020)
    ============================================================ */
+
+/* ============================================================
+   Navbar height — 56px to match marketing site (h-14 / 56px)
+   VitePress default is 64px.
+   ============================================================ */
+:root {
+  --vp-nav-height: 56px;
+}
+
+/* ============================================================
+   Typography — system-ui to match marketing site font stack
+   ============================================================ */
+:root {
+  --vp-font-family-base: system-ui, -apple-system, sans-serif;
+  --vp-font-family-mono: ui-monospace, "SFMono-Regular", "Menlo", monospace;
+}
+
 :root {
   --vp-c-brand-1: #e8a020;
   --vp-c-brand-2: #f5a623;
@@ -249,4 +266,27 @@
 
 .VPFeature .icon {
   color: var(--vp-c-brand-1);
+}
+
+/* ============================================================
+   Remove the vertical divider VitePress renders between the
+   logo and the nav links — marketing site has no divider.
+   ============================================================ */
+.VPNavBarTitle .divider {
+  display: none !important;
+}
+
+/* ============================================================
+   Footer — match marketing site treatment:
+   muted text, thin top border, compact padding.
+   ============================================================ */
+.VPFooter {
+  border-top: 1px solid rgba(255, 255, 255, 0.08) !important;
+  padding: 12px 24px !important;
+}
+
+.VPFooter .message,
+.VPFooter .copyright {
+  font-size: 12px !important;
+  color: rgba(255, 255, 255, 0.45) !important;
 }


### PR DESCRIPTION
## Summary

CSS-only changes to `docs-site/.vitepress/theme/style.css` to close the visual gap between the docs site (VitePress) and the marketing site (React/Vite).

| Element | Before | After |
|---|---|---|
| Navbar height | 64px (VitePress default) | 56px (matches `h-14` / `height: 56` on marketing) |
| Font stack | Inter (VitePress default) | `system-ui, -apple-system, sans-serif` (matches marketing) |
| Logo divider | Visible vertical divider after logo | Hidden — marketing site has no divider |
| Footer | VitePress default style | Muted text, thin border, compact padding matching marketing footer treatment |

No changes to JavaScript, Vue, or the marketing site React components.

## Test plan
- [x] `npm run build` in `docs-site/` completes cleanly
- [ ] Visually verify navbar height, font, and divider match at deployed URL

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)