### PR TITLE
fix: wait for loading skeletons before asserting cost section state in e2e

### DIFF
--- a/tests/e2e/test_dashboard_e2e.py
+++ b/tests/e2e/test_dashboard_e2e.py
@@ -77,6 +77,14 @@ class TestDashboardE2E:
         page = admin_browser_page
         page.locator("nav button:has-text('Dashboard')").click()
         page.wait_for_load_state("networkidle")
+        # networkidle can fire before React's useEffect has started the fetch calls.
+        # Wait until all loading skeletons (divs with pulse animation) disappear, which
+        # confirms the cost API calls have completed (success or error).
+        page.wait_for_function(
+            "() => [...document.querySelectorAll('div')]"
+            "  .every(d => !d.style.animation || !d.style.animation.includes('pulse'))",
+            timeout=15000,
+        )
         # Cost section heading is present
         assert page.locator("text=Monthly AWS Spend").is_visible()
         # Section must be in one of three valid resolved states (not a stuck spinner):


### PR DESCRIPTION
## Summary
- Adds `page.wait_for_function()` after `networkidle` to wait until all loading skeleton divs (identified by their `pulse` animation) have disappeared before asserting the cost section state
- This prevents a race condition where `networkidle` fires before React's `useEffect` has started the API fetch calls, leaving the test to see the skeleton loading state instead of the resolved state

## Root cause
`networkidle` fires when there have been no network connections for 500ms. React's `useEffect` runs asynchronously after the component renders — between the Dashboard tab click and the first fetch request, there's a microtask gap where the page appears idle. The test was checking conditions before the fetch calls even started.