### PR TITLE
fix(ui): use e.target.value in TagPicker Enter handler to eliminate stale closure race

### DIFF
--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -266,6 +266,7 @@ def _ensure_table(ddb_client, table_name: str) -> None:
                 {"AttributeName": "GSI2PK", "AttributeType": "S"},
                 {"AttributeName": "GSI2SK", "AttributeType": "S"},
                 {"AttributeName": "GSI3PK", "AttributeType": "S"},
+                {"AttributeName": "GSI4PK", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
                 {
@@ -288,6 +289,13 @@ def _ensure_table(ddb_client, table_name: str) -> None:
                     "IndexName": "ClientIndex",
                     "KeySchema": [
                         {"AttributeName": "GSI3PK", "KeyType": "HASH"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": "UserEmailIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI4PK", "KeyType": "HASH"},
                     ],
                     "Projection": {"ProjectionType": "ALL"},
                 },

--- a/tasks.py
+++ b/tasks.py
@@ -278,6 +278,9 @@ def dynamo_stop(ctx):
 def dev(ctx):
     """Start DynamoDB Local + MCP server + management API + UI dev server (Ctrl-C to stop all)"""
     jwt_secret = os.environ.get("HIVE_JWT_SECRET", "dev-secret")
+    # Allow all localhost Vite ports (5173–5179) so CORS doesn't break when
+    # 5173 is already occupied by another project and Vite picks the next port.
+    cors_origins = ",".join(f"http://localhost:{p}" for p in range(5173, 5180))
     dev_env = {
         **os.environ,
         "HIVE_JWT_SECRET": jwt_secret,
@@ -286,6 +289,10 @@ def dev(ctx):
         "AWS_ACCESS_KEY_ID": "local",
         "AWS_SECRET_ACCESS_KEY": "local",
         "AWS_DEFAULT_REGION": "us-east-1",
+        "CORS_ORIGINS": cors_origins,
+        # Prevents VectorStore instantiation from crashing on every request;
+        # semantic search will still fail locally (no real S3 Vectors bucket).
+        "HIVE_VECTORS_BUCKET": os.environ.get("HIVE_VECTORS_BUCKET", "local-dev"),
     }
     ui_env = {
         **os.environ,

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -56,9 +56,13 @@ export function TagPicker({ knownTags, value, onSelect }) {
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setActiveIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter" && activeIndex >= 0) {
+    } else if (e.key === "Enter") {
       e.preventDefault();
-      selectTag(suggestions[activeIndex]);
+      if (activeIndex >= 0) {
+        selectTag(suggestions[activeIndex]);
+      } else if (e.target.value.trim()) {
+        selectTag(e.target.value.trim());
+      }
     } else if (e.key === "Escape") {
       setOpen(false);
       setActiveIndex(-1);

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -44,9 +44,9 @@ export function TagPicker({ knownTags, value, onSelect }) {
   function handleKeyDown(e) {
     if (!open || suggestions.length === 0) {
       if (e.key === "Escape") setOpen(false);
-      else if (e.key === "Enter" && inputValue.trim()) {
+      else if (e.key === "Enter" && e.target.value.trim()) {
         e.preventDefault();
-        selectTag(inputValue.trim());
+        selectTag(e.target.value.trim());
       }
       return;
     }

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -151,6 +151,25 @@ describe("TagPicker", () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  it("Enter with typed value matching suggestions commits the typed value", () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.change(input, { target: { value: "tag1" } }); // matches → suggestions exist, open=true
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith("tag1");
+  });
+
+  it("Enter with empty input when suggestions are open does nothing", () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    fireEvent.change(input, { target: { value: "tag1" } }); // open suggestions
+    fireEvent.change(input, { target: { value: "" } }); // clear input
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
   it("Escape when suggestions are open closes the dropdown", async () => {
     render(<TagPicker knownTags={tags} value="" onSelect={vi.fn()} />);
     const input = screen.getByPlaceholderText("Filter by tag");

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -155,9 +155,22 @@ describe("TagPicker", () => {
     const onSelect = vi.fn();
     render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
     const input = screen.getByPlaceholderText("Filter by tag");
-    fireEvent.change(input, { target: { value: "tag1" } }); // matches → suggestions exist, open=true
+    fireEvent.change(input, { target: { value: "new-unique-tag" } }); // no match → no suggestions, first branch
     fireEvent.keyDown(input, { key: "Enter" });
-    expect(onSelect).toHaveBeenCalledWith("tag1");
+    expect(onSelect).toHaveBeenCalledWith("new-unique-tag");
+  });
+
+  it("Enter with typed value matching suggestions (dropdown open) commits typed value", async () => {
+    const onSelect = vi.fn();
+    render(<TagPicker knownTags={tags} value="" onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("Filter by tag");
+    // Wrap in act so React flushes state (open=true, suggestions populated) before keyDown
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "alpha" } });
+    });
+    // Now open=true, suggestions=["alpha"], activeIndex=-1 → second branch (line 64)
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith("alpha");
   });
 
   it("Enter with empty input when suggestions are open does nothing", () => {


### PR DESCRIPTION
## Summary

- **TagPicker Enter with suggestions open**: Enter was a no-op unless an item was selected with arrow keys. If the typed tag was already in \`knownTags\` (e.g. right after creating the memory), the dropdown opened but Enter did nothing — filter never applied. Fixed by committing the typed value when \`activeIndex < 0\`.
- **TagPicker stale closure race**: \`handleKeyDown\` read \`inputValue\` from the React closure, which could be stale if React hadn't flushed the \`onChange\` state update before \`press("Enter")\` fired. Changed to \`e.target.value\` (live DOM value, independent of React's render cycle).
- **\`scripts/seed_data.py\`**: \`_ensure_table\` was missing \`UserEmailIndex\` (GSI4), causing a 500 error on auth bypass login in local dev.
- **\`tasks.py\` \`inv dev\`**: Set \`HIVE_VECTORS_BUCKET=local-dev\` (prevents VectorStore from crashing every list-memories request) and allow all \`localhost:5173–5179\` CORS origins (so cross-origin API calls work when 5173 is occupied by another project).

## Test plan

- [ ] \`uv run inv pre-push\` — 404 JS tests, 314 Python unit tests pass
- [ ] \`test_create_and_see_memory\` — 10/10 passes locally against \`inv dev\` stack
- [ ] Full \`tests/e2e/test_ui_e2e.py\` — 4/4 pass locally

Closes #319