### PR TITLE
fix: replace prod e2e tests with API smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -860,17 +860,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Install Playwright
-        run: uv run playwright install chromium --with-deps
-
-      - name: Run auth + MCP e2e tests
+      # All e2e tests require HIVE_BYPASS_GOOGLE_AUTH which is dev-only.
+      # Run a lightweight smoke test instead — just verify the prod API is up.
+      - name: Smoke test prod API
         env:
           HIVE_API_URL: ${{ needs.deploy-prod.outputs.api_url }}
-          HIVE_MCP_URL: ${{ needs.deploy-prod.outputs.mcp_url }}
-        run: uv run pytest tests/e2e/test_auth_e2e.py tests/e2e/test_mcp_e2e.py -v
-
-      # UI e2e tests require HIVE_BYPASS_GOOGLE_AUTH which is dev-only.
-      # They run in the dev pipeline; no need to repeat against prod.
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HIVE_API_URL/health")
+          echo "Health check status: $STATUS"
+          [ "$STATUS" = "200" ] || (echo "Prod health check failed!" && exit 1)
 
       - name: Notify Slack — e2e failure
         if: failure() && env.SLACK_WEBHOOK_URL != ''


### PR DESCRIPTION
## Summary

All e2e tests (`test_auth_e2e.py`, `test_mcp_e2e.py`) use `HIVE_BYPASS_GOOGLE_AUTH` to acquire tokens — this is dev-only and can't be set in prod. The prod e2e job was failing at setup for every test with "Google OAuth redirect".

Replace with a simple curl health check against `GET /health`. Full e2e coverage already ran in the dev pipeline before this deploy.

## Root cause

`test_mcp_e2e.py` was added to the prod e2e job when the comment already noted that UI tests can't run in prod for this exact reason — the same constraint applies to all tests that need a token.