### PR TITLE
fix: eliminate CDK self-reference circular dependency in log viewer

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -411,14 +411,13 @@ class HiveStack(cdk.Stack):
             tracing=lambda_.Tracing.ACTIVE,
         )
 
-        # Pass the actual CloudWatch log group names to the API Lambda so it can
-        # query them without guessing CDK-generated function names at runtime.
-        # NOTE: api_fn.function_name is a CloudFormation token — it cannot appear
-        # in api_role's IAM policy (api_fn depends on api_role → circular).
-        # We use it only in add_environment (self-reference is permitted) and
-        # scope the IAM policy to the stack-name prefix, which is a plain string.
+        # Pass the MCP log group name so the API Lambda can query it.
+        # mcp_fn.function_name is safe here (mcp_fn has no dependency on api_fn).
+        # We do NOT pass the API log group name via CFN token — that would be a
+        # self-reference (api_fn → api_fn) and cause a circular dependency.
+        # Instead, logs.py derives it at runtime from AWS_LAMBDA_FUNCTION_NAME,
+        # which the Lambda runtime injects automatically.
         api_fn.add_environment("HIVE_MCP_LOG_GROUP", f"/aws/lambda/{mcp_fn.function_name}")
-        api_fn.add_environment("HIVE_API_LOG_GROUP", f"/aws/lambda/{api_fn.function_name}")
 
         # CDK names functions "{StackId}-{LogicalId}-{RandomSuffix}".
         # The stack construct_id is the first segment, so "/aws/lambda/HiveStack*"

--- a/src/hive/api/logs.py
+++ b/src/hive/api/logs.py
@@ -28,10 +28,16 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 
 ENVIRONMENT = os.environ.get("HIVE_ENV", os.environ.get("ENV", "local"))
 
-# Log group names are injected by CDK so we use the real (CDK-generated) Lambda
-# function names rather than guessing them at runtime.
+# MCP log group is injected by CDK (mcp_fn.function_name has no cycle).
+# API log group is derived from AWS_LAMBDA_FUNCTION_NAME, which the Lambda
+# runtime injects automatically — avoids a CDK self-reference circular dep.
 _MCP_LOG_GROUP = os.environ.get("HIVE_MCP_LOG_GROUP", f"/aws/lambda/hive-{ENVIRONMENT}-mcp")
-_API_LOG_GROUP = os.environ.get("HIVE_API_LOG_GROUP", f"/aws/lambda/hive-{ENVIRONMENT}-api")
+_AWS_FUNCTION_NAME = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "")
+_API_LOG_GROUP = (
+    f"/aws/lambda/{_AWS_FUNCTION_NAME}"
+    if _AWS_FUNCTION_NAME
+    else f"/aws/lambda/hive-{ENVIRONMENT}-api"
+)
 
 # Map human window labels → milliseconds
 _WINDOW_MS: dict[str, int] = {


### PR DESCRIPTION
## Summary

`api_fn.add_environment("HIVE_API_LOG_GROUP", api_fn.function_name)` is a self-reference — CloudFormation sees `api_fn` depending on itself, causing:

```
ValidationError: Circular dependency between resources: [ApiLambdaRoleDefaultPolicy..., ApiFunctionCE271BD4, ...]
```

Fix: derive the API log group from `AWS_LAMBDA_FUNCTION_NAME`, which the Lambda runtime injects automatically (no CFN token, no cycle). The MCP log group still comes via `HIVE_MCP_LOG_GROUP` env var (one-way dependency, safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)