### PR TITLE
fix: put NOSONAR at start of comment for SonarCloud recognition

### DIFF
--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -58,7 +58,7 @@ async def get_activity(
     today = date.today()
     dates = [
         (today - timedelta(days=i)).isoformat()
-        for i in range(days)  # `days` bounded by FastAPI Query(ge=1, le=90). NOSONAR
+        for i in range(days)  # NOSONAR — days bounded by FastAPI Query(ge=1, le=90)
     ]
     events = storage.get_events_for_dates(dates, limit=limit + 1)
 

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -159,7 +159,7 @@ async def authorize(
         params: dict[str, str] = {"code": auth_code.code}
         if state:
             params["state"] = state
-        return RedirectResponse(  # redirect_uri validated above (line 126). NOSONAR
+        return RedirectResponse(  # NOSONAR — redirect_uri validated above (line 126)
             f"{redirect_uri}?{urlencode(params)}", status_code=302
         )
 


### PR DESCRIPTION
## Summary

SonarCloud only recognises `# NOSONAR` when it is the first token after `#`. Comments of the form `# explanatory text. NOSONAR` are silently ignored — the suppression never fires.

- `oauth.py:162`: `# redirect_uri validated above. NOSONAR` → `# NOSONAR — redirect_uri validated above` (S5146)
- `stats.py:61`: `` # `days` bounded by Query. NOSONAR `` → `# NOSONAR — days bounded by Query` (S6680)

Closes #267