### PR TITLE
fix: use CDK-injected log group names in logs endpoint

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -371,18 +371,7 @@ class HiveStack(cdk.Stack):
                 resources=["*"],
             )
         )
-        api_role.add_to_policy(
-            iam.PolicyStatement(
-                actions=[
-                    "logs:FilterLogEvents",
-                    "logs:DescribeLogGroups",
-                ],
-                resources=[
-                    f"arn:aws:logs:{self.region}:{self.account}:log-group:/aws/lambda/hive-*",
-                    f"arn:aws:logs:{self.region}:{self.account}:log-group:/aws/lambda/hive-*:*",
-                ],
-            )
-        )
+        # CloudWatch Logs permission is scoped after mcp_fn/api_fn are defined below.
         # S3 Vectors + Bedrock Titan Embeddings V2 for API Lambda
         api_role.add_to_policy(
             iam.PolicyStatement(
@@ -420,6 +409,28 @@ class HiveStack(cdk.Stack):
             timeout=cdk.Duration.seconds(30),
             description=f"Hive management API (FastAPI) [{env_name}]",
             tracing=lambda_.Tracing.ACTIVE,
+        )
+
+        # Pass the actual CloudWatch log group names to the API Lambda so it can
+        # query them without guessing CDK-generated function names at runtime.
+        mcp_log_group_name = f"/aws/lambda/{mcp_fn.function_name}"
+        api_log_group_name = f"/aws/lambda/{api_fn.function_name}"
+        api_fn.add_environment("HIVE_MCP_LOG_GROUP", mcp_log_group_name)
+        api_fn.add_environment("HIVE_API_LOG_GROUP", api_log_group_name)
+
+        api_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "logs:FilterLogEvents",
+                    "logs:DescribeLogGroups",
+                ],
+                resources=[
+                    f"arn:aws:logs:{self.region}:{self.account}:log-group:{mcp_log_group_name}",
+                    f"arn:aws:logs:{self.region}:{self.account}:log-group:{mcp_log_group_name}:*",
+                    f"arn:aws:logs:{self.region}:{self.account}:log-group:{api_log_group_name}",
+                    f"arn:aws:logs:{self.region}:{self.account}:log-group:{api_log_group_name}:*",
+                ],
+            )
         )
 
         api_url = api_fn.add_function_url(

--- a/src/hive/api/logs.py
+++ b/src/hive/api/logs.py
@@ -30,12 +30,8 @@ ENVIRONMENT = os.environ.get("HIVE_ENV", os.environ.get("ENV", "local"))
 
 # Log group names are injected by CDK so we use the real (CDK-generated) Lambda
 # function names rather than guessing them at runtime.
-_MCP_LOG_GROUP = os.environ.get(
-    "HIVE_MCP_LOG_GROUP", f"/aws/lambda/hive-{ENVIRONMENT}-mcp"
-)
-_API_LOG_GROUP = os.environ.get(
-    "HIVE_API_LOG_GROUP", f"/aws/lambda/hive-{ENVIRONMENT}-api"
-)
+_MCP_LOG_GROUP = os.environ.get("HIVE_MCP_LOG_GROUP", f"/aws/lambda/hive-{ENVIRONMENT}-mcp")
+_API_LOG_GROUP = os.environ.get("HIVE_API_LOG_GROUP", f"/aws/lambda/hive-{ENVIRONMENT}-api")
 
 # Map human window labels → milliseconds
 _WINDOW_MS: dict[str, int] = {

--- a/src/hive/api/logs.py
+++ b/src/hive/api/logs.py
@@ -28,6 +28,15 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 
 ENVIRONMENT = os.environ.get("HIVE_ENV", os.environ.get("ENV", "local"))
 
+# Log group names are injected by CDK so we use the real (CDK-generated) Lambda
+# function names rather than guessing them at runtime.
+_MCP_LOG_GROUP = os.environ.get(
+    "HIVE_MCP_LOG_GROUP", f"/aws/lambda/hive-{ENVIRONMENT}-mcp"
+)
+_API_LOG_GROUP = os.environ.get(
+    "HIVE_API_LOG_GROUP", f"/aws/lambda/hive-{ENVIRONMENT}-api"
+)
+
 # Map human window labels → milliseconds
 _WINDOW_MS: dict[str, int] = {
     "15m": 15 * 60 * 1000,
@@ -41,13 +50,11 @@ _MAX_EVENTS = 500
 
 def _log_group_names(group: str) -> list[str]:
     """Return the CloudWatch log group name(s) for the requested group selector."""
-    mcp = f"/aws/lambda/hive-{ENVIRONMENT}-mcp"
-    api = f"/aws/lambda/hive-{ENVIRONMENT}-api"
     if group == "mcp":
-        return [mcp]
+        return [_MCP_LOG_GROUP]
     if group == "api":
-        return [api]
-    return [mcp, api]
+        return [_API_LOG_GROUP]
+    return [_MCP_LOG_GROUP, _API_LOG_GROUP]
 
 
 def _fetch_log_events(


### PR DESCRIPTION
## Summary

- CDK auto-generates Lambda function names like `HiveStack-dev-McpFunctionF370A1F8-*`, so the CloudWatch log groups never matched the hardcoded `hive-{env}-mcp` pattern
- CDK now passes the real log group names as `HIVE_MCP_LOG_GROUP` / `HIVE_API_LOG_GROUP` env vars to the API Lambda
- `logs.py` reads those env vars (falling back to the old pattern for local dev)
- IAM policy is now scoped to the exact log group ARNs instead of the `hive-*` wildcard that never matched

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)