### PR TITLE
fix: Sign in button border not visible in marketing site navbar

### DIFF
--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -159,7 +159,7 @@
   font-size: 14px;
   font-weight: 500;
   color: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.6);
   border-radius: 6px;
   text-decoration: none;
   white-space: nowrap;
@@ -168,7 +168,7 @@
 
 .docs-signin-btn:hover {
   color: #fff;
-  border-color: rgba(255, 255, 255, 0.5);
+  border-color: #fff;
 }
 
 /* Mobile nav screen group */

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -428,7 +428,10 @@ class TestDocsNavbar:
 
         border_color = page.evaluate("el => window.getComputedStyle(el).borderTopColor", el)
         _, _, _, alpha = _parse_rgb(border_color)
-        assert alpha > 0, f"Sign in button border is transparent ({border_color!r})."
+        assert alpha >= 0.5, (
+            f"Sign in button border alpha {alpha:.2f} ({border_color!r}) — "
+            "expected >= 0.5 to match marketing site (rgba(255,255,255,0.6))."
+        )
 
         padding = page.evaluate("el => window.getComputedStyle(el).padding", el)
         assert padding == "6px 16px", (

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -48,6 +48,35 @@ def browser_page():
         browser.close()
 
 
+class TestMarketingNav:
+    def test_signin_btn_border_is_visible(self):
+        """Sign in button on marketing navbar has a visible border (not transparent).
+
+        Asserts the computed border-color so CSS regressions can't sneak past a
+        class-name check.  The nav variant bakes border-white/60 into the variant
+        itself — no className override needed.
+        """
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto(f"{UI_URL}/", timeout=30_000, wait_until="networkidle")
+            signin_btn = page.locator(".marketing-signin-btn")
+            if not signin_btn.is_visible():
+                browser.close()
+                pytest.skip("Sign in button not visible (may be mobile viewport)")
+            border_color = signin_btn.evaluate("el => getComputedStyle(el).borderColor")
+            import re
+
+            nums = [float(x) for x in re.findall(r"[\d.]+", border_color)]
+            assert len(nums) >= 4 and nums[3] > 0, (
+                f"Sign in button border is transparent: {border_color!r}. "
+                "Check that the nav variant in button.jsx applies border-white/60."
+            )
+            browser.close()
+
+
 class TestUIE2E:
     def test_memories_tab_visible(self, browser_page):
         page = browser_page

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -35,7 +35,7 @@ export default function PageLayout({ children }) {
             <a href="/pricing" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/pricing")}>Pricing</a>
             <a href="/faq" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/faq")}>FAQ</a>
             <a href="/docs/" className={`text-white/75 ${NAV_LINK_BASE}`} style={{ borderBottom: "2px solid transparent", paddingBottom: 2 }}>Docs</a>
-            <Button variant="outline" size="sm" className="border-white/60 hover:border-white" onClick={() => navigate("/app")}>
+            <Button variant="nav" size="sm" className="marketing-signin-btn" onClick={() => navigate("/app")}>
               Sign in
             </Button>
           </div>

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -100,11 +100,12 @@ describe("PageLayout", () => {
     expect(faqLink.style.borderBottomColor).toBe("transparent");
   });
 
-  it("Sign in button has visible border", async () => {
+  it("Sign in button uses nav variant with visible border", async () => {
     await act(async () =>
       renderInRouter(<PageLayout><span /></PageLayout>)
     );
     const btn = screen.getByRole("button", { name: "Sign in" });
     expect(btn.className).toContain("border-white/60");
+    expect(btn.className).toContain("marketing-signin-btn");
   });
 });

--- a/ui/src/components/ui/button.jsx
+++ b/ui/src/components/ui/button.jsx
@@ -21,6 +21,8 @@ const buttonVariants = cva(
           "bg-red-600 text-white hover:opacity-90",
         secondary:
           "border border-[var(--border)] bg-transparent text-[var(--text)] hover:bg-[var(--surface)]",
+        nav:
+          "border border-white/60 bg-transparent text-white/80 hover:text-white hover:border-white",
       },
       size: {
         default: "px-4 py-2",

--- a/ui/src/components/ui/button.test.jsx
+++ b/ui/src/components/ui/button.test.jsx
@@ -47,7 +47,7 @@ describe("Button", () => {
   });
 
   it("renders all variants without error", () => {
-    const variants = ["default", "brand", "outline", "ghost", "danger", "secondary"];
+    const variants = ["default", "brand", "outline", "ghost", "danger", "secondary", "nav"];
     variants.forEach((variant) => {
       const { unmount } = render(<Button variant={variant}>{variant}</Button>);
       expect(screen.getByText(variant)).toBeTruthy();


### PR DESCRIPTION
Closes #322

## Summary
- Added `nav` variant to `button.jsx` with `border-white/60` baked in — removes the fragile `className` override that conflicted with `twMerge` + Tailwind v4
- Updated `PageLayout.jsx` to use `variant="nav"` instead of `variant="outline" className="border-white/60 hover:border-white"`, also adds `marketing-signin-btn` class for e2e selection
- Updated `docs-site/.vitepress/theme/style.css` to match: `.docs-signin-btn` border opacity raised from 0.3 → 0.6, hover border-color set to `#fff`
- Updated `PageLayout.test.jsx` to assert both `border-white/60` (from nav variant) and `marketing-signin-btn` class
- Added `button.test.jsx` coverage for the new `nav` variant
- Added e2e test in `test_ui_e2e.py` to assert the computed `borderColor` is not transparent
- Updated `test_docs_e2e.py` alpha assertion from `> 0` to `>= 0.5` to verify the stronger 0.6 opacity

## Approach
The root cause was `twMerge` v2 not reliably deduplicating Tailwind v4 opacity-modifier utilities. The fix removes the override pattern entirely — the correct style is now part of the `nav` variant definition. This is a single source of truth that can't be broken by class merging.