### PR TITLE
feat: relative timestamps on dashboard + keyboard nav on memory list

### DIFF
--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useRelativeTime } from "../hooks/useRelativeTime.js";
 import {
   Area,
   AreaChart,
@@ -330,6 +331,7 @@ export default function Dashboard() {
   const [costsError, setCostsError] = useState("");
   const [loading, setLoading] = useState(false);
   const [lastRefreshed, setLastRefreshed] = useState(null);
+  const relativeTime = useRelativeTime(lastRefreshed);
   const intervalRef = useRef(null);
 
   const TOOLS = ["remember", "recall", "forget", "list_memories", "summarize_context", "search_memories"];
@@ -421,9 +423,12 @@ export default function Dashboard() {
         </div>
         {loading && <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Loading…</span>}
         <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 12 }}>
-          {lastRefreshed && !loading && (
-            <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
-              Checked at {lastRefreshed.toLocaleTimeString()}
+          {relativeTime && !loading && (
+            <span
+              title={lastRefreshed.toLocaleTimeString()}
+              style={{ fontSize: 12, color: "var(--text-muted)", cursor: "default" }}
+            >
+              {relativeTime}
             </span>
           )}
           <button

--- a/ui/src/components/Dashboard.test.jsx
+++ b/ui/src/components/Dashboard.test.jsx
@@ -232,9 +232,9 @@ describe("Dashboard", () => {
     await waitFor(() => expect(screen.getByText(/Cost data lags/)).toBeTruthy());
   });
 
-  it("shows last refreshed time after load", async () => {
+  it("shows relative refresh time after load", async () => {
     await act(async () => render(<Dashboard />));
-    await waitFor(() => expect(screen.getByText(/Checked at/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("just now")).toBeTruthy());
   });
 
   it("switches period when a period button is clicked", async () => {

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -197,7 +197,9 @@ export default function MemoryBrowser() {
   const [editing, setEditing] = useState(null); // memory object or null
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState({ key: "", value: "", tags: "" });
+  const [focusedIndex, setFocusedIndex] = useState(-1);
   const searchDebounceRef = useRef(null);
+  const listRef = useRef(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -337,6 +339,41 @@ export default function MemoryBrowser() {
     setForm({ key: "", value: "", tags: "" });
   }
 
+  function closePanel() {
+    setEditing(null);
+    setCreating(false);
+  }
+
+  // Programmatically focus the card at focusedIndex when it changes
+  useEffect(() => {
+    if (focusedIndex >= 0 && listRef.current) {
+      const card = listRef.current.children[focusedIndex];
+      card?.focus();
+    }
+  }, [focusedIndex]);
+
+  function handleListKeyDown(e) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.min(i + 1, memories.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.max(i - 1, 0));
+    }
+  }
+
+  function handleCardKeyDown(e, m) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      openEdit(m);
+    } else if (e.key === "Delete" || e.key === "Backspace") {
+      e.preventDefault();
+      handleDelete(m.memory_id);
+    } else if (e.key === "Escape") {
+      closePanel();
+    }
+  }
+
   return (
     <div style={{ display: "flex", gap: 20 }}>
       {/* List */}
@@ -369,8 +406,12 @@ export default function MemoryBrowser() {
           </div>
         )}
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-          {memories.map((m) => (
+        <div
+          ref={listRef}
+          style={{ display: "flex", flexDirection: "column", gap: 10 }}
+          onKeyDown={handleListKeyDown}
+        >
+          {memories.map((m, i) => (
             <div
               key={m.memory_id}
               className="card"
@@ -378,7 +419,8 @@ export default function MemoryBrowser() {
               tabIndex={0}
               style={{ cursor: "pointer", borderLeft: "4px solid var(--accent)" }}
               onClick={() => openEdit(m)}
-              onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && openEdit(m)}
+              onFocus={() => setFocusedIndex(i)}
+              onKeyDown={(e) => handleCardKeyDown(e, m)}
             >
               <div
                 style={{
@@ -492,10 +534,7 @@ export default function MemoryBrowser() {
                 <button
                   className="secondary"
                   type="button"
-                  onClick={() => {
-                    setCreating(false);
-                    setEditing(null);
-                  }}
+                  onClick={closePanel}
                 >
                   Cancel
                 </button>

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -413,6 +413,100 @@ describe("MemoryBrowser", () => {
     expect(screen.queryByText("Edit: test-key")).toBeNull();
   });
 
+  // ---------------------------------------------------------------------------
+  // List keyboard navigation (#257)
+  // ---------------------------------------------------------------------------
+
+  it("ArrowDown moves focus to next card", async () => {
+    const m1 = makeMemory({ memory_id: "m1", key: "key1" });
+    const m2 = makeMemory({ memory_id: "m2", key: "key2" });
+    api.listMemories.mockResolvedValue({ items: [m1, m2], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("key1"));
+
+    const card1 = screen.getByText("key1").closest(".card");
+    const card2 = screen.getByText("key2").closest(".card");
+
+    // Focus card1 then press ArrowDown → card2 gets focus
+    await act(async () => fireEvent.focus(card1));
+    await act(async () => fireEvent.keyDown(card1, { key: "ArrowDown" }));
+    await waitFor(() => expect(card2).toHaveFocus());
+  });
+
+  it("ArrowUp moves focus to previous card", async () => {
+    const m1 = makeMemory({ memory_id: "m1", key: "key1" });
+    const m2 = makeMemory({ memory_id: "m2", key: "key2" });
+    api.listMemories.mockResolvedValue({ items: [m1, m2], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("key2"));
+
+    const card1 = screen.getByText("key1").closest(".card");
+    const card2 = screen.getByText("key2").closest(".card");
+
+    // Focus card2 then press ArrowUp → card1 gets focus
+    await act(async () => fireEvent.focus(card2));
+    await act(async () => fireEvent.keyDown(card2, { key: "ArrowUp" }));
+    await waitFor(() => expect(card1).toHaveFocus());
+  });
+
+  it("Delete key on focused card triggers delete", async () => {
+    api.listMemories
+      .mockResolvedValueOnce({ items: [makeMemory()], next_cursor: null })
+      .mockResolvedValue({ items: [], next_cursor: null });
+    api.deleteMemory.mockResolvedValue(null);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    const card = screen.getByText("test-key").closest(".card");
+    await act(async () => fireEvent.keyDown(card, { key: "Delete" }));
+    expect(api.deleteMemory).toHaveBeenCalledWith("m1");
+  });
+
+  it("Backspace key on focused card triggers delete", async () => {
+    api.listMemories
+      .mockResolvedValueOnce({ items: [makeMemory()], next_cursor: null })
+      .mockResolvedValue({ items: [], next_cursor: null });
+    api.deleteMemory.mockResolvedValue(null);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    const card = screen.getByText("test-key").closest(".card");
+    await act(async () => fireEvent.keyDown(card, { key: "Backspace" }));
+    expect(api.deleteMemory).toHaveBeenCalledWith("m1");
+  });
+
+  it("Escape key on card closes the edit panel", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+
+    // Open edit panel
+    fireEvent.click(screen.getByText("test-key").closest(".card"));
+    expect(screen.getByText("Edit: test-key")).toBeTruthy();
+
+    // Escape closes it
+    const card = screen.getByText("test-key").closest(".card");
+    await act(async () => fireEvent.keyDown(card, { key: "Escape" }));
+    expect(screen.queryByText("Edit: test-key")).toBeNull();
+  });
+
+  it("onFocus on card tracks focusedIndex (ArrowDown starts from focused card)", async () => {
+    const m1 = makeMemory({ memory_id: "m1", key: "key1" });
+    const m2 = makeMemory({ memory_id: "m2", key: "key2" });
+    const m3 = makeMemory({ memory_id: "m3", key: "key3" });
+    api.listMemories.mockResolvedValue({ items: [m1, m2, m3], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("key2"));
+
+    const card2 = screen.getByText("key2").closest(".card");
+    const card3 = screen.getByText("key3").closest(".card");
+
+    // Focus card2 (index 1) then ArrowDown → card3 (index 2)
+    await act(async () => fireEvent.focus(card2));
+    await act(async () => fireEvent.keyDown(card2, { key: "ArrowDown" }));
+    await waitFor(() => expect(card3).toHaveFocus());
+  });
+
   it("updates memory and closes form on success", async () => {
     api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
     api.updateMemory.mockResolvedValue({});

--- a/ui/src/hooks/useRelativeTime.js
+++ b/ui/src/hooks/useRelativeTime.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a human-readable relative time string for `date` (e.g. "just now",
+ * "3 mins ago", "2 hours ago"). Updates automatically every 30 seconds.
+ * Returns null when date is null/undefined.
+ */
+export function formatRelativeTime(date) {
+  if (!date) return null;
+  const secs = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (secs < 60) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins} ${mins === 1 ? "min" : "mins"} ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} ${hours === 1 ? "hour" : "hours"} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} ${days === 1 ? "day" : "days"} ago`;
+}
+
+export function useRelativeTime(date) {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!date) return;
+    const id = setInterval(() => setTick((n) => n + 1), 30_000);
+    return () => clearInterval(id);
+  }, [date]);
+
+  return formatRelativeTime(date);
+}

--- a/ui/src/hooks/useRelativeTime.test.js
+++ b/ui/src/hooks/useRelativeTime.test.js
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatRelativeTime, useRelativeTime } from "./useRelativeTime.js";
+
+// ---------------------------------------------------------------------------
+// formatRelativeTime — pure formatting logic
+// ---------------------------------------------------------------------------
+
+describe("formatRelativeTime", () => {
+  it("returns null for null input", () => {
+    expect(formatRelativeTime(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(formatRelativeTime(undefined)).toBeNull();
+  });
+
+  it("returns 'just now' for < 60 seconds ago", () => {
+    const date = new Date(Date.now() - 30_000);
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it("returns '1 min ago' for exactly 60 seconds ago", () => {
+    const date = new Date(Date.now() - 60_000);
+    expect(formatRelativeTime(date)).toBe("1 min ago");
+  });
+
+  it("returns '5 mins ago' for 5 minutes ago", () => {
+    const date = new Date(Date.now() - 5 * 60_000);
+    expect(formatRelativeTime(date)).toBe("5 mins ago");
+  });
+
+  it("returns '1 hour ago' for exactly 60 minutes ago", () => {
+    const date = new Date(Date.now() - 60 * 60_000);
+    expect(formatRelativeTime(date)).toBe("1 hour ago");
+  });
+
+  it("returns '3 hours ago' for 3 hours ago", () => {
+    const date = new Date(Date.now() - 3 * 60 * 60_000);
+    expect(formatRelativeTime(date)).toBe("3 hours ago");
+  });
+
+  it("returns '1 day ago' for exactly 24 hours ago", () => {
+    const date = new Date(Date.now() - 24 * 60 * 60_000);
+    expect(formatRelativeTime(date)).toBe("1 day ago");
+  });
+
+  it("returns '3 days ago' for 3 days ago", () => {
+    const date = new Date(Date.now() - 3 * 24 * 60 * 60_000);
+    expect(formatRelativeTime(date)).toBe("3 days ago");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useRelativeTime — hook behaviour
+// ---------------------------------------------------------------------------
+
+describe("useRelativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null when date is null", () => {
+    const { result } = renderHook(() => useRelativeTime(null));
+    expect(result.current).toBeNull();
+  });
+
+  it("returns relative string for a given date", () => {
+    const date = new Date(Date.now() - 10_000);
+    const { result } = renderHook(() => useRelativeTime(date));
+    expect(result.current).toBe("just now");
+  });
+
+  it("re-renders after 30 seconds to update the relative string", async () => {
+    // Start 50 seconds ago → "just now"
+    const date = new Date(Date.now() - 50_000);
+    const { result } = renderHook(() => useRelativeTime(date));
+    expect(result.current).toBe("just now");
+
+    // Advance 30 s — now 80 s ago → "1 min ago"
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(result.current).toBe("1 min ago");
+  });
+
+  it("clears interval on unmount", () => {
+    const clearSpy = vi.spyOn(globalThis, "clearInterval");
+    const date = new Date(Date.now() - 10_000);
+    const { unmount } = renderHook(() => useRelativeTime(date));
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it("does not set interval when date is null", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    renderHook(() => useRelativeTime(null));
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

**#290 — Relative timestamps on dashboard**
- New `useRelativeTime(date)` hook in `ui/src/hooks/useRelativeTime.js`
- Pure `formatRelativeTime(date)` helper: `just now` / `N mins ago` / `N hours ago` / `N days ago`
- Hook re-renders every 30 s via `setInterval` (cleaned up on unmount)
- Dashboard "Checked at HH:MM:SS" replaced with relative string; absolute time still visible as a `title` tooltip on hover

**#257 — Keyboard navigation on memory list**
- ArrowDown / ArrowUp move focus between memory cards (roving focus via `focusedIndex` state + `useEffect`)
- Enter / Space open the edit panel (retained from previous work)
- Delete / Backspace trigger delete with confirmation
- Escape closes the edit or create panel
- `onFocus` on each card syncs `focusedIndex` so navigation always starts from the currently focused card

## Test plan

- [x] 342 frontend tests pass, 100% branch/statement/function/line coverage
- [x] `pre-push` gate passes
- [ ] Smoke: dashboard shows "just now" after load; waits 1 min → updates to "1 min ago"
- [ ] Smoke: memory list — Tab to a card, ArrowDown/Up to navigate, Delete to remove, Escape to dismiss panel

Closes #290
Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)