### PR TITLE
fix: skip sonar quality gate wait on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          # SonarCloud free plan only supports one main branch (development).
+          # Quality gate status API returns 'not found' for main, so skip the
+          # wait on main-branch pushes; keep it enforced on development + PRs.
+          args: ${{ github.ref == 'refs/heads/main' && '-Dsonar.qualitygate.wait=false' || '' }}
 
       - name: Fetch SonarCloud issues as SARIF
         if: always()


### PR DESCRIPTION
## Summary

Free SonarCloud plan only supports one main branch — ours is `development`. The quality gate status API returns "Project not found" for `main`-branch analyses, blocking the release pipeline.

Pass `-Dsonar.qualitygate.wait=false` as an extra scanner arg only when running on `main`. The gate continues to be enforced on `development` pushes and PRs.

## Root cause

`sonar.qualitygate.wait=true` in `sonar-project.properties` is correct for development — but on a `main` push, SonarCloud's quality gate API can't find the project because `main` isn't the configured main branch in SonarCloud.