### PR TITLE
fix: remove redundant response_model from FastAPI routes

### DIFF
--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -37,7 +37,7 @@ def _user_filter(claims: dict[str, Any]) -> str | None:
     return None if claims.get("role") == "admin" else claims["sub"]
 
 
-@router.get("/clients", response_model=PagedResponse)
+@router.get("/clients")
 async def list_clients(
     limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
     cursor: str | None = Query(None),
@@ -56,7 +56,7 @@ async def list_clients(
     )
 
 
-@router.post("/clients", response_model=ClientRegistrationResponse, status_code=201)
+@router.post("/clients", status_code=201)
 async def create_client(
     body: ClientRegistrationRequest,
     claims: dict[str, Any] = Depends(require_mgmt_user),
@@ -84,7 +84,7 @@ async def create_client(
     return resp
 
 
-@router.get("/clients/{client_id}", response_model=ClientRegistrationResponse)
+@router.get("/clients/{client_id}")
 async def get_client(
     client_id: str,
     claims: dict[str, Any] = Depends(require_mgmt_user),

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -47,7 +47,7 @@ def _user_filter(claims: dict[str, Any]) -> str | None:
     return None if claims.get("role") == "admin" else claims["sub"]
 
 
-@router.get("/memories", response_model=PagedResponse)
+@router.get("/memories")
 async def list_memories(
     tag: str | None = Query(None, description="Filter by tag"),
     search: str | None = Query(None, description="Semantic search query"),
@@ -95,7 +95,7 @@ async def list_memories(
     )
 
 
-@router.post("/memories", response_model=MemoryResponse)
+@router.post("/memories")
 async def create_memory(
     body: MemoryCreate,
     response: Response,
@@ -153,7 +153,7 @@ async def create_memory(
     return MemoryResponse.from_memory(memory)
 
 
-@router.get("/memories/{memory_id}", response_model=MemoryResponse)
+@router.get("/memories/{memory_id}")
 async def get_memory(
     memory_id: str,
     claims: dict[str, Any] = Depends(require_mgmt_user),
@@ -168,7 +168,7 @@ async def get_memory(
     return MemoryResponse.from_memory(memory)
 
 
-@router.patch("/memories/{memory_id}", response_model=MemoryResponse)
+@router.patch("/memories/{memory_id}")
 async def update_memory(
     memory_id: str,
     body: MemoryUpdate,

--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -24,7 +24,7 @@ def _storage() -> HiveStorage:
     return HiveStorage()
 
 
-@router.get("/stats", response_model=StatsResponse)
+@router.get("/stats")
 async def get_stats(
     claims: dict[str, Any] = Depends(require_mgmt_user),
     storage: HiveStorage = Depends(_storage),
@@ -46,7 +46,7 @@ async def get_stats(
     )
 
 
-@router.get("/activity", response_model=PagedResponse)
+@router.get("/activity")
 async def get_activity(
     days: int = Query(7, ge=1, le=90, description="Number of days of history to return"),
     limit: int = Query(

--- a/src/hive/api/users.py
+++ b/src/hive/api/users.py
@@ -27,7 +27,7 @@ def _storage() -> HiveStorage:
     return HiveStorage()
 
 
-@router.get("/users/me", response_model=UserResponse)
+@router.get("/users/me")
 async def get_me(
     claims: dict[str, Any] = Depends(require_mgmt_user),
     storage: HiveStorage = Depends(_storage),
@@ -38,7 +38,7 @@ async def get_me(
     return UserResponse.from_user(user)
 
 
-@router.get("/users", response_model=PagedResponse)
+@router.get("/users")
 async def list_users(
     limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
     cursor: str | None = Query(None),


### PR DESCRIPTION
## Summary

Removes `response_model=` from route decorators where the return type annotation already specifies the model. FastAPI uses the return annotation directly — the parameter is redundant and triggers SonarCloud BLOCKER warnings.

Affected: `memories.py` (4), `clients.py` (3), `stats.py` (2), `users.py` (2).

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)