### PR TITLE
feat: GDPR account deletion — DELETE /api/account

### DIFF
--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Account self-service endpoint.
+
+DELETE /api/account — permanently erase all data for the authenticated user,
+satisfying GDPR Article 17 right-to-erasure.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from hive.api._auth import require_mgmt_user
+from hive.models import ActivityEvent, EventType
+from hive.storage import HiveStorage
+
+router = APIRouter(tags=["account"])
+
+
+def _storage() -> HiveStorage:
+    return HiveStorage()
+
+
+class AccountDeleteRequest(BaseModel):
+    confirm: bool = False
+
+
+@router.delete(
+    "/account",
+    summary="Delete my account",
+    description=(
+        "Permanently delete all data for the authenticated user: memories, OAuth clients, "
+        "and the user record itself. Requires `confirm: true` in the request body. "
+        "The deletion is recorded in an immutable audit log. This action cannot be undone."
+    ),
+    status_code=204,
+    responses={
+        400: {"description": "confirm must be true"},
+        401: {"description": "Unauthorized"},
+        404: {"description": "User not found"},
+    },
+)
+async def delete_account(
+    body: AccountDeleteRequest,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> None:
+    if not body.confirm:
+        raise HTTPException(status_code=400, detail="confirm must be true to delete your account")
+
+    user_id: str = claims["sub"]
+
+    user = storage.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    counts = storage.delete_user_data(user_id)
+
+    storage.log_audit_event(
+        ActivityEvent(
+            event_type=EventType.account_deleted,
+            client_id="SYSTEM",
+            metadata={
+                "deleted_user_id": user_id,
+                "deleted_memories": counts["deleted_memories"],
+                "deleted_clients": counts["deleted_clients"],
+            },
+        )
+    )

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -20,6 +20,7 @@ from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.responses import HTMLResponse
 
 from hive.api._auth import require_admin
+from hive.api.account import router as account_router
 from hive.api.admin import router as admin_router
 from hive.api.clients import router as clients_router
 from hive.api.logs import router as logs_router
@@ -130,6 +131,7 @@ app.include_router(memories_router, prefix="/api")
 app.include_router(clients_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
+app.include_router(account_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")
 app.include_router(logs_router, prefix="/api")
 

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -422,6 +422,7 @@ class EventType(str, Enum):
     token_revoked = "token_revoked"
     client_registered = "client_registered"
     client_deleted = "client_deleted"
+    account_deleted = "account_deleted"
 
 
 class ActivityEvent(BaseModel):

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -575,6 +575,59 @@ class HiveStorage:
         return resp.get("Count", 0)
 
     # ------------------------------------------------------------------
+    # Audit log (separate from user activity log)
+    # ------------------------------------------------------------------
+
+    def log_audit_event(self, event: ActivityEvent) -> None:
+        """Write an audit event to the immutable audit log (AUDIT# PK prefix).
+
+        Audit events use a separate PK prefix from activity log events (LOG#)
+        and are never deleted, even when a user's activity log is purged.
+        """
+        item = event.to_dynamo()
+        # Override the PK prefix so audit events are stored separately
+        date_hour_str = event.timestamp.strftime("%Y-%m-%d#%H")
+        item["PK"] = f"AUDIT#{date_hour_str}"
+        self.table.put_item(Item=item)
+
+    # ------------------------------------------------------------------
+    # Account deletion
+    # ------------------------------------------------------------------
+
+    def delete_user_data(self, user_id: str) -> dict[str, int]:
+        """Delete all data owned by a user.
+
+        Deletes all memories, OAuth clients, and the user record.
+        Tokens are not explicitly revoked — they carry short TTLs and
+        will expire naturally. Returns counts of deleted items.
+        """
+        deleted_memories = 0
+        cursor: str | None = None
+        while True:
+            memories, cursor = self.list_all_memories(
+                owner_user_id=user_id, limit=200, cursor=cursor
+            )
+            for memory in memories:
+                self.delete_memory(memory.memory_id)
+                deleted_memories += 1
+            if cursor is None:
+                break
+
+        deleted_clients = 0
+        cursor = None
+        while True:
+            clients, cursor = self.list_clients(owner_user_id=user_id, limit=200, cursor=cursor)
+            for client in clients:
+                self.delete_client(client.client_id)
+                deleted_clients += 1
+            if cursor is None:
+                break
+
+        self.delete_user(user_id)
+
+        return {"deleted_memories": deleted_memories, "deleted_clients": deleted_clients}
+
+    # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for the DELETE /api/account self-service account deletion endpoint.
+"""
+
+from __future__ import annotations
+
+import os
+
+import boto3
+import pytest
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-unit-account")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+os.environ.pop("DYNAMODB_ENDPOINT", None)
+
+_USER_ID = "account-user-001"
+_USER_CLAIMS = {"sub": _USER_ID, "role": "user", "email": "user@example.com"}
+
+
+def _create_table() -> None:
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName="hive-unit-account",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "UserEmailIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+@pytest.fixture()
+def client():
+    with mock_aws():
+        _create_table()
+        from hive.api import _auth as auth_mod
+        from hive.api import account as account_mod
+        from hive.api.main import app
+        from hive.models import Memory, User
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-account", region="us-east-1")
+
+        user = User(user_id=_USER_ID, email="user@example.com", display_name="Test", role="user")
+        storage.put_user(user)
+
+        # Pre-seed a memory and a client so we can verify deletion
+        memory = Memory(
+            key="test-key",
+            value="test-value",
+            tags=["t1"],
+            owner_client_id=_USER_ID,
+            owner_user_id=_USER_ID,
+        )
+        storage.put_memory(memory)
+
+        def _override_mgmt_user():
+            return _USER_CLAIMS
+
+        def _override_storage():
+            return storage
+
+        app.dependency_overrides[auth_mod.require_mgmt_user] = _override_mgmt_user
+        app.dependency_overrides[account_mod._storage] = _override_storage
+        yield TestClient(app), storage
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def unauthed_client():
+    with mock_aws():
+        _create_table()
+        from hive.api.main import app
+
+        app.dependency_overrides.clear()
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+class TestDeleteAccount:
+    def test_requires_confirm_true(self, client):
+        tc, _ = client
+        resp = tc.request("DELETE", "/api/account", json={"confirm": False})
+        assert resp.status_code == 400
+        assert "confirm" in resp.json()["detail"]
+
+    def test_requires_confirm_field(self, client):
+        tc, _ = client
+        resp = tc.request("DELETE", "/api/account", json={})
+        assert resp.status_code == 400
+
+    def test_deletes_account_and_data(self, client):
+        tc, storage = client
+        resp = tc.request("DELETE", "/api/account", json={"confirm": True})
+        assert resp.status_code == 204
+        # User record should be gone
+        assert storage.get_user_by_id(_USER_ID) is None
+        # Memory should be gone
+        memories, _ = storage.list_all_memories(owner_user_id=_USER_ID, limit=10)
+        assert memories == []
+
+    def test_returns_404_if_user_not_found(self, client):
+        tc, storage = client
+        # Delete user first so it's missing on the DELETE call
+        storage.delete_user(_USER_ID)
+        resp = tc.request("DELETE", "/api/account", json={"confirm": True})
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.request("DELETE", "/api/account", json={"confirm": True})
+        assert resp.status_code in (401, 403)

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -116,6 +116,17 @@ def unauthed_client():
         yield TestClient(app, raise_server_exceptions=False)
 
 
+class TestStorageDep:
+    def test_storage_dep_returns_hive_storage(self):
+        with mock_aws():
+            _create_table()
+            from hive.api.account import _storage
+            from hive.storage import HiveStorage
+
+            result = _storage()
+            assert isinstance(result, HiveStorage)
+
+
 class TestDeleteAccount:
     def test_requires_confirm_true(self, client):
         tc, _ = client
@@ -144,6 +155,27 @@ class TestDeleteAccount:
         storage.delete_user(_USER_ID)
         resp = tc.request("DELETE", "/api/account", json={"confirm": True})
         assert resp.status_code == 404
+
+    def test_deletes_clients(self, client):
+        tc, storage = client
+        from hive.auth.dcr import register_client
+        from hive.models import ClientRegistrationRequest
+
+        req = ClientRegistrationRequest(
+            client_name="test-client",
+            redirect_uris=["https://example.com/cb"],
+            grant_types=["authorization_code"],
+        )
+        resp_dcr = register_client(req, storage)
+        c = storage.get_client(resp_dcr.client_id)
+        assert c is not None
+        c.owner_user_id = _USER_ID
+        storage.put_client(c)
+
+        resp = tc.request("DELETE", "/api/account", json={"confirm": True})
+        assert resp.status_code == 204
+        # Client should be deleted
+        assert storage.get_client(resp_dcr.client_id) is None
 
     def test_requires_auth(self, unauthed_client):
         resp = unauthed_client.request("DELETE", "/api/account", json={"confirm": True})

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -88,4 +88,7 @@ export const api = {
     return request("GET", `/api/users?${params}`);
   },
   deleteUser: (id) => request("DELETE", `/api/users/${id}`),
+
+  // Account
+  deleteAccount: () => request("DELETE", "/api/account", { confirm: true }),
 };

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -262,6 +262,14 @@ describe("api", () => {
     expect(fetchMock.mock.calls[0][0]).toContain("/api/users/u99");
   });
 
+  it("deleteAccount calls DELETE /api/account with confirm body", async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 204 });
+    await api.deleteAccount();
+    expect(fetchMock.mock.calls[0][1].method).toBe("DELETE");
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/account");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ confirm: true });
+  });
+
   // ---------------------------------------------------------------------------
   // Admin
   // ---------------------------------------------------------------------------

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useState } from "react";
-import { Check } from "lucide-react";
+import { AlertTriangle, Check } from "lucide-react";
 import { api } from "../api.js";
 
 const STEP1_KEY = "hive_setup_step1_done";
@@ -13,6 +13,9 @@ export default function SetupPanel() {
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null); // "ok" | "error"
   const [testError, setTestError] = useState("");
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
 
   const step2Done = testResult === "ok";
 
@@ -38,6 +41,19 @@ export default function SetupPanel() {
     localStorage.setItem(STEP1_KEY, "1");
     setStep1Done(true);
     setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function handleDeleteAccount() {
+    setDeleting(true);
+    setDeleteError("");
+    try {
+      await api.deleteAccount();
+      localStorage.removeItem("hive_mgmt_token");
+      globalThis.location.replace("/");
+    } catch (e) {
+      setDeleteError(e.message ?? "Deletion failed");
+      setDeleting(false);
+    }
   }
 
   async function handleTest() {
@@ -185,6 +201,59 @@ export default function SetupPanel() {
             <span style={{ fontSize: 13, color: "var(--danger)" }}>{testError}</span>
           )}
         </div>
+      </section>
+
+      <section style={{ marginTop: 48, borderTop: "1px solid var(--border)", paddingTop: 32 }}>
+        <h3 style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 8, color: "var(--danger)" }}>
+          <AlertTriangle size={18} />
+          Danger Zone
+        </h3>
+        <p style={{ color: "var(--text-muted)", marginBottom: 16, fontSize: 14 }}>
+          Permanently delete your account and all associated data — memories, OAuth clients, and
+          your user profile. This action cannot be undone.
+        </p>
+
+        {!showDeleteConfirm ? (
+          <button
+            className="secondary"
+            style={{ borderColor: "var(--danger)", color: "var(--danger)" }}
+            onClick={() => setShowDeleteConfirm(true)}
+          >
+            Delete my account
+          </button>
+        ) : (
+          <div
+            className="card"
+            style={{ borderLeft: "4px solid var(--danger)", maxWidth: 480 }}
+          >
+            <p style={{ marginBottom: 16, fontWeight: 600 }}>
+              Are you sure? This will permanently erase all your data.
+            </p>
+            {deleteError && (
+              <p style={{ color: "var(--danger)", fontSize: 13, marginBottom: 12 }}>{deleteError}</p>
+            )}
+            <div style={{ display: "flex", gap: 8 }}>
+              <button
+                style={{
+                  background: "var(--danger)",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "8px 16px",
+                  cursor: deleting ? "not-allowed" : "pointer",
+                  opacity: deleting ? 0.7 : 1,
+                }}
+                onClick={handleDeleteAccount}
+                disabled={deleting}
+              >
+                {deleting ? "Deleting…" : "Yes, delete everything"}
+              </button>
+              <button className="secondary" onClick={() => { setShowDeleteConfirm(false); setDeleteError(""); }}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../api.js", () => ({
-  api: { listMemories: vi.fn() },
+  api: { listMemories: vi.fn(), deleteAccount: vi.fn() },
 }));
 
 import { api } from "../api.js";
@@ -168,5 +168,46 @@ describe("SetupPanel", () => {
     expect(handler).toHaveBeenCalled();
     expect(handler.mock.calls[0][0].detail).toBe("memories");
     window.removeEventListener("hive:switch-tab", handler);
+  });
+
+  it("renders Danger Zone section with delete button", async () => {
+    await act(async () => render(<SetupPanel />));
+    expect(screen.getByText("Danger Zone")).toBeTruthy();
+    expect(screen.getByText("Delete my account")).toBeTruthy();
+  });
+
+  it("shows confirmation dialog when Delete my account is clicked", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Delete my account"));
+    expect(screen.getByText(/Are you sure/)).toBeTruthy();
+    expect(screen.getByText("Yes, delete everything")).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
+  });
+
+  it("hides confirmation dialog on Cancel", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Delete my account"));
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.getByText("Delete my account")).toBeTruthy();
+    expect(screen.queryByText(/Are you sure/)).toBeNull();
+  });
+
+  it("calls api.deleteAccount and redirects on confirm", async () => {
+    api.deleteAccount.mockResolvedValue(null);
+    const replaceMock = vi.fn();
+    vi.stubGlobal("location", { replace: replaceMock });
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Delete my account"));
+    await act(async () => fireEvent.click(screen.getByText("Yes, delete everything")));
+    expect(api.deleteAccount).toHaveBeenCalled();
+    expect(replaceMock).toHaveBeenCalledWith("/");
+  });
+
+  it("shows error message when deleteAccount fails", async () => {
+    api.deleteAccount.mockRejectedValue(new Error("Server error"));
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Delete my account"));
+    await act(async () => fireEvent.click(screen.getByText("Yes, delete everything")));
+    await waitFor(() => expect(screen.getByText("Server error")).toBeTruthy());
   });
 });

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -210,4 +210,12 @@ describe("SetupPanel", () => {
     await act(async () => fireEvent.click(screen.getByText("Yes, delete everything")));
     await waitFor(() => expect(screen.getByText("Server error")).toBeTruthy());
   });
+
+  it("shows fallback error when deleteAccount rejects without message", async () => {
+    api.deleteAccount.mockRejectedValue({});
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Delete my account"));
+    await act(async () => fireEvent.click(screen.getByText("Yes, delete everything")));
+    await waitFor(() => expect(screen.getByText("Deletion failed")).toBeTruthy());
+  });
 });


### PR DESCRIPTION
Closes #149

## Summary
- Added `DELETE /api/account` endpoint requiring `{"confirm": true}` in the request body — immediately deletes all memories, OAuth clients, and the user record
- Added `account_deleted` EventType and `delete_user_data()` storage method
- Deletion is recorded in an immutable audit log using a separate `AUDIT#` PK prefix (distinct from user activity log `LOG#` items)
- Management UI (`SetupPanel`) gains a Danger Zone section at the bottom with a "Delete my account" button and a two-step confirmation dialog
- 5 backend unit tests + 5 frontend tests covering happy path, error cases, auth, and confirmation flow

## Approach
Implemented immediate hard deletion rather than soft-delete/grace-period, as the acceptance criteria specifies data wipe and the grace period approach is only in the proposed approach section. Tokens are not explicitly revoked since they carry short TTLs (1h access, 30d refresh) and there is no GSI to look up tokens by user — this is noted in the storage docstring. The audit log uses a separate `AUDIT#` PK prefix so audit records survive even if table-level cleanup is ever performed on `LOG#` items.