### PR TITLE
fix(ui): enlarge and center Hive logo on login page

### DIFF
--- a/ui/src/components/LoginPage.jsx
+++ b/ui/src/components/LoginPage.jsx
@@ -46,7 +46,7 @@ export default function LoginPage() {
             width: "100%",
           }}
         >
-          <img src="/logo.svg" alt="Hive" style={{ width: 64, height: 64, marginBottom: 16 }} />
+          <img src="/logo.svg" alt="Hive" style={{ width: 96, height: 96, display: "block", margin: "0 auto 20px" }} />
           <p style={{ color: "var(--text-muted)", marginBottom: 32 }}>
             Shared persistent memory for AI agents
           </p>


### PR DESCRIPTION
## Summary

- Increases logo from 64×64 to 96×96
- Adds `display: block` + `margin: 0 auto` to ensure it's properly centred within the card

## Test plan

- [x] Pre-push suite passes (386 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)