### PR TITLE
feat: bulk memory operations — forget_all, export, import

### DIFF
--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -9,10 +9,12 @@ Admins can access all memories.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
+from fastapi.responses import StreamingResponse
 
 from hive.api._auth import require_mgmt_user
 from hive.models import (
@@ -178,6 +180,96 @@ async def create_memory(
 
 
 @router.get(
+    "/memories/export",
+    summary="Export memories as JSON Lines",
+    description="Stream all memories (or those with a given tag) as newline-delimited JSON. Sets Content-Disposition for browser download.",
+    responses={401: {"description": "Unauthorized"}},
+)
+async def export_memories(
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+    tag: Annotated[str | None, Query(description="Filter by tag")] = None,
+) -> StreamingResponse:
+    owner_user_id = _user_filter(claims)
+
+    def _stream():
+        for memory in storage.iter_all_memories(owner_user_id=owner_user_id, tag=tag):
+            yield json.dumps(MemoryResponse.from_memory(memory).model_dump(), default=str) + "\n"
+
+    filename = f"memories-{tag}.jsonl" if tag else "memories.jsonl"
+    return StreamingResponse(
+        _stream(),
+        media_type="application/x-ndjson",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.post(
+    "/memories/import",
+    summary="Bulk import memories from JSON Lines",
+    description="Import memories from a newline-delimited JSON body. Each line must be a JSON object with key, value, and tags fields. Upserts by key.",
+    responses={401: {"description": "Unauthorized"}},
+)
+async def import_memories(
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+    body: Annotated[str, Body(media_type="application/x-ndjson")],
+) -> dict[str, Any]:
+    owner_user_id: str = claims["sub"]
+    created = 0
+    updated = 0
+    errors: list[dict[str, Any]] = []
+
+    for i, line in enumerate(body.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            key = data["key"]
+            value = data["value"]
+            tags = data.get("tags", [])
+        except (json.JSONDecodeError, KeyError) as exc:
+            errors.append({"line": i + 1, "error": str(exc)})
+            continue
+
+        existing = storage.get_memory_by_key(key)
+        if existing:
+            existing.value = value
+            existing.tags = tags
+            existing.updated_at = datetime.now(timezone.utc)
+            try:
+                storage.put_memory(existing)
+            except ValueError as exc:
+                errors.append({"line": i + 1, "key": key, "error": str(exc)})
+                continue
+            updated += 1
+        else:
+            memory = Memory(
+                key=key,
+                value=value,
+                tags=tags,
+                owner_client_id=owner_user_id,
+                owner_user_id=owner_user_id,
+            )
+            try:
+                storage.put_memory(memory)
+            except ValueError as exc:
+                errors.append({"line": i + 1, "key": key, "error": str(exc)})
+                continue
+            created += 1
+
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_created,
+            client_id=owner_user_id,
+            metadata={"created": created, "updated": updated},
+        )
+    )
+    return {"created": created, "updated": updated, "errors": errors}
+
+
+@router.get(
     "/memories/{memory_id}",
     summary="Get a memory by ID",
     description="Retrieve a single memory by its unique ID. Non-admins can only access their own memories.",
@@ -273,3 +365,31 @@ async def delete_memory(
             metadata={"memory_id": memory_id},
         )
     )
+
+
+@router.delete(
+    "/memories",
+    summary="Bulk delete memories by tag",
+    description="Delete all memories with the given tag. Non-admins can only delete their own memories.",
+    responses={
+        400: {"description": "tag query parameter is required"},
+        401: {"description": "Unauthorized"},
+    },
+)
+async def delete_memories_by_tag(
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+    tag: Annotated[str | None, Query(description="Tag to bulk-delete")] = None,
+) -> dict[str, int]:
+    if not tag:
+        raise HTTPException(status_code=400, detail="tag query parameter is required")
+    owner_user_id = _user_filter(claims)
+    deleted = storage.delete_memories_by_tag(tag, owner_user_id=owner_user_id)
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_deleted,
+            client_id=claims["sub"],
+            metadata={"tag": tag, "count": deleted},
+        )
+    )
+    return {"deleted": deleted}

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -327,6 +327,44 @@ async def forget(
 
 
 @mcp.tool()
+async def forget_all(
+    tag: Annotated[str, "Tag of the memories to delete"],
+    ctx: Context | None = None,
+) -> str:
+    """Delete all memories that have the given tag."""
+    t0 = time.monotonic()
+    storage, client_id = _auth(ctx, required_scope="memories:write")
+
+    deleted = storage.delete_memories_by_tag(tag)
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_deleted,
+            client_id=client_id,
+            metadata={"tag": tag, "count": deleted},
+        )
+    )
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "Deleted %d memories with tag '%s'",
+        deleted,
+        tag,
+        extra={
+            "tool": "forget_all",
+            "duration_ms": duration_ms,
+            "status": "success",
+        },
+    )
+    await emit_metric("ToolInvocations", operation="forget_all")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="forget_all",
+    )
+    return f"Deleted {deleted} memories with tag '{tag}'."
+
+
+@mcp.tool()
 async def list_memories(
     tag: Annotated[str, "Tag to filter memories by"],
     limit: Annotated[int, "Maximum number of memories to return (1–500)"] = 100,

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any
@@ -233,6 +234,72 @@ class HiveStorage:
             if lek is None:
                 return memories, None
             start_key = lek
+
+    def delete_memories_by_tag(
+        self,
+        tag: str,
+        owner_user_id: str | None = None,
+    ) -> int:
+        """Delete all memories with the given tag.
+
+        If owner_user_id is provided, only memories owned by that user are deleted.
+        Returns the count of memories deleted.
+        """
+        deleted = 0
+        cursor: str | None = None
+        while True:
+            items, cursor = self.list_memories_by_tag(tag, limit=100, cursor=cursor)
+            for memory in items:
+                if owner_user_id and memory.owner_user_id != owner_user_id:
+                    continue
+                self._delete_tag_items(memory)
+                self.table.delete_item(Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"})
+                deleted += 1
+            if cursor is None:
+                break
+        return deleted
+
+    def iter_all_memories(
+        self,
+        owner_user_id: str | None = None,
+        tag: str | None = None,
+    ) -> Iterator[Memory]:
+        """Yield all memories, optionally filtered by owner or tag.
+
+        For tag-filtered export, iterates TagIndex pages.
+        For unfiltered export, scans all META items.
+        This is a generator — use for streaming exports only.
+        """
+        if tag:
+            cursor: str | None = None
+            while True:
+                items, cursor = self.list_memories_by_tag(tag, limit=100, cursor=cursor)
+                for memory in items:
+                    if owner_user_id and memory.owner_user_id != owner_user_id:
+                        continue
+                    yield memory
+                if cursor is None:
+                    break
+        else:
+            filter_expr = "SK = :sk AND begins_with(PK, :pk_prefix)"
+            expr_vals: dict[str, Any] = {":sk": "META", ":pk_prefix": "MEMORY#"}
+            if owner_user_id:
+                filter_expr += _UID_FILTER
+                expr_vals[":uid"] = owner_user_id
+            start_key: dict[str, Any] | None = None
+            while True:
+                kwargs: dict[str, Any] = {
+                    "FilterExpression": filter_expr,
+                    "ExpressionAttributeValues": expr_vals,
+                }
+                if start_key:
+                    kwargs["ExclusiveStartKey"] = start_key
+                resp = self.table.scan(**kwargs)
+                for item in resp.get("Items", []):
+                    yield Memory.from_dynamo(item)
+                start_key = resp.get("LastEvaluatedKey")
+                if start_key is None:
+                    break
 
     # ------------------------------------------------------------------
     # OAuth Client management

--- a/tasks.py
+++ b/tasks.py
@@ -97,11 +97,15 @@ def _hosted_zone_id(ctx, zone_name: str = "warlordofmars.net") -> str:
     """
     if zone_id := os.environ.get("HOSTED_ZONE_ID"):
         return zone_id
-    return ctx.run(
-        f"aws route53 list-hosted-zones-by-name --dns-name {zone_name}"
-        " --query 'HostedZones[0].Id' --output text",
-        hide=True,
-    ).stdout.strip().split("/")[-1]
+    return (
+        ctx.run(
+            f"aws route53 list-hosted-zones-by-name --dns-name {zone_name}"
+            " --query 'HostedZones[0].Id' --output text",
+            hide=True,
+        )
+        .stdout.strip()
+        .split("/")[-1]
+    )
 
 
 def _cfn_output(ctx, key, env="prod"):
@@ -303,11 +307,7 @@ def e2e_local(ctx, tests="tests/e2e", n=1):
         "HIVE_UI_URL": ui_url,
     }
     # Docs tests require a deployed VitePress build — skip unless explicitly targeted
-    ignore = (
-        " --ignore=tests/e2e/test_docs_e2e.py"
-        if tests == "tests/e2e"
-        else ""
-    )
+    ignore = " --ignore=tests/e2e/test_docs_e2e.py" if tests == "tests/e2e" else ""
     for i in range(n):
         if n > 1:
             print(f"\n--- run {i + 1}/{n} ---")
@@ -503,6 +503,102 @@ def seed(ctx, env=None, token=None, reset=False):
 
     cmd = "uv run python scripts/seed_data.py " + " ".join(args)
     ctx.run(cmd, env=seed_env, pty=True)
+
+
+# ── Bulk memory operations ────────────────────────────────────────────────────
+
+
+@task
+def export(ctx, env=None, tag=None, output="-"):
+    """Export memories to JSON Lines (one memory per line).
+
+    Writes to stdout by default; use --output <file> to write to a file.
+    Use --env to target a deployed environment; defaults to local dev stack.
+    Use --tag to export only memories with that tag.
+
+    Example:
+        uv run inv export --env prod > memories.jsonl
+        uv run inv export --env prod --tag project > project.jsonl
+    """
+    import sys
+    import urllib.request
+
+    if env:
+        base_url = _cfn_output(ctx, "ApiFunctionUrl", env=env).rstrip("/")
+        token = os.environ.get("HIVE_EXPORT_TOKEN", "")
+        if not token:
+            print("Set HIVE_EXPORT_TOKEN to a valid management bearer token.", file=sys.stderr)
+            sys.exit(1)
+        url = f"{base_url}/api/memories/export"
+        if tag:
+            url += f"?tag={tag}"
+        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+        with urllib.request.urlopen(req) as resp:
+            data = resp.read()
+    else:
+        api_url = f"http://localhost:{API_PORT}/api/memories/export"
+        if tag:
+            api_url += f"?tag={tag}"
+        import os as _os
+
+        token = _os.environ.get("HIVE_EXPORT_TOKEN", "")
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        req = urllib.request.Request(api_url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                data = resp.read()
+        except urllib.error.URLError as exc:
+            print(f"Could not reach local API at {API_PORT}: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+    if output == "-":
+        sys.stdout.buffer.write(data)
+    else:
+        Path(output).write_bytes(data)
+        print(f"Exported to {output}", file=sys.stderr)
+
+
+@task
+def import_memories(ctx, env=None, input="-"):
+    """Import memories from JSON Lines (one memory per line).
+
+    Reads from stdin by default; use --input <file> to read from a file.
+    Use --env to target a deployed environment; defaults to local dev stack.
+
+    Example:
+        cat memories.jsonl | uv run inv import-memories --env dev
+        uv run inv import-memories --env dev --input memories.jsonl
+    """
+    import sys
+    import urllib.request
+
+    body = sys.stdin.buffer.read() if input == "-" else Path(input).read_bytes()
+
+    token = os.environ.get("HIVE_IMPORT_TOKEN", "")
+
+    if env:
+        base_url = _cfn_output(ctx, "ApiFunctionUrl", env=env).rstrip("/")
+        if not token:
+            print("Set HIVE_IMPORT_TOKEN to a valid management bearer token.", file=sys.stderr)
+            sys.exit(1)
+        url = f"{base_url}/api/memories/import"
+    else:
+        url = f"http://localhost:{API_PORT}/api/memories/import"
+
+    headers = {"Content-Type": "application/x-ndjson"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            result = resp.read().decode()
+        print(result)
+    except urllib.error.HTTPError as exc:
+        print(f"Import failed ({exc.code}): {exc.read().decode()}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as exc:
+        print(f"Could not reach API: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 # ── CDK ───────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1256,3 +1256,169 @@ class TestOriginVerifyMiddleware:
             tc = TestClient(app, raise_server_exceptions=False)
             resp = tc.get("/health")
         assert resp.status_code == 200
+
+
+class TestBulkDeleteByTag:
+    def test_delete_by_tag_returns_count(self, client):
+        tc, *_ = client
+        tc.post("/api/memories", json={"key": "a", "value": "1", "tags": ["bulk"]})
+        tc.post("/api/memories", json={"key": "b", "value": "2", "tags": ["bulk"]})
+        tc.post("/api/memories", json={"key": "c", "value": "3", "tags": ["other"]})
+        resp = tc.delete("/api/memories", params={"tag": "bulk"})
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 2
+
+    def test_delete_by_tag_requires_tag_param(self, client):
+        tc, *_ = client
+        resp = tc.delete("/api/memories")
+        assert resp.status_code == 400
+
+    def test_delete_by_tag_non_admin_only_owns_own(self, client):
+        tc, storage, claims = client
+        # Create memory owned by another user
+        from hive.models import Memory
+
+        other = Memory(
+            key="other-k", value="v", tags=["t"], owner_client_id="c2", owner_user_id="other-user"
+        )
+        storage.put_memory(other)
+        tc.post("/api/memories", json={"key": "mine", "value": "v", "tags": ["t"]})
+        resp = tc.delete("/api/memories", params={"tag": "t"})
+        assert resp.status_code == 200
+        # Only the owned memory should be deleted
+        assert resp.json()["deleted"] == 1
+        assert storage.get_memory_by_key("other-k") is not None
+
+    def test_delete_by_tag_requires_auth(self, unauthed_client):
+        resp = unauthed_client.delete("/api/memories", params={"tag": "t"})
+        assert resp.status_code in (401, 403)
+
+
+class TestExportMemories:
+    def test_export_returns_jsonl(self, client):
+        tc, *_ = client
+        tc.post("/api/memories", json={"key": "exp-a", "value": "1", "tags": ["e"]})
+        tc.post("/api/memories", json={"key": "exp-b", "value": "2", "tags": ["e"]})
+        resp = tc.get("/api/memories/export")
+        assert resp.status_code == 200
+        lines = [ln for ln in resp.text.splitlines() if ln.strip()]
+        assert len(lines) >= 2
+
+    def test_export_with_tag_filter(self, client):
+        tc, *_ = client
+        tc.post("/api/memories", json={"key": "in", "value": "1", "tags": ["export-tag"]})
+        tc.post("/api/memories", json={"key": "out", "value": "2", "tags": ["other"]})
+        resp = tc.get("/api/memories/export", params={"tag": "export-tag"})
+        assert resp.status_code == 200
+        lines = [ln for ln in resp.text.splitlines() if ln.strip()]
+        assert len(lines) == 1
+        import json as _json
+
+        assert _json.loads(lines[0])["key"] == "in"
+
+    def test_export_content_disposition(self, client):
+        tc, *_ = client
+        resp = tc.get("/api/memories/export")
+        assert resp.status_code == 200
+        assert "attachment" in resp.headers.get("content-disposition", "")
+
+    def test_export_requires_auth(self, unauthed_client):
+        resp = unauthed_client.get("/api/memories/export")
+        assert resp.status_code in (401, 403)
+
+
+class TestImportMemories:
+    def test_import_creates_memories(self, client):
+        import json as _json
+
+        tc, storage, _ = client
+        lines = "\n".join(
+            [
+                _json.dumps({"key": "imp-a", "value": "v1", "tags": ["imp"]}),
+                _json.dumps({"key": "imp-b", "value": "v2", "tags": []}),
+            ]
+        )
+        resp = tc.post(
+            "/api/memories/import", content=lines, headers={"Content-Type": "application/x-ndjson"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["created"] == 2
+        assert data["updated"] == 0
+        assert data["errors"] == []
+
+    def test_import_updates_existing(self, client):
+        import json as _json
+
+        tc, *_ = client
+        tc.post("/api/memories", json={"key": "upsert-k", "value": "old"})
+        line = _json.dumps({"key": "upsert-k", "value": "new", "tags": []})
+        resp = tc.post(
+            "/api/memories/import", content=line, headers={"Content-Type": "application/x-ndjson"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["updated"] == 1
+        assert data["created"] == 0
+
+    def test_import_records_errors_for_bad_lines(self, client):
+        tc, *_ = client
+        body = "not valid json\n"
+        resp = tc.post(
+            "/api/memories/import", content=body, headers={"Content-Type": "application/x-ndjson"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["errors"]) == 1
+
+    def test_import_skips_empty_lines(self, client):
+        import json as _json
+
+        tc, *_ = client
+        body = "\n" + _json.dumps({"key": "skip-empty", "value": "v", "tags": []}) + "\n\n"
+        resp = tc.post(
+            "/api/memories/import", content=body, headers={"Content-Type": "application/x-ndjson"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["created"] == 1
+
+    def test_import_requires_auth(self, unauthed_client):
+        resp = unauthed_client.post(
+            "/api/memories/import", content="{}", headers={"Content-Type": "application/x-ndjson"}
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_import_records_error_for_oversized_create(self, client):
+        import json as _json
+        from unittest.mock import patch
+
+        tc, storage, _ = client
+        line = _json.dumps({"key": "big-new", "value": "x" * 1000, "tags": []})
+        with patch.object(storage, "put_memory", side_effect=ValueError("too large")):
+            resp = tc.post(
+                "/api/memories/import",
+                content=line,
+                headers={"Content-Type": "application/x-ndjson"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["errors"]) == 1
+        assert data["created"] == 0
+
+    def test_import_records_error_for_oversized_update(self, client):
+        import json as _json
+        from unittest.mock import patch
+
+        tc, storage, _ = client
+        tc.post("/api/memories", json={"key": "big-exist", "value": "small"})
+        line = _json.dumps({"key": "big-exist", "value": "x" * 1000, "tags": []})
+        with patch.object(storage, "put_memory", side_effect=ValueError("too large")):
+            resp = tc.post(
+                "/api/memories/import",
+                content=line,
+                headers={"Content-Type": "application/x-ndjson"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["errors"]) == 1
+        assert data["updated"] == 0

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -693,3 +693,40 @@ class TestSearchMemories:
             result = await search_memories("anything", ctx=_make_ctx(jwt))
 
         assert result == {"items": [], "count": 0, "query": "anything"}
+
+
+# ---------------------------------------------------------------------------
+# forget_all
+# ---------------------------------------------------------------------------
+
+
+class TestForgetAll:
+    async def test_forget_all_deletes_tagged_memories(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.server import forget_all, remember
+
+        await remember("fa-a", "v1", ["purge"], ctx=_make_ctx(jwt))
+        await remember("fa-b", "v2", ["purge"], ctx=_make_ctx(jwt))
+        await remember("fa-c", "v3", ["keep"], ctx=_make_ctx(jwt))
+        result = await forget_all("purge", ctx=_make_ctx(jwt))
+        assert "2" in result
+        assert storage.get_memory_by_key("fa-a") is None
+        assert storage.get_memory_by_key("fa-b") is None
+        assert storage.get_memory_by_key("fa-c") is not None
+
+    async def test_forget_all_zero_when_tag_missing(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import forget_all
+
+        result = await forget_all("no-such-tag", ctx=_make_ctx(jwt))
+        assert "0" in result
+
+    async def test_forget_all_requires_write_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import forget_all
+
+        storage, _, _ = server_env
+        read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await forget_all("t", ctx=_make_ctx(read_only_jwt))

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -746,3 +746,102 @@ class TestApiKeyStorage:
 
     def test_delete_nonexistent(self, storage):
         assert storage.delete_api_key("no-such-key") is False
+
+
+# ---------------------------------------------------------------------------
+# Bulk memory operations
+# ---------------------------------------------------------------------------
+
+
+class TestBulkMemoryOperations:
+    def test_delete_memories_by_tag_returns_count(self, storage):
+        m1 = Memory(key="a", value="1", tags=["bulk"], owner_client_id="c1", owner_user_id="u1")
+        m2 = Memory(key="b", value="2", tags=["bulk"], owner_client_id="c1", owner_user_id="u1")
+        m3 = Memory(key="c", value="3", tags=["other"], owner_client_id="c1", owner_user_id="u1")
+        for m in [m1, m2, m3]:
+            storage.put_memory(m)
+        deleted = storage.delete_memories_by_tag("bulk")
+        assert deleted == 2
+        assert storage.get_memory_by_key("a") is None
+        assert storage.get_memory_by_key("b") is None
+        assert storage.get_memory_by_key("c") is not None
+
+    def test_delete_memories_by_tag_with_owner_filter(self, storage):
+        m1 = Memory(key="x", value="1", tags=["t"], owner_client_id="c1", owner_user_id="u1")
+        m2 = Memory(key="y", value="2", tags=["t"], owner_client_id="c2", owner_user_id="u2")
+        for m in [m1, m2]:
+            storage.put_memory(m)
+        deleted = storage.delete_memories_by_tag("t", owner_user_id="u1")
+        assert deleted == 1
+        assert storage.get_memory_by_key("x") is None
+        assert storage.get_memory_by_key("y") is not None
+
+    def test_delete_memories_by_tag_empty(self, storage):
+        assert storage.delete_memories_by_tag("no-such-tag") == 0
+
+    def test_iter_all_memories_no_filter(self, storage):
+        for i in range(3):
+            storage.put_memory(Memory(key=f"k{i}", value=f"v{i}", owner_client_id="c1"))
+        result = list(storage.iter_all_memories())
+        assert len(result) == 3
+
+    def test_iter_all_memories_with_tag(self, storage):
+        m1 = Memory(key="tagged", value="1", tags=["export"], owner_client_id="c1")
+        m2 = Memory(key="untagged", value="2", tags=[], owner_client_id="c1")
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        result = list(storage.iter_all_memories(tag="export"))
+        assert len(result) == 1
+        assert result[0].key == "tagged"
+
+    def test_iter_all_memories_with_owner_filter(self, storage):
+        m1 = Memory(key="mine", value="1", owner_client_id="c1", owner_user_id="u1")
+        m2 = Memory(key="theirs", value="2", owner_client_id="c2", owner_user_id="u2")
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        result = list(storage.iter_all_memories(owner_user_id="u1"))
+        assert len(result) == 1
+        assert result[0].key == "mine"
+
+    def test_iter_all_memories_tag_and_owner_filter(self, storage):
+        m1 = Memory(key="a", value="1", tags=["t"], owner_client_id="c1", owner_user_id="u1")
+        m2 = Memory(key="b", value="2", tags=["t"], owner_client_id="c2", owner_user_id="u2")
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        result = list(storage.iter_all_memories(tag="t", owner_user_id="u2"))
+        assert len(result) == 1
+        assert result[0].key == "b"
+
+    def test_iter_all_memories_follows_scan_pages(self, storage):
+        """iter_all_memories should follow DynamoDB scan pages via ExclusiveStartKey."""
+
+        memories = [Memory(key=f"page-{i}", value=f"v{i}", owner_client_id="c1") for i in range(3)]
+        for m in memories:
+            storage.put_memory(m)
+
+        # Capture calls to prove pagination works by using real storage
+        # (moto handles pagination internally, so just verify all items returned)
+        result = list(storage.iter_all_memories())
+        assert len(result) == 3
+
+    def test_iter_all_memories_multi_page(self, storage):
+        """iter_all_memories handles scan responses with ExclusiveStartKey."""
+        from unittest.mock import patch
+
+        from hive.models import Memory as _Memory
+
+        m1 = _Memory(key="page1", value="v1", owner_client_id="c1")
+        m1_item = m1.to_dynamo_meta()
+
+        page1_resp = {
+            "Items": [m1_item],
+            "LastEvaluatedKey": {"PK": "MEMORY#page1", "SK": "META"},
+        }
+        m2 = _Memory(key="page2", value="v2", owner_client_id="c1")
+        m2_item = m2.to_dynamo_meta()
+        page2_resp = {"Items": [m2_item]}
+
+        with patch.object(storage.table, "scan", side_effect=[page1_resp, page2_resp]):
+            result = list(storage.iter_all_memories())
+
+        assert len(result) == 2


### PR DESCRIPTION
Closes #26

## Summary
- `forget_all(tag)` MCP tool deletes all memories with a given tag; logs count; enforces `memories:write` scope
- `DELETE /api/memories?tag=` bulk-deletes by tag; non-admins filtered to own memories only
- `GET /api/memories/export` streams JSONL with optional tag filter; sets `Content-Disposition: attachment`
- `POST /api/memories/import` bulk-upserts from JSONL body; returns `{created, updated, errors}`
- `storage.delete_memories_by_tag()` paginates TagIndex to handle large tag sets
- `storage.iter_all_memories()` generator for streaming export without loading everything into RAM
- `inv export` and `inv import-memories` invoke tasks for local and deployed environments

## Approach
- Routes `/memories/export` and `/memories/import` are registered **before** `/memories/{memory_id}` so FastAPI doesn't treat "export" as a memory_id path parameter
- `delete_memories_by_tag` accepts an optional `owner_user_id` to apply the non-admin ownership filter
- Import uses upsert-by-key semantics (matching existing `create_memory` behavior)
- Tasks use `HIVE_EXPORT_TOKEN` / `HIVE_IMPORT_TOKEN` env vars for auth against deployed envs