### PR TITLE
fix(docs): add orange active indicator to Docs nav link on docs site navbar

### DIFF
--- a/docs-site/.vitepress/theme/index.js
+++ b/docs-site/.vitepress/theme/index.js
@@ -21,7 +21,7 @@ export default {
           h("a", { href: "/faq", class: "docs-nav-link" }, "FAQ"),
           h(
             "a",
-            { href: "/docs/getting-started/what-is-hive", class: "docs-nav-link" },
+            { href: "/docs/getting-started/what-is-hive", class: "docs-nav-link docs-nav-link--active" },
             "Docs",
           ),
           h("a", { href: "/app", class: "docs-signin-btn" }, "Sign in"),

--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -133,16 +133,23 @@
 
 .docs-nav-link {
   padding: 0 12px;
+  padding-bottom: 2px;
   font-size: 14px;
   font-weight: 500;
   color: rgba(255, 255, 255, 0.75);
   text-decoration: none;
   white-space: nowrap;
-  transition: color 0.25s;
+  border-bottom: 2px solid transparent;
+  transition: color 0.25s, border-color 0.25s;
 }
 
 .docs-nav-link:hover {
   color: #fff;
+}
+
+.docs-nav-link--active {
+  color: #fff;
+  border-bottom-color: #e8a020;
 }
 
 .docs-signin-btn {

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -455,6 +455,26 @@ class TestDocsNavbar:
         font_size = page.evaluate("el => window.getComputedStyle(el).fontSize", el)
         assert font_size == "14px", f"Docs link font-size {font_size!r} — expected '14px'."
 
+    def test_docs_link_active_indicator(self, docs_page):
+        """Docs nav link has orange bottom border (active indicator) on the docs site.
+
+        The Docs link is always 'active' on the docs site — the .docs-nav-link--active
+        class is baked into the element and the orange border is always shown.
+        """
+        page = docs_page
+        page.goto(f"{UI_URL}/docs/", timeout=30_000, wait_until="networkidle")
+        docs_link = page.locator(".docs-nav-link", has_text="Docs")
+        if not docs_link.is_visible():
+            pytest.skip("Docs nav link not visible (may be mobile viewport)")
+
+        el = docs_link.element_handle()
+        border_color = page.evaluate("el => window.getComputedStyle(el).borderBottomColor", el)
+        r, g, b, _ = _parse_rgb(border_color)
+        # #e8a020 == rgb(232, 160, 32) — orange active indicator
+        assert r > 200 and g > 100 and b < 100, (
+            f"Docs link border-bottom-color {border_color!r} — expected orange (#e8a020 / rgb(232,160,32))."
+        )
+
     def test_navbar_hamburger_visible_mobile(self, docs_page_mobile):
         """Hamburger menu button is visible on mobile viewport."""
         page = docs_page_mobile


### PR DESCRIPTION
Closes #323

## Summary
- Added `docs-nav-link--active` class to the Docs `<a>` element in `docs-site/.vitepress/theme/index.js`
- Added `border-bottom: 2px solid transparent` default and `.docs-nav-link--active { border-bottom-color: #e8a020 }` rule to `style.css` to match marketing site active indicator
- Added `padding-bottom: 2px` to prevent layout shift from the 2px border
- Added e2e assertion in `test_docs_e2e.py` that the Docs link border-bottom-color is orange

## Approach
The Docs link is always "active" on the docs site (you're always on the docs site), so the `--active` class is baked in rather than computed at runtime. This matches the fix described in the issue exactly.