### PR TITLE
fix(ui): marketing nav active orange selector + Sign in button border

### DIFF
--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -1,10 +1,21 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+
+const NAV_LINK_BASE = "text-sm no-underline hover:text-white transition-colors";
 
 export default function PageLayout({ children }) {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  function navLinkStyle(href) {
+    const active = pathname === href;
+    return {
+      borderBottom: active ? "2px solid #e8a020" : "2px solid transparent",
+      paddingBottom: 2,
+    };
+  }
 
   return (
     <div className="font-[system-ui,sans-serif] text-[var(--text)] flex flex-col min-h-screen">
@@ -19,12 +30,12 @@ export default function PageLayout({ children }) {
             <span className="font-bold text-xl tracking-[1px]">Hive</span>
           </button>
           <div className="flex items-center gap-6">
-            <a href="/use-cases" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Use cases</a>
-            <a href="/clients" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Clients</a>
-            <a href="/pricing" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Pricing</a>
-            <a href="/faq" className="text-white/75 text-sm no-underline hover:text-white transition-colors">FAQ</a>
-            <a href="/docs/" className="text-white/75 text-sm no-underline hover:text-white transition-colors">Docs</a>
-            <Button variant="outline" size="sm" onClick={() => navigate("/app")}>
+            <a href="/use-cases" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/use-cases")}>Use cases</a>
+            <a href="/clients" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/clients")}>Clients</a>
+            <a href="/pricing" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/pricing")}>Pricing</a>
+            <a href="/faq" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/faq")}>FAQ</a>
+            <a href="/docs/" className={`text-white/75 ${NAV_LINK_BASE}`} style={{ borderBottom: "2px solid transparent", paddingBottom: 2 }}>Docs</a>
+            <Button variant="outline" size="sm" className="border-white/60 hover:border-white" onClick={() => navigate("/app")}>
               Sign in
             </Button>
           </div>

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import PageLayout from "./PageLayout.jsx";
@@ -10,8 +10,8 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-function renderInRouter(ui) {
-  return render(<MemoryRouter>{ui}</MemoryRouter>);
+function renderInRouter(ui, path = "/") {
+  return render(<MemoryRouter initialEntries={[path]}>{ui}</MemoryRouter>);
 }
 
 describe("PageLayout", () => {
@@ -80,5 +80,31 @@ describe("PageLayout", () => {
     expect(screen.getAllByText("FAQ").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("Use cases").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("Clients").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("active nav link has orange bottom border for current page", async () => {
+    const { container } = await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>, "/pricing")
+    );
+    const header = container.querySelector("header");
+    const pricingLink = within(header).getByRole("link", { name: "Pricing" });
+    expect(pricingLink.style.borderBottomColor).toBe("rgb(232, 160, 32)");
+  });
+
+  it("inactive nav links have transparent bottom border", async () => {
+    const { container } = await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>, "/pricing")
+    );
+    const header = container.querySelector("header");
+    const faqLink = within(header).getByRole("link", { name: "FAQ" });
+    expect(faqLink.style.borderBottomColor).toBe("transparent");
+  });
+
+  it("Sign in button has visible border", async () => {
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    const btn = screen.getByRole("button", { name: "Sign in" });
+    expect(btn.className).toContain("border-white/60");
   });
 });


### PR DESCRIPTION
## Summary

Two small polish fixes to the marketing site navbar (closes #251 follow-up):

- **Active nav link indicator**: uses `useLocation` to apply the same `2px solid #e8a020` orange bottom-border that the app tab bar uses. The active link reflects the current React route.
- **Sign in button border**: bumps from `border-white/30` (barely visible on dark navy) to `border-white/60` via a `className` override that `twMerge` resolves correctly.

## Test plan

- [ ] Pre-push checks pass (402 tests) ✓
- [ ] Navigate to `/pricing` — Pricing link has orange underline, others don't
- [ ] Navigate to `/faq` — FAQ link has orange underline
- [ ] Sign in button has a clearly visible white border on the navy navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)