### PR TITLE
fix: move NOSONAR suppressions to flagged lines; suppress ReDoS false positive

### DIFF
--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -56,8 +56,9 @@ async def get_activity(
     ] = _ACTIVITY_LIMIT_DEFAULT,
 ) -> PagedResponse:
     today = date.today()
-    # `days` is bounded by FastAPI Query(ge=1, le=90) above. NOSONAR
-    dates = [(today - timedelta(days=i)).isoformat() for i in range(days)]
+    dates = [
+        (today - timedelta(days=i)).isoformat() for i in range(days)
+    ]  # `days` bounded by FastAPI Query(ge=1, le=90). NOSONAR
     events = storage.get_events_for_dates(dates, limit=limit + 1)
 
     has_more = len(events) > limit

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -159,8 +159,9 @@ async def authorize(
         params: dict[str, str] = {"code": auth_code.code}
         if state:
             params["state"] = state
-        # redirect_uri was validated against client.redirect_uris above (line 126). NOSONAR
-        return RedirectResponse(f"{redirect_uri}?{urlencode(params)}", status_code=302)
+        return RedirectResponse(
+            f"{redirect_uri}?{urlencode(params)}", status_code=302
+        )  # redirect_uri validated above (line 126). NOSONAR
 
     # Production: store PKCE state, then redirect to Google for identity verification.
     from hive.auth.google import google_authorization_url
@@ -250,9 +251,9 @@ async def google_callback(
     params: dict[str, str] = {"code": auth_code.code}
     if pending.original_state:
         params["state"] = pending.original_state
-    # pending.redirect_uri was validated against client.redirect_uris when the pending auth
-    # was created (authorize endpoint, line 126). NOSONAR
-    return RedirectResponse(f"{pending.redirect_uri}?{urlencode(params)}", status_code=302)
+    return RedirectResponse(
+        f"{pending.redirect_uri}?{urlencode(params)}", status_code=302
+    )  # redirect_uri validated at authorize, line 126. NOSONAR
 
 
 # ---------------------------------------------------------------------------

--- a/ui/src/components/ChangelogPage.jsx
+++ b/ui/src/components/ChangelogPage.jsx
@@ -41,7 +41,7 @@ export function parseChangelog(raw) {
     const itemMatch = line.match(/^- (.+)/);
     if (itemMatch && currentGroup) {
       // Strip PR refs like (#123, #456) from item text
-      currentGroup.items.push(itemMatch[1].replace(/\s*\(#[\d, #]+\)/g, "").trim());
+      currentGroup.items.push(itemMatch[1].replace(/\s*\(#[\d, #]+\)/g, "").trim()); // NOSONAR — input is a static changelog file, not user-supplied
     }
   }
 


### PR DESCRIPTION
## Summary

- Move `NOSONAR` suppressions from preceding comment lines onto the exact lines SonarCloud flags (S5146 open-redirect in `oauth.py` × 2, S6680 loop-bounds in `stats.py`)
- Add `// NOSONAR` on the regex line in `ChangelogPage.jsx` to suppress S5852 ReDoS false positive (input is a static changelog file, not user-supplied)

All three were root causes of the quality gate failure on the `development` branch after enabling `sonar.qualitygate.wait=true` in #266/#276.

Closes #267
Closes #274
Closes #276
Closes #266