### PR TITLE
chore: track batch progress in .autonomous-progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ infra/cdk.out/
 
 # Claude Code
 .claude/
+.autonomous-progress

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,11 @@ calls and document them in the PR description.
 When given one or more GitHub issue numbers, process them **sequentially**.
 Complete the full cycle for each issue before starting the next.
 
+When processing a batch of issues, after completing each issue cycle
+successfully, append the issue number to `.autonomous-progress` in the
+repo root. This allows an interrupted batch to be resumed by checking
+which issues are already recorded there.
+
 #### 1. Understand the issue
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `.autonomous-progress` to `.gitignore`
- Document in CLAUDE.md that after each issue cycle completes, the issue number should be appended to `.autonomous-progress` in the repo root — allows interrupted batches to be resumed without re-processing completed issues

## Approach

Kept as a flat file (one issue number per line) for simplicity — easy to read, write, and check with `grep`.