### PR TITLE
feat: Slack notifications for CI/CD pipeline events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,33 @@ jobs:
           sarif_file: trivy-iac.sarif
           category: trivy-iac
 
+  notify-pipeline-failure:
+    name: Notify Slack — CI Failure
+    needs: [lint-typecheck, audit, unit-tests, integration-tests, coverage, frontend, infra-synth]
+    if: >-
+      always() &&
+      contains(needs.*.result, 'failure') &&
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Notify Slack
+        if: env.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: CI pipeline failed on *${{ github.ref_name }}*",
+              "attachments": [{
+                "color": "danger",
+                "text": "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              }]
+            }
+
 # ── Deploy to dev (push to development) ───────────────────────────────────────
 
   deploy-dev:
@@ -481,6 +508,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     outputs:
       mcp_url: ${{ steps.urls.outputs.mcp_url }}
       api_url: ${{ steps.urls.outputs.api_url }}
@@ -535,11 +564,43 @@ jobs:
           echo "api_url=$(query ApiFunctionUrl)"  >> "$GITHUB_OUTPUT"
           echo "ui_url=$(query UiUrl)"            >> "$GITHUB_OUTPUT"
 
+      - name: Notify Slack — deploy success
+        if: env.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":white_check_mark: Deploy to *dev* succeeded",
+              "attachments": [{
+                "color": "good",
+                "text": "MCP: ${{ steps.urls.outputs.mcp_url }}\nAPI: ${{ steps.urls.outputs.api_url }}\nUI: ${{ steps.urls.outputs.ui_url }}"
+              }]
+            }
+
+      - name: Notify Slack — deploy failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: Deploy to *dev* failed",
+              "attachments": [{
+                "color": "danger",
+                "text": "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              }]
+            }
+
   e2e-dev:
     name: E2E Tests (dev)
     needs: deploy-dev
     if: github.event_name == 'push' && github.ref == 'refs/heads/development'
     runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -630,6 +691,21 @@ jobs:
           HIVE_BEARER_TOKEN: ${{ steps.synth-token.outputs.token }}
         run: uv run python scripts/synthetic_traffic.py
 
+      - name: Notify Slack — e2e failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: E2E tests failed on *dev* after deploy",
+              "attachments": [{
+                "color": "danger",
+                "text": "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              }]
+            }
+
 # ── Release + deploy to prod (push to main) ───────────────────────────────────
 
   release:
@@ -675,6 +751,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     outputs:
       mcp_url: ${{ steps.urls.outputs.mcp_url }}
       api_url: ${{ steps.urls.outputs.api_url }}
@@ -730,11 +808,43 @@ jobs:
           echo "api_url=$(query ApiFunctionUrl)"  >> "$GITHUB_OUTPUT"
           echo "ui_url=$(query UiUrl)"            >> "$GITHUB_OUTPUT"
 
+      - name: Notify Slack — deploy success
+        if: env.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":white_check_mark: Deploy to *prod* succeeded — version `${{ needs.release.outputs.version }}`",
+              "attachments": [{
+                "color": "good",
+                "text": "MCP: ${{ steps.urls.outputs.mcp_url }}\nAPI: ${{ steps.urls.outputs.api_url }}\nUI: ${{ steps.urls.outputs.ui_url }}"
+              }]
+            }
+
+      - name: Notify Slack — deploy failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: Deploy to *prod* failed — version `${{ needs.release.outputs.version }}`",
+              "attachments": [{
+                "color": "danger",
+                "text": "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              }]
+            }
+
   e2e-prod:
     name: E2E Tests (prod)
     needs: deploy-prod
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -756,6 +866,21 @@ jobs:
 
       # UI e2e tests require HIVE_BYPASS_GOOGLE_AUTH which is dev-only.
       # They run in the dev pipeline; no need to repeat against prod.
+
+      - name: Notify Slack — e2e failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: E2E tests failed on *prod* after deploy",
+              "attachments": [{
+                "color": "danger",
+                "text": "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              }]
+            }
 
   back-merge:
     name: Back-merge main → development


### PR DESCRIPTION
Closes #43

## Summary
- Adds `notify-pipeline-failure` job that fires when any CI job (lint, tests, infra synth) fails on `development` or `main` pushes
- Adds deploy success/failure notifications to `deploy-dev` and `deploy-prod` with version and stack URLs
- Adds e2e failure notifications to `e2e-dev` and `e2e-prod`
- All notifications are gated on `SLACK_WEBHOOK_URL` secret being set — the workflow degrades gracefully when the secret is absent

## Approach
Uses `slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d` (v2.0.0) pinned to commit SHA per project convention. The `SLACK_WEBHOOK_URL` secret is set as a job-level env var and checked with `if: env.SLACK_WEBHOOK_URL != ''` on each notify step, which avoids breaking forks or environments that haven't configured the secret.

GitHub events (PR opened/merged, release published) are covered by the GitHub → Slack app (Option A from the issue) and require no workflow changes.