### PR TITLE
feat(dev): harden local dev stack and add inv e2e-local task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,84 @@ gh pr merge --auto --merge
 
    **Never run `gh release create` manually** — the pipeline owns this.
 
+## Running the full stack locally
+
+```bash
+# 1. Start all services (DynamoDB Local, MCP server, API, Vite dev server)
+#    Add --seed to also seed demo data automatically once the API is ready
+uv run inv dev [--seed]
+```
+
+`inv dev` sets automatically:
+
+- `CORS_ORIGINS` — `localhost:5173` through `localhost:5179` (handles port
+  collisions if 5173 is already taken by another project)
+- `HIVE_VECTORS_BUCKET=local-dev` — prevents VectorStore from crashing on
+  every list-memories request (semantic search will still fail locally)
+- `HIVE_BYPASS_GOOGLE_AUTH=1` — enables the `?test_email=` auth shortcut
+  (only activates when that query param is present; normal browser flows
+  are unaffected)
+
+```bash
+# 2. Seed DynamoDB with demo data (also creates the table) — if not using --seed
+uv run inv seed
+```
+
+Must be re-run after every `inv dev` restart (DynamoDB Local is ephemeral).
+
+### Running UI e2e tests locally
+
+```bash
+# Auto-detects the Vite port — no env vars to set manually
+uv run inv e2e-local
+
+# Run a specific test file
+uv run inv e2e-local --tests tests/e2e/test_ui_e2e.py
+
+# Repeat N times to check for flakiness
+uv run inv e2e-local --n 5
+```
+
+`inv e2e-local` probes ports 5173–5179 for the Hive Vite dev server (via
+`/auth/login?test_email=probe`) and passes the detected URL as `HIVE_UI_URL`.
+
+Key local e2e gotchas:
+
+- The Vite proxy handles `/auth`, `/api`, `/oauth`, `/mcp` — tests must use
+  the Vite URL (not the API URL directly) so the auth bypass sets
+  `localStorage` at the correct origin.
+- If Vite lands on a port other than 5173, `CORS_ORIGINS` must include that
+  port. `inv dev` covers 5173–5179; if you're outside that range, pass
+  `CORS_ORIGINS=http://localhost:<port>` when starting the stack.
+- `inv seed` (or `inv dev --seed`) must succeed before running e2e tests —
+  if auth bypass returns 500, the table is likely missing.
+- `test_docs_e2e.py` is excluded automatically — those tests require a
+  deployed VitePress build; run them against the deployed stack with `inv e2e`.
+
+### When to run local e2e tests
+
+Not required on every PR — `uv run inv pre-push` (unit + frontend tests) is
+the standard gate. Run `inv e2e-local` before opening a PR when the change
+touches any of the following:
+
+**Always required:**
+
+- Fixing a failing e2e test — the fix must pass locally before the PR opens
+- Auth flows (`auth/`, `AuthCallback.jsx`, `LoginPage.jsx`, OAuth endpoints)
+- MCP tool logic (`server.py`) — remember, recall, forget, search, list
+- Management API endpoints (`api/`) that the UI or MCP tests exercise
+
+**Use judgement:**
+
+- UI component changes that affect user-visible flows (memory CRUD, client
+  management, activity log) — run the relevant `--tests` file at minimum
+- Vite proxy config or API base URL changes
+
+**Not needed:**
+
+- Pure unit test fixes, documentation, infra/CDK changes, style/CSS tweaks,
+  or any change fully covered by unit + frontend tests
+
 ## Pre-PR checklist (required before every push)
 
 Run `uv run inv pre-push` — this runs the same gate as CI:

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -171,7 +171,10 @@ async def remember(
             raise ToolError(str(exc)) from exc
         event_type = EventType.memory_updated
         action = "Updated"
-        _vector_store().upsert_memory(existing)
+        try:
+            _vector_store().upsert_memory(existing)
+        except Exception:
+            logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
     else:
         memory = Memory(key=key, value=value, tags=tags, owner_client_id=client_id)
         try:
@@ -181,7 +184,10 @@ async def remember(
             raise ToolError(str(exc)) from exc
         event_type = EventType.memory_created
         action = "Stored"
-        _vector_store().upsert_memory(memory)
+        try:
+            _vector_store().upsert_memory(memory)
+        except Exception:
+            logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
 
     storage.log_event(
         ActivityEvent(
@@ -279,7 +285,10 @@ async def forget(
         raise ToolError(f"No memory found for key '{key}'.")
 
     storage.delete_memory(existing.memory_id)
-    _vector_store().delete_memory(existing.memory_id, client_id)
+    try:
+        _vector_store().delete_memory(existing.memory_id, client_id)
+    except Exception:
+        logger.warning("Vector delete failed (non-fatal)", exc_info=True)
     storage.log_event(
         ActivityEvent(
             event_type=EventType.memory_deleted,
@@ -433,6 +442,9 @@ async def search_memories(
     try:
         pairs = _vector_store().search(query, client_id, top_k=top_k)
     except VectorIndexNotFoundError:
+        return {"items": [], "count": 0, "query": query}
+    except Exception:
+        logger.warning("Vector search failed (non-fatal)", exc_info=True)
         return {"items": [], "count": 0, "query": query}
 
     results = storage.hydrate_memory_ids(pairs)

--- a/tasks.py
+++ b/tasks.py
@@ -11,6 +11,7 @@ Usage:
     uv run inv test-integration             # integration tests (requires DynamoDB Local)
     uv run inv dev                          # start DynamoDB Local + API + UI dev servers
     uv run inv e2e                          # run e2e tests against deployed stack
+    uv run inv e2e-local                    # run e2e tests against local dev stack (inv dev must be running)
     uv run inv deploy                       # deploy to AWS via CDK
     uv run inv synth                        # synthesize CDK template (no Docker bundling)
     uv run inv outputs                      # print CloudFormation stack outputs
@@ -123,6 +124,25 @@ def _wait_for_http(url: str, label: str, timeout: int = 30) -> bool:
             time.sleep(1)
     print(f"  {label} did not start in time")
     return False
+
+
+def _find_vite_port() -> int | None:
+    """Scan ports 5173-5179 to find the Hive Vite dev server.
+
+    Identifies Hive's Vite by probing /auth/login?test_email=probe — only the
+    Hive API (via Vite proxy) responds with the bypass HTML.  Other projects
+    on the same port range won't have this endpoint.
+    """
+    for port in range(5173, 5180):
+        try:
+            url = f"http://localhost:{port}/auth/login?test_email=probe"
+            resp = urllib.request.urlopen(url, timeout=2)
+            body = resp.read(512).decode("utf-8", errors="ignore")
+            if "localStorage.setItem" in body:
+                return port
+        except Exception:
+            pass
+    return None
 
 
 # ── Lint ──────────────────────────────────────────────────────────────────────
@@ -252,6 +272,48 @@ def e2e(ctx, env="prod"):
     )
 
 
+@task
+def e2e_local(ctx, tests="tests/e2e", n=1):
+    """Run e2e tests against the local dev stack (inv dev must already be running).
+
+    Automatically detects the Vite port — no env vars to set manually.
+    Pass --n=N to run the suite N times (useful for flakiness detection).
+
+    test_docs_e2e.py is excluded by default — it requires a deployed VitePress
+    build which is not served in the local dev stack.
+    """
+    api_url = f"http://localhost:{API_PORT}"
+    if not _wait_for_http(f"{api_url}/health", "API", timeout=3):
+        print(f"ERROR: API not responding at {api_url} — is 'inv dev' running?")
+        sys.exit(1)
+    vite_port = _find_vite_port()
+    if not vite_port:
+        print("ERROR: Could not find Hive Vite dev server on ports 5173-5179")
+        print("       Make sure 'inv dev' is running and the UI has started.")
+        sys.exit(1)
+    ui_url = f"http://localhost:{vite_port}"
+    mcp_url = f"http://localhost:{MCP_PORT}"
+    print(f"  API: {api_url}")
+    print(f"  MCP: {mcp_url}")
+    print(f"  UI:  {ui_url}")
+    extra_env = {
+        **os.environ,
+        "HIVE_API_URL": api_url,
+        "HIVE_MCP_URL": mcp_url,
+        "HIVE_UI_URL": ui_url,
+    }
+    # Docs tests require a deployed VitePress build — skip unless explicitly targeted
+    ignore = (
+        " --ignore=tests/e2e/test_docs_e2e.py"
+        if tests == "tests/e2e"
+        else ""
+    )
+    for i in range(n):
+        if n > 1:
+            print(f"\n--- run {i + 1}/{n} ---")
+        ctx.run(f"uv run pytest {tests}{ignore} -v", env=extra_env, pty=True)
+
+
 # ── Local dev ─────────────────────────────────────────────────────────────────
 
 
@@ -275,8 +337,11 @@ def dynamo_stop(ctx):
 
 
 @task
-def dev(ctx):
-    """Start DynamoDB Local + MCP server + management API + UI dev server (Ctrl-C to stop all)"""
+def dev(ctx, seed=False):
+    """Start DynamoDB Local + MCP server + management API + UI dev server (Ctrl-C to stop all).
+
+    Pass --seed to automatically seed demo data once the API is ready.
+    """
     jwt_secret = os.environ.get("HIVE_JWT_SECRET", "dev-secret")
     # Allow all localhost Vite ports (5173–5179) so CORS doesn't break when
     # 5173 is already occupied by another project and Vite picks the next port.
@@ -293,6 +358,9 @@ def dev(ctx):
         # Prevents VectorStore instantiation from crashing on every request;
         # semantic search will still fail locally (no real S3 Vectors bucket).
         "HIVE_VECTORS_BUCKET": os.environ.get("HIVE_VECTORS_BUCKET", "local-dev"),
+        # Always enable auth bypass in local dev — the bypass only activates when
+        # ?test_email= is present, so normal browser flows are unaffected.
+        "HIVE_BYPASS_GOOGLE_AUTH": "1",
     }
     ui_env = {
         **os.environ,
@@ -358,11 +426,15 @@ def dev(ctx):
     signal.signal(signal.SIGINT, _shutdown)
     signal.signal(signal.SIGTERM, _shutdown)
 
+    # Detect the actual Vite port (may differ from UI_PORT if that port is taken)
+    _wait_for_http(f"http://localhost:{API_PORT}/health", "API", timeout=20)
+    actual_ui_port = _find_vite_port() or UI_PORT
+
     print("\nServices starting:")
     print(f"  DynamoDB Local → http://localhost:{DYNAMO_PORT}")
     print(f"  MCP server      → http://localhost:{MCP_PORT}/mcp")
     print(f"  Management API  → http://localhost:{API_PORT}")
-    print(f"  UI dev server   → http://localhost:{UI_PORT}")
+    print(f"  UI dev server   → http://localhost:{actual_ui_port}")
     print()
     print("Claude Desktop stdio config (add to claude_desktop_config.json):")
     print("  {")
@@ -381,7 +453,22 @@ def dev(ctx):
     print("      }")
     print("    }")
     print("  }")
-    print("\nRun 'uv run inv seed' in a new terminal to populate with demo data.")
+    if seed:
+        print("Waiting for API to be ready before seeding…")
+        if _wait_for_http(f"http://localhost:{API_PORT}/health", "API", timeout=30):
+            seed_env = {
+                **dev_env,
+                "DYNAMODB_ENDPOINT": f"http://localhost:{DYNAMO_PORT}",
+            }
+            subprocess.run(
+                ["uv", "run", "python", "scripts/seed_data.py"],
+                cwd=ROOT,
+                env=seed_env,
+            )
+        else:
+            print("  API did not start — skipping seed")
+    else:
+        print("Run 'uv run inv seed' in a new terminal to populate with demo data.")
     print("Press Ctrl-C to stop all services.\n")
 
     for p in procs:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -629,3 +629,67 @@ class TestSearchMemories:
             await forget("forget-dw-key", ctx=_make_ctx(jwt))
 
         mock_vs.delete_memory.assert_called_once()
+
+    async def test_remember_vector_upsert_failure_is_non_fatal(self, server_env):
+        """VectorStore errors during remember() are logged but do not raise."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import remember
+
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+        mock_vs.upsert_memory.side_effect = RuntimeError("no bucket")
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await remember("vec-fail-new", "v", [], ctx=_make_ctx(jwt))
+
+        assert "Stored" in result
+
+    async def test_remember_vector_upsert_failure_on_update_is_non_fatal(self, server_env):
+        """VectorStore errors during remember() update are logged but do not raise."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import remember
+
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await remember("vec-fail-upd", "original", [], ctx=_make_ctx(jwt))
+
+        mock_vs.upsert_memory.side_effect = RuntimeError("no bucket")
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await remember("vec-fail-upd", "updated", [], ctx=_make_ctx(jwt))
+
+        assert "Updated" in result
+
+    async def test_forget_vector_delete_failure_is_non_fatal(self, server_env):
+        """VectorStore errors during forget() are logged but do not raise."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import forget, remember
+
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+        mock_vs.delete_memory.side_effect = RuntimeError("no bucket")
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await remember("vec-fail-forget", "v", [], ctx=_make_ctx(jwt))
+            result = await forget("vec-fail-forget", ctx=_make_ctx(jwt))
+
+        assert "Deleted" in result
+
+    async def test_search_vector_failure_returns_empty(self, server_env):
+        """Unexpected VectorStore errors during search_memories() return empty results."""
+        from unittest.mock import patch
+
+        from hive.server import search_memories
+
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+        mock_vs.search.side_effect = RuntimeError("no bucket")
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("anything", ctx=_make_ctx(jwt))
+
+        assert result == {"items": [], "count": 0, "query": "anything"}


### PR DESCRIPTION
## Summary

- `inv dev` now sets `HIVE_BYPASS_GOOGLE_AUTH=1`, `HIVE_VECTORS_BUCKET`, and `CORS_ORIGINS` (5173–5179) automatically — no manual env vars needed
- `inv dev --seed` auto-seeds after API health check passes
- New `inv e2e-local` task auto-detects the Vite port and runs all e2e tests (except docs) against the local stack — no env vars to set
- VectorStore calls in `server.py` wrapped in `try/except` — matches design intent in `vector_store.py` ("best-effort, errors never propagate"); `remember`/`forget`/`search_memories` now degrade gracefully without a real S3 Vectors bucket
- 4 new unit tests covering the VectorStore failure paths
- CLAUDE.md documents the full local dev workflow and when local e2e testing is required before opening a PR

Closes #320

## Test plan

- [x] `uv run inv pre-push` — all lint, typecheck, unit, and frontend tests pass (318 Python + 405 JS)
- [x] `uv run inv e2e-local` against running local stack — 21 passed, 8 skipped, 2 xfailed, 0 failures
- [x] Confirmed `test_create_and_see_memory` passes reliably locally
- [x] Confirmed MCP tools (remember, forget, search) pass locally with VectorStore degrading gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)