### PR TITLE
feat: per-client rate limiting with 429 Retry-After

### DIFF
--- a/src/hive/api/_auth.py
+++ b/src/hive/api/_auth.py
@@ -10,6 +10,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from hive.auth.tokens import decode_mgmt_jwt, validate_bearer_token
 from hive.metrics import emit_metric
+from hive.rate_limiter import RateLimitExceeded, check_rate_limit
 from hive.storage import HiveStorage
 
 _bearer = HTTPBearer()
@@ -25,13 +26,21 @@ async def require_token(
 ) -> tuple[HiveStorage, str]:
     """
     FastAPI dependency that validates the Bearer token and returns
-    (storage, client_id).  Raises HTTP 401 on failure.
+    (storage, client_id).  Raises HTTP 401 on failure, 429 on rate limit.
     """
     try:
         token = validate_bearer_token(f"Bearer {credentials.credentials}", storage)
     except ValueError as exc:
         await emit_metric("TokenValidationFailures")
         raise HTTPException(status_code=401, detail=str(exc)) from exc
+    try:
+        check_rate_limit(token.client_id, storage)
+    except RateLimitExceeded as exc:
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": str(exc.retry_after)},
+        ) from exc
     return storage, token.client_id
 
 

--- a/src/hive/rate_limiter.py
+++ b/src/hive/rate_limiter.py
@@ -80,9 +80,7 @@ def check_rate_limit(client_id: str, storage: HiveStorage) -> None:
 
     # Per-minute window — counter expires 2 minutes after the window key
     min_key = now.strftime("%Y-%m-%dT%H:%M")
-    min_count = storage.increment_rate_limit_counter(
-        client_id, f"min#{min_key}", ttl_seconds=120
-    )
+    min_count = storage.increment_rate_limit_counter(client_id, f"min#{min_key}", ttl_seconds=120)
     if min_count > rpm:
         retry_after = 60 - now.second
         raise RateLimitExceeded(retry_after=retry_after)

--- a/src/hive/rate_limiter.py
+++ b/src/hive/rate_limiter.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Per-client rate limiting for Hive.
+
+Rate limit counters are stored in DynamoDB using atomic increments so they
+are safe under concurrent Lambda invocations. Counters expire automatically
+via DynamoDB TTL.
+
+Configuration (environment variables):
+  HIVE_RATE_LIMIT_RPM              Requests per minute per client (default 60)
+  HIVE_RATE_LIMIT_RPD              Requests per day per client (default 1000)
+  HIVE_RATE_LIMIT_EXEMPT_CLIENTS   Comma-separated client IDs exempt from limits
+
+Override mechanism: set HIVE_RATE_LIMIT_EXEMPT_CLIENTS to a comma-separated
+list of client IDs that should bypass rate limiting (e.g. internal test clients
+or trusted integrations).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+from hive.storage import HiveStorage
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via environment variables)
+# ---------------------------------------------------------------------------
+
+DEFAULT_RATE_LIMIT_RPM = 60
+DEFAULT_RATE_LIMIT_RPD = 1000
+
+
+def _rpm() -> int:
+    return int(os.environ.get("HIVE_RATE_LIMIT_RPM", str(DEFAULT_RATE_LIMIT_RPM)))
+
+
+def _rpd() -> int:
+    return int(os.environ.get("HIVE_RATE_LIMIT_RPD", str(DEFAULT_RATE_LIMIT_RPD)))
+
+
+def _exempt_clients() -> set[str]:
+    raw = os.environ.get("HIVE_RATE_LIMIT_EXEMPT_CLIENTS", "")
+    return {c.strip() for c in raw.split(",") if c.strip()}
+
+
+# ---------------------------------------------------------------------------
+# Exception
+# ---------------------------------------------------------------------------
+
+
+class RateLimitExceeded(Exception):
+    """Raised when a client exceeds its rate limit."""
+
+    def __init__(self, retry_after: int) -> None:
+        self.retry_after = retry_after
+        super().__init__(f"Rate limit exceeded. Retry after {retry_after}s.")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_rate_limit(client_id: str, storage: HiveStorage) -> None:
+    """Check and enforce per-client rate limits.
+
+    Atomically increments DynamoDB counters for the current minute and day
+    windows. Raises RateLimitExceeded (with retry_after seconds) if either
+    limit is exceeded.
+
+    Does nothing for clients listed in HIVE_RATE_LIMIT_EXEMPT_CLIENTS.
+    """
+    if client_id in _exempt_clients():
+        return
+
+    now = datetime.now(timezone.utc)
+    rpm = _rpm()
+    rpd = _rpd()
+
+    # Per-minute window — counter expires 2 minutes after the window key
+    min_key = now.strftime("%Y-%m-%dT%H:%M")
+    min_count = storage.increment_rate_limit_counter(
+        client_id, f"min#{min_key}", ttl_seconds=120
+    )
+    if min_count > rpm:
+        retry_after = 60 - now.second
+        raise RateLimitExceeded(retry_after=retry_after)
+
+    # Per-day window — counter expires 2 days after the window key
+    day_key = now.strftime("%Y-%m-%d")
+    day_count = storage.increment_rate_limit_counter(
+        client_id, f"day#{day_key}", ttl_seconds=86400 * 2
+    )
+    if day_count > rpd:
+        retry_after = 86400 - (now.hour * 3600 + now.minute * 60 + now.second)
+        raise RateLimitExceeded(retry_after=retry_after)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -32,6 +32,7 @@ from hive.auth.tokens import _origin_verify_secret, validate_bearer_token
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 from hive.metrics import emit_metric
 from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult
+from hive.rate_limiter import RateLimitExceeded, check_rate_limit
 from hive.storage import HiveStorage
 from hive.vector_store import VectorIndexNotFoundError, VectorStore
 
@@ -120,6 +121,11 @@ def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple[HiveS
 
     if required_scope and required_scope not in set(token.scope.split()):
         raise ToolError(f"Insufficient scope: '{required_scope}' required")
+
+    try:
+        check_rate_limit(token.client_id, storage)
+    except RateLimitExceeded as exc:
+        raise ToolError(f"Rate limit exceeded. Retry after {exc.retry_after}s.") from exc
 
     set_request_context(request_id, token.client_id)
     return storage, token.client_id

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -16,6 +16,7 @@ import base64
 import json
 import os
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from typing import Any
 
 import boto3
@@ -573,6 +574,37 @@ class HiveStorage:
             ExpressionAttributeValues={":sk": "META", _PK_PREFIX_KEY: "USER#"},
         )
         return resp.get("Count", 0)
+
+    # ------------------------------------------------------------------
+    # Rate limiting
+    # ------------------------------------------------------------------
+
+    def increment_rate_limit_counter(
+        self, client_id: str, window_key: str, ttl_seconds: int
+    ) -> int:
+        """Atomically increment a rate limit counter and return the new value.
+
+        The counter item is created on first access. TTL is set only on the
+        first write (``if_not_exists``) so DynamoDB TTL can clean up expired
+        counters automatically.
+
+        Args:
+            client_id:   The OAuth client being rate-limited.
+            window_key:  Window identifier, e.g. ``min#2026-04-12T10:30``.
+            ttl_seconds: Seconds from now after which the item should expire.
+        """
+        import time
+
+        pk = f"RATELIMIT#{client_id}#{window_key}"
+        ttl_epoch = int(time.time()) + ttl_seconds
+        resp = self.table.update_item(
+            Key={"PK": pk, "SK": "META"},
+            UpdateExpression="SET #ttl = if_not_exists(#ttl, :ttl) ADD #c :one",
+            ExpressionAttributeNames={"#c": "count", "#ttl": "ttl"},
+            ExpressionAttributeValues={":one": Decimal("1"), ":ttl": ttl_epoch},
+            ReturnValues="UPDATED_NEW",
+        )
+        return int(resp["Attributes"]["count"])
 
     # ------------------------------------------------------------------
     # Audit log (separate from user activity log)

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for per-client rate limiting.
+
+Tests the rate_limiter module, the storage counter, and the 429 behaviour
+wired into both the MCP server auth helper and the management API require_token
+dependency.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-unit-ratelimit")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+os.environ.pop("DYNAMODB_ENDPOINT", None)
+
+
+def _create_table() -> None:
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName="hive-unit-ratelimit",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+class TestIncrementRateLimitCounter:
+    def test_first_call_returns_one(self):
+        with mock_aws():
+            _create_table()
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            count = storage.increment_rate_limit_counter("client-1", "min#2026-04-12T10:00", 120)
+            assert count == 1
+
+    def test_increments_on_repeated_calls(self):
+        with mock_aws():
+            _create_table()
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            storage.increment_rate_limit_counter("c1", "min#2026-04-12T10:00", 120)
+            storage.increment_rate_limit_counter("c1", "min#2026-04-12T10:00", 120)
+            count = storage.increment_rate_limit_counter("c1", "min#2026-04-12T10:00", 120)
+            assert count == 3
+
+    def test_different_windows_are_independent(self):
+        with mock_aws():
+            _create_table()
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            c1 = storage.increment_rate_limit_counter("c1", "min#2026-04-12T10:00", 120)
+            c2 = storage.increment_rate_limit_counter("c1", "min#2026-04-12T10:01", 120)
+            assert c1 == 1
+            assert c2 == 1
+
+    def test_different_clients_are_independent(self):
+        with mock_aws():
+            _create_table()
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            c1 = storage.increment_rate_limit_counter("client-A", "min#2026-04-12T10:00", 120)
+            c2 = storage.increment_rate_limit_counter("client-B", "min#2026-04-12T10:00", 120)
+            assert c1 == 1
+            assert c2 == 1
+
+
+class TestCheckRateLimit:
+    def test_allows_request_under_limit(self):
+        with mock_aws():
+            _create_table()
+            from hive.rate_limiter import check_rate_limit
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            with patch.dict(os.environ, {"HIVE_RATE_LIMIT_RPM": "5", "HIVE_RATE_LIMIT_RPD": "100"}):
+                # Should not raise
+                check_rate_limit("client-1", storage)
+
+    def test_raises_when_rpm_exceeded(self):
+        with mock_aws():
+            _create_table()
+            from hive.rate_limiter import RateLimitExceeded, check_rate_limit
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            with patch.dict(os.environ, {"HIVE_RATE_LIMIT_RPM": "2", "HIVE_RATE_LIMIT_RPD": "1000"}):
+                check_rate_limit("client-x", storage)
+                check_rate_limit("client-x", storage)
+                with pytest.raises(RateLimitExceeded) as exc_info:
+                    check_rate_limit("client-x", storage)
+                assert exc_info.value.retry_after > 0
+
+    def test_raises_when_rpd_exceeded(self):
+        with mock_aws():
+            _create_table()
+            from hive.rate_limiter import RateLimitExceeded, check_rate_limit
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            with patch.dict(os.environ, {"HIVE_RATE_LIMIT_RPM": "1000", "HIVE_RATE_LIMIT_RPD": "2"}):
+                check_rate_limit("client-y", storage)
+                check_rate_limit("client-y", storage)
+                with pytest.raises(RateLimitExceeded) as exc_info:
+                    check_rate_limit("client-y", storage)
+                assert exc_info.value.retry_after > 0
+
+    def test_exempt_client_bypasses_limit(self):
+        with mock_aws():
+            _create_table()
+            from hive.rate_limiter import check_rate_limit
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            with patch.dict(
+                os.environ,
+                {
+                    "HIVE_RATE_LIMIT_RPM": "1",
+                    "HIVE_RATE_LIMIT_RPD": "1",
+                    "HIVE_RATE_LIMIT_EXEMPT_CLIENTS": "exempt-client",
+                },
+            ):
+                for _ in range(10):
+                    check_rate_limit("exempt-client", storage)
+
+    def test_exempt_clients_list_multiple(self):
+        with mock_aws():
+            _create_table()
+            from hive.rate_limiter import check_rate_limit
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
+            with patch.dict(
+                os.environ,
+                {
+                    "HIVE_RATE_LIMIT_RPM": "1",
+                    "HIVE_RATE_LIMIT_EXEMPT_CLIENTS": "a, b, c",
+                },
+            ):
+                check_rate_limit("a", storage)
+                check_rate_limit("b", storage)
+                check_rate_limit("c", storage)
+
+    def test_retry_after_is_positive_int(self):
+        from hive.rate_limiter import RateLimitExceeded
+
+        exc = RateLimitExceeded(retry_after=30)
+        assert exc.retry_after == 30
+        assert "30" in str(exc)
+
+
+class TestMcpRateLimitIntegration:
+    """Verify _auth() in server.py raises ToolError on rate limit exceeded."""
+
+    def test_mcp_auth_raises_tool_error_on_rate_limit(self):
+        from fastmcp.exceptions import ToolError
+
+        from hive.rate_limiter import RateLimitExceeded
+
+        with patch("hive.server.validate_bearer_token") as mock_validate, patch(
+            "hive.server.check_rate_limit"
+        ) as mock_rl, patch("hive.server.HiveStorage"), patch(
+            "hive.server.get_http_request", side_effect=RuntimeError("no request")
+        ):
+            mock_token = MagicMock()
+            mock_token.client_id = "test-client"
+            mock_token.scope = "memories:read"
+            mock_validate.return_value = mock_token
+            mock_rl.side_effect = RateLimitExceeded(retry_after=45)
+
+            from hive.server import _auth
+
+            with pytest.raises(ToolError) as exc_info:
+                _auth(None, required_scope="memories:read")
+            assert "Rate limit exceeded" in str(exc_info.value)
+            assert "45" in str(exc_info.value)
+
+
+class TestApiRateLimitIntegration:
+    """Verify require_token raises HTTP 429 on rate limit exceeded."""
+
+    def test_require_token_returns_429_on_rate_limit(self):
+        import asyncio
+
+        from fastapi import HTTPException
+        from fastapi.security import HTTPAuthorizationCredentials
+
+        from hive.rate_limiter import RateLimitExceeded
+
+        with patch("hive.api._auth.validate_bearer_token") as mock_validate, patch(
+            "hive.api._auth.check_rate_limit"
+        ) as mock_rl, patch("hive.api._auth.emit_metric") as _:
+            mock_token = MagicMock()
+            mock_token.client_id = "test-client"
+            mock_validate.return_value = mock_token
+            mock_rl.side_effect = RateLimitExceeded(retry_after=30)
+
+            from hive.api._auth import require_token
+            from hive.storage import HiveStorage
+
+            creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="fake-token")
+            storage = MagicMock(spec=HiveStorage)
+
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.get_event_loop().run_until_complete(require_token(creds, storage))
+            assert exc_info.value.status_code == 429
+            assert exc_info.value.headers["Retry-After"] == "30"

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -103,7 +103,9 @@ class TestCheckRateLimit:
             from hive.storage import HiveStorage
 
             storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
-            with patch.dict(os.environ, {"HIVE_RATE_LIMIT_RPM": "2", "HIVE_RATE_LIMIT_RPD": "1000"}):
+            with patch.dict(
+                os.environ, {"HIVE_RATE_LIMIT_RPM": "2", "HIVE_RATE_LIMIT_RPD": "1000"}
+            ):
                 check_rate_limit("client-x", storage)
                 check_rate_limit("client-x", storage)
                 with pytest.raises(RateLimitExceeded) as exc_info:
@@ -117,7 +119,9 @@ class TestCheckRateLimit:
             from hive.storage import HiveStorage
 
             storage = HiveStorage(table_name="hive-unit-ratelimit", region="us-east-1")
-            with patch.dict(os.environ, {"HIVE_RATE_LIMIT_RPM": "1000", "HIVE_RATE_LIMIT_RPD": "2"}):
+            with patch.dict(
+                os.environ, {"HIVE_RATE_LIMIT_RPM": "1000", "HIVE_RATE_LIMIT_RPD": "2"}
+            ):
                 check_rate_limit("client-y", storage)
                 check_rate_limit("client-y", storage)
                 with pytest.raises(RateLimitExceeded) as exc_info:
@@ -176,10 +180,11 @@ class TestMcpRateLimitIntegration:
 
         from hive.rate_limiter import RateLimitExceeded
 
-        with patch("hive.server.validate_bearer_token") as mock_validate, patch(
-            "hive.server.check_rate_limit"
-        ) as mock_rl, patch("hive.server.HiveStorage"), patch(
-            "hive.server.get_http_request", side_effect=RuntimeError("no request")
+        with (
+            patch("hive.server.validate_bearer_token") as mock_validate,
+            patch("hive.server.check_rate_limit") as mock_rl,
+            patch("hive.server.HiveStorage"),
+            patch("hive.server.get_http_request", side_effect=RuntimeError("no request")),
         ):
             mock_token = MagicMock()
             mock_token.client_id = "test-client"
@@ -206,9 +211,11 @@ class TestApiRateLimitIntegration:
 
         from hive.rate_limiter import RateLimitExceeded
 
-        with patch("hive.api._auth.validate_bearer_token") as mock_validate, patch(
-            "hive.api._auth.check_rate_limit"
-        ) as mock_rl, patch("hive.api._auth.emit_metric") as _:
+        with (
+            patch("hive.api._auth.validate_bearer_token") as mock_validate,
+            patch("hive.api._auth.check_rate_limit") as mock_rl,
+            patch("hive.api._auth.emit_metric") as _,
+        ):
             mock_token = MagicMock()
             mock_token.client_id = "test-client"
             mock_validate.return_value = mock_token


### PR DESCRIPTION
Closes #144

## Summary
- Added `src/hive/rate_limiter.py` with `check_rate_limit(client_id, storage)` — enforces per-minute and per-day limits using DynamoDB atomic `ADD` counters with TTL
- Rate limit counters stored as `RATELIMIT#{client_id}#{window}` items; expire automatically via DynamoDB TTL
- 429 response with `Retry-After` header on management API OAuth token paths; `ToolError` with retry info on MCP tool calls
- `increment_rate_limit_counter()` added to `HiveStorage` — uses a single `update_item` with `SET if_not_exists` + `ADD` for atomic, concurrent-safe increments
- Defaults: 60 req/min, 1000 req/day — configurable via `HIVE_RATE_LIMIT_RPM` / `HIVE_RATE_LIMIT_RPD`
- Override mechanism: `HIVE_RATE_LIMIT_EXEMPT_CLIENTS` (comma-separated) for trusted/internal clients
- 12 unit tests covering counter logic, limit enforcement, reset by window, exempt clients, and end-to-end 429 wiring in both MCP and API paths

## Approach
Applied rate limiting to OAuth Bearer token holders (MCP clients and API token users) in `_auth()` (server.py) and `require_token()` (api/_auth.py). Management JWT users (browser sessions) are not rate-limited — this is an interactive flow, not programmatic API access. Rate limit counters are checked after token validation so unauthorized requests are rejected before incrementing any counters.