### PR TITLE
feat: tag picker with suggestions for memory filter

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.3",
@@ -6068,7 +6069,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6455,7 +6455,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -6467,7 +6466,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/psl": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.3",

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
 import { X } from "lucide-react";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
@@ -113,6 +114,7 @@ export function TagPicker({ knownTags, value, onSelect }) {
         // Input
         <input
           id="tag-filter-input"
+          role="combobox"
           style={{ width: "100%" }}
           placeholder="Filter by tag"
           value={inputValue}
@@ -129,7 +131,7 @@ export function TagPicker({ knownTags, value, onSelect }) {
       )}
 
       {open && suggestions.length > 0 && (
-        <ul
+        <div
           id="tag-suggestions"
           ref={listRef}
           role="listbox"
@@ -147,11 +149,10 @@ export function TagPicker({ knownTags, value, onSelect }) {
             zIndex: 100,
             margin: 0,
             padding: "4px 0",
-            listStyle: "none",
           }}
         >
           {suggestions.map((t, i) => (
-            <li
+            <div
               key={t}
               id={`tag-opt-${i}`}
               role="option"
@@ -166,13 +167,19 @@ export function TagPicker({ knownTags, value, onSelect }) {
               }}
             >
               {t}
-            </li>
+            </div>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   );
 }
+
+TagPicker.propTypes = {
+  knownTags: PropTypes.arrayOf(PropTypes.string).isRequired,
+  value: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired,
+};
 
 // ------------------------------------------------------------------
 // MemoryBrowser
@@ -237,7 +244,7 @@ export default function MemoryBrowser() {
   }, [searchQuery, runSearch]);
 
   // Collect distinct tags from loaded memories for suggestions
-  const knownTags = [...new Set(memories.flatMap((m) => m.tags))].sort();
+  const knownTags = [...new Set(memories.flatMap((m) => m.tags))].sort((a, b) => a.localeCompare(b));
 
   function handleTagSelect(tag) {
     setTagFilter(tag);

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -1,7 +1,182 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
+
+// ------------------------------------------------------------------
+// TagPicker — combobox that shows suggestions from known tags,
+// renders the selected tag as a removable chip, and calls
+// onSelect(tag | "") when the filter changes.
+// ------------------------------------------------------------------
+
+export function TagPicker({ knownTags, value, onSelect }) {
+  const [inputValue, setInputValue] = useState("");
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const listRef = useRef(null);
+
+  const suggestions = knownTags.filter(
+    (t) => t.toLowerCase().includes(inputValue.toLowerCase()) && t !== value,
+  );
+
+  function selectTag(tag) {
+    onSelect(tag);
+    setInputValue("");
+    setOpen(false);
+    setActiveIndex(-1);
+  }
+
+  function clearTag() {
+    onSelect("");
+    setInputValue("");
+    setOpen(false);
+    setActiveIndex(-1);
+  }
+
+  function handleInputChange(e) {
+    setInputValue(e.target.value);
+    setOpen(true);
+    setActiveIndex(-1);
+  }
+
+  function handleKeyDown(e) {
+    if (!open || suggestions.length === 0) {
+      if (e.key === "Escape") setOpen(false);
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter" && activeIndex >= 0) {
+      e.preventDefault();
+      selectTag(suggestions[activeIndex]);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+      setActiveIndex(-1);
+    }
+  }
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (activeIndex >= 0 && listRef.current) {
+      const item = listRef.current.children[activeIndex];
+      item?.scrollIntoView?.({ block: "nearest" });
+    }
+  }, [activeIndex]);
+
+  return (
+    <div style={{ position: "relative", width: 160 }}>
+      {value ? (
+        // Selected chip
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "4px 8px",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 999,
+            fontSize: 12,
+            fontWeight: 600,
+            color: "var(--text)",
+            width: "100%",
+            boxSizing: "border-box",
+          }}
+        >
+          <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {value}
+          </span>
+          <button
+            type="button"
+            aria-label="Clear tag filter"
+            onClick={clearTag}
+            style={{
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              color: "var(--text-muted)",
+              flexShrink: 0,
+            }}
+          >
+            <X size={11} />
+          </button>
+        </div>
+      ) : (
+        // Input
+        <input
+          id="tag-filter-input"
+          style={{ width: "100%" }}
+          placeholder="Filter by tag"
+          value={inputValue}
+          autoComplete="off"
+          onChange={handleInputChange}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+          onKeyDown={handleKeyDown}
+          aria-autocomplete="list"
+          aria-expanded={open && suggestions.length > 0}
+          aria-controls="tag-suggestions"
+          aria-activedescendant={activeIndex >= 0 ? `tag-opt-${activeIndex}` : undefined}
+        />
+      )}
+
+      {open && suggestions.length > 0 && (
+        <ul
+          id="tag-suggestions"
+          ref={listRef}
+          role="listbox"
+          style={{
+            position: "absolute",
+            top: "calc(100% + 4px)",
+            left: 0,
+            right: 0,
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            boxShadow: "0 4px 12px rgba(0,0,0,.12)",
+            maxHeight: 200,
+            overflowY: "auto",
+            zIndex: 100,
+            margin: 0,
+            padding: "4px 0",
+            listStyle: "none",
+          }}
+        >
+          {suggestions.map((t, i) => (
+            <li
+              key={t}
+              id={`tag-opt-${i}`}
+              role="option"
+              aria-selected={i === activeIndex}
+              onMouseDown={() => selectTag(t)}
+              style={{
+                padding: "6px 12px",
+                fontSize: 13,
+                cursor: "pointer",
+                background: i === activeIndex ? "var(--accent)" : "transparent",
+                color: i === activeIndex ? "var(--accent-fg)" : "var(--text)",
+              }}
+            >
+              {t}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ------------------------------------------------------------------
+// MemoryBrowser
+// ------------------------------------------------------------------
 
 export default function MemoryBrowser() {
   const [memories, setMemories] = useState([]);
@@ -61,9 +236,12 @@ export default function MemoryBrowser() {
     return () => clearTimeout(searchDebounceRef.current);
   }, [searchQuery, runSearch]);
 
-  function handleTagFilterChange(e) {
-    setTagFilter(e.target.value);
-    if (e.target.value) {
+  // Collect distinct tags from loaded memories for suggestions
+  const knownTags = [...new Set(memories.flatMap((m) => m.tags))].sort();
+
+  function handleTagSelect(tag) {
+    setTagFilter(tag);
+    if (tag) {
       setSearchQuery("");
       setIsSearchMode(false);
     }
@@ -164,12 +342,7 @@ export default function MemoryBrowser() {
             value={searchQuery}
             onChange={handleSearchQueryChange}
           />
-          <input
-            style={{ width: 150 }}
-            placeholder="Filter by tag"
-            value={tagFilter}
-            onChange={handleTagFilterChange}
-          />
+          <TagPicker knownTags={knownTags} value={tagFilter} onSelect={handleTagSelect} />
           <button className="primary" onClick={openCreate}>
             + New
           </button>

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import MemoryBrowser from "./MemoryBrowser.jsx";
+import MemoryBrowser, { TagPicker } from "./MemoryBrowser.jsx";
 
 vi.mock("../api.js", () => ({
   api: {
@@ -22,6 +22,173 @@ const makeMemory = (overrides = {}) => ({
   tags: ["tag1"],
   ...overrides,
 });
+
+// ------------------------------------------------------------------
+// TagPicker — isolated unit tests
+// ------------------------------------------------------------------
+
+describe("TagPicker", () => {
+  const tags = ["alpha", "beta", "gamma"];
+
+  it("renders input when no value is selected", () => {
+    render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
+    expect(screen.getByPlaceholderText("Filter by tag")).toBeTruthy();
+  });
+
+  it("renders chip when a value is selected", () => {
+    render(<TagPicker knownTags={tags} value="alpha" onSelect={vi.fn()} />);
+    expect(screen.getByText("alpha")).toBeTruthy();
+    expect(screen.queryByPlaceholderText("Filter by tag")).toBeNull();
+  });
+
+  it("clear button calls onSelect with empty string", () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="alpha" onSelect={onSelect} />);
+    fireEvent.click(screen.getByLabelText("Clear tag filter"));
+    expect(onSelect).toHaveBeenCalledWith("");
+  });
+
+  it("shows all suggestions on focus", async () => {
+    render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
+    fireEvent.focus(screen.getByPlaceholderText("Filter by tag"));
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeTruthy());
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
+  it("filters suggestions based on typed input", async () => {
+    render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("Filter by tag"), {
+      target: { value: "al" },
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "alpha" })).toBeTruthy();
+      expect(screen.queryByRole("option", { name: "beta" })).toBeNull();
+    });
+  });
+
+  it("mousedown on suggestion calls onSelect", async () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    fireEvent.focus(screen.getByPlaceholderText("Filter by tag"));
+    await waitFor(() => screen.getByRole("option", { name: "alpha" }));
+    fireEvent.mouseDown(screen.getByRole("option", { name: "alpha" }));
+    expect(onSelect).toHaveBeenCalledWith("alpha");
+  });
+
+  it("ArrowDown highlights next suggestion and cannot go past last", async () => {
+    render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.focus(input);
+    await waitFor(() => screen.getByRole("option", { name: "alpha" }));
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getByRole("option", { name: "alpha" }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getByRole("option", { name: "beta" }).getAttribute("aria-selected")).toBe("true");
+
+    // Past last item — stays on last
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getByRole("option", { name: "gamma" }).getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("ArrowUp highlights previous suggestion and cannot go before first", async () => {
+    render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.focus(input);
+    await waitFor(() => screen.getByRole("option", { name: "alpha" }));
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getByRole("option", { name: "beta" }).getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(screen.getByRole("option", { name: "alpha" }).getAttribute("aria-selected")).toBe("true");
+
+    // Cannot go before first
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(screen.getByRole("option", { name: "alpha" }).getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("Enter with active item selects it", async () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.focus(input);
+    await waitFor(() => screen.getByRole("option", { name: "alpha" }));
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith("alpha");
+  });
+
+  it("Enter with no active item does nothing", async () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.focus(input);
+    await waitFor(() => screen.getByRole("option", { name: "alpha" }));
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Escape when suggestions are open closes the dropdown", async () => {
+    render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.focus(input);
+    await waitFor(() => screen.getByRole("listbox"));
+    fireEvent.keyDown(input, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("listbox")).toBeNull());
+  });
+
+  it("Escape when no suggestions still closes open state", () => {
+    render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    // "zzz" has no matches but sets open=true; Escape should close
+    fireEvent.change(input, { target: { value: "zzz" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("non-navigation key when no suggestions does nothing", () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.change(input, { target: { value: "zzz" } }); // no matches
+    fireEvent.keyDown(input, { key: "a" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("non-navigation key when dropdown is open does nothing", async () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.focus(input);
+    await waitFor(() => screen.getByRole("listbox"));
+    fireEvent.keyDown(input, { key: "Tab" });
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByRole("listbox")).toBeTruthy();
+  });
+
+  it("blur closes dropdown after delay", async () => {
+    render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.focus(input);
+    await waitFor(() => screen.getByRole("listbox"));
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.queryByRole("listbox")).toBeNull(), { timeout: 500 });
+  });
+
+  it("shows no dropdown when knownTags is empty", () => {
+    render(<TagPicker knownTags={[]} value="" onSelect={vi.fn()} />);
+    fireEvent.focus(screen.getByPlaceholderText("Filter by tag"));
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+});
+
+// ------------------------------------------------------------------
+// MemoryBrowser
+// ------------------------------------------------------------------
 
 describe("MemoryBrowser", () => {
   beforeEach(() => {
@@ -74,10 +241,25 @@ describe("MemoryBrowser", () => {
     await waitFor(() => expect(screen.getByText("Load failed")).toBeTruthy());
   });
 
-  it("passes tag filter to listMemories", async () => {
+  it("passes tag filter to listMemories when a tag is selected", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ tags: ["mytag"] })],
+      next_cursor: null,
+    });
     await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+
+    // Type to surface suggestion then select it
     const filterInput = screen.getByPlaceholderText("Filter by tag");
-    await act(async () => fireEvent.change(filterInput, { target: { value: "mytag" } }));
+    await act(async () => fireEvent.focus(filterInput));
+    await act(async () =>
+      fireEvent.change(filterInput, { target: { value: "my" } }),
+    );
+    await waitFor(() => screen.getByRole("option", { name: "mytag" }));
+    await act(async () =>
+      fireEvent.mouseDown(screen.getByRole("option", { name: "mytag" })),
+    );
+
     await waitFor(() =>
       expect(api.listMemories).toHaveBeenCalledWith("mytag"),
     );
@@ -360,28 +542,60 @@ describe("MemoryBrowser", () => {
     await waitFor(() => expect(screen.getByText("87% match")).toBeTruthy(), { timeout: 1000 });
   });
 
-  it("clears tag filter when search query is typed", async () => {
+  it("clears tag filter chip when search query is typed", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ tags: ["mytag"] })],
+      next_cursor: null,
+    });
     await act(async () => render(<MemoryBrowser />));
-    const tagInput = screen.getByPlaceholderText("Filter by tag");
-    const searchInput = screen.getByPlaceholderText("Search by meaning…");
+    await waitFor(() => screen.getByText("test-key"));
 
-    await act(async () => fireEvent.change(tagInput, { target: { value: "mytag" } }));
+    // Select tag via TagPicker
+    const filterInput = screen.getByPlaceholderText("Filter by tag");
+    await act(async () => fireEvent.focus(filterInput));
+    await act(async () =>
+      fireEvent.change(filterInput, { target: { value: "my" } }),
+    );
+    await waitFor(() => screen.getByRole("option", { name: "mytag" }));
+    await act(async () =>
+      fireEvent.mouseDown(screen.getByRole("option", { name: "mytag" })),
+    );
+
+    // Chip is now shown; input is gone
+    expect(screen.queryByPlaceholderText("Filter by tag")).toBeNull();
+
+    // Type in search — tag chip should clear (input reappears)
+    const searchInput = screen.getByPlaceholderText("Search by meaning…");
     await act(async () =>
       fireEvent.change(searchInput, { target: { value: "query" } }),
     );
-
-    expect(tagInput.value).toBe("");
+    expect(screen.getByPlaceholderText("Filter by tag")).toBeTruthy();
   });
 
-  it("clears search query when tag filter is typed", async () => {
+  it("clears search query when tag is selected from picker", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ tags: ["mytag"] })],
+      next_cursor: null,
+    });
     await act(async () => render(<MemoryBrowser />));
-    const tagInput = screen.getByPlaceholderText("Filter by tag");
-    const searchInput = screen.getByPlaceholderText("Search by meaning…");
+    await waitFor(() => screen.getByText("test-key"));
 
+    // Enter search mode
+    const searchInput = screen.getByPlaceholderText("Search by meaning…");
     await act(async () =>
       fireEvent.change(searchInput, { target: { value: "query" } }),
     );
-    await act(async () => fireEvent.change(tagInput, { target: { value: "mytag" } }));
+
+    // Select tag via TagPicker
+    const filterInput = screen.getByPlaceholderText("Filter by tag");
+    await act(async () => fireEvent.focus(filterInput));
+    await act(async () =>
+      fireEvent.change(filterInput, { target: { value: "my" } }),
+    );
+    await waitFor(() => screen.getByRole("option", { name: "mytag" }));
+    await act(async () =>
+      fireEvent.mouseDown(screen.getByRole("option", { name: "mytag" })),
+    );
 
     expect(searchInput.value).toBe("");
   });

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -1,2 +1,6 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import "@testing-library/jest-dom";
+
+// jsdom does not implement scrollIntoView; stub it so components that call it
+// do not throw and coverage branches are reachable.
+window.HTMLElement.prototype.scrollIntoView = function () {};

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -3,4 +3,4 @@ import "@testing-library/jest-dom";
 
 // jsdom does not implement scrollIntoView; stub it so components that call it
 // do not throw and coverage branches are reachable.
-window.HTMLElement.prototype.scrollIntoView = function () {};
+globalThis.HTMLElement.prototype.scrollIntoView = function () {};


### PR DESCRIPTION
## Summary

- Replaces the plain tag filter text input in MemoryBrowser with a `TagPicker` combobox
- Shows a filtered dropdown of known tags (derived from loaded memories) as the user types
- Selecting a tag renders it as a removable chip; clicking × clears the filter
- Full keyboard support: ArrowDown/Up to navigate, Enter to select, Escape to close
- ARIA combobox attributes (`aria-autocomplete`, `aria-expanded`, `aria-controls`, `aria-activedescendant`, `role="listbox"`, `role="option"`)
- `TagPicker` is exported as a named export for isolated unit testing
- `scrollIntoView` stubbed in `setupTests.js` so jsdom doesn't throw on scroll-into-view calls

## Test plan

- [x] All 322 frontend tests pass, 100% branch/statement/function coverage
- [x] `pre-push` gate passes (lint, mypy, unit tests, frontend tests)
- [ ] Smoke test in browser: type a partial tag, select from dropdown, verify list filters; click × to clear

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)