### PR TITLE
feat: live CloudWatch log viewer for admin UI

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -371,6 +371,18 @@ class HiveStack(cdk.Stack):
                 resources=["*"],
             )
         )
+        api_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "logs:FilterLogEvents",
+                    "logs:DescribeLogGroups",
+                ],
+                resources=[
+                    f"arn:aws:logs:{self.region}:{self.account}:log-group:/aws/lambda/hive-*",
+                    f"arn:aws:logs:{self.region}:{self.account}:log-group:/aws/lambda/hive-*:*",
+                ],
+            )
+        )
         # S3 Vectors + Bedrock Titan Embeddings V2 for API Lambda
         api_role.add_to_policy(
             iam.PolicyStatement(

--- a/src/hive/api/logs.py
+++ b/src/hive/api/logs.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Admin-only endpoint for CloudWatch Logs browsing.
+
+GET /api/admin/logs
+  ?group=all|mcp|api   (default: all)
+  &window=15m|1h|3h|24h (default: 1h)
+  &filter=<pattern>     (optional CloudWatch filter pattern)
+  &next_token=<token>   (optional pagination token from previous response)
+
+Returns up to 500 log events sorted newest-first, with an optional
+next_token for pagination.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from hive.api._auth import require_admin
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+ENVIRONMENT = os.environ.get("HIVE_ENV", os.environ.get("ENV", "local"))
+
+# Map human window labels → milliseconds
+_WINDOW_MS: dict[str, int] = {
+    "15m": 15 * 60 * 1000,
+    "1h": 60 * 60 * 1000,
+    "3h": 3 * 60 * 60 * 1000,
+    "24h": 24 * 60 * 60 * 1000,
+}
+
+_MAX_EVENTS = 500
+
+
+def _log_group_names(group: str) -> list[str]:
+    """Return the CloudWatch log group name(s) for the requested group selector."""
+    mcp = f"/aws/lambda/hive-{ENVIRONMENT}-mcp"
+    api = f"/aws/lambda/hive-{ENVIRONMENT}-api"
+    if group == "mcp":
+        return [mcp]
+    if group == "api":
+        return [api]
+    return [mcp, api]
+
+
+def _fetch_log_events(
+    group_names: list[str],
+    start_ms: int,
+    end_ms: int,
+    filter_pattern: str,
+    next_token: str | None,
+    limit: int,
+) -> dict[str, Any]:
+    """Call CloudWatch Logs FilterLogEvents across one or more log groups."""
+    client = boto3.client("logs")
+    all_events: list[dict[str, Any]] = []
+    returned_token: str | None = None
+
+    for group_name in group_names:
+        kwargs: dict[str, Any] = {
+            "logGroupName": group_name,
+            "startTime": start_ms,
+            "endTime": end_ms,
+            "limit": limit,
+        }
+        if filter_pattern:
+            kwargs["filterPattern"] = filter_pattern
+        if next_token:
+            kwargs["nextToken"] = next_token
+
+        try:
+            resp = client.filter_log_events(**kwargs)
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code == "ResourceNotFoundException":
+                # Log group doesn't exist yet (e.g. local/dev env with no traffic)
+                continue
+            raise HTTPException(status_code=502, detail=f"CloudWatch Logs error: {code}") from exc
+
+        for event in resp.get("events", []):
+            all_events.append(
+                {
+                    "timestamp": event["timestamp"],
+                    "message": event["message"],
+                    "log_group": group_name,
+                    "log_stream": event.get("logStreamName", ""),
+                    "event_id": event.get("eventId", ""),
+                }
+            )
+        if not returned_token:
+            returned_token = resp.get("nextToken")
+
+    # Sort newest-first
+    all_events.sort(key=lambda e: e["timestamp"], reverse=True)
+    return {
+        "events": all_events[:limit],
+        "next_token": returned_token,
+    }
+
+
+@router.get("/logs")
+async def get_logs(
+    group: str = Query("all", pattern="^(all|mcp|api)$"),
+    window: str = Query("1h", pattern="^(15m|1h|3h|24h)$"),
+    filter_pattern: str = Query("", alias="filter"),
+    next_token: str | None = Query(None),
+    _claims: dict[str, Any] = Depends(require_admin),
+) -> dict[str, Any]:
+    """Return recent CloudWatch log events. Admin-only.
+
+    Args:
+        group: Which log group(s) to query — mcp, api, or all.
+        window: Lookback window — 15m, 1h, 3h, or 24h.
+        filter_pattern: Optional CloudWatch filter pattern (passed verbatim).
+        next_token: Pagination token from a previous response.
+    """
+    end_ms = int(time.time() * 1000)
+    start_ms = end_ms - _WINDOW_MS[window]
+    group_names = _log_group_names(group)
+    return _fetch_log_events(group_names, start_ms, end_ms, filter_pattern, next_token, _MAX_EVENTS)

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -19,6 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from hive.api.admin import router as admin_router
 from hive.api.clients import router as clients_router
+from hive.api.logs import router as logs_router
 from hive.api.memories import router as memories_router
 from hive.api.stats import router as stats_router
 from hive.api.users import router as users_router
@@ -125,6 +126,7 @@ app.include_router(clients_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")
+app.include_router(logs_router, prefix="/api")
 
 
 @app.get("/health", include_in_schema=False)

--- a/tests/unit/test_logs_api.py
+++ b/tests/unit/test_logs_api.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for GET /api/admin/logs.
+
+CloudWatch Logs boto3 calls are mocked via unittest.mock so tests run
+without any AWS credentials.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-unit-logs")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+os.environ.pop("DYNAMODB_ENDPOINT", None)
+
+_ADMIN_CLAIMS = {"sub": "admin-001", "role": "admin", "email": "admin@example.com"}
+_USER_CLAIMS = {"sub": "user-001", "role": "user", "email": "user@example.com"}
+
+_NOW_MS = int(time.time() * 1000)
+
+_SAMPLE_EVENT = {
+    "timestamp": _NOW_MS - 5000,
+    "message": '{"level": "INFO", "message": "tool called", "tool": "remember"}',
+    "logStreamName": "2026/04/11/[$LATEST]abc123",
+    "eventId": "evt-001",
+}
+
+
+def _create_table() -> None:
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName="hive-unit-logs",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ClientIdIndex",
+                "KeySchema": [{"AttributeName": "GSI4PK", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+@pytest.fixture()
+def admin_tc():
+    with mock_aws():
+        _create_table()
+        from hive.api import _auth as auth_mod
+        from hive.api.main import app
+
+        app.dependency_overrides[auth_mod.require_mgmt_user] = lambda: _ADMIN_CLAIMS
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def user_tc():
+    with mock_aws():
+        _create_table()
+        from hive.api import _auth as auth_mod
+        from hive.api.main import app
+
+        app.dependency_overrides[auth_mod.require_mgmt_user] = lambda: _USER_CLAIMS
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+
+def _mock_logs_client(events=None, next_token=None):
+    """Return a mock boto3 logs client that returns given events."""
+    mock_client = MagicMock()
+    mock_client.filter_log_events.return_value = {
+        "events": events or [],
+        **({"nextToken": next_token} if next_token else {}),
+    }
+    return mock_client
+
+
+class TestGetLogs:
+    def test_requires_admin(self, user_tc):
+        resp = user_tc.get("/api/admin/logs")
+        assert resp.status_code == 403
+
+    def test_returns_empty_events_when_no_logs(self, admin_tc):
+        mock_client = _mock_logs_client(events=[])
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            resp = admin_tc.get("/api/admin/logs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["events"] == []
+        assert data["next_token"] is None
+
+    def test_returns_log_events_for_mcp_group(self, admin_tc):
+        mock_client = _mock_logs_client(events=[_SAMPLE_EVENT])
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            resp = admin_tc.get("/api/admin/logs?group=mcp")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        assert len(events) == 1
+        assert events[0]["message"] == _SAMPLE_EVENT["message"]
+        assert events[0]["log_stream"] == _SAMPLE_EVENT["logStreamName"]
+        assert events[0]["event_id"] == _SAMPLE_EVENT["eventId"]
+        assert "log_group" in events[0]
+        assert "mcp" in events[0]["log_group"]
+
+    def test_returns_events_from_both_groups_for_all(self, admin_tc):
+        mcp_event = {**_SAMPLE_EVENT, "eventId": "evt-mcp", "timestamp": _NOW_MS - 2000}
+        api_event = {**_SAMPLE_EVENT, "eventId": "evt-api", "timestamp": _NOW_MS - 1000}
+        call_count = 0
+
+        def side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "mcp" in kwargs["logGroupName"]:
+                return {"events": [mcp_event]}
+            return {"events": [api_event]}
+
+        mock_client = MagicMock()
+        mock_client.filter_log_events.side_effect = side_effect
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            resp = admin_tc.get("/api/admin/logs?group=all")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        # Both groups queried
+        assert call_count == 2
+        assert len(events) == 2
+        # Newest first
+        assert events[0]["event_id"] == "evt-api"
+        assert events[1]["event_id"] == "evt-mcp"
+
+    def test_events_sorted_newest_first(self, admin_tc):
+        older = {**_SAMPLE_EVENT, "eventId": "old", "timestamp": _NOW_MS - 10000}
+        newer = {**_SAMPLE_EVENT, "eventId": "new", "timestamp": _NOW_MS - 1000}
+        mock_client = _mock_logs_client(events=[older, newer])
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            resp = admin_tc.get("/api/admin/logs?group=mcp")
+        events = resp.json()["events"]
+        assert events[0]["event_id"] == "new"
+        assert events[1]["event_id"] == "old"
+
+    def test_passes_filter_pattern(self, admin_tc):
+        mock_client = _mock_logs_client()
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            admin_tc.get("/api/admin/logs?group=mcp&filter=ERROR")
+        call_kwargs = mock_client.filter_log_events.call_args[1]
+        assert call_kwargs["filterPattern"] == "ERROR"
+
+    def test_no_filter_pattern_when_empty(self, admin_tc):
+        mock_client = _mock_logs_client()
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            admin_tc.get("/api/admin/logs?group=mcp")
+        call_kwargs = mock_client.filter_log_events.call_args[1]
+        assert "filterPattern" not in call_kwargs
+
+    def test_passes_next_token(self, admin_tc):
+        mock_client = _mock_logs_client()
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            admin_tc.get("/api/admin/logs?group=mcp&next_token=abc123")
+        call_kwargs = mock_client.filter_log_events.call_args[1]
+        assert call_kwargs["nextToken"] == "abc123"
+
+    def test_returns_next_token_from_response(self, admin_tc):
+        mock_client = _mock_logs_client(next_token="page2token")
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            resp = admin_tc.get("/api/admin/logs?group=mcp")
+        assert resp.json()["next_token"] == "page2token"
+
+    def test_window_parameter_accepted(self, admin_tc):
+        mock_client = _mock_logs_client()
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            for w in ("15m", "1h", "3h", "24h"):
+                resp = admin_tc.get(f"/api/admin/logs?group=mcp&window={w}")
+                assert resp.status_code == 200
+
+    def test_invalid_window_rejected(self, admin_tc):
+        resp = admin_tc.get("/api/admin/logs?window=99h")
+        assert resp.status_code == 422
+
+    def test_invalid_group_rejected(self, admin_tc):
+        resp = admin_tc.get("/api/admin/logs?group=unknown")
+        assert resp.status_code == 422
+
+    def test_resource_not_found_skips_group(self, admin_tc):
+        """Log group doesn't exist yet — should return empty, not 502."""
+        error_response = {
+            "Error": {"Code": "ResourceNotFoundException", "Message": "group not found"}
+        }
+        mock_client = MagicMock()
+        mock_client.filter_log_events.side_effect = ClientError(error_response, "FilterLogEvents")
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            resp = admin_tc.get("/api/admin/logs?group=mcp")
+        assert resp.status_code == 200
+        assert resp.json()["events"] == []
+
+    def test_unexpected_aws_error_returns_502(self, admin_tc):
+        error_response = {"Error": {"Code": "ThrottlingException", "Message": "throttled"}}
+        mock_client = MagicMock()
+        mock_client.filter_log_events.side_effect = ClientError(error_response, "FilterLogEvents")
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            resp = admin_tc.get("/api/admin/logs?group=mcp")
+        assert resp.status_code == 502
+        assert "ThrottlingException" in resp.json()["detail"]
+
+    def test_log_group_names_for_all(self, admin_tc):
+        """Both log groups are queried when group=all."""
+        queried_groups: list[str] = []
+
+        def capture(**kwargs):
+            queried_groups.append(kwargs["logGroupName"])
+            return {"events": []}
+
+        mock_client = MagicMock()
+        mock_client.filter_log_events.side_effect = capture
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            admin_tc.get("/api/admin/logs?group=all")
+        assert any("mcp" in g for g in queried_groups)
+        assert any("api" in g for g in queried_groups)
+
+    def test_log_group_names_for_api_only(self, admin_tc):
+        queried_groups: list[str] = []
+
+        def capture(**kwargs):
+            queried_groups.append(kwargs["logGroupName"])
+            return {"events": []}
+
+        mock_client = MagicMock()
+        mock_client.filter_log_events.side_effect = capture
+        with patch("hive.api.logs.boto3.client", return_value=mock_client):
+            admin_tc.get("/api/admin/logs?group=api")
+        assert len(queried_groups) == 1
+        assert "api" in queried_groups[0]

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -8,6 +8,7 @@ import ActivityLog from "./components/ActivityLog.jsx";
 import AuthCallback from "./components/AuthCallback.jsx";
 import ClientManager from "./components/ClientManager.jsx";
 import Dashboard from "./components/Dashboard.jsx";
+import LogViewer from "./components/LogViewer.jsx";
 import ChangelogPage from "./components/ChangelogPage.jsx";
 import FaqPage from "./components/FaqPage.jsx";
 import HomePage from "./components/HomePage.jsx";
@@ -31,6 +32,7 @@ const ADMIN_TABS = [
   ...BASE_TABS,
   { id: "users", label: "Users" },
   { id: "dashboard", label: "Dashboard" },
+  { id: "logs", label: "Logs" },
 ];
 
 function parseToken(token) {
@@ -187,6 +189,7 @@ function AppShell() {
         {tab === "users" && isAdmin && <UsersPanel />}
         {tab === "setup" && <SetupPanel />}
         {tab === "dashboard" && isAdmin && <Dashboard />}
+        {tab === "logs" && isAdmin && <LogViewer />}
       </main>
 
       {version && (

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -30,6 +30,9 @@ vi.mock("./components/HomePage.jsx", () => ({
 vi.mock("./components/Dashboard.jsx", () => ({
   default: () => <div data-testid="dashboard" />,
 }));
+vi.mock("./components/LogViewer.jsx", () => ({
+  default: () => <div data-testid="log-viewer" />,
+}));
 
 /** Build a syntactically-valid mgmt JWT with given claims. */
 function makeToken({ expOffsetSeconds = 3600, role = "user", email = "u@example.com" } = {}) {
@@ -234,6 +237,14 @@ describe("AppShell", () => {
     await act(async () => render(<App />));
     fireEvent.click(screen.getByText("Dashboard"));
     expect(screen.getByTestId("dashboard")).toBeTruthy();
+    expect(screen.queryByTestId("memory-browser")).toBeNull();
+  });
+
+  it("switches to LogViewer when Logs tab is clicked (admin only)", async () => {
+    _storage["hive_mgmt_token"] = makeToken({ role: "admin" });
+    await act(async () => render(<App />));
+    fireEvent.click(screen.getByText("Logs"));
+    expect(screen.getByTestId("log-viewer")).toBeTruthy();
     expect(screen.queryByTestId("memory-browser")).toBeNull();
   });
 

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -72,6 +72,12 @@ export const api = {
   // Admin
   getMetrics: (period = "24h") => request("GET", `/api/admin/metrics?period=${period}`),
   getCosts: () => request("GET", "/api/admin/costs"),
+  getLogs: ({ group = "all", window = "1h", filter = "", nextToken } = {}) => {
+    const params = new URLSearchParams({ group, window });
+    if (filter) params.set("filter", filter);
+    if (nextToken) params.set("next_token", nextToken);
+    return request("GET", `/api/admin/logs?${params}`);
+  },
 
   // Users
   getMe: () => request("GET", "/api/users/me"),

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -284,6 +284,32 @@ describe("api", () => {
     expect(fetchMock.mock.calls[0][0]).toContain("/api/admin/costs");
   });
 
+  it("getLogs with defaults calls correct endpoint", async () => {
+    mockOk({ events: [], next_token: null });
+    await api.getLogs();
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/admin/logs");
+    expect(fetchMock.mock.calls[0][0]).toContain("group=all");
+    expect(fetchMock.mock.calls[0][0]).toContain("window=1h");
+  });
+
+  it("getLogs with filter appends filter param", async () => {
+    mockOk({ events: [], next_token: null });
+    await api.getLogs({ group: "mcp", window: "3h", filter: "ERROR" });
+    expect(fetchMock.mock.calls[0][0]).toContain("filter=ERROR");
+  });
+
+  it("getLogs omits filter when empty", async () => {
+    mockOk({ events: [], next_token: null });
+    await api.getLogs({ group: "mcp", window: "1h", filter: "" });
+    expect(fetchMock.mock.calls[0][0]).not.toContain("filter=");
+  });
+
+  it("getLogs with nextToken appends next_token param", async () => {
+    mockOk({ events: [], next_token: null });
+    await api.getLogs({ nextToken: "tok123" });
+    expect(fetchMock.mock.calls[0][0]).toContain("next_token=tok123");
+  });
+
   // ---------------------------------------------------------------------------
   // 401 handling — clears token and redirects
   // ---------------------------------------------------------------------------

--- a/ui/src/components/LogViewer.jsx
+++ b/ui/src/components/LogViewer.jsx
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { Play, Pause, RefreshCw, ChevronDown, ChevronRight } from "lucide-react";
+import { api } from "../api.js";
+
+const WINDOWS = ["15m", "1h", "3h", "24h"];
+const GROUPS = ["all", "mcp", "api"];
+const LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"];
+const POLL_INTERVAL_MS = 10_000;
+
+const LEVEL_STYLES = {
+  ERROR:   { background: "rgba(239,68,68,.15)",   color: "var(--danger)",       border: "1px solid rgba(239,68,68,.3)" },
+  WARNING: { background: "rgba(234,179,8,.15)",   color: "#ca8a04",             border: "1px solid rgba(234,179,8,.3)" },
+  INFO:    { background: "rgba(59,130,246,.12)",  color: "#3b82f6",             border: "1px solid rgba(59,130,246,.3)" },
+  DEBUG:   { background: "var(--surface)",        color: "var(--text-muted)",   border: "1px solid var(--border)" },
+};
+
+function levelOf(message) {
+  try {
+    const parsed = JSON.parse(message);
+    const raw = (parsed.level || parsed.levelname || parsed.severity || "").toUpperCase();
+    return LEVELS.includes(raw) ? raw : "INFO";
+  } catch {
+    if (/\bERROR\b/i.test(message)) return "ERROR";
+    if (/\bWARN/i.test(message)) return "WARNING";
+    if (/\bDEBUG\b/i.test(message)) return "DEBUG";
+    return "INFO";
+  }
+}
+
+function formatTs(ms) {
+  return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function LogRow({ event }) {
+  const [expanded, setExpanded] = useState(false);
+  const level = levelOf(event.message);
+  const levelStyle = LEVEL_STYLES[level];
+
+  let parsed = null;
+  try { parsed = JSON.parse(event.message); } catch { /* not JSON */ }
+
+  const summary = parsed
+    ? (parsed.message || parsed.msg || event.message).slice(0, 200)
+    : event.message.slice(0, 200);
+
+  return (
+    <div
+      style={{
+        borderBottom: "1px solid var(--border)",
+        fontSize: 12,
+        fontFamily: "ui-monospace, monospace",
+      }}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => setExpanded((v) => !v)}
+        onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && setExpanded((v) => !v)}
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 8,
+          padding: "6px 10px",
+          cursor: "pointer",
+          background: expanded ? "var(--surface)" : "transparent",
+        }}
+      >
+        <span style={{ color: "var(--text-muted)", whiteSpace: "nowrap", flexShrink: 0 }}>
+          {formatTs(event.timestamp)}
+        </span>
+        <span
+          style={{
+            ...levelStyle,
+            borderRadius: 4,
+            padding: "1px 6px",
+            fontSize: 10,
+            fontWeight: 700,
+            flexShrink: 0,
+          }}
+        >
+          {level}
+        </span>
+        <span style={{ color: "var(--text-muted)", flexShrink: 0, fontSize: 10 }}>
+          {event.log_group.split("/").pop()}
+        </span>
+        <span style={{ flex: 1, color: "var(--text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {summary}
+        </span>
+        <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>
+          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </span>
+      </div>
+      {expanded && (
+        <pre
+          style={{
+            margin: 0,
+            padding: "8px 10px 10px 10px",
+            background: "var(--surface)",
+            color: "var(--text)",
+            overflowX: "auto",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-all",
+          }}
+        >
+          {parsed ? JSON.stringify(parsed, null, 2) : event.message}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+LogRow.propTypes = {
+  event: PropTypes.shape({
+    timestamp: PropTypes.number.isRequired,
+    message: PropTypes.string.isRequired,
+    log_group: PropTypes.string.isRequired,
+    log_stream: PropTypes.string.isRequired,
+    event_id: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default function LogViewer() {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [group, setGroup] = useState("all");
+  const [window, setWindow] = useState("1h");
+  const [filter, setFilter] = useState("");
+  const [levelFilter, setLevelFilter] = useState(new Set(LEVELS));
+  const [paused, setPaused] = useState(false);
+  const [filterInput, setFilterInput] = useState("");
+  const intervalRef = useRef(null);
+  const debounceRef = useRef(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const data = await api.getLogs({ group, window, filter });
+      setEvents(data.events);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [group, window, filter]);
+
+  // Initial load and refresh when params change
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Polling
+  useEffect(() => {
+    if (paused) {
+      clearInterval(intervalRef.current);
+      return;
+    }
+    intervalRef.current = setInterval(load, POLL_INTERVAL_MS);
+    return () => clearInterval(intervalRef.current);
+  }, [load, paused]);
+
+  // Debounce free-text filter input
+  function handleFilterInput(e) {
+    const val = e.target.value;
+    setFilterInput(val);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setFilter(val), 400);
+  }
+
+  function toggleLevel(level) {
+    setLevelFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(level)) {
+        next.delete(level);
+      } else {
+        next.add(level);
+      }
+      return next;
+    });
+  }
+
+  const visibleEvents = events.filter((e) => levelFilter.has(levelOf(e.message)));
+
+  return (
+    <div>
+      {/* Toolbar */}
+      <div style={{ display: "flex", gap: 10, marginBottom: 14, alignItems: "center", flexWrap: "wrap" }}>
+        <h2 style={{ fontSize: 18, marginRight: 4 }}>Logs</h2>
+
+        {/* Group selector */}
+        <select
+          aria-label="Log group"
+          value={group}
+          onChange={(e) => setGroup(e.target.value)}
+          style={{ fontSize: 13 }}
+        >
+          {GROUPS.map((g) => (
+            <option key={g} value={g}>{g === "all" ? "All groups" : g.toUpperCase()}</option>
+          ))}
+        </select>
+
+        {/* Window selector */}
+        <select
+          aria-label="Time window"
+          value={window}
+          onChange={(e) => setWindow(e.target.value)}
+          style={{ fontSize: 13 }}
+        >
+          {WINDOWS.map((w) => <option key={w} value={w}>Last {w}</option>)}
+        </select>
+
+        {/* Free-text filter */}
+        <input
+          style={{ width: 200, fontSize: 13 }}
+          placeholder="Filter pattern…"
+          value={filterInput}
+          onChange={handleFilterInput}
+        />
+
+        {/* Level toggles */}
+        <div style={{ display: "flex", gap: 4 }}>
+          {LEVELS.map((level) => {
+            const active = levelFilter.has(level);
+            const style = LEVEL_STYLES[level];
+            return (
+              <button
+                key={level}
+                onClick={() => toggleLevel(level)}
+                style={{
+                  ...( active ? style : { background: "transparent", color: "var(--text-muted)", border: "1px solid var(--border)" }),
+                  borderRadius: 4,
+                  padding: "2px 8px",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                }}
+              >
+                {level}
+              </button>
+            );
+          })}
+        </div>
+
+        <div style={{ marginLeft: "auto", display: "flex", gap: 8, alignItems: "center" }}>
+          {loading && <RefreshCw size={14} style={{ color: "var(--text-muted)", animation: "spin 1s linear infinite" }} />}
+          <button
+            onClick={() => setPaused((v) => !v)}
+            title={paused ? "Resume live tail" : "Pause live tail"}
+            style={{
+              background: "transparent",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              padding: "4px 10px",
+              fontSize: 13,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            {paused ? <Play size={13} /> : <Pause size={13} />}
+            {paused ? "Resume" : "Pause"}
+          </button>
+          <button
+            onClick={load}
+            style={{
+              background: "transparent",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              padding: "4px 10px",
+              fontSize: 13,
+              cursor: "pointer",
+            }}
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {error && <p style={{ color: "var(--danger)", marginBottom: 10, fontSize: 13 }}>{error}</p>}
+
+      {/* Event list */}
+      <div
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius)",
+          overflow: "hidden",
+          maxHeight: "calc(100vh - 260px)",
+          overflowY: "auto",
+        }}
+      >
+        {!loading && visibleEvents.length === 0 && (
+          <p style={{ padding: 20, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>
+            No log events found.
+          </p>
+        )}
+        {visibleEvents.map((event) => (
+          <LogRow key={`${event.log_group}:${event.event_id}:${event.timestamp}`} event={event} />
+        ))}
+      </div>
+
+      <p style={{ marginTop: 8, fontSize: 11, color: "var(--text-muted)" }}>
+        {visibleEvents.length} event{visibleEvents.length !== 1 ? "s" : ""} shown
+        {paused ? " · paused" : " · live (10 s)"}
+      </p>
+    </div>
+  );
+}

--- a/ui/src/components/LogViewer.test.jsx
+++ b/ui/src/components/LogViewer.test.jsx
@@ -1,0 +1,334 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LogViewer from "./LogViewer.jsx";
+
+vi.mock("../api.js", () => ({
+  api: { getLogs: vi.fn() },
+}));
+
+import { api } from "../api.js";
+
+const makeEvent = (overrides = {}) => ({
+  timestamp: Date.now() - 5000,
+  message: '{"level":"INFO","message":"tool called"}',
+  log_group: "/aws/lambda/hive-dev-mcp",
+  log_stream: "2026/04/11/[$LATEST]abc",
+  event_id: "evt-001",
+  ...overrides,
+});
+
+describe("LogViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getLogs.mockResolvedValue({ events: [], next_token: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Initial render
+  // ---------------------------------------------------------------------------
+
+  it("renders heading and controls", async () => {
+    await act(async () => render(<LogViewer />));
+    expect(screen.getByText("Logs")).toBeTruthy();
+    expect(screen.getByLabelText("Log group")).toBeTruthy();
+    expect(screen.getByLabelText("Time window")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Filter pattern…")).toBeTruthy();
+  });
+
+  it("shows empty message when no events", async () => {
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getByText("No log events found.")).toBeTruthy());
+  });
+
+  it("calls getLogs on mount with defaults", async () => {
+    await act(async () => render(<LogViewer />));
+    await waitFor(() =>
+      expect(api.getLogs).toHaveBeenCalledWith({ group: "all", window: "1h", filter: "" }),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Log event rendering
+  // ---------------------------------------------------------------------------
+
+  it("renders a log event row", async () => {
+    api.getLogs.mockResolvedValue({ events: [makeEvent()], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getByText("tool called")).toBeTruthy());
+    // toolbar has one INFO button + row has one INFO badge = 2 total
+    expect(screen.getAllByText("INFO").length).toBe(2);
+    expect(screen.getByText("hive-dev-mcp")).toBeTruthy(); // group suffix
+  });
+
+  it("renders ERROR level badge", async () => {
+    const event = makeEvent({ message: '{"level":"ERROR","message":"something broke"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    // toolbar button + row badge = 2
+    await waitFor(() => expect(screen.getAllByText("ERROR").length).toBe(2));
+  });
+
+  it("renders WARNING level badge", async () => {
+    const event = makeEvent({ message: '{"level":"WARNING","message":"heads up"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("WARNING").length).toBe(2));
+  });
+
+  it("renders DEBUG level badge", async () => {
+    const event = makeEvent({ message: '{"level":"DEBUG","message":"debug info"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("DEBUG").length).toBe(2));
+  });
+
+  it("falls back to INFO for unknown JSON level", async () => {
+    const event = makeEvent({ message: '{"level":"TRACE","message":"trace msg"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("INFO").length).toBe(2));
+  });
+
+  it("detects ERROR level from plain text", async () => {
+    const event = makeEvent({ message: "ERROR something went wrong" });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("ERROR").length).toBe(2));
+  });
+
+  it("detects WARNING level from plain text", async () => {
+    const event = makeEvent({ message: "WARN something is fishy" });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("WARNING").length).toBe(2));
+  });
+
+  it("detects DEBUG level from plain text", async () => {
+    const event = makeEvent({ message: "DEBUG verbose stuff" });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("DEBUG").length).toBe(2));
+  });
+
+  it("falls back to INFO for plain text with no level keyword", async () => {
+    const event = makeEvent({ message: "something happened" });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("INFO").length).toBe(2));
+  });
+
+  it("uses msg field when message field is absent", async () => {
+    const event = makeEvent({ message: '{"level":"INFO","msg":"alt field"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getByText("alt field")).toBeTruthy());
+  });
+
+  it("detects level from levelname field", async () => {
+    const event = makeEvent({ message: '{"levelname":"ERROR","message":"from levelname"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("ERROR").length).toBe(2));
+  });
+
+  it("detects level from severity field", async () => {
+    const event = makeEvent({ message: '{"severity":"WARNING","message":"from severity"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("WARNING").length).toBe(2));
+  });
+
+  it("falls back to INFO when JSON has no level/levelname/severity field", async () => {
+    const event = makeEvent({ message: '{"data":"no level field"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getAllByText("INFO").length).toBe(2));
+  });
+
+  it("falls back to raw message when neither message nor msg is present in JSON", async () => {
+    const event = makeEvent({ message: '{"level":"INFO","data":"no text field"}' });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getByText('{"level":"INFO","data":"no text field"}')).toBeTruthy());
+  });
+
+  // ---------------------------------------------------------------------------
+  // Expand / collapse row
+  // ---------------------------------------------------------------------------
+
+  it("expands row on click to show full JSON", async () => {
+    api.getLogs.mockResolvedValue({ events: [makeEvent()], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => screen.getByText("tool called"));
+
+    const row = screen.getByText("tool called").closest("[role='button']");
+    fireEvent.click(row);
+    await waitFor(() => expect(screen.getByText(/"message": "tool called"/)).toBeTruthy());
+  });
+
+  it("expands row via keyboard Enter", async () => {
+    api.getLogs.mockResolvedValue({ events: [makeEvent()], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => screen.getByText("tool called"));
+
+    const row = screen.getByText("tool called").closest("[role='button']");
+    fireEvent.keyDown(row, { key: "Enter" });
+    await waitFor(() => expect(screen.getByText(/"message": "tool called"/)).toBeTruthy());
+  });
+
+  it("expands row via keyboard Space", async () => {
+    api.getLogs.mockResolvedValue({ events: [makeEvent()], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => screen.getByText("tool called"));
+
+    const row = screen.getByText("tool called").closest("[role='button']");
+    fireEvent.keyDown(row, { key: " " });
+    await waitFor(() => expect(screen.getByText(/"message": "tool called"/)).toBeTruthy());
+  });
+
+  it("collapses row on second click", async () => {
+    api.getLogs.mockResolvedValue({ events: [makeEvent()], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => screen.getByText("tool called"));
+
+    const row = screen.getByText("tool called").closest("[role='button']");
+    fireEvent.click(row);
+    await waitFor(() => screen.getByText(/"message": "tool called"/));
+    fireEvent.click(row);
+    await waitFor(() =>
+      expect(screen.queryByText(/"message": "tool called"/)).toBeNull(),
+    );
+  });
+
+  it("shows raw text in expanded view for non-JSON message", async () => {
+    const event = makeEvent({ message: "plain text log line" });
+    api.getLogs.mockResolvedValue({ events: [event], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => screen.getAllByText("plain text log line"));
+
+    const row = screen.getAllByText("plain text log line")[0].closest("[role='button']");
+    fireEvent.click(row);
+    // raw text appears in the expanded <pre>
+    await waitFor(() => expect(screen.getAllByText("plain text log line").length).toBeGreaterThan(1));
+  });
+
+  // ---------------------------------------------------------------------------
+  // Controls
+  // ---------------------------------------------------------------------------
+
+  it("changes group and reloads", async () => {
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(api.getLogs).toHaveBeenCalled());
+    api.getLogs.mockClear();
+
+    await act(async () =>
+      fireEvent.change(screen.getByLabelText("Log group"), { target: { value: "mcp" } }),
+    );
+    await waitFor(() =>
+      expect(api.getLogs).toHaveBeenCalledWith(expect.objectContaining({ group: "mcp" })),
+    );
+  });
+
+  it("changes window and reloads", async () => {
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(api.getLogs).toHaveBeenCalled());
+    api.getLogs.mockClear();
+
+    await act(async () =>
+      fireEvent.change(screen.getByLabelText("Time window"), { target: { value: "3h" } }),
+    );
+    await waitFor(() =>
+      expect(api.getLogs).toHaveBeenCalledWith(expect.objectContaining({ window: "3h" })),
+    );
+  });
+
+  it("debounces filter input and reloads", async () => {
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(api.getLogs).toHaveBeenCalled());
+    api.getLogs.mockClear();
+
+    await act(async () =>
+      fireEvent.change(screen.getByPlaceholderText("Filter pattern…"), {
+        target: { value: "ERROR" },
+      }),
+    );
+    await waitFor(
+      () => expect(api.getLogs).toHaveBeenCalledWith(expect.objectContaining({ filter: "ERROR" })),
+      { timeout: 1000 },
+    );
+  });
+
+  it("level toggle hides events of that level", async () => {
+    const infoEvent = makeEvent({ event_id: "e1", message: '{"level":"INFO","message":"info msg"}' });
+    const errorEvent = makeEvent({ event_id: "e2", message: '{"level":"ERROR","message":"error msg"}' });
+    api.getLogs.mockResolvedValue({ events: [infoEvent, errorEvent], next_token: null });
+
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => screen.getByText("info msg"));
+
+    // Deactivate INFO
+    fireEvent.click(screen.getAllByText("INFO")[0]);
+    await waitFor(() => expect(screen.queryByText("info msg")).toBeNull());
+    expect(screen.getByText("error msg")).toBeTruthy();
+
+    // Reactivate INFO
+    fireEvent.click(screen.getAllByText("INFO")[0]);
+    await waitFor(() => expect(screen.getByText("info msg")).toBeTruthy());
+  });
+
+  it("pause button stops polling", async () => {
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(api.getLogs).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText("Pause"));
+    expect(screen.getByText("Resume")).toBeTruthy();
+  });
+
+  it("resume button re-enables polling", async () => {
+    await act(async () => render(<LogViewer />));
+    fireEvent.click(screen.getByText("Pause"));
+    fireEvent.click(screen.getByText("Resume"));
+    expect(screen.getByText("Pause")).toBeTruthy();
+  });
+
+  it("refresh button triggers reload", async () => {
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(api.getLogs).toHaveBeenCalled());
+    api.getLogs.mockClear();
+
+    await act(async () => fireEvent.click(screen.getByText("Refresh")));
+    await waitFor(() => expect(api.getLogs).toHaveBeenCalled());
+  });
+
+  it("shows error when getLogs fails", async () => {
+    api.getLogs.mockRejectedValue(new Error("fetch failed"));
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getByText("fetch failed")).toBeTruthy());
+  });
+
+  it("shows event count in footer", async () => {
+    api.getLogs.mockResolvedValue({ events: [makeEvent()], next_token: null });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getByText(/1 event shown/)).toBeTruthy());
+  });
+
+  it("shows plural event count", async () => {
+    api.getLogs.mockResolvedValue({
+      events: [makeEvent({ event_id: "e1" }), makeEvent({ event_id: "e2" })],
+      next_token: null,
+    });
+    await act(async () => render(<LogViewer />));
+    await waitFor(() => expect(screen.getByText(/2 events shown/)).toBeTruthy());
+  });
+
+  it("shows paused in footer when paused", async () => {
+    await act(async () => render(<LogViewer />));
+    fireEvent.click(screen.getByText("Pause"));
+    expect(screen.getByText(/paused/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `GET /api/admin/logs` admin-only endpoint that queries CloudWatch Logs via boto3 `filter_log_events`, supporting group (`all`/`mcp`/`api`), time window, filter pattern, and pagination
- Adds `LogViewer` React component to the admin tab set — polls every 10 s, shows expandable log rows with level badges, group/window/filter controls, level toggle buttons, and pause/resume
- Grants the API Lambda IAM permission to call `logs:FilterLogEvents` and `logs:DescribeLogGroups` on hive log groups
- 16 new Python unit tests + 33 new frontend tests, 100% coverage maintained

## Test plan

- [ ] Python unit tests pass: `uv run pytest tests/unit/test_logs_api.py -v`
- [ ] Frontend tests pass at 100% coverage: `npm test` in `ui/`
- [ ] `uv run inv pre-push` passes all gates
- [ ] Admin user sees "Logs" tab in management UI; non-admin does not
- [ ] Log rows expand/collapse on click, Enter, and Space
- [ ] Pause/Resume stops/restarts 10 s polling
- [ ] Refresh button triggers immediate reload
- [ ] Level toggle buttons hide/show rows of that level

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)