### PR TITLE
fix: replace deprecated sonarcloud-github-action with sonarqube-scan-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
             }
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
+        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Replaces `SonarSource/sonarcloud-github-action` (deprecated) with `SonarSource/sonarqube-scan-action` as recommended by the deprecation notice in CI logs
- Drop-in replacement at the same v5.0.0 tag — no behaviour change
- Should clear the configuration error shown in the GitHub Security tab

Closes #267