### PR TITLE
fix(e2e): eliminate race in test_create_and_see_memory

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -123,8 +123,11 @@ class TestUIE2E:
         tag_input.fill(unique_tag)
         tag_input.press("Enter")
 
-        page.wait_for_selector(f"text={memory_key}", timeout=30_000)
-        assert page.locator(f"text={memory_key}").first.is_visible()
+        # Wait for the filtered list to fully load before asserting visibility.
+        # Without this, wait_for_selector can find the card in the *old* (unfiltered)
+        # list and then is_visible() checks after that list has been replaced.
+        page.wait_for_load_state("networkidle")
+        page.wait_for_selector(f"text={memory_key}", state="visible", timeout=30_000)
 
     def test_clients_tab(self, browser_page):
         page = browser_page


### PR DESCRIPTION
## Summary
- `wait_for_selector` with default `state="attached"` was resolving against the old (unfiltered) memory list before the tag-filter API call completed
- By the time `is_visible()` ran, the list had been swapped for the filtered results, making the previously-found element detached/hidden → returns `False`
- Fix: add `wait_for_load_state("networkidle")` after pressing Enter to wait for the filtered API response, then use `state="visible"` in `wait_for_selector` so the assertion itself waits for visibility

## Approach
This is a test hardening fix — the application code is unchanged. The race surfaced reliably after the shadcn/ui migration PR (#334) landed on the dev environment, where the accumulated memory list is long enough that the new memory is on page 1 of the unfiltered list, making the race reliably reproducible.