### PR TITLE
fix(e2e): select tag from TagPicker dropdown in create-memory test

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -84,8 +84,14 @@ class TestUIE2E:
             page.locator("button:has-text('Save')").click()
         assert resp_info.value.ok, f"POST /api/memories failed: {resp_info.value.status}"
 
-        # Filter by the unique tag so only this memory is in the list.
+        # Wait for the list to reload after save so knownTags is populated.
+        page.wait_for_load_state("networkidle")
+
+        # Filter by the unique tag — type to open the combobox dropdown, then
+        # click the matching suggestion to commit the filter.
         page.locator("input[placeholder='Filter by tag']").fill(unique_tag)
+        page.get_by_role("option", name=unique_tag).click()
+
         page.wait_for_selector(f"text={memory_key}", timeout=30_000)
         assert page.locator(f"text={memory_key}").first.is_visible()
 


### PR DESCRIPTION
## Summary

- The `test_create_and_see_memory` e2e test was filling the TagPicker combobox input but never clicking a dropdown suggestion, so `tagFilter` was never set and the filtered list never loaded — causing a 30s timeout
- Added `wait_for_load_state("networkidle")` after save so `knownTags` is populated before trying to filter
- Added `page.get_by_role("option", name=unique_tag).click()` to actually commit the tag filter via the dropdown

## Test plan

- [x] Pre-push suite passes locally (386 tests)
- [ ] Dev e2e should pass once merged

Closes the e2e regression introduced by the TagPicker combobox implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)