### PR TITLE
fix: use JS eval to detect cost error banner in dashboard e2e test

### DIFF
--- a/tests/e2e/test_dashboard_e2e.py
+++ b/tests/e2e/test_dashboard_e2e.py
@@ -88,7 +88,13 @@ class TestDashboardE2E:
             page.locator("text=No cost data available yet.").is_visible()
             or page.locator("text=No daily cost data available yet.").is_visible()
         )
-        has_error = page.locator("[style*='var(--danger)']").count() > 0
+        # CSS attribute selectors don't reliably match React inline-style CSS custom
+        # properties in Chromium, so evaluate via JavaScript instead.
+        has_error = page.evaluate(
+            "() => [...document.querySelectorAll('div')].some("
+            "  d => d.style.color === 'var(--danger)'"
+            ")"
+        )
         assert has_data or has_placeholder or has_error, (
             "Cost section shows neither a chart, a no-data placeholder, nor an error banner — "
             "the spinner may be stuck or the section failed silently"


### PR DESCRIPTION
## Summary
- Fixes `test_cost_section_renders_without_error` which was failing because `[style*='var(--danger)']` CSS attribute selectors don't reliably match React inline styles using CSS custom properties in Chromium
- Replaces the CSS selector with `page.evaluate()` to check `element.style.color === 'var(--danger)'` directly via JavaScript

## Why this matters
When the costs API returns an error with a message other than the default "Failed to load costs", the ErrorBanner renders with `color: var(--danger)` but the charts render `null`. The previous test had no way to detect this valid resolved state, causing it to assert neither a chart, placeholder, nor error was visible.