### PR TITLE
fix(ui): TagPicker commits typed value on Enter with no suggestions

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -84,14 +84,15 @@ class TestUIE2E:
             page.locator("button:has-text('Save')").click()
         assert resp_info.value.ok, f"POST /api/memories failed: {resp_info.value.status}"
 
-        # Wait for the list to reload after save so knownTags is populated.
+        # Wait for the list to reload after save.
         page.wait_for_load_state("networkidle")
 
-        # Filter by the unique tag — type to open the combobox dropdown, then
-        # click the matching suggestion to commit the filter.
-        page.locator("input[placeholder='Filter by tag']").fill(unique_tag)
-        page.wait_for_selector(f"[role='option']:has-text('{unique_tag}')", timeout=10_000)
-        page.locator("[role='option']", has_text=unique_tag).click()
+        # Filter by the unique tag — type and press Enter.  Enter now commits
+        # any typed value even when the suggestion dropdown is empty (e.g. the
+        # new memory isn't on page 1 of an accumulated dev list).
+        tag_input = page.locator("input[placeholder='Filter by tag']")
+        tag_input.fill(unique_tag)
+        tag_input.press("Enter")
 
         page.wait_for_selector(f"text={memory_key}", timeout=30_000)
         assert page.locator(f"text={memory_key}").first.is_visible()

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -44,6 +44,10 @@ export function TagPicker({ knownTags, value, onSelect }) {
   function handleKeyDown(e) {
     if (!open || suggestions.length === 0) {
       if (e.key === "Escape") setOpen(false);
+      else if (e.key === "Enter" && inputValue.trim()) {
+        e.preventDefault();
+        selectTag(inputValue.trim());
+      }
       return;
     }
     if (e.key === "ArrowDown") {

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -132,6 +132,25 @@ describe("TagPicker", () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  it("Enter with typed value and no suggestions commits the typed value", () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.change(input, { target: { value: "new-tag" } }); // no matches → no suggestions
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith("new-tag");
+  });
+
+  it("Enter with empty input and no suggestions does nothing", () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.change(input, { target: { value: "zzz" } }); // no matches → no suggestions
+    fireEvent.change(input, { target: { value: "" } }); // clear
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
   it("Escape when suggestions are open closes the dropdown", async () => {
     render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
     const input = screen.getByPlaceholderText("Filter by tag");


### PR DESCRIPTION
## Summary

Fixes the recurring `test_create_and_see_memory` e2e failure.

**Root cause**: `knownTags` in `MemoryBrowser` is derived only from the currently loaded page of memories (limit 50). In a populated dev environment, a newly created memory may not appear on page 1, so its tag is absent from `knownTags`, the suggestion dropdown never renders, and `wait_for_selector("[role='option']")` times out.

**Fix**: When `Enter` is pressed in the tag filter input and there are no suggestions (or the dropdown is closed), commit the typed value directly. This lets users filter by any tag regardless of pagination state — also a genuine UX improvement.

- `MemoryBrowser.jsx`: one-line addition to `handleKeyDown`'s no-suggestions guard
- `MemoryBrowser.test.jsx`: two new tests covering the new branch (100% coverage maintained)
- `test_ui_e2e.py`: replace the fragile `wait_for_selector` dropdown approach with `fill(tag)` + `press("Enter")` — works in all environments

## Test plan

- [ ] Pre-push: lint, mypy, unit + frontend tests all pass (399 tests) ✓
- [ ] E2E `test_create_and_see_memory` passes after merge to `development`

🤖 Generated with [Claude Code](https://claude.com/claude-code)