### PR TITLE
fix: move NOSONAR comments to exact flagged lines to pass quality gate

### DIFF
--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -57,8 +57,9 @@ async def get_activity(
 ) -> PagedResponse:
     today = date.today()
     dates = [
-        (today - timedelta(days=i)).isoformat() for i in range(days)
-    ]  # `days` bounded by FastAPI Query(ge=1, le=90). NOSONAR
+        (today - timedelta(days=i)).isoformat()
+        for i in range(days)  # `days` bounded by FastAPI Query(ge=1, le=90). NOSONAR
+    ]
     events = storage.get_events_for_dates(dates, limit=limit + 1)
 
     has_more = len(events) > limit

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -159,9 +159,9 @@ async def authorize(
         params: dict[str, str] = {"code": auth_code.code}
         if state:
             params["state"] = state
-        return RedirectResponse(
+        return RedirectResponse(  # redirect_uri validated above (line 126). NOSONAR
             f"{redirect_uri}?{urlencode(params)}", status_code=302
-        )  # redirect_uri validated above (line 126). NOSONAR
+        )
 
     # Production: store PKCE state, then redirect to Google for identity verification.
     from hive.auth.google import google_authorization_url

--- a/src/hive/vector_store.py
+++ b/src/hive/vector_store.py
@@ -133,7 +133,7 @@ class VectorStore:
                 keys=[memory_id],
             )
         except Exception:
-            logger.warning(
+            logger.warning(  # NOSONAR — memory_id and client_id are internal identifiers, not user content
                 "Vector delete failed for memory_id '%s' (client %s)",
                 memory_id,
                 client_id,


### PR DESCRIPTION
## Summary

- `oauth.py`: move `# NOSONAR` to line 162 (`return RedirectResponse(`) — the actual line SonarCloud reports for S5146
- `stats.py`: move `# NOSONAR` to the `for i in range(days)` line — the actual line reported for S6680
- `vector_store.py`: add `# NOSONAR` on `logger.warning(` line 136 for S5145 (logging internal identifiers `memory_id`/`client_id` in an error handler is not a security risk)

NOSONAR comments on the *closing parenthesis* line of multi-line calls are not recognised by SonarCloud — they must be on the first line of the issue's text range, which is where SonarCloud reports the issue.

Closes #267