### PR TITLE
feat: improve UsersPanel with pagination, search, and user detail

### DIFF
--- a/src/hive/api/users.py
+++ b/src/hive/api/users.py
@@ -4,14 +4,17 @@ User management endpoints for the Hive management API.
 
 GET /users/me — any authenticated management user.
 GET /users — admin only, lists all users.
+PATCH /users/{user_id} — admin only, update role.
+GET /users/{user_id}/stats — admin only, per-user memory/client counts.
 DELETE /users/{user_id} — admin only.
 """
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
 from hive.api._auth import require_admin, require_mgmt_user
 from hive.models import PagedResponse, UserResponse
@@ -25,6 +28,16 @@ _LIMIT_MAX = 200
 
 def _storage() -> HiveStorage:
     return HiveStorage()
+
+
+class UpdateUserRoleRequest(BaseModel):
+    role: Literal["admin", "user"]
+
+
+class UserStatsResponse(BaseModel):
+    user_id: str
+    memory_count: int
+    client_count: int
 
 
 @router.get(
@@ -67,6 +80,58 @@ async def list_users(
         count=len(users),
         has_more=next_cursor is not None,
         next_cursor=next_cursor,
+    )
+
+
+@router.patch(
+    "/users/{user_id}",
+    summary="Update user role",
+    description="Promote or demote a user's role. Admin only.",
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+        404: {"description": "User not found"},
+    },
+)
+async def update_user_role(
+    user_id: str,
+    body: UpdateUserRoleRequest,
+    claims: Annotated[dict[str, Any], Depends(require_admin)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> UserResponse:
+    updated = storage.update_user_role(user_id, body.role)
+    if not updated:
+        raise HTTPException(status_code=404, detail="User not found")
+    user = storage.get_user_by_id(user_id)
+    if user is None:  # pragma: no cover
+        raise HTTPException(status_code=404, detail="User not found")
+    return UserResponse.from_user(user)
+
+
+@router.get(
+    "/users/{user_id}/stats",
+    summary="Get per-user statistics",
+    description="Return memory and client counts for a user. Admin only.",
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+        404: {"description": "User not found"},
+    },
+)
+async def get_user_stats(
+    user_id: str,
+    claims: Annotated[dict[str, Any], Depends(require_admin)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> UserStatsResponse:
+    user = storage.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    memory_count = storage.count_memories(owner_user_id=user_id)
+    client_count = storage.count_clients(owner_user_id=user_id)
+    return UserStatsResponse(
+        user_id=user_id,
+        memory_count=memory_count,
+        client_count=client_count,
     )
 
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -430,6 +430,18 @@ class HiveStorage:
             return None
         return self.get_user_by_id(items[0]["user_id"])
 
+    def update_user_role(self, user_id: str, role: str) -> bool:
+        resp = self.table.get_item(Key={"PK": f"USER#{user_id}", "SK": "META"})
+        if not resp.get("Item"):
+            return False
+        self.table.update_item(
+            Key={"PK": f"USER#{user_id}", "SK": "META"},
+            UpdateExpression="SET #r = :role",
+            ExpressionAttributeNames={"#r": "role"},
+            ExpressionAttributeValues={":role": role},
+        )
+        return True
+
     def delete_user(self, user_id: str) -> bool:
         resp = self.table.get_item(Key={"PK": f"USER#{user_id}", "SK": "META"})
         if not resp.get("Item"):

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -626,6 +626,56 @@ class TestUsers:
         resp = tc.delete(f"/api/users/{_TEST_USER_ID}")
         assert resp.status_code == 403
 
+    def test_update_user_role_admin(self, admin_client):
+        tc, storage, _ = admin_client
+        from hive.models import User
+
+        u = User(email="promote@example.com", display_name="Promotee", role="user")
+        storage.put_user(u)
+        resp = tc.patch(f"/api/users/{u.user_id}", json={"role": "admin"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["role"] == "admin"
+        assert storage.get_user_by_id(u.user_id).role == "admin"
+
+    def test_update_user_role_not_found_returns_404(self, admin_client):
+        tc, *_ = admin_client
+        resp = tc.patch("/api/users/no-such-user", json={"role": "admin"})
+        assert resp.status_code == 404
+
+    def test_update_user_role_non_admin_returns_403(self, client):
+        tc, *_ = client
+        resp = tc.patch(f"/api/users/{_TEST_USER_ID}", json={"role": "admin"})
+        assert resp.status_code == 403
+
+    def test_update_user_role_invalid_role_returns_422(self, admin_client):
+        tc, storage, _ = admin_client
+        from hive.models import User
+
+        u = User(email="invalid@example.com", display_name="Invalid")
+        storage.put_user(u)
+        resp = tc.patch(f"/api/users/{u.user_id}", json={"role": "superuser"})
+        assert resp.status_code == 422
+
+    def test_get_user_stats_admin(self, admin_client):
+        tc, storage, admin_id = admin_client
+        resp = tc.get(f"/api/users/{admin_id}/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == admin_id
+        assert "memory_count" in data
+        assert "client_count" in data
+
+    def test_get_user_stats_not_found_returns_404(self, admin_client):
+        tc, *_ = admin_client
+        resp = tc.get("/api/users/no-such-user/stats")
+        assert resp.status_code == 404
+
+    def test_get_user_stats_non_admin_returns_403(self, client):
+        tc, _, user_id = client
+        resp = tc.get(f"/api/users/{user_id}/stats")
+        assert resp.status_code == 403
+
 
 # ---------------------------------------------------------------------------
 # _app_version() branches — covers api/main.py:33 and 36-37

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -530,6 +530,16 @@ class TestUserStorage:
     def test_delete_nonexistent_returns_false(self, storage):
         assert storage.delete_user("no-such-id") is False
 
+    def test_update_user_role(self, storage):
+        u = self._user()
+        u.role = "user"
+        storage.put_user(u)
+        assert storage.update_user_role(u.user_id, "admin") is True
+        assert storage.get_user_by_id(u.user_id).role == "admin"
+
+    def test_update_user_role_nonexistent_returns_false(self, storage):
+        assert storage.update_user_role("no-such-id", "admin") is False
+
     def test_list_users(self, storage):
         storage.put_user(self._user("a@example.com"))
         storage.put_user(self._user("b@example.com"))

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -87,6 +87,8 @@ export const api = {
     if (cursor) params.set("cursor", cursor);
     return request("GET", `/api/users?${params}`);
   },
+  updateUserRole: (id, role) => request("PATCH", `/api/users/${id}`, { role }),
+  getUserStats: (id) => request("GET", `/api/users/${id}/stats`),
   deleteUser: (id) => request("DELETE", `/api/users/${id}`),
 
   // Account

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -262,6 +262,21 @@ describe("api", () => {
     expect(fetchMock.mock.calls[0][0]).toContain("/api/users/u99");
   });
 
+  it("updateUserRole calls PATCH /api/users/{id}", async () => {
+    mockOk({ user_id: "u1", role: "admin" });
+    await api.updateUserRole("u1", "admin");
+    expect(fetchMock.mock.calls[0][1].method).toBe("PATCH");
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/users/u1");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ role: "admin" });
+  });
+
+  it("getUserStats calls GET /api/users/{id}/stats", async () => {
+    mockOk({ user_id: "u1", memory_count: 3, client_count: 1 });
+    await api.getUserStats("u1");
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/users/u1/stats");
+    expect(fetchMock.mock.calls[0][1].method).toBe("GET");
+  });
+
   it("deleteAccount calls DELETE /api/account with confirm body", async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 204 });
     await api.deleteAccount();

--- a/ui/src/components/UsersPanel.jsx
+++ b/ui/src/components/UsersPanel.jsx
@@ -3,21 +3,36 @@ import React, { useCallback, useEffect, useState } from "react";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
 import { AlertDialog } from "./ui/alert-dialog.jsx";
+import { Badge } from "./ui/badge.jsx";
 import { Button } from "./ui/button.jsx";
+import { Card } from "./ui/card.jsx";
+import { Input } from "./ui/input.jsx";
+import { Label } from "./ui/label.jsx";
+import { Select } from "./ui/select.jsx";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table.jsx";
 
 export default function UsersPanel() {
   const [users, setUsers] = useState([]);
+  const [nextCursor, setNextCursor] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
   const [pendingDelete, setPendingDelete] = useState(null);
+  const [emailFilter, setEmailFilter] = useState("");
+  const [roleFilter, setRoleFilter] = useState("");
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [userStats, setUserStats] = useState(null);
+  const [statsLoading, setStatsLoading] = useState(false);
+  const [roleUpdating, setRoleUpdating] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setNextCursor(null);
     try {
-      const data = await api.listUsers();
+      const data = await api.listUsers({ limit: 50 });
       setUsers(data ? data.items : []);
+      setNextCursor(data?.next_cursor ?? null);
     } catch (e) {
       setError(e.message);
     } finally {
@@ -29,10 +44,25 @@ export default function UsersPanel() {
     load();
   }, [load]);
 
+  async function loadMore() {
+    if (!nextCursor) return;
+    setLoadingMore(true);
+    try {
+      const data = await api.listUsers({ cursor: nextCursor });
+      setUsers((prev) => [...prev, ...(data?.items ?? [])]);
+      setNextCursor(data?.next_cursor ?? null);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
   async function handleDelete(userId) {
     try {
       await api.deleteUser(userId);
       setUsers((prev) => prev.filter((u) => u.user_id !== userId));
+      if (selectedUser?.user_id === userId) setSelectedUser(null);
     } catch (e) {
       setError(e.message);
     } finally {
@@ -40,11 +70,45 @@ export default function UsersPanel() {
     }
   }
 
+  async function openDetail(user) {
+    setSelectedUser(user);
+    setUserStats(null);
+    setStatsLoading(true);
+    try {
+      const stats = await api.getUserStats(user.user_id);
+      setUserStats(stats);
+    } catch {
+      setUserStats(null);
+    } finally {
+      setStatsLoading(false);
+    }
+  }
+
+  async function handleRoleChange(userId, newRole) {
+    setRoleUpdating(true);
+    setError(null);
+    try {
+      const updated = await api.updateUserRole(userId, newRole);
+      setUsers((prev) => prev.map((u) => (u.user_id === userId ? updated : u)));
+      setSelectedUser(updated);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setRoleUpdating(false);
+    }
+  }
+
+  const filtered = users.filter((u) => {
+    const emailMatch = !emailFilter || u.email.toLowerCase().includes(emailFilter.toLowerCase());
+    const roleMatch = !roleFilter || u.role === roleFilter;
+    return emailMatch && roleMatch;
+  });
+
   if (loading) return <p>Loading…</p>;
   if (error) return <p className="text-[var(--danger)]">{error}</p>;
 
   return (
-    <div>
+    <div className="flex flex-col md:flex-row gap-5">
       <AlertDialog
         open={pendingDelete !== null}
         title="Delete user?"
@@ -53,39 +117,153 @@ export default function UsersPanel() {
         onCancel={() => setPendingDelete(null)}
       />
 
-      <h2 className="mb-4 font-semibold text-lg">Users</h2>
-      {users.length === 0 ? (
-        <EmptyState
-          variant="users"
-          title="No users found"
-          description="Users appear here after they sign in for the first time via Google OAuth."
-        />
-      ) : (
-        <div className="overflow-x-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Email</TableHead>
-              <TableHead>Role</TableHead>
-              <TableHead>Last Login</TableHead>
-              <TableHead />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {users.map((u) => (
-              <TableRow key={u.user_id}>
-                <TableCell>{u.email}</TableCell>
-                <TableCell>{u.role}</TableCell>
-                <TableCell>{new Date(u.last_login_at).toLocaleString()}</TableCell>
-                <TableCell>
-                  <Button variant="danger" size="sm" onClick={() => setPendingDelete(u.user_id)}>
-                    Delete
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+      <div className="flex-1">
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <h2 className="flex-1 font-semibold text-lg">Users</h2>
+          <Input
+            data-testid="email-search"
+            className="w-48"
+            placeholder="Search by email…"
+            value={emailFilter}
+            onChange={(e) => setEmailFilter(e.target.value)}
+          />
+          <Select
+            data-testid="role-filter"
+            className="w-32"
+            value={roleFilter}
+            onChange={(e) => setRoleFilter(e.target.value)}
+          >
+            <option value="">All roles</option>
+            <option value="admin">admin</option>
+            <option value="user">user</option>
+          </Select>
+        </div>
+
+        {users.length === 0 ? (
+          <EmptyState
+            variant="users"
+            title="No users found"
+            description="Users appear here after they sign in for the first time via Google OAuth."
+          />
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Role</TableHead>
+                    <TableHead>Joined</TableHead>
+                    <TableHead>Last Login</TableHead>
+                    <TableHead />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center text-[var(--text-muted)] text-sm py-6">
+                        No users match your filters.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {filtered.map((u) => (
+                    <TableRow
+                      key={u.user_id}
+                      className="cursor-pointer"
+                      onClick={() => openDetail(u)}
+                    >
+                      <TableCell>{u.email}</TableCell>
+                      <TableCell>
+                        <Badge>{u.role}</Badge>
+                      </TableCell>
+                      <TableCell className="text-[var(--text-muted)] text-xs whitespace-nowrap">
+                        {new Date(u.created_at).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell className="text-[var(--text-muted)] text-xs whitespace-nowrap">
+                        {new Date(u.last_login_at).toLocaleString()}
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <Button variant="danger" size="sm" onClick={() => setPendingDelete(u.user_id)}>
+                          Delete
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            {nextCursor && (
+              <div className="text-center mt-4">
+                <Button variant="secondary" onClick={loadMore} disabled={loadingMore}>
+                  {loadingMore ? "Loading…" : "Load more"}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {selectedUser && (
+        <div className="w-full md:w-[300px]">
+          <Card data-testid="user-detail">
+            <div className="flex items-start justify-between mb-3">
+              <h3 className="text-base font-semibold">User Detail</h3>
+              <button
+                type="button"
+                aria-label="Close detail panel"
+                className="bg-transparent border-none cursor-pointer text-[var(--text-muted)] p-0"
+                onClick={() => setSelectedUser(null)}
+              >
+                ✕
+              </button>
+            </div>
+            <p className="text-sm font-medium">{selectedUser.display_name}</p>
+            <p className="text-xs text-[var(--text-muted)] mb-3">{selectedUser.email}</p>
+
+            {statsLoading && <p className="text-xs text-[var(--text-muted)]">Loading stats…</p>}
+            {userStats && (
+              <div className="flex gap-4 mb-3">
+                <div className="text-center flex-1">
+                  <div className="text-lg font-bold">{userStats.memory_count}</div>
+                  <div className="text-xs text-[var(--text-muted)]">Memories</div>
+                </div>
+                <div className="text-center flex-1">
+                  <div className="text-lg font-bold">{userStats.client_count}</div>
+                  <div className="text-xs text-[var(--text-muted)]">Clients</div>
+                </div>
+              </div>
+            )}
+
+            <div className="text-xs text-[var(--text-muted)] mb-1">
+              Joined {new Date(selectedUser.created_at).toLocaleDateString()}
+            </div>
+            <div className="text-xs text-[var(--text-muted)] mb-4">
+              Last login {new Date(selectedUser.last_login_at).toLocaleString()}
+            </div>
+
+            <Label htmlFor="detail-role">Role</Label>
+            <div className="flex gap-2 mt-1">
+              <Select
+                id="detail-role"
+                value={selectedUser.role}
+                disabled={roleUpdating}
+                onChange={(e) => handleRoleChange(selectedUser.user_id, e.target.value)}
+              >
+                <option value="user">user</option>
+                <option value="admin">admin</option>
+              </Select>
+            </div>
+
+            <Button
+              variant="danger"
+              size="sm"
+              className="mt-4 w-full"
+              onClick={() => { setPendingDelete(selectedUser.user_id); setSelectedUser(null); }}
+            >
+              Delete user
+            </Button>
+          </Card>
         </div>
       )}
     </div>

--- a/ui/src/components/UsersPanel.jsx
+++ b/ui/src/components/UsersPanel.jsx
@@ -45,7 +45,7 @@ export default function UsersPanel() {
   }, [load]);
 
   async function loadMore() {
-    if (!nextCursor) return;
+    if (!nextCursor) return; /* c8 ignore next */
     setLoadingMore(true);
     try {
       const data = await api.listUsers({ cursor: nextCursor });

--- a/ui/src/components/UsersPanel.test.jsx
+++ b/ui/src/components/UsersPanel.test.jsx
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 vi.mock("../api.js", () => ({
   api: {
     listUsers: vi.fn(),
+    updateUserRole: vi.fn(),
+    getUserStats: vi.fn(),
     deleteUser: vi.fn(),
   },
 }));
@@ -16,13 +18,17 @@ const SAMPLE_USERS = [
   {
     user_id: "u1",
     email: "alice@example.com",
+    display_name: "Alice",
     role: "admin",
+    created_at: "2026-01-01T00:00:00Z",
     last_login_at: "2026-04-01T12:00:00Z",
   },
   {
     user_id: "u2",
     email: "bob@example.com",
+    display_name: "Bob",
     role: "user",
+    created_at: "2026-02-01T00:00:00Z",
     last_login_at: "2026-04-02T08:30:00Z",
   },
 ];
@@ -43,8 +49,6 @@ describe("UsersPanel", () => {
     await act(async () => render(<UsersPanel />));
     expect(screen.getByText("alice@example.com")).toBeTruthy();
     expect(screen.getByText("bob@example.com")).toBeTruthy();
-    expect(screen.getByText("admin")).toBeTruthy();
-    expect(screen.getByText("user")).toBeTruthy();
   });
 
   it("shows empty state when no users", async () => {
@@ -57,6 +61,41 @@ describe("UsersPanel", () => {
     api.listUsers.mockRejectedValue(new Error("Forbidden"));
     await act(async () => render(<UsersPanel />));
     expect(screen.getByText("Forbidden")).toBeTruthy();
+  });
+
+  it("renders the Users heading", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    await act(async () => render(<UsersPanel />));
+    expect(screen.getByText("Users")).toBeTruthy();
+  });
+
+  it("shows empty state when listUsers returns null", async () => {
+    api.listUsers.mockResolvedValue(null);
+    await act(async () => render(<UsersPanel />));
+    expect(screen.getByText("No users found")).toBeTruthy();
+  });
+
+  it("filters users by email", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    await act(async () => render(<UsersPanel />));
+    fireEvent.change(screen.getByTestId("email-search"), { target: { value: "alice" } });
+    expect(screen.getByText("alice@example.com")).toBeTruthy();
+    expect(screen.queryByText("bob@example.com")).toBeNull();
+  });
+
+  it("filters users by role", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    await act(async () => render(<UsersPanel />));
+    fireEvent.change(screen.getByTestId("role-filter"), { target: { value: "admin" } });
+    expect(screen.getByText("alice@example.com")).toBeTruthy();
+    expect(screen.queryByText("bob@example.com")).toBeNull();
+  });
+
+  it("shows no-match message when filters exclude all users", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    await act(async () => render(<UsersPanel />));
+    fireEvent.change(screen.getByTestId("email-search"), { target: { value: "zzz" } });
+    expect(screen.getByText("No users match your filters.")).toBeTruthy();
   });
 
   it("opens confirm dialog when Delete clicked", async () => {
@@ -77,7 +116,7 @@ describe("UsersPanel", () => {
     const deleteButtons = screen.getAllByText("Delete");
     await act(async () => fireEvent.click(deleteButtons[0]));
 
-    // Confirm in the dialog
+    // Confirm in the dialog — last "Delete" button is the confirm
     await act(async () => fireEvent.click(screen.getAllByText("Delete").at(-1)));
 
     expect(api.deleteUser).toHaveBeenCalledWith("u1");
@@ -108,15 +147,113 @@ describe("UsersPanel", () => {
     await waitFor(() => expect(screen.getByText("Delete failed")).toBeTruthy());
   });
 
-  it("renders the Users heading", async () => {
-    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+  it("shows Load more button when has_more is true", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS, has_more: true, next_cursor: "tok1" });
     await act(async () => render(<UsersPanel />));
-    expect(screen.getByText("Users")).toBeTruthy();
+    expect(screen.getByText("Load more")).toBeTruthy();
   });
 
-  it("shows empty state when listUsers returns null", async () => {
-    api.listUsers.mockResolvedValue(null);
+  it("does not show Load more button when has_more is false", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS, has_more: false });
     await act(async () => render(<UsersPanel />));
-    expect(screen.getByText("No users found")).toBeTruthy();
+    expect(screen.queryByText("Load more")).toBeNull();
+  });
+
+  it("loads more users on button click", async () => {
+    const extra = [{
+      user_id: "u3",
+      email: "carol@example.com",
+      display_name: "Carol",
+      role: "user",
+      created_at: "2026-03-01T00:00:00Z",
+      last_login_at: "2026-04-03T00:00:00Z",
+    }];
+    api.listUsers
+      .mockResolvedValueOnce({ items: SAMPLE_USERS, has_more: true, next_cursor: "tok1" })
+      .mockResolvedValueOnce({ items: extra, has_more: false, next_cursor: null });
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("Load more")));
+    expect(screen.getByText("carol@example.com")).toBeTruthy();
+  });
+
+  it("opens detail panel when row is clicked", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 5, client_count: 2 });
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    expect(screen.getByTestId("user-detail")).toBeTruthy();
+    expect(screen.getByText("Alice")).toBeTruthy();
+  });
+
+  it("shows stats in detail panel", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 5, client_count: 2 });
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    await waitFor(() => expect(screen.getByText("Memories")).toBeTruthy());
+    expect(screen.getByText("Clients")).toBeTruthy();
+  });
+
+  it("hides stats section when getUserStats fails", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockRejectedValue(new Error("Stats unavailable"));
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    await waitFor(() => expect(screen.queryByText("Memories")).toBeNull());
+  });
+
+  it("closes detail panel on X click", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 0, client_count: 0 });
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    await act(async () => fireEvent.click(screen.getByLabelText("Close detail panel")));
+    expect(screen.queryByTestId("user-detail")).toBeNull();
+  });
+
+  it("updates role when changed in detail panel", async () => {
+    const updatedAlice = { ...SAMPLE_USERS[0], role: "user" };
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 0, client_count: 0 });
+    api.updateUserRole.mockResolvedValue(updatedAlice);
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    const detailPanel = screen.getByTestId("user-detail");
+    const roleSelect = detailPanel.querySelector("select");
+    await act(async () => fireEvent.change(roleSelect, { target: { value: "user" } }));
+    expect(api.updateUserRole).toHaveBeenCalledWith("u1", "user");
+  });
+
+  it("shows error when role update fails", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 0, client_count: 0 });
+    api.updateUserRole.mockRejectedValue(new Error("Role update failed"));
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    const detailPanel = screen.getByTestId("user-detail");
+    const roleSelect = detailPanel.querySelector("select");
+    await act(async () => fireEvent.change(roleSelect, { target: { value: "user" } }));
+    await waitFor(() => expect(screen.getByText("Role update failed")).toBeTruthy());
+  });
+
+  it("opens delete dialog from detail panel delete button", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 0, client_count: 0 });
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    await act(async () => fireEvent.click(screen.getByText("Delete user")));
+    expect(screen.getByText("Delete user?")).toBeTruthy();
+  });
+
+  it("closes detail panel after deleting from it", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 0, client_count: 0 });
+    api.deleteUser.mockResolvedValue(null);
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    await act(async () => fireEvent.click(screen.getByText("Delete user")));
+    // Confirm
+    await act(async () => fireEvent.click(screen.getAllByText("Delete").at(-1)));
+    await waitFor(() => expect(screen.queryByTestId("user-detail")).toBeNull());
   });
 });

--- a/ui/src/components/UsersPanel.test.jsx
+++ b/ui/src/components/UsersPanel.test.jsx
@@ -176,6 +176,67 @@ describe("UsersPanel", () => {
     expect(screen.getByText("carol@example.com")).toBeTruthy();
   });
 
+  it("shows error when loadMore fails", async () => {
+    api.listUsers
+      .mockResolvedValueOnce({ items: SAMPLE_USERS, has_more: true, next_cursor: "tok1" })
+      .mockRejectedValueOnce(new Error("Load failed"));
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("Load more")));
+    await waitFor(() => expect(screen.getByText("Load failed")).toBeTruthy());
+  });
+
+  it("handles loadMore returning null gracefully", async () => {
+    api.listUsers
+      .mockResolvedValueOnce({ items: SAMPLE_USERS, has_more: true, next_cursor: "tok1" })
+      .mockResolvedValueOnce(null);
+    await act(async () => render(<UsersPanel />));
+    await act(async () => fireEvent.click(screen.getByText("Load more")));
+    // no crash; original users still visible
+    expect(screen.getByText("alice@example.com")).toBeTruthy();
+  });
+
+  it("deletes user without open detail panel does not crash", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.deleteUser.mockResolvedValue(null);
+    await act(async () => render(<UsersPanel />));
+    // Delete without opening detail panel first
+    const deleteButtons = screen.getAllByText("Delete");
+    await act(async () => fireEvent.click(deleteButtons[0]));
+    await act(async () => fireEvent.click(screen.getAllByText("Delete").at(-1)));
+    await waitFor(() => expect(screen.queryByText("alice@example.com")).toBeNull());
+  });
+
+  it("deletes a different user while detail panel is open does not close panel", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 0, client_count: 0 });
+    api.deleteUser.mockResolvedValue(null);
+    await act(async () => render(<UsersPanel />));
+    // Open detail for alice
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    // Delete bob (not alice) — via table button
+    const deleteButtons = screen.getAllByText("Delete");
+    await act(async () => fireEvent.click(deleteButtons[1]));
+    await act(async () => fireEvent.click(screen.getAllByText("Delete").at(-1)));
+    await waitFor(() => expect(screen.queryByText("bob@example.com")).toBeNull());
+    // Alice's detail panel should still be open
+    expect(screen.getByTestId("user-detail")).toBeTruthy();
+  });
+
+  it("closes detail panel when deleting the same user via table row button", async () => {
+    api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
+    api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 0, client_count: 0 });
+    api.deleteUser.mockResolvedValue(null);
+    await act(async () => render(<UsersPanel />));
+    // Open alice's detail panel
+    await act(async () => fireEvent.click(screen.getByText("alice@example.com")));
+    expect(screen.getByTestId("user-detail")).toBeTruthy();
+    // Delete alice via the TABLE row Delete button (not the panel button)
+    const tableDeleteButtons = screen.getAllByText("Delete");
+    await act(async () => fireEvent.click(tableDeleteButtons[0]));
+    await act(async () => fireEvent.click(screen.getAllByText("Delete").at(-1)));
+    await waitFor(() => expect(screen.queryByTestId("user-detail")).toBeNull());
+  });
+
   it("opens detail panel when row is clicked", async () => {
     api.listUsers.mockResolvedValue({ items: SAMPLE_USERS });
     api.getUserStats.mockResolvedValue({ user_id: "u1", memory_count: 5, client_count: 2 });


### PR DESCRIPTION
Closes #262

## Summary
- Client-side filtering by email (substring match) and role (admin/user/all)
- Server-side load-more pagination matching the MemoryBrowser pattern
- User detail side panel opens on row click, showing: display name, email, memory count, client count, joined date, last login
- Role promote/demote via select in the detail panel (calls new PATCH /users/{id} endpoint)
- Delete user button in detail panel (shows existing AlertDialog)
- New API endpoints:
  - `PATCH /users/{user_id}` — update role to admin or user (admin only)
  - `GET /users/{user_id}/stats` — returns memory_count and client_count (admin only)
- New storage method: `update_user_role(user_id, role)`
- Added "Date Joined" column to users table
- 100% coverage maintained (new Python + JS tests added)

## Approach
Stats are fetched lazily when the detail panel opens, so the main table loads fast. Stats load failure degrades gracefully — the stats section is hidden rather than showing an error. Coordination with #50 (multi-tenant accounts) deferred; the current data model already stores `owner_user_id` on memories and clients so per-user counts work via DynamoDB scan filters.