### PR TITLE
feat: per-user usage quotas for free tier

### DIFF
--- a/.vite/vitest/results.json
+++ b/.vite/vitest/results.json
@@ -1,0 +1,1 @@
+{"version":"1.6.1","results":[[":ui/src/components/PageLayout.test.jsx",{"duration":0,"failed":true}]]}

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -21,6 +21,7 @@ from hive.models import (
     EventType,
     PagedResponse,
 )
+from hive.quota import QuotaExceeded, check_client_quota
 from hive.storage import HiveStorage
 
 router = APIRouter(tags=["clients"])
@@ -78,6 +79,10 @@ async def create_client(
     storage: Annotated[HiveStorage, Depends(_storage)],
 ) -> ClientRegistrationResponse:
     owner_user_id: str = claims["sub"]
+    try:
+        check_client_quota(owner_user_id, storage)
+    except QuotaExceeded as exc:
+        raise HTTPException(status_code=429, detail=exc.detail) from exc
     try:
         resp = register_client(body, storage)
     except ValueError as exc:

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -25,6 +25,7 @@ from hive.models import (
     MemoryUpdate,
     PagedResponse,
 )
+from hive.quota import QuotaExceeded, check_memory_quota
 from hive.storage import HiveStorage
 from hive.vector_store import VectorIndexNotFoundError, VectorStore
 
@@ -150,6 +151,10 @@ async def create_memory(
         response.status_code = 200
         return MemoryResponse.from_memory(existing)
 
+    try:
+        check_memory_quota(owner_user_id, storage)
+    except QuotaExceeded as exc:
+        raise HTTPException(status_code=429, detail=exc.detail) from exc
     memory = Memory(
         key=body.key,
         value=body.value,

--- a/src/hive/api/stats.py
+++ b/src/hive/api/stats.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, Query
 
 from hive.api._auth import require_mgmt_user
 from hive.models import PagedResponse, StatsResponse
+from hive.quota import _exempt_users, get_client_limit, get_memory_limit
 from hive.storage import HiveStorage
 
 router = APIRouter(tags=["stats"])
@@ -42,12 +43,15 @@ async def get_stats(
     events_7 = storage.get_events_for_dates(last_7, limit=10000)
 
     is_admin = claims.get("role") == "admin"
+    is_exempt = claims["sub"] in _exempt_users()
     return StatsResponse(
         total_memories=storage.count_memories(owner_user_id=owner_user_id),
         total_clients=storage.count_clients(owner_user_id=owner_user_id),
         total_users=storage.count_users() if is_admin else None,
         events_today=len(events_today),
         events_last_7_days=len(events_7),
+        memory_limit=None if (is_admin or is_exempt) else get_memory_limit(),
+        client_limit=None if (is_admin or is_exempt) else get_client_limit(),
     )
 
 

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -551,6 +551,8 @@ class StatsResponse(BaseModel):
     total_users: int | None = None  # admin only
     events_today: int
     events_last_7_days: int
+    memory_limit: int | None = None  # None = unlimited (admin or exempt)
+    client_limit: int | None = None  # None = unlimited (admin or exempt)
 
 
 class PagedResponse(BaseModel):

--- a/src/hive/quota.py
+++ b/src/hive/quota.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Per-user usage quotas for Hive free tier.
+
+Quota limits are configurable via environment variables and checked before
+write operations (creating a new memory, registering a new OAuth client).
+
+Configuration (environment variables):
+  HIVE_QUOTA_MAX_MEMORIES    Max stored memories per user (default 500)
+  HIVE_QUOTA_MAX_CLIENTS     Max OAuth clients per user (default 10)
+  HIVE_QUOTA_EXEMPT_USERS    Comma-separated user IDs exempt from quotas
+"""
+
+from __future__ import annotations
+
+import os
+
+from hive.storage import HiveStorage
+
+DEFAULT_QUOTA_MAX_MEMORIES = 500
+DEFAULT_QUOTA_MAX_CLIENTS = 10
+
+
+def _max_memories() -> int:
+    return int(os.environ.get("HIVE_QUOTA_MAX_MEMORIES", str(DEFAULT_QUOTA_MAX_MEMORIES)))
+
+
+def _max_clients() -> int:
+    return int(os.environ.get("HIVE_QUOTA_MAX_CLIENTS", str(DEFAULT_QUOTA_MAX_CLIENTS)))
+
+
+def _exempt_users() -> set[str]:
+    raw = os.environ.get("HIVE_QUOTA_EXEMPT_USERS", "")
+    return {u.strip() for u in raw.split(",") if u.strip()}
+
+
+def get_memory_limit() -> int:
+    """Return the configured memory quota limit."""
+    return _max_memories()
+
+
+def get_client_limit() -> int:
+    """Return the configured client quota limit."""
+    return _max_clients()
+
+
+class QuotaExceeded(Exception):
+    """Raised when a user exceeds a quota limit."""
+
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(detail)
+
+
+def check_memory_quota(user_id: str | None, storage: HiveStorage) -> None:
+    """Raise QuotaExceeded if the user has reached their memory limit.
+
+    Passes silently for None user_id (pre-migration items without an owner)
+    and for users listed in HIVE_QUOTA_EXEMPT_USERS.
+    """
+    if user_id is None or user_id in _exempt_users():
+        return
+    limit = _max_memories()
+    count = storage.count_memories(owner_user_id=user_id)
+    if count >= limit:
+        raise QuotaExceeded(
+            f"Memory quota reached ({count}/{limit}). Delete some memories to store new ones."
+        )
+
+
+def check_client_quota(user_id: str, storage: HiveStorage) -> None:
+    """Raise QuotaExceeded if the user has reached their client limit."""
+    if user_id in _exempt_users():
+        return
+    limit = _max_clients()
+    count = storage.count_clients(owner_user_id=user_id)
+    if count >= limit:
+        raise QuotaExceeded(
+            f"Client quota reached ({count}/{limit}). "
+            "Delete an existing client to register a new one."
+        )

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -32,6 +32,7 @@ from hive.auth.tokens import _origin_verify_secret, validate_bearer_token
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 from hive.metrics import emit_metric
 from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult
+from hive.quota import QuotaExceeded, check_memory_quota
 from hive.rate_limiter import RateLimitExceeded, check_rate_limit
 from hive.storage import HiveStorage
 from hive.vector_store import VectorIndexNotFoundError, VectorStore
@@ -182,6 +183,12 @@ async def remember(
         except Exception:
             logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
     else:
+        client = storage.get_client(client_id)
+        owner_user_id = client.owner_user_id if client else None
+        try:
+            check_memory_quota(owner_user_id, storage)
+        except QuotaExceeded as exc:
+            raise ToolError(exc.detail) from exc
         memory = Memory(key=key, value=value, tags=tags, owner_client_id=client_id)
         try:
             storage.put_memory(memory)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -272,6 +272,27 @@ class TestMemories:
         assert resp.status_code == 413
         assert "too large" in resp.json()["detail"]
 
+    def test_create_returns_429_when_memory_quota_exceeded(self, client):
+        import os
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "0"}):
+            tc, *_ = client
+            resp = tc.post("/api/memories", json={"key": "blocked", "value": "v"})
+        assert resp.status_code == 429
+        assert "quota" in resp.json()["detail"].lower()
+
+    def test_update_does_not_check_quota(self, client):
+        """Updating an existing memory must not be blocked by quota."""
+        import os
+        from unittest.mock import patch
+
+        tc, *_ = client
+        tc.post("/api/memories", json={"key": "existing", "value": "v1"})
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "0"}):
+            resp = tc.post("/api/memories", json={"key": "existing", "value": "v2"})
+        assert resp.status_code == 200
+
     def test_update_oversized_returns_413(self, client):
         from unittest.mock import patch
 
@@ -466,6 +487,16 @@ class TestClients:
         resp = tc.delete("/api/clients/no-such-id")
         assert resp.status_code == 404
 
+    def test_create_returns_429_when_client_quota_exceeded(self, client):
+        import os
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_CLIENTS": "0"}):
+            tc, *_ = client
+            resp = tc.post("/api/clients", json={"client_name": "Blocked"})
+        assert resp.status_code == 429
+        assert "quota" in resp.json()["detail"].lower()
+
 
 # ---------------------------------------------------------------------------
 # Stats + activity endpoints
@@ -483,6 +514,28 @@ class TestStats:
         assert "total_clients" in data
         assert "events_today" in data
         assert "events_last_7_days" in data
+
+    def test_get_stats_includes_quota_limits_for_user(self, client):
+        import os
+        from unittest.mock import patch
+
+        tc, *_ = client
+        with patch.dict(
+            os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "500", "HIVE_QUOTA_MAX_CLIENTS": "10"}
+        ):
+            resp = tc.get("/api/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["memory_limit"] == 500
+        assert data["client_limit"] == 10
+
+    def test_get_stats_admin_has_no_quota_limits(self, admin_client):
+        tc, *_ = admin_client
+        resp = tc.get("/api/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["memory_limit"] is None
+        assert data["client_limit"] is None
 
     def test_get_stats_admin_sees_all(self, admin_client):
         """Admin role passes owner_user_id=None so all items are counted."""

--- a/tests/unit/test_quota.py
+++ b/tests/unit/test_quota.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for per-user usage quotas.
+
+Tests the quota module, enforcement in server.py (MCP ToolError),
+enforcement in memories.py (HTTP 429), and enforcement in clients.py (HTTP 429).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+
+
+class TestQuotaExceeded:
+    def test_has_detail_attribute(self):
+        from hive.quota import QuotaExceeded
+
+        exc = QuotaExceeded("too many memories")
+        assert exc.detail == "too many memories"
+        assert str(exc) == "too many memories"
+
+
+class TestCheckMemoryQuota:
+    def test_allows_when_under_limit(self):
+        from hive.quota import check_memory_quota
+
+        storage = MagicMock()
+        storage.count_memories.return_value = 10
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "500"}):
+            check_memory_quota("user-1", storage)  # should not raise
+
+    def test_raises_when_at_limit(self):
+        from hive.quota import QuotaExceeded, check_memory_quota
+
+        storage = MagicMock()
+        storage.count_memories.return_value = 500
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "500"}):
+            with pytest.raises(QuotaExceeded) as exc_info:
+                check_memory_quota("user-1", storage)
+            assert "500/500" in exc_info.value.detail
+
+    def test_raises_when_over_limit(self):
+        from hive.quota import QuotaExceeded, check_memory_quota
+
+        storage = MagicMock()
+        storage.count_memories.return_value = 600
+        with (
+            patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "500"}),
+            pytest.raises(QuotaExceeded),
+        ):
+            check_memory_quota("user-1", storage)
+
+    def test_skips_none_user_id(self):
+        from hive.quota import check_memory_quota
+
+        storage = MagicMock()
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "0"}):
+            check_memory_quota(None, storage)  # should not raise
+        storage.count_memories.assert_not_called()
+
+    def test_skips_exempt_user(self):
+        from hive.quota import check_memory_quota
+
+        storage = MagicMock()
+        storage.count_memories.return_value = 9999
+        with patch.dict(
+            os.environ,
+            {"HIVE_QUOTA_MAX_MEMORIES": "1", "HIVE_QUOTA_EXEMPT_USERS": "exempt-user"},
+        ):
+            check_memory_quota("exempt-user", storage)  # should not raise
+        storage.count_memories.assert_not_called()
+
+    def test_exempt_users_list_multiple(self):
+        from hive.quota import check_memory_quota
+
+        storage = MagicMock()
+        storage.count_memories.return_value = 9999
+        with patch.dict(
+            os.environ,
+            {"HIVE_QUOTA_MAX_MEMORIES": "1", "HIVE_QUOTA_EXEMPT_USERS": "a, b, c"},
+        ):
+            check_memory_quota("a", storage)
+            check_memory_quota("b", storage)
+            check_memory_quota("c", storage)
+        storage.count_memories.assert_not_called()
+
+
+class TestCheckClientQuota:
+    def test_allows_when_under_limit(self):
+        from hive.quota import check_client_quota
+
+        storage = MagicMock()
+        storage.count_clients.return_value = 5
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_CLIENTS": "10"}):
+            check_client_quota("user-1", storage)  # should not raise
+
+    def test_raises_when_at_limit(self):
+        from hive.quota import QuotaExceeded, check_client_quota
+
+        storage = MagicMock()
+        storage.count_clients.return_value = 10
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_CLIENTS": "10"}):
+            with pytest.raises(QuotaExceeded) as exc_info:
+                check_client_quota("user-1", storage)
+            assert "10/10" in exc_info.value.detail
+
+    def test_skips_exempt_user(self):
+        from hive.quota import check_client_quota
+
+        storage = MagicMock()
+        storage.count_clients.return_value = 9999
+        with patch.dict(
+            os.environ,
+            {"HIVE_QUOTA_MAX_CLIENTS": "1", "HIVE_QUOTA_EXEMPT_USERS": "exempt-user"},
+        ):
+            check_client_quota("exempt-user", storage)  # should not raise
+        storage.count_clients.assert_not_called()
+
+
+class TestGetLimits:
+    def test_get_memory_limit_returns_configured_value(self):
+        from hive.quota import get_memory_limit
+
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "250"}):
+            assert get_memory_limit() == 250
+
+    def test_get_client_limit_returns_configured_value(self):
+        from hive.quota import get_client_limit
+
+        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_CLIENTS": "5"}):
+            assert get_client_limit() == 5
+
+
+class TestMcpQuotaIntegration:
+    """Verify remember() in server.py raises ToolError when quota exceeded."""
+
+    def test_remember_raises_tool_error_on_quota_exceeded(self):
+        import asyncio
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.quota import QuotaExceeded
+
+        with (
+            patch("hive.server.validate_bearer_token") as mock_validate,
+            patch("hive.server.check_rate_limit"),
+            patch("hive.server.HiveStorage") as MockStorage,
+            patch("hive.server.get_http_request", side_effect=RuntimeError("no request")),
+            patch("hive.server.check_memory_quota") as mock_quota,
+        ):
+            mock_token = MagicMock()
+            mock_token.client_id = "test-client"
+            mock_token.scope = "memories:write"
+            mock_validate.return_value = mock_token
+            MockStorage.return_value.get_memory_by_key.return_value = None  # new memory path
+            mock_quota.side_effect = QuotaExceeded("Memory quota reached (500/500).")
+
+            from hive.server import remember
+
+            with pytest.raises(ToolError) as exc_info:
+                asyncio.get_event_loop().run_until_complete(remember("k", "v"))
+            assert "quota" in str(exc_info.value).lower()
+
+    def test_remember_does_not_check_quota_on_update(self):
+        """Updating an existing memory must not trigger quota check."""
+        import asyncio
+
+        with (
+            patch("hive.server.validate_bearer_token") as mock_validate,
+            patch("hive.server.check_rate_limit"),
+            patch("hive.server.HiveStorage") as MockStorage,
+            patch("hive.server.get_http_request", side_effect=RuntimeError("no request")),
+            patch("hive.server.check_memory_quota") as mock_quota,
+            patch("hive.server.VectorStore"),
+            patch("hive.server.emit_metric"),
+        ):
+            mock_token = MagicMock()
+            mock_token.client_id = "test-client"
+            mock_token.scope = "memories:write"
+            mock_validate.return_value = mock_token
+
+            existing_memory = MagicMock()
+            existing_memory.value = "old-value"
+            existing_memory.tags = []
+            instance = MockStorage.return_value
+            instance.get_memory_by_key.return_value = existing_memory
+
+            from hive.server import remember
+
+            asyncio.get_event_loop().run_until_complete(remember("k", "new-value"))
+            mock_quota.assert_not_called()
+
+
+class TestApiMemoryQuotaIntegration:
+    """Verify create_memory raises 429 when memory quota exceeded."""
+
+    def test_create_memory_returns_429_on_quota_exceeded(self):
+        import asyncio
+
+        from fastapi import HTTPException
+
+        from hive.quota import QuotaExceeded
+
+        with (
+            patch("hive.api.memories.require_mgmt_user"),
+            patch("hive.api.memories.check_memory_quota") as mock_quota,
+        ):
+            mock_quota.side_effect = QuotaExceeded("Memory quota reached (500/500).")
+
+            from hive.api.memories import create_memory
+            from hive.models import MemoryCreate
+
+            body = MemoryCreate(key="k", value="v", tags=[])
+            storage = MagicMock()
+            storage.get_memory_by_key.return_value = None
+            claims = {"sub": "user-1", "role": "user"}
+            response = MagicMock()
+
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.get_event_loop().run_until_complete(
+                    create_memory(body, response, claims, storage)
+                )
+            assert exc_info.value.status_code == 429
+            assert "quota" in exc_info.value.detail.lower()
+
+
+class TestApiClientQuotaIntegration:
+    """Verify create_client raises 429 when client quota exceeded."""
+
+    def test_create_client_returns_429_on_quota_exceeded(self):
+        import asyncio
+
+        from fastapi import HTTPException
+
+        from hive.quota import QuotaExceeded
+
+        with (
+            patch("hive.api.clients.require_mgmt_user"),
+            patch("hive.api.clients.check_client_quota") as mock_quota,
+        ):
+            mock_quota.side_effect = QuotaExceeded("Client quota reached (10/10).")
+
+            from hive.api.clients import create_client
+            from hive.models import ClientRegistrationRequest
+
+            body = ClientRegistrationRequest(
+                client_name="test",
+                redirect_uris=["https://example.com/callback"],
+            )
+            storage = MagicMock()
+            claims = {"sub": "user-1"}
+
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.get_event_loop().run_until_complete(create_client(body, claims, storage))
+            assert exc_info.value.status_code == 429
+            assert "quota" in exc_info.value.detail.lower()

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AlertTriangle, Check } from "lucide-react";
 import { api } from "../api.js";
 
@@ -16,6 +16,13 @@ export default function SetupPanel() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
+  const [quota, setQuota] = useState(null);
+
+  useEffect(function loadQuota() {
+    api.getStats().then(function handleStats(s) {
+      if (s && s.memory_limit != null) setQuota(s);
+    }).catch(function handleError() {});
+  }, []);
 
   const step2Done = testResult === "ok";
 
@@ -203,6 +210,16 @@ export default function SetupPanel() {
         </div>
       </section>
 
+      {quota && (
+        <section style={{ marginTop: 48, borderTop: "1px solid var(--border)", paddingTop: 32 }}>
+          <h3 style={{ marginBottom: 16 }}>Usage</h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+            <QuotaBar label="Memories" used={quota.total_memories} limit={quota.memory_limit} />
+            <QuotaBar label="Clients" used={quota.total_clients} limit={quota.client_limit} />
+          </div>
+        </section>
+      )}
+
       <section style={{ marginTop: 48, borderTop: "1px solid var(--border)", paddingTop: 32 }}>
         <h3 style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 8, color: "var(--danger)" }}>
           <AlertTriangle size={18} />
@@ -255,6 +272,26 @@ export default function SetupPanel() {
           </div>
         )}
       </section>
+    </div>
+  );
+}
+
+function QuotaBar({ label, used, limit }) {
+  const pct = Math.min((used / limit) * 100, 100);
+  const nearLimit = pct >= 80;
+  const atLimit = pct >= 100;
+  const color = atLimit ? "var(--danger)" : nearLimit ? "var(--amber)" : "var(--success)";
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13, marginBottom: 4 }}>
+        <span>{label}</span>
+        <span style={{ color: atLimit ? "var(--danger)" : "var(--text-muted)" }}>
+          {used} / {limit}
+        </span>
+      </div>
+      <div style={{ height: 6, borderRadius: 3, background: "var(--border)", overflow: "hidden" }}>
+        <div style={{ height: "100%", width: `${pct}%`, background: color, borderRadius: 3, transition: "width 0.3s" }} />
+      </div>
     </div>
   );
 }

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -273,6 +273,20 @@ describe("SetupPanel", () => {
     expect(label.style.color).toBe("var(--text-muted)");
   });
 
+  it("shows amber bar color for quota between 80% and 99%", async () => {
+    api.getStats.mockResolvedValue({
+      total_memories: 420,
+      total_clients: 1,
+      memory_limit: 500,
+      client_limit: 10,
+    });
+    await act(async () => render(<SetupPanel />));
+    await waitFor(() => expect(screen.getByText("420 / 500")).toBeTruthy());
+    // bar fill div is the one with inline background = amber
+    const bars = document.querySelectorAll('[style*="background: var(--amber)"]');
+    expect(bars.length).toBeGreaterThan(0);
+  });
+
   it("hides Usage section when getStats rejects", async () => {
     api.getStats.mockRejectedValue(new Error("network error"));
     await act(async () => render(<SetupPanel />));

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../api.js", () => ({
-  api: { listMemories: vi.fn(), deleteAccount: vi.fn() },
+  api: { listMemories: vi.fn(), deleteAccount: vi.fn(), getStats: vi.fn() },
 }));
 
 import { api } from "../api.js";
@@ -24,6 +24,7 @@ describe("SetupPanel", () => {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
     api.listMemories.mockResolvedValue({ items: [] });
+    api.getStats.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -217,5 +218,64 @@ describe("SetupPanel", () => {
     fireEvent.click(screen.getByText("Delete my account"));
     await act(async () => fireEvent.click(screen.getByText("Yes, delete everything")));
     await waitFor(() => expect(screen.getByText("Deletion failed")).toBeTruthy());
+  });
+
+  it("does not render Usage section when getStats returns null", async () => {
+    api.getStats.mockResolvedValue(null);
+    await act(async () => render(<SetupPanel />));
+    expect(screen.queryByText("Usage")).toBeNull();
+  });
+
+  it("does not render Usage section when stats have no memory_limit", async () => {
+    api.getStats.mockResolvedValue({ total_memories: 10, total_clients: 2, memory_limit: null });
+    await act(async () => render(<SetupPanel />));
+    expect(screen.queryByText("Usage")).toBeNull();
+  });
+
+  it("renders Usage section with quota bars when limits are present", async () => {
+    api.getStats.mockResolvedValue({
+      total_memories: 42,
+      total_clients: 3,
+      memory_limit: 500,
+      client_limit: 10,
+    });
+    await act(async () => render(<SetupPanel />));
+    await waitFor(() => expect(screen.getByText("Usage")).toBeTruthy());
+    expect(screen.getByText("Memories")).toBeTruthy();
+    expect(screen.getByText("Clients")).toBeTruthy();
+    expect(screen.getByText("42 / 500")).toBeTruthy();
+    expect(screen.getByText("3 / 10")).toBeTruthy();
+  });
+
+  it("shows danger color for quota at 100%", async () => {
+    api.getStats.mockResolvedValue({
+      total_memories: 500,
+      total_clients: 1,
+      memory_limit: 500,
+      client_limit: 10,
+    });
+    await act(async () => render(<SetupPanel />));
+    await waitFor(() => expect(screen.getByText("500 / 500")).toBeTruthy());
+    const label = screen.getByText("500 / 500");
+    expect(label.style.color).toBe("var(--danger)");
+  });
+
+  it("shows muted color for quota under 80%", async () => {
+    api.getStats.mockResolvedValue({
+      total_memories: 10,
+      total_clients: 1,
+      memory_limit: 500,
+      client_limit: 10,
+    });
+    await act(async () => render(<SetupPanel />));
+    await waitFor(() => expect(screen.getByText("10 / 500")).toBeTruthy());
+    const label = screen.getByText("10 / 500");
+    expect(label.style.color).toBe("var(--text-muted)");
+  });
+
+  it("hides Usage section when getStats rejects", async () => {
+    api.getStats.mockRejectedValue(new Error("network error"));
+    await act(async () => render(<SetupPanel />));
+    expect(screen.queryByText("Usage")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #145

## Summary
- New `hive.quota` module — `check_memory_quota` / `check_client_quota` backed by existing DynamoDB count methods
- Quota enforced in MCP `remember` tool (new memories only, not updates) → raises `ToolError`
- Quota enforced in management API `POST /api/memories` and `POST /api/clients` → returns 429
- Quota limits surfaced in `GET /api/stats` response as `memory_limit` / `client_limit` (null for admins and exempt users)
- SetupPanel shows a live **Usage** section with colour-coded progress bars (green < 80%, amber ≥ 80%, red ≥ 100%)

## Approach
- Defaults: 500 memories / 10 clients per user, configurable via `HIVE_QUOTA_MAX_MEMORIES`, `HIVE_QUOTA_MAX_CLIENTS`
- `HIVE_QUOTA_EXEMPT_USERS` comma-separated list bypasses all quota checks (like rate limiting's exempt list)
- Admins get `memory_limit: null` / `client_limit: null` in stats and the Usage section doesn't render for them
- Quota check is skipped on memory updates (upsert path) — only new creates count against the quota