### PR TITLE
fix: MCP auth — Meta.get() error and missing HTTP 401 for OAuth clients

### DIFF
--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -79,6 +79,25 @@ async def oauth_metadata(request: Request) -> JSONResponse:
     )
 
 
+@router.get("/.well-known/oauth-protected-resource", include_in_schema=False)
+async def protected_resource_metadata() -> JSONResponse:
+    """RFC 9728 protected resource metadata.
+
+    Tells OAuth clients (e.g. Claude Desktop) which authorization server
+    issues valid tokens for the Hive MCP server.  CloudFront routes
+    /.well-known/* to this API Lambda, so the document must live here rather
+    than on the MCP Lambda.
+    """
+    return JSONResponse(
+        {
+            "resource": f"{ISSUER}/mcp",
+            "authorization_servers": [ISSUER],
+            "scopes_supported": ["memories:read", "memories:write"],
+            "bearer_methods_supported": ["header"],
+        }
+    )
+
+
 # ---------------------------------------------------------------------------
 # Dynamic Client Registration
 # ---------------------------------------------------------------------------

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -23,12 +23,15 @@ from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
+from fastmcp.server.auth import AccessToken as FastMCPAccessToken
+from fastmcp.server.auth import RemoteAuthProvider, TokenVerifier
 from fastmcp.server.dependencies import get_http_request
+from pydantic import AnyHttpUrl
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse as StarletteJSONResponse
 
-from hive.auth.tokens import _origin_verify_secret, validate_bearer_token
+from hive.auth.tokens import ISSUER, _origin_verify_secret, validate_bearer_token
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 from hive.metrics import emit_metric
 from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult
@@ -41,6 +44,28 @@ configure_logging("mcp")
 logger = get_logger("hive.server")
 
 _MEMORIES_READ_SCOPE = "memories:read"
+
+
+class HiveTokenVerifier(TokenVerifier):
+    """Wraps Hive token validation for FastMCP's built-in auth middleware.
+
+    Enables FastMCP to return HTTP 401 + WWW-Authenticate headers on
+    unauthenticated requests, triggering the OAuth flow in clients like
+    Claude Desktop.  The full validation (rate limit, scope) is still
+    enforced per-tool by _auth().
+    """
+
+    async def verify_token(self, token: str) -> FastMCPAccessToken | None:
+        try:
+            validated = validate_bearer_token(f"Bearer {token}", HiveStorage())
+            return FastMCPAccessToken(
+                token=token,
+                client_id=validated.client_id,
+                scopes=validated.scope.split(),
+                expires_at=int(validated.expires_at.timestamp()),
+            )
+        except ValueError:
+            return None
 
 
 class _OriginVerifyMiddleware(BaseHTTPMiddleware):
@@ -76,6 +101,13 @@ mcp = FastMCP(
         "Use the memory tools to store, retrieve, and organise information across "
         "conversations and agent runs."
     ),
+    auth=RemoteAuthProvider(
+        token_verifier=HiveTokenVerifier(),
+        authorization_servers=[AnyHttpUrl(ISSUER)],
+        base_url=ISSUER,
+        scopes_supported=["memories:read", "memories:write"],
+        resource_name="Hive",
+    ),
 )
 
 # ---------------------------------------------------------------------------
@@ -110,10 +142,16 @@ def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple[HiveS
     except RuntimeError:
         pass
 
-    # Fallback: direct invocation or integration tests pass token via meta
+    # Fallback: direct invocation or integration tests pass token via meta.
+    # Tests inject a plain dict; FastMCP passes a Pydantic Meta model whose
+    # extra fields live in model_extra rather than being dict-accessible.
     if not auth_header and ctx and ctx.request_context and ctx.request_context.meta:
-        meta: dict[str, Any] = ctx.request_context.meta  # type: ignore[assignment]
-        auth_header = meta.get("Authorization") or meta.get("authorization")
+        meta = ctx.request_context.meta
+        if isinstance(meta, dict):
+            meta_dict: dict[str, Any] = meta
+        else:
+            meta_dict = getattr(meta, "model_extra", None) or {}
+        auth_header = meta_dict.get("Authorization") or meta_dict.get("authorization")
 
     try:
         token = validate_bearer_token(auth_header, storage)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -263,6 +263,20 @@ class TestOAuthDiscovery:
         assert "code_challenge_methods_supported" in data
         assert "S256" in data["code_challenge_methods_supported"]
 
+    def test_protected_resource_metadata(self, oauth_client):
+        tc, *_ = oauth_client
+        resp = tc.get("/.well-known/oauth-protected-resource")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "resource" in data
+        assert "/mcp" in data["resource"]
+        assert "authorization_servers" in data
+        assert len(data["authorization_servers"]) > 0
+        assert "scopes_supported" in data
+        assert "memories:read" in data["scopes_supported"]
+        assert "memories:write" in data["scopes_supported"]
+        assert data["bearer_methods_supported"] == ["header"]
+
 
 class TestOAuthRegister:
     def test_register_public_client(self, oauth_client):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -857,3 +857,28 @@ class TestRestoreMemory:
         read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
         with pytest.raises(ToolError, match="Insufficient scope"):
             await restore_memory("k", "ts", ctx=_make_ctx(read_only_jwt))
+
+
+# ---------------------------------------------------------------------------
+# HiveTokenVerifier
+# ---------------------------------------------------------------------------
+
+
+class TestHiveTokenVerifier:
+    async def test_valid_token_returns_access_token(self, server_env):
+        from hive.server import HiveTokenVerifier
+
+        _, client_id, jwt = server_env
+        verifier = HiveTokenVerifier()
+        result = await verifier.verify_token(jwt)
+        assert result is not None
+        assert result.client_id == client_id
+        assert "memories:read" in result.scopes
+        assert "memories:write" in result.scopes
+
+    async def test_invalid_token_returns_none(self, server_env):
+        from hive.server import HiveTokenVerifier
+
+        verifier = HiveTokenVerifier()
+        result = await verifier.verify_token("not-a-valid-token")
+        assert result is None


### PR DESCRIPTION
Closes #370

## Summary

- Fix `_auth()` fallback path: `ctx.request_context.meta` is now a Pydantic `RequestParams.Meta` model, not a plain dict — use `model_extra` for the production path, keep the dict branch for test mocks
- Add `HiveTokenVerifier` + `RemoteAuthProvider` to `FastMCP(auth=...)` so unauthenticated HTTP requests return a proper 401 + `WWW-Authenticate: Bearer resource_metadata="..."` header, triggering the OAuth flow in Claude Desktop and other compliant MCP clients
- Add `GET /.well-known/oauth-protected-resource` (RFC 9728) to the API Lambda — CloudFront routes `/.well-known/*` to the API app, so the document that points clients at the authorization server must live there, not on the MCP Lambda

## Approach

`RemoteAuthProvider` is composed with a thin `HiveTokenVerifier` wrapper around the existing `validate_bearer_token` logic. The existing `_auth()` per-tool helper is unchanged — it still enforces rate limits, per-tool scope checking, and handles test injection via meta. This means tokens are validated twice on the HTTP path (once by FastMCP middleware, once by `_auth()`), which is an acceptable trade-off for keeping the change minimal and low-risk.

The `/.well-known/oauth-protected-resource` route is added to the API Lambda's `oauth.py` router. FastMCP also generates this route internally on the MCP Lambda, but that copy is unreachable because CloudFront routes all `/.well-known/*` traffic to the API Lambda.