### PR TITLE
feat: responsive mobile layout for management UI

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useEffect, useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
-import { Moon, Sun } from "lucide-react";
+import { Menu, Moon, Sun, X } from "lucide-react";
 import { trackEvent, trackPageView } from "./analytics.js";
 import { api } from "./api.js";
 import ActivityLog from "./components/ActivityLog.jsx";
@@ -58,6 +58,7 @@ function signOut() {
 
 function AppShell() {
   const [tab, setTab] = useState("memories");
+  const [menuOpen, setMenuOpen] = useState(false);
 
   function switchTab(id) {
     setTab(id);
@@ -103,7 +104,7 @@ function AppShell() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="bg-navy text-white px-6 flex items-center gap-6 h-14">
+      <header className="bg-navy text-white px-4 md:px-6 flex items-center gap-3 md:gap-6 h-14 relative">
         <button
           onClick={() => navigate("/")}
           className="flex items-center gap-2 cursor-pointer bg-transparent border-none p-0 text-inherit"
@@ -112,7 +113,8 @@ function AppShell() {
           <span className="font-bold text-xl tracking-wide">Hive</span>
         </button>
 
-        <nav className="flex gap-1 flex-1">
+        {/* Desktop tab nav — hidden on mobile */}
+        <nav className="hidden md:flex gap-1 flex-1">
           {tabs.map((t) => (
             <Button
               key={t.id}
@@ -128,15 +130,18 @@ function AppShell() {
           ))}
         </nav>
 
+        {/* Spacer on mobile so right-side items stay right */}
+        <div className="flex-1 md:hidden" />
+
         <a
           href="/docs/"
-          className="text-[13px] text-white/60 no-underline hover:text-white/90"
+          className="hidden md:block text-[13px] text-white/60 no-underline hover:text-white/90"
         >
           Docs
         </a>
 
         {userEmail && (
-          <span className="text-[13px] text-white/70">{userEmail}</span>
+          <span className="hidden md:inline text-[13px] text-white/70">{userEmail}</span>
         )}
 
         <Button variant="outline" size="sm" onClick={signOut}>
@@ -151,9 +156,42 @@ function AppShell() {
         >
           {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
         </Button>
+
+        {/* Hamburger — mobile only */}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="md:hidden text-white hover:bg-white/10"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Toggle navigation"
+          aria-expanded={menuOpen}
+        >
+          {menuOpen ? <X size={20} /> : <Menu size={20} />}
+        </Button>
+
+        {/* Mobile nav dropdown */}
+        {menuOpen && (
+          <nav
+            data-testid="mobile-nav"
+            className="absolute top-14 left-0 right-0 bg-navy border-t border-white/10 z-50"
+          >
+            {tabs.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                className={`w-full text-left px-6 py-3 text-sm text-white bg-transparent border-none cursor-pointer font-[inherit] min-h-[44px] hover:bg-white/10 ${
+                  tab === t.id ? "font-semibold bg-white/5" : ""
+                }`}
+                onClick={() => { switchTab(t.id); setMenuOpen(false); }}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
+        )}
       </header>
 
-      <main className="flex-1 p-6 max-w-[1100px] mx-auto w-full">
+      <main className="flex-1 p-4 md:p-6 max-w-[1100px] mx-auto w-full">
         {tab === "memories" && <MemoryBrowser />}
         {tab === "clients" && <ClientManager />}
         {tab === "activity" && <ActivityLog />}

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -389,4 +389,28 @@ describe("AppShell", () => {
     const link = screen.getByText("Hive 1.2.3").closest("a");
     expect(link.className).toContain("focus:underline");
   });
+
+  it("renders hamburger toggle button", async () => {
+    await act(async () => render(<App />));
+    expect(screen.getByRole("button", { name: /toggle navigation/i })).toBeTruthy();
+  });
+
+  it("hamburger click shows mobile nav", async () => {
+    await act(async () => render(<App />));
+    expect(screen.queryByTestId("mobile-nav")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /toggle navigation/i }));
+    expect(screen.getByTestId("mobile-nav")).toBeTruthy();
+  });
+
+  it("clicking tab in mobile nav switches panel and closes menu", async () => {
+    await act(async () => render(<App />));
+    await waitFor(() => expect(screen.getByTestId("memory-browser")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /toggle navigation/i }));
+    const mobileNav = screen.getByTestId("mobile-nav");
+    // Click "OAuth Clients" (second tab button in mobile nav)
+    const mobileButtons = mobileNav.querySelectorAll("button[type='button']");
+    fireEvent.click(mobileButtons[1]);
+    expect(screen.queryByTestId("mobile-nav")).toBeNull();
+    expect(screen.getByTestId("client-manager")).toBeTruthy();
+  });
 });

--- a/ui/src/components/ActivityLog.jsx
+++ b/ui/src/components/ActivityLog.jsx
@@ -104,7 +104,7 @@ export default function ActivityLog() {
 
       {loading && <p className="text-[var(--text-muted)]">Loading…</p>}
 
-      <Card className="p-0 overflow-hidden">
+      <Card className="p-0 overflow-x-auto">
         <Table>
           <TableHeader>
             <TableRow>

--- a/ui/src/components/ClientManager.jsx
+++ b/ui/src/components/ClientManager.jsx
@@ -165,7 +165,7 @@ export default function ClientManager() {
 
       {loading && <p className="text-[var(--text-muted)]">Loading…</p>}
 
-      <Card className="p-0 overflow-hidden">
+      <Card className="p-0 overflow-x-auto">
         <Table>
           <TableHeader>
             <TableRow>

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -349,7 +349,7 @@ export default function MemoryBrowser() {
   }
 
   return (
-    <div className="flex gap-5">
+    <div className="flex flex-col md:flex-row gap-5">
       <AlertDialog
         open={pendingDelete !== null}
         title="Delete this memory?"
@@ -437,7 +437,7 @@ export default function MemoryBrowser() {
 
       {/* Side form */}
       {(creating || editing) && (
-        <div className="w-[360px]">
+        <div className="w-full md:w-[360px]">
           <Card>
             <h3 className="mb-4 text-base font-semibold">
               {creating ? "New Memory" : `Edit: ${editing.key}`}

--- a/ui/src/components/UsersPanel.jsx
+++ b/ui/src/components/UsersPanel.jsx
@@ -61,6 +61,7 @@ export default function UsersPanel() {
           description="Users appear here after they sign in for the first time via Google OAuth."
         />
       ) : (
+        <div className="overflow-x-auto">
         <Table>
           <TableHeader>
             <TableRow>
@@ -85,6 +86,7 @@ export default function UsersPanel() {
             ))}
           </TableBody>
         </Table>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Closes #261

## Summary
- Added hamburger menu button (mobile only) to the app header with toggle state
- Mobile nav dropdown renders below header with full-width tab buttons that close the menu on tap
- Desktop nav unchanged — hidden on mobile, visible on `md:` and above
- Tables in ActivityLog, ClientManager, UsersPanel wrapped with `overflow-x-auto` for horizontal scrolling on small screens
- MemoryBrowser two-column layout stacks vertically on mobile (`flex-col md:flex-row`), side form expands to full-width (`w-full md:w-[360px]`)
- Three new App tests: hamburger renders, click shows mobile nav, tab click switches panel and closes menu

## Approach
Used Tailwind responsive prefixes (`hidden md:flex`, `md:hidden`) throughout rather than JS-based media queries, keeping behaviour declarative. The mobile nav is conditionally rendered (not just hidden) so it doesn't appear in the DOM when closed, which simplifies testing.