### PR TITLE
feat: e2e tests for cost data in admin dashboard

### DIFF
--- a/tests/e2e/test_admin_e2e.py
+++ b/tests/e2e/test_admin_e2e.py
@@ -120,3 +120,55 @@ class TestAdminMetricsE2E:
             assert total_invocations > 0, (
                 "No invocation data found in 7d window — synthetic traffic may not have run yet"
             )
+
+
+@pytest.mark.asyncio
+class TestAdminCostsE2E:
+    async def test_costs_returns_200(self, live_admin_token):
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/costs",
+                headers={"Authorization": f"Bearer {live_admin_token}"},
+            )
+            assert resp.status_code == 200, resp.text
+
+    async def test_costs_response_structure(self, live_admin_token):
+        """Response must contain required keys regardless of whether billing data exists."""
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/costs",
+                headers={"Authorization": f"Bearer {live_admin_token}"},
+            )
+            assert resp.status_code == 200, resp.text
+            data = resp.json()
+            assert "monthly" in data, "Response missing 'monthly' key"
+            assert "daily" in data, "Response missing 'daily' key"
+            assert "currency" in data, "Response missing 'currency' key"
+            assert "environment" in data, "Response missing 'environment' key"
+            assert isinstance(data["monthly"], list)
+            assert isinstance(data["daily"], list)
+
+    async def test_costs_monthly_items_have_correct_shape(self, live_admin_token):
+        """Each monthly item must have period, total, and by_service keys."""
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/costs",
+                headers={"Authorization": f"Bearer {live_admin_token}"},
+            )
+            assert resp.status_code == 200, resp.text
+            monthly = resp.json()["monthly"]
+            for item in monthly:
+                assert "period" in item, f"Monthly item missing 'period': {item}"
+                assert "total" in item, f"Monthly item missing 'total': {item}"
+                assert "by_service" in item, f"Monthly item missing 'by_service': {item}"
+                assert isinstance(item["total"], (int, float))
+                assert isinstance(item["by_service"], dict)
+
+    async def test_costs_requires_admin(self, live_token):
+        """MCP access tokens must not grant access to admin cost endpoints."""
+        async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:
+            resp = await http.get(
+                "/api/admin/costs",
+                headers={"Authorization": f"Bearer {live_token}"},
+            )
+            assert resp.status_code == 401

--- a/tests/e2e/test_dashboard_e2e.py
+++ b/tests/e2e/test_dashboard_e2e.py
@@ -71,3 +71,23 @@ class TestDashboardE2E:
             assert not page.locator("text=Failed to load metrics").is_visible(), (
                 f"Error banner appeared after switching to {period}"
             )
+
+    def test_cost_section_renders_without_error(self, admin_browser_page):
+        """Cost section must render without an error banner and without a stuck spinner."""
+        page = admin_browser_page
+        page.locator("nav button:has-text('Dashboard')").click()
+        page.wait_for_load_state("networkidle")
+        # No cost error banner
+        assert not page.locator("text=Failed to load costs").is_visible()
+        # Cost section heading is present
+        assert page.locator("text=Cost").first.is_visible()
+        # Either a cost chart or the "no data" placeholder must be visible (not a stuck spinner)
+        has_data = page.locator(".recharts-responsive-container").count() > 0
+        has_placeholder = (
+            page.locator("text=No cost data available yet.").is_visible()
+            or page.locator("text=No daily cost data available yet.").is_visible()
+        )
+        assert has_data or has_placeholder, (
+            "Cost section shows neither a chart nor a no-data placeholder — "
+            "the spinner may be stuck or the section failed silently"
+        )


### PR DESCRIPTION
Closes #142

## Summary
- Add `TestAdminCostsE2E` class to `test_admin_e2e.py` with 4 tests covering the `GET /api/admin/costs` endpoint structure and auth requirements
- Add `test_cost_section_renders_without_error` to `test_dashboard_e2e.py` verifying the UI cost section renders without error banners and shows either a chart or a no-data placeholder

## Approach
Cost data may be sparse (especially after a fresh deploy), so tests assert structure rather than dollar amounts. The UI test uses Playwright's `.recharts-responsive-container` selector to detect rendered charts, with fallback to text placeholders. Both tests will soft-pass when data is absent but error out if the section fails silently.