### PR TITLE
refactor: convert FastAPI dep injection to Annotated style

### DIFF
--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any
+from typing import Annotated, Any
 
 import boto3
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -233,8 +233,8 @@ def _get_cost_data() -> dict[str, Any]:
 
 @router.get("/metrics")
 async def get_metrics(
-    period: str = Query("24h", pattern="^(1h|24h|7d|30d)$"),
-    _claims: dict[str, Any] = Depends(require_admin),
+    _claims: Annotated[dict[str, Any], Depends(require_admin)],
+    period: Annotated[str, Query(pattern="^(1h|24h|7d|30d)$")] = "24h",
 ) -> dict[str, Any]:
     """Return CloudWatch metric time-series for the current environment.
 
@@ -249,7 +249,7 @@ async def get_metrics(
 
 @router.get("/costs")
 async def get_costs(
-    _claims: dict[str, Any] = Depends(require_admin),
+    _claims: Annotated[dict[str, Any], Depends(require_admin)],
 ) -> dict[str, Any]:
     """Return AWS Cost Explorer monthly spend breakdown.
 

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -8,7 +8,7 @@ Non-admins see only their own clients; admins see all.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -39,10 +39,10 @@ def _user_filter(claims: dict[str, Any]) -> str | None:
 
 @router.get("/clients")
 async def list_clients(
-    limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
-    cursor: str | None = Query(None),
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+    limit: Annotated[int, Query(ge=1, le=_LIMIT_MAX)] = _LIMIT_DEFAULT,
+    cursor: Annotated[str | None, Query()] = None,
 ) -> PagedResponse:
     owner_user_id = _user_filter(claims)
     clients, next_cursor = storage.list_clients(
@@ -59,8 +59,8 @@ async def list_clients(
 @router.post("/clients", status_code=201)
 async def create_client(
     body: ClientRegistrationRequest,
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> ClientRegistrationResponse:
     owner_user_id: str = claims["sub"]
     try:
@@ -87,8 +87,8 @@ async def create_client(
 @router.get("/clients/{client_id}")
 async def get_client(
     client_id: str,
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> ClientRegistrationResponse:
     client = storage.get_client(client_id)
     if client is None:
@@ -102,8 +102,8 @@ async def get_client(
 @router.delete("/clients/{client_id}", status_code=204)
 async def delete_client(
     client_id: str,
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> None:
     client = storage.get_client(client_id)
     if client is None:

--- a/src/hive/api/logs.py
+++ b/src/hive/api/logs.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any
+from typing import Annotated, Any
 
 import boto3
 from botocore.exceptions import ClientError
@@ -116,11 +116,11 @@ def _fetch_log_events(
 
 @router.get("/logs")
 async def get_logs(
-    group: str = Query("all", pattern="^(all|mcp|api)$"),
-    window: str = Query("1h", pattern="^(15m|1h|3h|24h)$"),
-    filter_pattern: str = Query("", alias="filter"),
-    next_token: str | None = Query(None),
-    _claims: dict[str, Any] = Depends(require_admin),
+    _claims: Annotated[dict[str, Any], Depends(require_admin)],
+    group: Annotated[str, Query(pattern="^(all|mcp|api)$")] = "all",
+    window: Annotated[str, Query(pattern="^(15m|1h|3h|24h)$")] = "1h",
+    filter_pattern: Annotated[str, Query(alias="filter")] = "",
+    next_token: Annotated[str | None, Query()] = None,
 ) -> dict[str, Any]:
     """Return recent CloudWatch log events. Admin-only.
 

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -10,7 +10,7 @@ Admins can access all memories.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
@@ -49,13 +49,17 @@ def _user_filter(claims: dict[str, Any]) -> str | None:
 
 @router.get("/memories")
 async def list_memories(
-    tag: str | None = Query(None, description="Filter by tag"),
-    search: str | None = Query(None, description="Semantic search query"),
-    limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX, description="Max items to return"),
-    cursor: str | None = Query(None, description="Pagination cursor from previous response"),
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
-    vs: VectorStore = Depends(_vector_store),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+    vs: Annotated[VectorStore, Depends(_vector_store)],
+    tag: Annotated[str | None, Query(description="Filter by tag")] = None,
+    search: Annotated[str | None, Query(description="Semantic search query")] = None,
+    limit: Annotated[
+        int, Query(ge=1, le=_LIMIT_MAX, description="Max items to return")
+    ] = _LIMIT_DEFAULT,
+    cursor: Annotated[
+        str | None, Query(description="Pagination cursor from previous response")
+    ] = None,
 ) -> PagedResponse:
     owner_user_id = _user_filter(claims)
 
@@ -99,8 +103,8 @@ async def list_memories(
 async def create_memory(
     body: MemoryCreate,
     response: Response,
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> MemoryResponse:
     owner_user_id: str = claims["sub"]
 
@@ -156,8 +160,8 @@ async def create_memory(
 @router.get("/memories/{memory_id}")
 async def get_memory(
     memory_id: str,
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> MemoryResponse:
     memory = storage.get_memory_by_id(memory_id)
     if memory is None:
@@ -172,8 +176,8 @@ async def get_memory(
 async def update_memory(
     memory_id: str,
     body: MemoryUpdate,
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> MemoryResponse:
     memory = storage.get_memory_by_id(memory_id)
     if memory is None:
@@ -205,8 +209,8 @@ async def update_memory(
 @router.delete("/memories/{memory_id}", status_code=204)
 async def delete_memory(
     memory_id: str,
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> None:
     memory = storage.get_memory_by_id(memory_id)
     if memory is None:

--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -6,7 +6,7 @@ Usage stats and activity log endpoints for the Hive management API.
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
 
@@ -26,8 +26,8 @@ def _storage() -> HiveStorage:
 
 @router.get("/stats")
 async def get_stats(
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> StatsResponse:
     owner_user_id = None if claims.get("role") == "admin" else claims["sub"]
     today = date.today()
@@ -48,15 +48,12 @@ async def get_stats(
 
 @router.get("/activity")
 async def get_activity(
-    days: int = Query(7, ge=1, le=90, description="Number of days of history to return"),
-    limit: int = Query(
-        _ACTIVITY_LIMIT_DEFAULT,
-        ge=1,
-        le=_ACTIVITY_LIMIT_MAX,
-        description="Max events to return",
-    ),
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+    days: Annotated[int, Query(ge=1, le=90, description="Number of days of history to return")] = 7,
+    limit: Annotated[
+        int, Query(ge=1, le=_ACTIVITY_LIMIT_MAX, description="Max events to return")
+    ] = _ACTIVITY_LIMIT_DEFAULT,
 ) -> PagedResponse:
     today = date.today()
     # `days` is bounded by FastAPI Query(ge=1, le=90) above. NOSONAR

--- a/src/hive/api/users.py
+++ b/src/hive/api/users.py
@@ -9,7 +9,7 @@ DELETE /users/{user_id} — admin only.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -29,8 +29,8 @@ def _storage() -> HiveStorage:
 
 @router.get("/users/me")
 async def get_me(
-    claims: dict[str, Any] = Depends(require_mgmt_user),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> UserResponse:
     user = storage.get_user_by_id(claims["sub"])
     if user is None:
@@ -40,10 +40,10 @@ async def get_me(
 
 @router.get("/users")
 async def list_users(
-    limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
-    cursor: str | None = Query(None),
-    claims: dict[str, Any] = Depends(require_admin),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_admin)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+    limit: Annotated[int, Query(ge=1, le=_LIMIT_MAX)] = _LIMIT_DEFAULT,
+    cursor: Annotated[str | None, Query()] = None,
 ) -> PagedResponse:
     users, next_cursor = storage.list_users(limit=limit, cursor=cursor)
     return PagedResponse(
@@ -57,8 +57,8 @@ async def list_users(
 @router.delete("/users/{user_id}", status_code=204)
 async def delete_user(
     user_id: str,
-    claims: dict[str, Any] = Depends(require_admin),
-    storage: HiveStorage = Depends(_storage),
+    claims: Annotated[dict[str, Any], Depends(require_admin)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> None:
     deleted = storage.delete_user(user_id)
     if not deleted:

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -17,6 +17,7 @@ import hashlib
 import os
 import secrets
 from datetime import datetime, timezone
+from typing import Annotated
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response
@@ -86,7 +87,7 @@ async def oauth_metadata(request: Request) -> JSONResponse:
 @router.post("/oauth/register", status_code=201)
 async def register(
     req: ClientRegistrationRequest,
-    storage: HiveStorage = Depends(get_storage),
+    storage: Annotated[HiveStorage, Depends(get_storage)],
 ) -> JSONResponse:
     try:
         resp = register_client(req, storage)
@@ -110,6 +111,7 @@ async def register(
 
 @router.get("/oauth/authorize")
 async def authorize(
+    storage: Annotated[HiveStorage, Depends(get_storage)],
     response_type: str,
     client_id: str,
     redirect_uri: str,
@@ -117,7 +119,6 @@ async def authorize(
     scope: str = "memories:read memories:write",
     code_challenge: str = "",
     code_challenge_method: str = "S256",
-    storage: HiveStorage = Depends(get_storage),
 ) -> RedirectResponse:
     # Validate client
     client = storage.get_client(client_id)
@@ -181,10 +182,10 @@ async def authorize(
 
 @router.get("/oauth/google/callback")
 async def google_callback(
+    storage: Annotated[HiveStorage, Depends(get_storage)],
     code: str = "",
     state: str = "",
     error: str = "",
-    storage: HiveStorage = Depends(get_storage),
 ) -> RedirectResponse:
     """Handle the redirect from Google after user authentication."""
     from hive.auth.google import exchange_google_code, is_email_allowed, verify_google_id_token
@@ -257,6 +258,7 @@ def _verify_pkce(code_verifier: str, stored_challenge: str) -> bool:
 
 @router.post("/oauth/token")
 async def token(
+    storage: Annotated[HiveStorage, Depends(get_storage)],
     grant_type: str = Form(...),
     code: str | None = Form(None),
     redirect_uri: str | None = Form(None),
@@ -265,7 +267,6 @@ async def token(
     code_verifier: str | None = Form(None),
     refresh_token: str | None = Form(None),
     request: Request = None,  # type: ignore[assignment]  # FastAPI injects this; None satisfies Python's default-after-default rule
-    storage: HiveStorage = Depends(get_storage),
 ) -> JSONResponse:
     # --- Client authentication ---
     # Try HTTP Basic first, then form params
@@ -378,8 +379,8 @@ async def token(
 
 @router.post("/oauth/revoke")
 async def revoke(
+    storage: Annotated[HiveStorage, Depends(get_storage)],
     token: str = Form(...),
-    storage: HiveStorage = Depends(get_storage),
 ) -> Response:
     from jose import JWTError
 


### PR DESCRIPTION
Converts all `= Depends(...)` and `= Query(...)` route handler parameters to the `Annotated[T, Depends(...)]` / `Annotated[T, Query(...)]` style recommended by FastAPI and flagged by SonarCloud (#267).

**Files changed:** `api/memories.py`, `api/clients.py`, `api/stats.py`, `api/users.py`, `api/admin.py`, `api/logs.py`, `auth/oauth.py`

**Note:** Dependency params are reordered to appear before defaulted query params — this is required by Python's syntax rule that non-default parameters cannot follow default parameters in a positional argument list.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)