### PR TITLE
feat: per-memory TTL at creation time

### DIFF
--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -10,7 +10,7 @@ Admins can access all memories.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
@@ -139,6 +139,8 @@ async def create_memory(
         existing.value = body.value
         existing.tags = body.tags
         existing.updated_at = datetime.now(timezone.utc)
+        if body.ttl_seconds is not None:
+            existing.expires_at = datetime.now(timezone.utc) + timedelta(seconds=body.ttl_seconds)
         try:
             storage.put_memory(existing)
         except ValueError as exc:
@@ -157,12 +159,16 @@ async def create_memory(
         check_memory_quota(owner_user_id, storage)
     except QuotaExceeded as exc:
         raise HTTPException(status_code=429, detail=exc.detail) from exc
+    expires_at = None
+    if body.ttl_seconds is not None:
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=body.ttl_seconds)
     memory = Memory(
         key=body.key,
         value=body.value,
         tags=body.tags,
         owner_client_id=owner_user_id,
         owner_user_id=owner_user_id,
+        expires_at=expires_at,
     )
     try:
         storage.put_memory(memory)
@@ -319,6 +325,12 @@ async def update_memory(
         memory.value = body.value
     if body.tags is not None:
         memory.tags = body.tags
+    if body.ttl_seconds is not None:
+        memory.expires_at = (
+            None
+            if body.ttl_seconds == 0
+            else datetime.now(timezone.utc) + timedelta(seconds=body.ttl_seconds)
+        )
     memory.updated_at = datetime.now(timezone.utc)
 
     try:

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -58,6 +58,7 @@ class Memory(BaseModel):
     updated_at: datetime = Field(default_factory=_now_utc)
     owner_client_id: str  # which OAuth client owns this memory
     owner_user_id: str | None = None  # which user owns this memory (None for pre-migration items)
+    expires_at: datetime | None = None  # optional TTL; None means never expires
 
     # ------------------------------------------------------------------
     # DynamoDB serialisation
@@ -81,6 +82,9 @@ class Memory(BaseModel):
         }
         if self.owner_user_id is not None:
             item["owner_user_id"] = self.owner_user_id
+        if self.expires_at is not None:
+            item["expires_at"] = self.expires_at.isoformat()
+            item["ttl"] = int(self.expires_at.timestamp())
         return item
 
     def to_dynamo_tag_items(self) -> list[dict[str, Any]]:
@@ -103,6 +107,9 @@ class Memory(BaseModel):
 
     @classmethod
     def from_dynamo(cls, item: dict[str, Any]) -> Memory:
+        expires_at = None
+        if ea := item.get("expires_at"):
+            expires_at = datetime.fromisoformat(ea)
         return cls(
             memory_id=item["memory_id"],
             key=item["key"],
@@ -112,7 +119,12 @@ class Memory(BaseModel):
             updated_at=datetime.fromisoformat(item["updated_at"]),
             owner_client_id=item["owner_client_id"],
             owner_user_id=item.get("owner_user_id"),
+            expires_at=expires_at,
         )
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires_at is not None and _now_utc() >= self.expires_at
 
 
 # ---------------------------------------------------------------------------
@@ -470,11 +482,17 @@ class MemoryCreate(BaseModel):
     key: str
     value: str
     tags: list[str] = Field(default_factory=list)
+    ttl_seconds: int | None = Field(
+        default=None, ge=1, description="Seconds until expiry. None = never expires."
+    )
 
 
 class MemoryUpdate(BaseModel):
     value: str | None = None
     tags: list[str] | None = None
+    ttl_seconds: int | None = Field(
+        default=None, ge=0, description="Seconds until expiry. 0 = clear TTL. None = no change."
+    )
 
 
 class MemoryResponse(BaseModel):
@@ -484,6 +502,7 @@ class MemoryResponse(BaseModel):
     tags: list[str]
     created_at: datetime
     updated_at: datetime
+    expires_at: datetime | None = None
 
     @classmethod
     def from_memory(cls, m: Memory) -> MemoryResponse:
@@ -494,6 +513,7 @@ class MemoryResponse(BaseModel):
             tags=m.tags,
             created_at=m.created_at,
             updated_at=m.updated_at,
+            expires_at=m.expires_at,
         )
 
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import importlib.metadata
 import os
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
@@ -146,19 +146,31 @@ async def remember(
     key: Annotated[str, "Unique key to store the memory under"],
     value: Annotated[str, "Content of the memory"],
     tags: Annotated[list[str] | None, "Optional tags for categorisation"] = None,
+    ttl_seconds: Annotated[
+        int | None, "Seconds until the memory expires. None = never expires."
+    ] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Store or update a memory with optional tags."""
+    """Store or update a memory with optional tags and optional TTL."""
     t0 = time.monotonic()
     storage, client_id = _auth(ctx, required_scope="memories:write")
     tags = tags or []
+    expires_at = (
+        datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
+        if ttl_seconds is not None
+        else None
+    )
 
     # Check if a memory with this key already exists (upsert path)
     existing = storage.get_memory_by_key(key)
 
     if existing:
         # Idempotent: skip write and log if nothing changed
-        if existing.value == value and set(existing.tags) == set(tags):
+        if (
+            existing.value == value
+            and set(existing.tags) == set(tags)
+            and existing.expires_at == expires_at
+        ):
             logger.info(
                 "Memory unchanged",
                 extra={
@@ -170,6 +182,7 @@ async def remember(
             return f"Memory '{key}' unchanged."
         existing.value = value
         existing.tags = tags
+        existing.expires_at = expires_at
         existing.updated_at = datetime.now(timezone.utc)
         try:
             storage.put_memory(existing)
@@ -189,7 +202,9 @@ async def remember(
             check_memory_quota(owner_user_id, storage)
         except QuotaExceeded as exc:
             raise ToolError(exc.detail) from exc
-        memory = Memory(key=key, value=value, tags=tags, owner_client_id=client_id)
+        memory = Memory(
+            key=key, value=value, tags=tags, owner_client_id=client_id, expires_at=expires_at
+        )
         try:
             storage.put_memory(memory)
         except ValueError as exc:

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -114,7 +114,10 @@ class HiveStorage:
         item = self._get_memory_meta(memory_id)
         if item is None:
             return None
-        return Memory.from_dynamo(item)
+        memory = Memory.from_dynamo(item)
+        if memory.is_expired:
+            return None
+        return memory
 
     def get_memory_by_key(self, key: str) -> Memory | None:
         """Look up a memory by its human-readable key using GSI1."""

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -437,6 +437,51 @@ class TestMemories:
 
 
 # ---------------------------------------------------------------------------
+# Memory TTL endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryTTL:
+    def test_create_with_ttl_returns_expires_at(self, client):
+        tc, *_ = client
+        resp = tc.post("/api/memories", json={"key": "ttl-k", "value": "v", "ttl_seconds": 3600})
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["expires_at"] is not None
+
+    def test_create_without_ttl_expires_at_is_null(self, client):
+        tc, *_ = client
+        resp = tc.post("/api/memories", json={"key": "no-ttl", "value": "v"})
+        assert resp.status_code == 201
+        assert resp.json()["expires_at"] is None
+
+    def test_upsert_with_ttl_updates_expires_at(self, client):
+        tc, *_ = client
+        tc.post("/api/memories", json={"key": "upsert-ttl", "value": "v"})
+        resp = tc.post(
+            "/api/memories", json={"key": "upsert-ttl", "value": "v2", "ttl_seconds": 7200}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["expires_at"] is not None
+
+    def test_patch_sets_ttl(self, client):
+        tc, *_ = client
+        mid = tc.post("/api/memories", json={"key": "patch-ttl", "value": "v"}).json()["memory_id"]
+        resp = tc.patch(f"/api/memories/{mid}", json={"ttl_seconds": 3600})
+        assert resp.status_code == 200
+        assert resp.json()["expires_at"] is not None
+
+    def test_patch_clears_ttl_with_zero(self, client):
+        tc, *_ = client
+        mid = tc.post(
+            "/api/memories", json={"key": "clear-ttl", "value": "v", "ttl_seconds": 3600}
+        ).json()["memory_id"]
+        resp = tc.patch(f"/api/memories/{mid}", json={"ttl_seconds": 0})
+        assert resp.status_code == 200
+        assert resp.json()["expires_at"] is None
+
+
+# ---------------------------------------------------------------------------
 # Client endpoints
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -174,6 +174,39 @@ class TestRemember:
         ):
             await remember("big-key", "x" * 1000, [], ctx=_make_ctx(jwt))
 
+    async def test_remember_with_ttl_sets_expires_at(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.server import remember
+
+        result = await remember("ttl-key", "ttl-val", [], ttl_seconds=3600, ctx=_make_ctx(jwt))
+        assert result == "Stored memory 'ttl-key'."
+        m = storage.get_memory_by_key("ttl-key")
+        assert m is not None
+        assert m.expires_at is not None
+
+    async def test_remember_without_ttl_no_expires_at(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.server import remember
+
+        await remember("no-ttl-key", "v", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("no-ttl-key")
+        assert m is not None
+        assert m.expires_at is None
+
+    async def test_idempotent_with_same_ttl(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.server import remember
+
+        await remember("idem-ttl", "v", [], ttl_seconds=3600, ctx=_make_ctx(jwt))
+        m1 = storage.get_memory_by_key("idem-ttl")
+        assert m1 is not None
+        # Second call with same value but no ttl should NOT be idempotent
+        result = await remember("idem-ttl", "v", [], ttl_seconds=None, ctx=_make_ctx(jwt))
+        assert result == "Updated memory 'idem-ttl'."
+        m2 = storage.get_memory_by_key("idem-ttl")
+        assert m2 is not None
+        assert m2.expires_at is None
+
 
 # ---------------------------------------------------------------------------
 # recall

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -195,6 +195,67 @@ class TestMemoryStorage:
             with pytest.raises(ClientError):
                 storage.put_memory(m)
 
+    def test_put_and_get_memory_with_ttl(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        m = Memory(key="ttl-key", value="ttl-val", owner_client_id="c1", expires_at=expires_at)
+        storage.put_memory(m)
+        result = storage.get_memory_by_id(m.memory_id)
+        assert result is not None
+        assert result.expires_at is not None
+        assert abs((result.expires_at - expires_at).total_seconds()) < 1
+
+    def test_get_expired_memory_returns_none(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        past = datetime.now(timezone.utc) - timedelta(seconds=1)
+        m = Memory(key="expired-key", value="gone", owner_client_id="c1", expires_at=past)
+        storage.put_memory(m)
+        # DynamoDB TTL is eventually consistent; filter client-side
+        result = storage.get_memory_by_id(m.memory_id)
+        assert result is None
+
+    def test_get_memory_by_key_expired_returns_none(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        past = datetime.now(timezone.utc) - timedelta(seconds=1)
+        m = Memory(key="expired-key2", value="gone", owner_client_id="c1", expires_at=past)
+        storage.put_memory(m)
+        result = storage.get_memory_by_key("expired-key2")
+        assert result is None
+
+    def test_memory_serialise_ttl_in_dynamo(self):
+        from datetime import datetime, timedelta, timezone
+
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
+        m = Memory(key="k", value="v", owner_client_id="c1", expires_at=expires_at)
+        item = m.to_dynamo_meta()
+        assert "expires_at" in item
+        assert "ttl" in item
+        assert item["ttl"] == int(expires_at.timestamp())
+
+    def test_memory_deserialise_ttl_from_dynamo(self):
+        from datetime import datetime, timedelta, timezone
+
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
+        m = Memory(key="k", value="v", owner_client_id="c1", expires_at=expires_at)
+        item = m.to_dynamo_meta()
+        restored = Memory.from_dynamo(item)
+        assert restored.expires_at is not None
+        assert abs((restored.expires_at - expires_at).total_seconds()) < 1
+
+    def test_memory_is_expired_false_when_no_ttl(self):
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        assert not m.is_expired
+
+    def test_memory_is_expired_true_when_past(self):
+        from datetime import datetime, timedelta, timezone
+
+        past = datetime.now(timezone.utc) - timedelta(seconds=1)
+        m = Memory(key="k", value="v", owner_client_id="c1", expires_at=past)
+        assert m.is_expired
+
 
 # ---------------------------------------------------------------------------
 # Client tests

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -10,7 +10,16 @@ import { Button } from "./ui/button.jsx";
 import { Card } from "./ui/card.jsx";
 import { Input } from "./ui/input.jsx";
 import { Label } from "./ui/label.jsx";
+import { Select } from "./ui/select.jsx";
 import { Textarea } from "./ui/textarea.jsx";
+
+const TTL_OPTIONS = [
+  { label: "Never expires", value: "" },
+  { label: "1 hour", value: "3600" },
+  { label: "1 day", value: "86400" },
+  { label: "1 week", value: "604800" },
+  { label: "30 days", value: "2592000" },
+];
 
 // ------------------------------------------------------------------
 // TagPicker — combobox that shows suggestions from known tags,
@@ -172,7 +181,7 @@ export default function MemoryBrowser() {
   const [isSearchMode, setIsSearchMode] = useState(false);
   const [editing, setEditing] = useState(null); // memory object or null
   const [creating, setCreating] = useState(false);
-  const [form, setForm] = useState({ key: "", value: "", tags: "" });
+  const [form, setForm] = useState({ key: "", value: "", tags: "", ttl: "" });
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [pendingDelete, setPendingDelete] = useState(null);
   const searchDebounceRef = useRef(null);
@@ -261,16 +270,18 @@ export default function MemoryBrowser() {
   async function handleCreate(e) {
     e.preventDefault();
     try {
-      await api.createMemory({
+      const body = {
         key: form.key,
         value: form.value,
         tags: form.tags
           .split(",")
           .map((t) => t.trim())
           .filter(Boolean),
-      });
+      };
+      if (form.ttl) body.ttl_seconds = parseInt(form.ttl, 10);
+      await api.createMemory(body);
       setCreating(false);
-      setForm({ key: "", value: "", tags: "" });
+      setForm({ key: "", value: "", tags: "", ttl: "" });
       load();
     } catch (err) {
       setError(err.message);
@@ -280,13 +291,15 @@ export default function MemoryBrowser() {
   async function handleUpdate(e) {
     e.preventDefault();
     try {
-      await api.updateMemory(editing.memory_id, {
+      const body = {
         value: form.value,
         tags: form.tags
           .split(",")
           .map((t) => t.trim())
           .filter(Boolean),
-      });
+      };
+      body.ttl_seconds = form.ttl === "" ? 0 : parseInt(form.ttl, 10);
+      await api.updateMemory(editing.memory_id, body);
       setEditing(null);
       load();
     } catch (err) {
@@ -307,14 +320,14 @@ export default function MemoryBrowser() {
 
   function openEdit(m) {
     setEditing(m);
-    setForm({ key: m.key, value: m.value, tags: m.tags.join(", ") });
+    setForm({ key: m.key, value: m.value, tags: m.tags.join(", "), ttl: "" });
     setCreating(false);
   }
 
   function openCreate() {
     setCreating(true);
     setEditing(null);
-    setForm({ key: "", value: "", tags: "" });
+    setForm({ key: "", value: "", tags: "", ttl: "" });
   }
 
   function closePanel() {
@@ -403,6 +416,9 @@ export default function MemoryBrowser() {
                     {m.score !== undefined && (
                       <Badge>{Math.round(m.score * 100)}% match</Badge>
                     )}
+                    {m.expires_at && (
+                      <Badge className="border-[var(--amber)] text-[var(--amber)]">Expires {new Date(m.expires_at).toLocaleDateString()}</Badge>
+                    )}
                   </div>
                   <p className="mt-1 text-[var(--text-muted)] text-[13px] whitespace-pre-wrap">
                     {m.value.length > 160 ? m.value.slice(0, 160) + "…" : m.value}
@@ -466,7 +482,7 @@ export default function MemoryBrowser() {
                   placeholder="Memory content…"
                 />
               </div>
-              <div className="mb-4">
+              <div className="mb-3">
                 <Label htmlFor="memory-tags">Tags (comma-separated)</Label>
                 <Input
                   id="memory-tags"
@@ -474,6 +490,18 @@ export default function MemoryBrowser() {
                   onChange={(e) => setForm({ ...form, tags: e.target.value })}
                   placeholder="tag1, tag2"
                 />
+              </div>
+              <div className="mb-4">
+                <Label htmlFor="memory-ttl">Expires in</Label>
+                <Select
+                  id="memory-ttl"
+                  value={form.ttl}
+                  onChange={(e) => setForm({ ...form, ttl: e.target.value })}
+                >
+                  {TTL_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </Select>
               </div>
               <div className="flex gap-2">
                 <Button type="submit">Save</Button>

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -799,4 +799,86 @@ describe("MemoryBrowser", () => {
       timeout: 1000,
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // TTL / expiry
+  // ---------------------------------------------------------------------------
+
+  it("shows expiry badge for memories with expires_at", async () => {
+    const expiry = new Date("2027-01-15T00:00:00.000Z").toISOString();
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ expires_at: expiry })],
+      next_cursor: null,
+    });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    expect(screen.getByText(/Expires/)).toBeTruthy();
+  });
+
+  it("creates memory with TTL when Expires In is set", async () => {
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+    api.listMemories
+      .mockResolvedValueOnce({ items: [], next_cursor: null })
+      .mockResolvedValue({ items: [], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "ttl-key" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "ttl-val" },
+    });
+    fireEvent.change(screen.getByLabelText("Expires in"), {
+      target: { value: "3600" },
+    });
+
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    expect(api.createMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ ttl_seconds: 3600 }),
+    );
+  });
+
+  it("updates memory with ttl_seconds 0 to clear TTL when form.ttl is empty", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.updateMemory.mockResolvedValue({});
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    fireEvent.click(getCard());
+
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("Memory content…").closest("form")),
+    );
+
+    expect(api.updateMemory).toHaveBeenCalledWith(
+      "m1",
+      expect.objectContaining({ ttl_seconds: 0 }),
+    );
+  });
+
+  it("updates memory with parsed ttl_seconds when TTL is set", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.updateMemory.mockResolvedValue({});
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    fireEvent.click(getCard());
+
+    fireEvent.change(screen.getByLabelText("Expires in"), {
+      target: { value: "86400" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("Memory content…").closest("form")),
+    );
+
+    expect(api.updateMemory).toHaveBeenCalledWith(
+      "m1",
+      expect.objectContaining({ ttl_seconds: 86400 }),
+    );
+  });
 });


### PR DESCRIPTION
Closes #25

## Summary
- Added `ttl_seconds` param to `remember` MCP tool; stores `expires_at` on the Memory model
- `POST /api/memories` and `PATCH /api/memories/{id}` accept `ttl_seconds`; PATCH with `ttl_seconds=0` clears the TTL
- `get_memory_by_id` / `get_memory_by_key` filter out client-side expired items so agents never see stale entries
- `Memory.to_dynamo_meta()` serialises `expires_at` + `ttl` for DynamoDB auto-deletion
- UI: "Expires in" dropdown (Never / 1 hour / 1 day / 1 week / 30 days) in create/edit form; expiry badge on memory cards

## Approach
- TTL stored as `expires_at` (ISO datetime) + `ttl` (Unix int) following the same pattern used by ApiKey
- Client-side expiry check added to both lookup paths; DynamoDB TTL deletion is eventually consistent so this guards the ~48h window
- `MemoryResponse` now includes `expires_at: datetime | None` for API consumers