### PR TITLE
feat: harden repo against malicious contributions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files require review by the repository owner.
+* @warlordofmars

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,3 +17,4 @@
 - [ ] PR title is descriptive
 - [ ] Closes #<!-- issue number -->
 - [ ] Docs updated if behaviour changed
+- [ ] No secrets or credentials committed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
           sarif_file: trivy-deps.sarif
           category: trivy-deps
 
+      - name: Gitleaks — secret scan
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #163

## Summary
- Add `.github/CODEOWNERS` requiring `@warlordofmars` review on all files
- Add gitleaks secret scan step to the Security Audit CI job (pinned to commit SHA)
- Add "no secrets committed" item to the PR checklist template
- Apply branch protection on `main`: required reviews, CODEOWNERS enforcement, all CI status checks required, no direct pushes, no force pushes, enforce admins
- Apply branch protection on `development`: required CI status checks, no force pushes

## Approach
GitHub API was used to set branch protection rules immediately — no manual Settings UI steps needed. Gitleaks v2 pinned to `ff98106e4c7b2bc287b24eaf42907196329070c7`. Dependabot already covers pip + npm + GitHub Actions. Trivy + SonarCloud + coverage gate already enforce IaC, CVE, and test integrity.