### PR TITLE
docs: add HTTPException response codes to route decorators

### DIFF
--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -231,7 +231,14 @@ def _get_cost_data() -> dict[str, Any]:
     return data
 
 
-@router.get("/metrics")
+@router.get(
+    "/metrics",
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+        502: {"description": "CloudWatch error"},
+    },
+)
 async def get_metrics(
     period: str = Query("24h", pattern="^(1h|24h|7d|30d)$"),
     _claims: dict[str, Any] = Depends(require_admin),
@@ -247,7 +254,14 @@ async def get_metrics(
     }
 
 
-@router.get("/costs")
+@router.get(
+    "/costs",
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+        502: {"description": "Cost Explorer error"},
+    },
+)
 async def get_costs(
     _claims: dict[str, Any] = Depends(require_admin),
 ) -> dict[str, Any]:

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -37,7 +37,7 @@ def _user_filter(claims: dict[str, Any]) -> str | None:
     return None if claims.get("role") == "admin" else claims["sub"]
 
 
-@router.get("/clients")
+@router.get("/clients", responses={401: {"description": "Unauthorized"}})
 async def list_clients(
     limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
     cursor: str | None = Query(None),
@@ -56,7 +56,14 @@ async def list_clients(
     )
 
 
-@router.post("/clients", status_code=201)
+@router.post(
+    "/clients",
+    status_code=201,
+    responses={
+        400: {"description": "Invalid client registration request"},
+        401: {"description": "Unauthorized"},
+    },
+)
 async def create_client(
     body: ClientRegistrationRequest,
     claims: dict[str, Any] = Depends(require_mgmt_user),
@@ -84,7 +91,13 @@ async def create_client(
     return resp
 
 
-@router.get("/clients/{client_id}")
+@router.get(
+    "/clients/{client_id}",
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "Client not found"},
+    },
+)
 async def get_client(
     client_id: str,
     claims: dict[str, Any] = Depends(require_mgmt_user),
@@ -99,7 +112,14 @@ async def get_client(
     return ClientRegistrationResponse.from_client(client)
 
 
-@router.delete("/clients/{client_id}", status_code=204)
+@router.delete(
+    "/clients/{client_id}",
+    status_code=204,
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "Client not found"},
+    },
+)
 async def delete_client(
     client_id: str,
     claims: dict[str, Any] = Depends(require_mgmt_user),

--- a/src/hive/api/logs.py
+++ b/src/hive/api/logs.py
@@ -114,7 +114,14 @@ def _fetch_log_events(
     }
 
 
-@router.get("/logs")
+@router.get(
+    "/logs",
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+        502: {"description": "CloudWatch Logs error"},
+    },
+)
 async def get_logs(
     group: str = Query("all", pattern="^(all|mcp|api)$"),
     window: str = Query("1h", pattern="^(15m|1h|3h|24h)$"),

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -47,7 +47,7 @@ def _user_filter(claims: dict[str, Any]) -> str | None:
     return None if claims.get("role") == "admin" else claims["sub"]
 
 
-@router.get("/memories")
+@router.get("/memories", responses={401: {"description": "Unauthorized"}})
 async def list_memories(
     tag: str | None = Query(None, description="Filter by tag"),
     search: str | None = Query(None, description="Semantic search query"),
@@ -95,7 +95,14 @@ async def list_memories(
     )
 
 
-@router.post("/memories")
+@router.post(
+    "/memories",
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "Memory not found (non-admin cannot overwrite another user's memory)"},
+        413: {"description": "Memory value too large"},
+    },
+)
 async def create_memory(
     body: MemoryCreate,
     response: Response,
@@ -153,7 +160,13 @@ async def create_memory(
     return MemoryResponse.from_memory(memory)
 
 
-@router.get("/memories/{memory_id}")
+@router.get(
+    "/memories/{memory_id}",
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "Memory not found"},
+    },
+)
 async def get_memory(
     memory_id: str,
     claims: dict[str, Any] = Depends(require_mgmt_user),
@@ -168,7 +181,14 @@ async def get_memory(
     return MemoryResponse.from_memory(memory)
 
 
-@router.patch("/memories/{memory_id}")
+@router.patch(
+    "/memories/{memory_id}",
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "Memory not found"},
+        413: {"description": "Memory value too large"},
+    },
+)
 async def update_memory(
     memory_id: str,
     body: MemoryUpdate,
@@ -202,7 +222,14 @@ async def update_memory(
     return MemoryResponse.from_memory(memory)
 
 
-@router.delete("/memories/{memory_id}", status_code=204)
+@router.delete(
+    "/memories/{memory_id}",
+    status_code=204,
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "Memory not found"},
+    },
+)
 async def delete_memory(
     memory_id: str,
     claims: dict[str, Any] = Depends(require_mgmt_user),

--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -24,7 +24,7 @@ def _storage() -> HiveStorage:
     return HiveStorage()
 
 
-@router.get("/stats")
+@router.get("/stats", responses={401: {"description": "Unauthorized"}})
 async def get_stats(
     claims: dict[str, Any] = Depends(require_mgmt_user),
     storage: HiveStorage = Depends(_storage),
@@ -46,7 +46,7 @@ async def get_stats(
     )
 
 
-@router.get("/activity")
+@router.get("/activity", responses={401: {"description": "Unauthorized"}})
 async def get_activity(
     days: int = Query(7, ge=1, le=90, description="Number of days of history to return"),
     limit: int = Query(

--- a/src/hive/api/users.py
+++ b/src/hive/api/users.py
@@ -27,7 +27,13 @@ def _storage() -> HiveStorage:
     return HiveStorage()
 
 
-@router.get("/users/me")
+@router.get(
+    "/users/me",
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "User not found"},
+    },
+)
 async def get_me(
     claims: dict[str, Any] = Depends(require_mgmt_user),
     storage: HiveStorage = Depends(_storage),
@@ -38,7 +44,13 @@ async def get_me(
     return UserResponse.from_user(user)
 
 
-@router.get("/users")
+@router.get(
+    "/users",
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+    },
+)
 async def list_users(
     limit: int = Query(_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
     cursor: str | None = Query(None),
@@ -54,7 +66,15 @@ async def list_users(
     )
 
 
-@router.delete("/users/{user_id}", status_code=204)
+@router.delete(
+    "/users/{user_id}",
+    status_code=204,
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+        404: {"description": "User not found"},
+    },
+)
 async def delete_user(
     user_id: str,
     claims: dict[str, Any] = Depends(require_admin),

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -83,7 +83,11 @@ async def oauth_metadata(request: Request) -> JSONResponse:
 # ---------------------------------------------------------------------------
 
 
-@router.post("/oauth/register", status_code=201)
+@router.post(
+    "/oauth/register",
+    status_code=201,
+    responses={400: {"description": "Invalid client registration request"}},
+)
 async def register(
     req: ClientRegistrationRequest,
     storage: HiveStorage = Depends(get_storage),
@@ -108,7 +112,7 @@ async def register(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/oauth/authorize")
+@router.get("/oauth/authorize", responses={400: {"description": "Invalid authorization request"}})
 async def authorize(
     response_type: str,
     client_id: str,
@@ -179,7 +183,13 @@ async def authorize(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/oauth/google/callback")
+@router.get(
+    "/oauth/google/callback",
+    responses={
+        400: {"description": "Invalid or expired Google OAuth callback"},
+        403: {"description": "Email not authorised"},
+    },
+)
 async def google_callback(
     code: str = "",
     state: str = "",
@@ -255,7 +265,13 @@ def _verify_pkce(code_verifier: str, stored_challenge: str) -> bool:
     return secrets.compare_digest(computed, stored_challenge)
 
 
-@router.post("/oauth/token")
+@router.post(
+    "/oauth/token",
+    responses={
+        400: {"description": "Invalid grant request"},
+        401: {"description": "Invalid client credentials"},
+    },
+)
 async def token(
     grant_type: str = Form(...),
     code: str | None = Form(None),


### PR DESCRIPTION
Adds `responses=` parameter to all FastAPI route decorators that raise HTTPExceptions, documenting 400/401/403/404/413/502 responses in the generated OpenAPI schema.

**Files changed:** `api/memories.py`, `api/clients.py`, `api/stats.py`, `api/users.py`, `api/admin.py`, `api/logs.py`, `auth/oauth.py`

Documentation-only — no behaviour changes.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)