### PR TITLE
fix: suppress false-positive SonarCloud security findings

### DIFF
--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -59,6 +59,7 @@ async def get_activity(
     storage: HiveStorage = Depends(_storage),
 ) -> PagedResponse:
     today = date.today()
+    # `days` is bounded by FastAPI Query(ge=1, le=90) above. NOSONAR
     dates = [(today - timedelta(days=i)).isoformat() for i in range(days)]
     events = storage.get_events_for_dates(dates, limit=limit + 1)
 

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -154,6 +154,7 @@ async def authorize(
         params: dict[str, str] = {"code": auth_code.code}
         if state:
             params["state"] = state
+        # redirect_uri was validated against client.redirect_uris above (line 126). NOSONAR
         return RedirectResponse(f"{redirect_uri}?{urlencode(params)}", status_code=302)
 
     # Production: store PKCE state, then redirect to Google for identity verification.
@@ -238,6 +239,8 @@ async def google_callback(
     params: dict[str, str] = {"code": auth_code.code}
     if pending.original_state:
         params["state"] = pending.original_state
+    # pending.redirect_uri was validated against client.redirect_uris when the pending auth
+    # was created (authorize endpoint, line 126). NOSONAR
     return RedirectResponse(f"{pending.redirect_uri}?{urlencode(params)}", status_code=302)
 
 


### PR DESCRIPTION
## Summary

Both SonarCloud BLOCKER/CRITICAL findings are false positives — the validation is already in place but SonarCloud can't trace it statically.

**oauth.py — open redirect (lines 157, 241):** `redirect_uri` is validated against `client.redirect_uris` at line 126 before any redirect is issued. Added `# NOSONAR` comments on both `RedirectResponse` calls explaining this.

**stats.py — user-controlled loop bounds (line 62):** `days` is bounded by `FastAPI Query(ge=1, le=90)` in the function signature. Added `# NOSONAR` comment on the `range(days)` call.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)