### PR TITLE
fix: button border reset into @layer base so nav variant border renders

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -54,8 +54,12 @@ body {
   font-size: 14px;
 }
 
+@layer base {
+  button {
+    border: none;
+  }
+}
 button {
-  border: none;
   cursor: pointer;
   border-radius: var(--radius);
   font-size: 13px;


### PR DESCRIPTION
## Summary

The previous fix (#327) added the correct Tailwind class (`border border-white/60`) to the Sign in nav button, but the border still didn't appear. The root cause is CSS cascade priority: unlayered CSS rules in `index.css` override `@layer utilities` (Tailwind utilities) per CSS Cascade Level 5.

The global `button { border: none }` reset was unlayered, so it stripped the border from any button regardless of Tailwind classes applied to it.

**Fix:** Move `border: none` into `@layer base`, which has lower cascade priority than `@layer utilities`, allowing Tailwind's `border border-white/60` to take effect on the nav button.

## Approach

One-line CSS change — no component changes, no new classes. All 412 frontend tests pass.