### PR TITLE
feat: expose OpenAPI/Swagger UI on management API

### DIFF
--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -237,6 +237,7 @@ def _get_cost_data() -> dict[str, Any]:
 
 @router.get(
     "/metrics",
+    summary="Get CloudWatch metrics",
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Admin role required"},
@@ -260,6 +261,7 @@ async def get_metrics(
 
 @router.get(
     "/costs",
+    summary="Get AWS cost data",
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Admin role required"},
@@ -313,6 +315,7 @@ def _get_alarm_data() -> dict[str, Any]:
 
 @router.get(
     "/alarms",
+    summary="Get CloudWatch alarm states",
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Admin role required"},

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -38,7 +38,12 @@ def _user_filter(claims: dict[str, Any]) -> str | None:
     return None if claims.get("role") == "admin" else claims["sub"]
 
 
-@router.get("/clients", responses={401: {"description": "Unauthorized"}})
+@router.get(
+    "/clients",
+    summary="List OAuth clients",
+    description="Return a paginated list of OAuth clients. Non-admins see only their own clients.",
+    responses={401: {"description": "Unauthorized"}},
+)
 async def list_clients(
     claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
     storage: Annotated[HiveStorage, Depends(_storage)],
@@ -59,6 +64,8 @@ async def list_clients(
 
 @router.post(
     "/clients",
+    summary="Register an OAuth client",
+    description="Register a new OAuth 2.1 client via Dynamic Client Registration (RFC 7591). Returns the client credentials including the client secret.",
     status_code=201,
     responses={
         400: {"description": "Invalid client registration request"},
@@ -94,6 +101,8 @@ async def create_client(
 
 @router.get(
     "/clients/{client_id}",
+    summary="Get an OAuth client",
+    description="Retrieve a single OAuth client by its client ID. Non-admins can only access their own clients.",
     responses={
         401: {"description": "Unauthorized"},
         404: {"description": _CLIENT_NOT_FOUND},
@@ -115,6 +124,8 @@ async def get_client(
 
 @router.delete(
     "/clients/{client_id}",
+    summary="Delete an OAuth client",
+    description="Permanently delete an OAuth client by its client ID. Non-admins can only delete their own clients.",
     status_code=204,
     responses={
         401: {"description": "Unauthorized"},

--- a/src/hive/api/logs.py
+++ b/src/hive/api/logs.py
@@ -116,6 +116,7 @@ def _fetch_log_events(
 
 @router.get(
     "/logs",
+    summary="Get CloudWatch log events",
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Admin role required"},

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -14,9 +14,12 @@ import os
 import time
 from typing import Any
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.responses import HTMLResponse
 
+from hive.api._auth import require_admin
 from hive.api.admin import router as admin_router
 from hive.api.clients import router as clients_router
 from hive.api.logs import router as logs_router
@@ -48,6 +51,8 @@ app = FastAPI(
     title="Hive Management API",
     version=APP_VERSION,
     description="REST API for managing Hive memories, OAuth clients, and viewing activity stats.",
+    docs_url=None,
+    redoc_url=None,
 )
 
 # Allow the React dev server (port 5173) and any configured UI origin
@@ -127,6 +132,18 @@ app.include_router(stats_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")
 app.include_router(logs_router, prefix="/api")
+
+
+@app.get("/docs", include_in_schema=False)
+async def swagger_ui(_claims: dict = Depends(require_admin)) -> HTMLResponse:
+    """Swagger UI — admin only."""
+    return get_swagger_ui_html(openapi_url="/openapi.json", title="Hive Management API")
+
+
+@app.get("/redoc", include_in_schema=False)
+async def redoc_ui(_claims: dict = Depends(require_admin)) -> HTMLResponse:
+    """ReDoc UI — admin only."""
+    return get_redoc_html(openapi_url="/openapi.json", title="Hive Management API")
 
 
 @app.get("/health", include_in_schema=False)

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -48,7 +48,12 @@ def _user_filter(claims: dict[str, Any]) -> str | None:
     return None if claims.get("role") == "admin" else claims["sub"]
 
 
-@router.get("/memories", responses={401: {"description": "Unauthorized"}})
+@router.get(
+    "/memories",
+    summary="List or search memories",
+    description="Return a paginated list of memories. Supports optional tag filtering and semantic search. Non-admins see only their own memories.",
+    responses={401: {"description": "Unauthorized"}},
+)
 async def list_memories(
     claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
     storage: Annotated[HiveStorage, Depends(_storage)],
@@ -102,6 +107,8 @@ async def list_memories(
 
 @router.post(
     "/memories",
+    summary="Create or update a memory",
+    description="Create a new memory or update an existing one with the same key. Returns 201 on create, 200 on update. Non-admins cannot overwrite another user's memory.",
     responses={
         401: {"description": "Unauthorized"},
         404: {"description": "Memory not found (non-admin cannot overwrite another user's memory)"},
@@ -167,6 +174,8 @@ async def create_memory(
 
 @router.get(
     "/memories/{memory_id}",
+    summary="Get a memory by ID",
+    description="Retrieve a single memory by its unique ID. Non-admins can only access their own memories.",
     responses={
         401: {"description": "Unauthorized"},
         404: {"description": _MEMORY_NOT_FOUND},
@@ -188,6 +197,8 @@ async def get_memory(
 
 @router.patch(
     "/memories/{memory_id}",
+    summary="Update a memory",
+    description="Partially update a memory's value and/or tags by ID. Non-admins can only update their own memories.",
     responses={
         401: {"description": "Unauthorized"},
         404: {"description": _MEMORY_NOT_FOUND},
@@ -229,6 +240,8 @@ async def update_memory(
 
 @router.delete(
     "/memories/{memory_id}",
+    summary="Delete a memory",
+    description="Permanently delete a memory by ID. Non-admins can only delete their own memories.",
     status_code=204,
     responses={
         401: {"description": "Unauthorized"},

--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -24,7 +24,12 @@ def _storage() -> HiveStorage:
     return HiveStorage()
 
 
-@router.get("/stats", responses={401: {"description": "Unauthorized"}})
+@router.get(
+    "/stats",
+    summary="Get usage statistics",
+    description="Return summary counts for memories, clients, and activity events. Admins see platform-wide totals; non-admins see only their own data.",
+    responses={401: {"description": "Unauthorized"}},
+)
 async def get_stats(
     claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
     storage: Annotated[HiveStorage, Depends(_storage)],
@@ -46,7 +51,12 @@ async def get_stats(
     )
 
 
-@router.get("/activity", responses={401: {"description": "Unauthorized"}})
+@router.get(
+    "/activity",
+    summary="Get activity log",
+    description="Return recent activity events (memory creates, updates, deletes, client registrations, etc.) for the configured number of days.",
+    responses={401: {"description": "Unauthorized"}},
+)
 async def get_activity(
     claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
     storage: Annotated[HiveStorage, Depends(_storage)],

--- a/src/hive/api/users.py
+++ b/src/hive/api/users.py
@@ -29,6 +29,8 @@ def _storage() -> HiveStorage:
 
 @router.get(
     "/users/me",
+    summary="Get current user",
+    description="Return the profile of the currently authenticated management user.",
     responses={
         401: {"description": "Unauthorized"},
         404: {"description": "User not found"},
@@ -46,6 +48,8 @@ async def get_me(
 
 @router.get(
     "/users",
+    summary="List all users",
+    description="Return a paginated list of all registered users. Admin only.",
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Admin role required"},
@@ -68,6 +72,8 @@ async def list_users(
 
 @router.delete(
     "/users/{user_id}",
+    summary="Delete a user",
+    description="Permanently delete a user account by ID. Admin only.",
     status_code=204,
     responses={
         401: {"description": "Unauthorized"},

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -179,6 +179,51 @@ class TestHealth:
 
 
 # ---------------------------------------------------------------------------
+# OpenAPI schema + protected docs endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAPI:
+    def test_openapi_schema_is_non_empty(self, admin_client):
+        tc, *_ = admin_client
+        resp = tc.get("/openapi.json")
+        assert resp.status_code == 200
+        schema = resp.json()
+        assert schema.get("info", {}).get("title") == "Hive Management API"
+        assert schema.get("paths"), "OpenAPI schema must define at least one path"
+
+    def test_docs_accessible_by_admin(self, admin_client):
+        tc, *_ = admin_client
+        resp = tc.get("/docs")
+        assert resp.status_code == 200
+        assert b"swagger" in resp.content.lower()
+
+    def test_redoc_accessible_by_admin(self, admin_client):
+        tc, *_ = admin_client
+        resp = tc.get("/redoc")
+        assert resp.status_code == 200
+        assert b"redoc" in resp.content.lower()
+
+    def test_docs_forbidden_for_non_admin(self, client):
+        tc, *_ = client
+        resp = tc.get("/docs")
+        assert resp.status_code == 403
+
+    def test_redoc_forbidden_for_non_admin(self, client):
+        tc, *_ = client
+        resp = tc.get("/redoc")
+        assert resp.status_code == 403
+
+    def test_docs_requires_auth(self, unauthed_client):
+        resp = unauthed_client.get("/docs")
+        assert resp.status_code in (401, 403)
+
+    def test_redoc_requires_auth(self, unauthed_client):
+        resp = unauthed_client.get("/redoc")
+        assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
 # Auth failures
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #148

## Summary
- Added admin-only `/docs` (Swagger UI) and `/redoc` (ReDoc) endpoints protected by `require_admin` dependency — unauthenticated or non-admin requests get 401/403
- Disabled FastAPI's built-in `docs_url` and `redoc_url` (set to `None`) so the unprotected defaults are never served; `/openapi.json` remains available for schema consumers
- Added `summary` and `description` annotations to all management API route handlers across `memories.py`, `clients.py`, `stats.py`, `users.py`, `admin.py`, and `logs.py`
- Added 7 unit tests validating schema is non-empty, docs are accessible to admins, and forbidden to non-admins/unauthenticated users

## Approach
Protected `/docs` and `/redoc` via FastAPI dependency injection (`require_admin`) rather than middleware, keeping the auth logic consistent with all other protected endpoints. `/openapi.json` is left unprotected at the FastAPI layer since the entire API is already gated by the CloudFront origin-verify secret in production.