### PR TITLE
feat: memory versioning — preserve previous values on overwrite

### DIFF
--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -28,6 +28,7 @@ from hive.api.logs import router as logs_router
 from hive.api.memories import router as memories_router
 from hive.api.stats import router as stats_router
 from hive.api.users import router as users_router
+from hive.api.versions import router as versions_router
 from hive.auth.mgmt_auth import router as mgmt_auth_router
 from hive.auth.oauth import router as oauth_router
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
@@ -129,6 +130,7 @@ app.include_router(mgmt_auth_router)
 
 # Management API endpoints (Bearer token required)
 app.include_router(memories_router, prefix="/api")
+app.include_router(versions_router, prefix="/api")
 app.include_router(clients_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(users_router, prefix="/api")

--- a/src/hive/api/versions.py
+++ b/src/hive/api/versions.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Memory version history endpoints for the Hive management API.
+
+All routes require a valid management JWT via require_mgmt_user.
+Non-admin users can only access versions of their own memories.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from hive.api._auth import require_mgmt_user
+from hive.models import (
+    ActivityEvent,
+    EventType,
+    MemoryVersionResponse,
+)
+from hive.storage import HiveStorage
+
+router = APIRouter(tags=["versions"])
+
+_MEMORY_NOT_FOUND = "Memory not found"
+_VERSION_NOT_FOUND = "Version not found"
+
+
+def _storage() -> HiveStorage:
+    return HiveStorage()
+
+
+def _user_filter(claims: dict[str, Any]) -> str | None:
+    return None if claims.get("role") == "admin" else claims["sub"]
+
+
+@router.get(
+    "/memories/{memory_id}/versions",
+    summary="List version history for a memory",
+    description="Return all previous versions of a memory, newest first. Non-admins can only access their own memories.",
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": _MEMORY_NOT_FOUND},
+    },
+)
+async def list_versions(
+    memory_id: str,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> list[MemoryVersionResponse]:
+    memory = storage.get_memory_by_id(memory_id)
+    if memory is None:
+        raise HTTPException(status_code=404, detail=_MEMORY_NOT_FOUND)
+    owner_user_id = _user_filter(claims)
+    if owner_user_id and memory.owner_user_id != owner_user_id:
+        raise HTTPException(status_code=404, detail=_MEMORY_NOT_FOUND)
+    versions = storage.list_memory_versions(memory_id)
+    return [MemoryVersionResponse.from_version(v) for v in versions]
+
+
+@router.post(
+    "/memories/{memory_id}/restore",
+    summary="Restore a memory to a previous version",
+    description="Overwrite the current memory value with a previous version snapshot. Non-admins can only restore their own memories.",
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": _MEMORY_NOT_FOUND},
+    },
+)
+async def restore_version(
+    memory_id: str,
+    version_timestamp: str,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> MemoryVersionResponse:
+    memory = storage.get_memory_by_id(memory_id)
+    if memory is None:
+        raise HTTPException(status_code=404, detail=_MEMORY_NOT_FOUND)
+    owner_user_id = _user_filter(claims)
+    if owner_user_id and memory.owner_user_id != owner_user_id:
+        raise HTTPException(status_code=404, detail=_MEMORY_NOT_FOUND)
+
+    version = storage.get_memory_version(memory_id, version_timestamp)
+    if version is None:
+        raise HTTPException(status_code=404, detail=_VERSION_NOT_FOUND)
+
+    memory.value = version.value
+    memory.tags = version.tags
+    memory.updated_at = datetime.now(timezone.utc)
+    storage.put_memory(memory)
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_updated,
+            client_id=claims["sub"],
+            metadata={"memory_id": memory_id, "version_timestamp": version_timestamp},
+        )
+    )
+    return MemoryVersionResponse.from_version(version)

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -474,6 +474,58 @@ class ActivityEvent(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Memory version (snapshot of a memory value before overwrite)
+# ---------------------------------------------------------------------------
+
+
+class MemoryVersion(BaseModel):
+    """A point-in-time snapshot of a memory, written before an overwrite."""
+
+    memory_id: str
+    version_timestamp: str  # ISO-formatted UTC timestamp used as SK
+    key: str
+    value: str
+    tags: list[str]
+    recorded_at: datetime
+
+    def to_dynamo(self) -> dict[str, Any]:
+        return {
+            "PK": f"MEMORY#{self.memory_id}",
+            "SK": f"VERSION#{self.version_timestamp}",
+            "memory_id": self.memory_id,
+            "version_timestamp": self.version_timestamp,
+            "key": self.key,
+            "value": self.value,
+            "tags": self.tags,
+            "recorded_at": self.recorded_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dynamo(cls, item: dict[str, Any]) -> MemoryVersion:
+        return cls(
+            memory_id=item["memory_id"],
+            version_timestamp=item["version_timestamp"],
+            key=item["key"],
+            value=item["value"],
+            tags=item.get("tags", []),
+            recorded_at=datetime.fromisoformat(item["recorded_at"]),
+        )
+
+    @classmethod
+    def from_memory(cls, memory: Memory) -> MemoryVersion:
+        """Snapshot the current state of a memory."""
+        now = _now_utc()
+        return cls(
+            memory_id=memory.memory_id,
+            version_timestamp=now.strftime("%Y%m%dT%H%M%S%f"),
+            key=memory.key,
+            value=memory.value,
+            tags=memory.tags,
+            recorded_at=now,
+        )
+
+
+# ---------------------------------------------------------------------------
 # API request / response schemas (used by FastAPI routes)
 # ---------------------------------------------------------------------------
 
@@ -514,6 +566,26 @@ class MemoryResponse(BaseModel):
             created_at=m.created_at,
             updated_at=m.updated_at,
             expires_at=m.expires_at,
+        )
+
+
+class MemoryVersionResponse(BaseModel):
+    memory_id: str
+    version_timestamp: str
+    key: str
+    value: str
+    tags: list[str]
+    recorded_at: datetime
+
+    @classmethod
+    def from_version(cls, v: MemoryVersion) -> MemoryVersionResponse:
+        return cls(
+            memory_id=v.memory_id,
+            version_timestamp=v.version_timestamp,
+            key=v.key,
+            value=v.value,
+            tags=v.tags,
+            recorded_at=v.recorded_at,
         )
 
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -380,6 +380,77 @@ async def forget_all(
 
 
 @mcp.tool()
+async def memory_history(
+    key: Annotated[str, "Key of the memory to retrieve history for"],
+    ctx: Context | None = None,
+) -> list[dict[str, Any]]:
+    """Return the version history of a memory (previous values before each overwrite)."""
+    t0 = time.monotonic()
+    storage, client_id = _auth(ctx, required_scope="memories:read")
+
+    memory = storage.get_memory_by_key(key)
+    if memory is None:
+        raise ToolError(f"No memory found for key '{key}'.")
+    versions = storage.list_memory_versions(memory.memory_id)
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    await emit_metric("ToolInvocations", operation="memory_history")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="memory_history",
+    )
+    return [
+        {
+            "version_timestamp": v.version_timestamp,
+            "value": v.value,
+            "tags": v.tags,
+            "recorded_at": v.recorded_at.isoformat(),
+        }
+        for v in versions
+    ]
+
+
+@mcp.tool()
+async def restore_memory(
+    key: Annotated[str, "Key of the memory to restore"],
+    version_timestamp: Annotated[str, "Version timestamp to restore (from memory_history)"],
+    ctx: Context | None = None,
+) -> str:
+    """Restore a memory to a previous version."""
+    t0 = time.monotonic()
+    storage, client_id = _auth(ctx, required_scope="memories:write")
+
+    memory = storage.get_memory_by_key(key)
+    if memory is None:
+        raise ToolError(f"No memory found for key '{key}'.")
+    version = storage.get_memory_version(memory.memory_id, version_timestamp)
+    if version is None:
+        raise ToolError(f"Version '{version_timestamp}' not found for memory '{key}'.")
+
+    memory.value = version.value
+    memory.tags = version.tags
+    memory.updated_at = datetime.now(timezone.utc)
+    storage.put_memory(memory)
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_updated,
+            client_id=client_id,
+            metadata={"key": key, "version_timestamp": version_timestamp},
+        )
+    )
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    await emit_metric("ToolInvocations", operation="restore_memory")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="restore_memory",
+    )
+    return f"Restored memory '{key}' to version '{version_timestamp}'."
+
+
+@mcp.tool()
 async def list_memories(
     tag: Annotated[str, "Tag to filter memories by"],
     limit: Annotated[int, "Maximum number of memories to return (1–500)"] = 100,

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -29,6 +29,7 @@ from hive.models import (
     ApiKey,
     AuthorizationCode,
     Memory,
+    MemoryVersion,
     MgmtPendingState,
     OAuthClient,
     PendingAuth,
@@ -45,6 +46,9 @@ DYNAMODB_ENDPOINT = os.environ.get("DYNAMODB_ENDPOINT")
 _UID_FILTER = " AND owner_user_id = :uid"
 _PK_PREFIX_KEY = ":prefix"
 _SK_PK_PREFIX_EXPR = "SK = :sk AND begins_with(PK, :prefix)"
+
+# Version retention
+_VERSION_RETENTION_DAYS = int(os.environ.get("HIVE_VERSION_RETENTION_DAYS", "30"))
 
 # Token lifetimes
 ACCESS_TOKEN_TTL_SECONDS = 3600  # 1 hour
@@ -90,11 +94,17 @@ class HiveStorage:
     # ------------------------------------------------------------------
 
     def put_memory(self, memory: Memory) -> None:
-        """Write (create or replace) a memory and all its tag items."""
+        """Write (create or replace) a memory and all its tag items.
+
+        When replacing an existing memory, the previous state is snapshotted
+        as a VERSION item so it can be retrieved via list_memory_versions.
+        """
         # First delete old tag items if the memory already exists
         existing_raw = self._get_memory_meta(memory.memory_id)
         if existing_raw:
-            self._delete_tag_items(Memory.from_dynamo(existing_raw))
+            old = Memory.from_dynamo(existing_raw)
+            self._delete_tag_items(old)
+            self.save_memory_version(old)
 
         try:
             with self.table.batch_writer() as batch:
@@ -142,6 +152,39 @@ class HiveStorage:
         self._delete_tag_items(memory)
         self.table.delete_item(Key={"PK": f"MEMORY#{memory_id}", "SK": "META"})
         return True
+
+    # ------------------------------------------------------------------
+    # Memory version history
+    # ------------------------------------------------------------------
+
+    def save_memory_version(self, memory: Memory) -> MemoryVersion:
+        """Snapshot the current state of a memory as a VERSION item."""
+        version = MemoryVersion.from_memory(memory)
+        item = version.to_dynamo()
+        # Set TTL so old versions are auto-pruned
+        expires = _now() + timedelta(days=_VERSION_RETENTION_DAYS)
+        item["ttl"] = int(expires.timestamp())
+        self.table.put_item(Item=item)
+        return version
+
+    def list_memory_versions(self, memory_id: str) -> list[MemoryVersion]:
+        """Return all version snapshots for a memory, newest first."""
+        resp = self.table.query(
+            KeyConditionExpression=Key("PK").eq(f"MEMORY#{memory_id}")
+            & Key("SK").begins_with("VERSION#"),
+            ScanIndexForward=False,
+        )
+        return [MemoryVersion.from_dynamo(item) for item in resp.get("Items", [])]
+
+    def get_memory_version(self, memory_id: str, version_timestamp: str) -> MemoryVersion | None:
+        """Fetch a specific version snapshot."""
+        resp = self.table.get_item(
+            Key={"PK": f"MEMORY#{memory_id}", "SK": f"VERSION#{version_timestamp}"}
+        )
+        item = resp.get("Item")
+        if item is None:
+            return None
+        return MemoryVersion.from_dynamo(item)
 
     def hydrate_memory_ids(
         self, id_score_pairs: list[tuple[str, float]]

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -94,6 +94,7 @@ def _setup_app_overrides(app, storage, claims):
     from hive.api import memories as memories_mod
     from hive.api import stats as stats_mod
     from hive.api import users as users_mod
+    from hive.api import versions as versions_mod
 
     def _override_mgmt_user():
         return claims
@@ -102,7 +103,7 @@ def _setup_app_overrides(app, storage, claims):
         return storage
 
     app.dependency_overrides[auth_mod.require_mgmt_user] = _override_mgmt_user
-    for mod in (memories_mod, clients_mod, stats_mod, users_mod):
+    for mod in (memories_mod, clients_mod, stats_mod, users_mod, versions_mod):
         app.dependency_overrides[mod._storage] = _override_storage
 
 
@@ -479,6 +480,100 @@ class TestMemoryTTL:
         resp = tc.patch(f"/api/memories/{mid}", json={"ttl_seconds": 0})
         assert resp.status_code == 200
         assert resp.json()["expires_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Memory version endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestVersionEndpoints:
+    def test_list_versions_empty(self, client):
+        tc, *_ = client
+        mid = tc.post("/api/memories", json={"key": "ver-k", "value": "v1"}).json()["memory_id"]
+        resp = tc.get(f"/api/memories/{mid}/versions")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_versions_after_update(self, client):
+        tc, *_ = client
+        mid = tc.post("/api/memories", json={"key": "ver-upd", "value": "v1"}).json()["memory_id"]
+        tc.patch(f"/api/memories/{mid}", json={"value": "v2"})
+        resp = tc.get(f"/api/memories/{mid}/versions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["value"] == "v1"
+
+    def test_list_versions_memory_not_found(self, client):
+        tc, *_ = client
+        resp = tc.get("/api/memories/no-such-id/versions")
+        assert resp.status_code == 404
+
+    def test_list_versions_non_admin_cannot_see_other_user_memory(self, client):
+        tc, storage, _ = client
+        from hive.models import Memory
+
+        other = Memory(key="other", value="v", owner_client_id="x", owner_user_id="other-user")
+        storage.put_memory(other)
+        resp = tc.get(f"/api/memories/{other.memory_id}/versions")
+        assert resp.status_code == 404
+
+    def test_restore_version(self, client):
+        tc, *_ = client
+        mid = tc.post("/api/memories", json={"key": "restore-k", "value": "v1"}).json()["memory_id"]
+        tc.patch(f"/api/memories/{mid}", json={"value": "v2"})
+        versions = tc.get(f"/api/memories/{mid}/versions").json()
+        assert len(versions) == 1
+        vts = versions[0]["version_timestamp"]
+        resp = tc.post(f"/api/memories/{mid}/restore?version_timestamp={vts}")
+        assert resp.status_code == 200
+        assert resp.json()["value"] == "v1"
+        # Verify the memory was actually restored
+        current = tc.get(f"/api/memories/{mid}").json()
+        assert current["value"] == "v1"
+
+    def test_restore_memory_not_found(self, client):
+        tc, *_ = client
+        resp = tc.post("/api/memories/no-such-id/restore?version_timestamp=ts")
+        assert resp.status_code == 404
+
+    def test_restore_version_not_found(self, client):
+        tc, *_ = client
+        mid = tc.post("/api/memories", json={"key": "rv-nf", "value": "v"}).json()["memory_id"]
+        resp = tc.post(f"/api/memories/{mid}/restore?version_timestamp=no-such-ts")
+        assert resp.status_code == 404
+
+    def test_restore_non_admin_cannot_restore_other_user_memory(self, client):
+        tc, storage, _ = client
+        from hive.models import Memory
+
+        other = Memory(key="other2", value="v", owner_client_id="x", owner_user_id="other-user")
+        storage.put_memory(other)
+        resp = tc.post(f"/api/memories/{other.memory_id}/restore?version_timestamp=ts")
+        assert resp.status_code == 404
+
+    def test_versions_dep_returns_storage(self):
+        import boto3
+        from moto import mock_aws
+
+        with mock_aws():
+            boto3.client("dynamodb", region_name="us-east-1").create_table(
+                TableName="hive",
+                KeySchema=[
+                    {"AttributeName": "PK", "KeyType": "HASH"},
+                    {"AttributeName": "SK", "KeyType": "RANGE"},
+                ],
+                AttributeDefinitions=[
+                    {"AttributeName": "PK", "AttributeType": "S"},
+                    {"AttributeName": "SK", "AttributeType": "S"},
+                ],
+                BillingMode="PAY_PER_REQUEST",
+            )
+            from hive.api.versions import _storage
+            from hive.storage import HiveStorage
+
+            assert isinstance(_storage(), HiveStorage)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -763,3 +763,97 @@ class TestForgetAll:
         read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
         with pytest.raises(ToolError, match="Insufficient scope"):
             await forget_all("t", ctx=_make_ctx(read_only_jwt))
+
+
+# ---------------------------------------------------------------------------
+# memory_history
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryHistory:
+    async def test_memory_history_returns_versions(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.server import memory_history, remember
+
+        await remember("hist-k", "v1", [], ctx=_make_ctx(jwt))
+        await remember("hist-k", "v2", [], ctx=_make_ctx(jwt))
+        result = await memory_history("hist-k", ctx=_make_ctx(jwt))
+        assert len(result) == 1
+        assert result[0]["value"] == "v1"
+
+    async def test_memory_history_empty_for_new_memory(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.server import memory_history, remember
+
+        await remember("new-hist", "v1", [], ctx=_make_ctx(jwt))
+        result = await memory_history("new-hist", ctx=_make_ctx(jwt))
+        assert result == []
+
+    async def test_memory_history_raises_for_missing_key(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import memory_history
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="No memory found"):
+            await memory_history("no-such-key", ctx=_make_ctx(jwt))
+
+    async def test_memory_history_requires_read_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import memory_history
+
+        storage, _, _ = server_env
+        write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await memory_history("k", ctx=_make_ctx(write_only_jwt))
+
+
+# ---------------------------------------------------------------------------
+# restore_memory
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreMemory:
+    async def test_restore_memory_reverts_value(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.server import memory_history, remember, restore_memory
+
+        await remember("rst-k", "v1", [], ctx=_make_ctx(jwt))
+        await remember("rst-k", "v2", [], ctx=_make_ctx(jwt))
+        versions = await memory_history("rst-k", ctx=_make_ctx(jwt))
+        vts = versions[0]["version_timestamp"]
+        result = await restore_memory("rst-k", vts, ctx=_make_ctx(jwt))
+        assert "rst-k" in result
+        m = storage.get_memory_by_key("rst-k")
+        assert m is not None
+        assert m.value == "v1"
+
+    async def test_restore_memory_raises_for_missing_key(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import restore_memory
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="No memory found"):
+            await restore_memory("no-such-key", "ts", ctx=_make_ctx(jwt))
+
+    async def test_restore_memory_raises_for_missing_version(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember, restore_memory
+
+        _, _, jwt = server_env
+        await remember("rv-k", "v", [], ctx=_make_ctx(jwt))
+        with pytest.raises(ToolError, match="not found"):
+            await restore_memory("rv-k", "bad-ts", ctx=_make_ctx(jwt))
+
+    async def test_restore_memory_requires_write_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import restore_memory
+
+        storage, _, _ = server_env
+        read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await restore_memory("k", "ts", ctx=_make_ctx(read_only_jwt))

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -256,6 +256,82 @@ class TestMemoryStorage:
         m = Memory(key="k", value="v", owner_client_id="c1", expires_at=past)
         assert m.is_expired
 
+    def test_put_memory_saves_version_on_update(self, storage):
+        """Updating an existing memory should create a version snapshot."""
+        m = Memory(key="v-key", value="v1", owner_client_id="c1")
+        storage.put_memory(m)
+        m.value = "v2"
+        storage.put_memory(m)
+        versions = storage.list_memory_versions(m.memory_id)
+        assert len(versions) == 1
+        assert versions[0].value == "v1"
+
+    def test_put_new_memory_does_not_create_version(self, storage):
+        """Creating a brand-new memory should NOT create a version snapshot."""
+        m = Memory(key="fresh", value="x", owner_client_id="c1")
+        storage.put_memory(m)
+        assert storage.list_memory_versions(m.memory_id) == []
+
+
+# ---------------------------------------------------------------------------
+# Memory version tests
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryVersionStorage:
+    def test_list_versions_newest_first(self, storage):
+
+        m = Memory(key="hist", value="v1", owner_client_id="c1")
+        storage.put_memory(m)
+        # two updates → two version snapshots
+        m.value = "v2"
+        storage.put_memory(m)
+        m.value = "v3"
+        storage.put_memory(m)
+        versions = storage.list_memory_versions(m.memory_id)
+        assert len(versions) == 2
+        # newest first (ScanIndexForward=False)
+        assert versions[0].value == "v2"
+        assert versions[1].value == "v1"
+
+    def test_get_memory_version_found(self, storage):
+        m = Memory(key="gv", value="original", owner_client_id="c1")
+        storage.put_memory(m)
+        m.value = "updated"
+        storage.put_memory(m)
+        versions = storage.list_memory_versions(m.memory_id)
+        assert len(versions) == 1
+        fetched = storage.get_memory_version(m.memory_id, versions[0].version_timestamp)
+        assert fetched is not None
+        assert fetched.value == "original"
+
+    def test_get_memory_version_not_found(self, storage):
+        m = Memory(key="missing-v", value="v", owner_client_id="c1")
+        storage.put_memory(m)
+        result = storage.get_memory_version(m.memory_id, "nonexistent-ts")
+        assert result is None
+
+    def test_version_serialise_deserialise(self):
+        from hive.models import MemoryVersion
+
+        m = Memory(key="ser", value="old-val", tags=["t1"], owner_client_id="c1")
+        v = MemoryVersion.from_memory(m)
+        item = v.to_dynamo()
+        restored = MemoryVersion.from_dynamo(item)
+        assert restored.memory_id == v.memory_id
+        assert restored.value == "old-val"
+        assert restored.tags == ["t1"]
+
+    def test_version_response_from_version(self):
+        from hive.models import MemoryVersion, MemoryVersionResponse
+
+        m = Memory(key="resp", value="v", tags=[], owner_client_id="c1")
+        v = MemoryVersion.from_memory(m)
+        resp = MemoryVersionResponse.from_version(v)
+        assert resp.memory_id == v.memory_id
+        assert resp.version_timestamp == v.version_timestamp
+        assert resp.value == "v"
+
 
 # ---------------------------------------------------------------------------
 # Client tests

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -53,6 +53,9 @@ export const api = {
   createMemory: (body) => request("POST", "/api/memories", body),
   updateMemory: (id, body) => request("PATCH", `/api/memories/${id}`, body),
   deleteMemory: (id) => request("DELETE", `/api/memories/${id}`),
+  listMemoryVersions: (id) => request("GET", `/api/memories/${id}/versions`),
+  restoreMemoryVersion: (id, versionTimestamp) =>
+    request("POST", `/api/memories/${id}/restore?version_timestamp=${encodeURIComponent(versionTimestamp)}`),
 
   // Clients
   listClients: ({ limit = 50, cursor } = {}) => {

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -362,6 +362,24 @@ describe("api", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Version history endpoints
+  // ---------------------------------------------------------------------------
+
+  it("listMemoryVersions calls correct URL", async () => {
+    mockOk([]);
+    await api.listMemoryVersions("mem-123");
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/memories/mem-123/versions");
+  });
+
+  it("restoreMemoryVersion calls correct URL with encoded timestamp", async () => {
+    mockOk({});
+    await api.restoreMemoryVersion("mem-123", "20260412T120000");
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      "/api/memories/mem-123/restore?version_timestamp=20260412T120000",
+    );
+  });
+
+  // ---------------------------------------------------------------------------
   // 401 handling — clears token and redirects
   // ---------------------------------------------------------------------------
 

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -182,6 +182,9 @@ export default function MemoryBrowser() {
   const [editing, setEditing] = useState(null); // memory object or null
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState({ key: "", value: "", tags: "", ttl: "" });
+  const [viewingHistory, setViewingHistory] = useState(null); // memory object or null
+  const [versions, setVersions] = useState([]);
+  const [versionsLoading, setVersionsLoading] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [pendingDelete, setPendingDelete] = useState(null);
   const searchDebounceRef = useRef(null);
@@ -322,17 +325,51 @@ export default function MemoryBrowser() {
     setEditing(m);
     setForm({ key: m.key, value: m.value, tags: m.tags.join(", "), ttl: "" });
     setCreating(false);
+    setViewingHistory(null);
+    setVersions([]);
   }
 
   function openCreate() {
     setCreating(true);
     setEditing(null);
     setForm({ key: "", value: "", tags: "", ttl: "" });
+    setViewingHistory(null);
+    setVersions([]);
   }
 
   function closePanel() {
     setEditing(null);
     setCreating(false);
+  }
+
+  async function openHistory(m) {
+    setViewingHistory(m);
+    setEditing(null);
+    setCreating(false);
+    setVersionsLoading(true);
+    try {
+      const vs = await api.listMemoryVersions(m.memory_id);
+      setVersions(vs);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setVersionsLoading(false);
+    }
+  }
+
+  function closeHistory() {
+    setViewingHistory(null);
+    setVersions([]);
+  }
+
+  async function handleRestore(versionTimestamp) {
+    try {
+      await api.restoreMemoryVersion(viewingHistory.memory_id, versionTimestamp);
+      closeHistory();
+      load();
+    } catch (err) {
+      setError(err.message);
+    }
   }
 
   // Programmatically focus the card at focusedIndex when it changes
@@ -431,9 +468,17 @@ export default function MemoryBrowser() {
                 </div>
               </button>
               <Button
+                variant="secondary"
+                size="sm"
+                className="ml-2 shrink-0 self-center"
+                onClick={() => openHistory(m)}
+              >
+                History
+              </Button>
+              <Button
                 variant="danger"
                 size="sm"
-                className="ml-3 shrink-0 self-center"
+                className="ml-2 shrink-0 self-center"
                 onClick={() => setPendingDelete(m.memory_id)}
               >
                 Delete
@@ -510,6 +555,41 @@ export default function MemoryBrowser() {
                 </Button>
               </div>
             </form>
+          </Card>
+        </div>
+      )}
+
+      {/* Version history panel */}
+      {viewingHistory && (
+        <div className="w-full md:w-[360px]">
+          <Card>
+            <h3 className="mb-4 text-base font-semibold">History: {viewingHistory.key}</h3>
+            {versionsLoading && <p className="text-[var(--text-muted)]">Loading…</p>}
+            {!versionsLoading && versions.length === 0 && (
+              <p className="text-[var(--text-muted)] text-sm">No previous versions.</p>
+            )}
+            <ul className="flex flex-col gap-3 list-none m-0 p-0">
+              {versions.map((v) => (
+                <li key={v.version_timestamp} className="border border-[var(--border)] rounded-[var(--radius)] p-3">
+                  <div className="text-[11px] text-[var(--text-muted)] mb-1">
+                    {new Date(v.recorded_at).toLocaleString()}
+                  </div>
+                  <p className="text-[13px] whitespace-pre-wrap mb-2">
+                    {v.value.length > 120 ? v.value.slice(0, 120) + "…" : v.value}
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => handleRestore(v.version_timestamp)}
+                  >
+                    Restore
+                  </Button>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-4">
+              <Button variant="secondary" onClick={closeHistory}>Close</Button>
+            </div>
           </Card>
         </div>
       )}

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -10,6 +10,8 @@ vi.mock("../api.js", () => ({
     createMemory: vi.fn(),
     updateMemory: vi.fn(),
     deleteMemory: vi.fn(),
+    listMemoryVersions: vi.fn(),
+    restoreMemoryVersion: vi.fn(),
   },
 }));
 
@@ -880,5 +882,140 @@ describe("MemoryBrowser", () => {
       "m1",
       expect.objectContaining({ ttl_seconds: 86400 }),
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Version history
+  // ---------------------------------------------------------------------------
+
+  it("opens history panel on History button click with no versions", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listMemoryVersions.mockResolvedValue([]);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+
+    await waitFor(() => expect(screen.getByText("History: test-key")).toBeTruthy());
+    expect(screen.getByText("No previous versions.")).toBeTruthy();
+  });
+
+  it("shows versions in history panel and truncates long values", async () => {
+    const shortVersion = {
+      version_timestamp: "20260412T120000000000",
+      value: "old value",
+      tags: [],
+      recorded_at: "2026-04-12T12:00:00.000Z",
+    };
+    const longVersion = {
+      version_timestamp: "20260412T110000000000",
+      value: "x".repeat(200),
+      tags: [],
+      recorded_at: "2026-04-12T11:00:00.000Z",
+    };
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listMemoryVersions.mockResolvedValue([shortVersion, longVersion]);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+
+    await waitFor(() => expect(screen.getByText("old value")).toBeTruthy());
+    // Long value gets truncated with ellipsis
+    expect(screen.getByText(/x{120}…/)).toBeTruthy();
+    expect(screen.getAllByText("Restore")).toHaveLength(2);
+  });
+
+  it("restores a version and closes history panel", async () => {
+    const version = {
+      version_timestamp: "20260412T120000000000",
+      value: "old value",
+      tags: [],
+      recorded_at: "2026-04-12T12:00:00.000Z",
+    };
+    api.listMemories
+      .mockResolvedValueOnce({ items: [makeMemory()], next_cursor: null })
+      .mockResolvedValue({ items: [], next_cursor: null });
+    api.listMemoryVersions.mockResolvedValue([version]);
+    api.restoreMemoryVersion.mockResolvedValue({});
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+    await waitFor(() => screen.getByText("Restore"));
+    await act(async () => fireEvent.click(screen.getByText("Restore")));
+
+    expect(api.restoreMemoryVersion).toHaveBeenCalledWith("m1", "20260412T120000000000");
+    await waitFor(() => expect(screen.queryByText("History: test-key")).toBeNull());
+  });
+
+  it("shows error when restore fails", async () => {
+    const version = {
+      version_timestamp: "20260412T120000000000",
+      value: "old value",
+      tags: [],
+      recorded_at: "2026-04-12T12:00:00.000Z",
+    };
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listMemoryVersions.mockResolvedValue([version]);
+    api.restoreMemoryVersion.mockRejectedValue(new Error("Restore failed"));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+    await waitFor(() => screen.getByText("Restore"));
+    await act(async () => fireEvent.click(screen.getByText("Restore")));
+
+    await waitFor(() => expect(screen.getByText("Restore failed")).toBeTruthy());
+  });
+
+  it("closes history panel on Close button click", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listMemoryVersions.mockResolvedValue([]);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+    await waitFor(() => screen.getByText("History: test-key"));
+    fireEvent.click(screen.getByText("Close"));
+    expect(screen.queryByText("History: test-key")).toBeNull();
+  });
+
+  it("shows error when listMemoryVersions fails", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listMemoryVersions.mockRejectedValue(new Error("History load failed"));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+
+    await waitFor(() => expect(screen.getByText("History load failed")).toBeTruthy());
+  });
+
+  it("opening create form clears history panel", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listMemoryVersions.mockResolvedValue([]);
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+    await waitFor(() => screen.getByText("History: test-key"));
+    fireEvent.click(screen.getByText("+ New"));
+    expect(screen.queryByText("History: test-key")).toBeNull();
+    expect(screen.getByText("New Memory")).toBeTruthy();
+  });
+
+  it("opening edit form clears history panel", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listMemoryVersions.mockResolvedValue([]);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+    await waitFor(() => screen.getByText("History: test-key"));
+    fireEvent.click(getCard());
+    expect(screen.queryByText("History: test-key")).toBeNull();
+    expect(screen.getByText("Edit: test-key")).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #150

## Summary
- `put_memory` now snapshots the current value as `VERSION#{timestamp}` item before overwriting, with a 30-day TTL (configurable via `HIVE_VERSION_RETENTION_DAYS`)
- New MCP tools: `memory_history(key)` returns all previous versions; `restore_memory(key, version_timestamp)` reverts to a prior snapshot
- New REST endpoints: `GET /api/memories/{id}/versions` and `POST /api/memories/{id}/restore?version_timestamp=`
- MemoryBrowser UI: "History" button per card opens a side panel showing version timeline with timestamps and Restore buttons

## Approach
- Version items use `PK=MEMORY#{id}`, `SK=VERSION#{timestamp}` (same partition as the memory), queried with `begins_with("VERSION#")` and `ScanIndexForward=False` for newest-first order
- TTL set on version items so DynamoDB auto-prunes old history after retention period
- `MemoryVersion.from_memory()` creates a snapshot from the current Memory state before any mutation