### PR TITLE
fix: omit client_secret from DCR response for public clients

### DIFF
--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -619,8 +619,8 @@ class ClientRegistrationResponse(BaseModel):
     client_id_issued_at: int  # Unix timestamp
 
     @model_serializer(mode="wrap")
-    def _drop_null_secret(self, handler: object) -> dict:  # type: ignore[override]
-        data = handler(self)  # type: ignore[call-arg]
+    def _drop_null_secret(self, handler: Any) -> dict:  # type: ignore[override]
+        data = handler(self)
         if data.get("client_secret") is None:
             data.pop("client_secret", None)
         return data

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
 
 _DEFAULT_SCOPE = "memories:read memories:write"
 
@@ -601,7 +601,12 @@ class ClientRegistrationRequest(BaseModel):
 
 
 class ClientRegistrationResponse(BaseModel):
-    """RFC 7591 dynamic client registration response."""
+    """RFC 7591 dynamic client registration response.
+
+    ``client_secret`` is omitted entirely for public clients (RFC 7591 §3.2.1)
+    rather than serialised as ``null``, which breaks strict Zod schemas in
+    clients such as mcp-remote.
+    """
 
     client_id: str
     client_secret: str | None = None
@@ -612,6 +617,13 @@ class ClientRegistrationResponse(BaseModel):
     scope: str
     token_endpoint_auth_method: str
     client_id_issued_at: int  # Unix timestamp
+
+    @model_serializer(mode="wrap")
+    def _drop_null_secret(self, handler: object) -> dict:  # type: ignore[override]
+        data = handler(self)  # type: ignore[call-arg]
+        if data.get("client_secret") is None:
+            data.pop("client_secret", None)
+        return data
 
     @classmethod
     def from_client(cls, c: OAuthClient) -> ClientRegistrationResponse:

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, model_serializer
+from pydantic import BaseModel, Field, model_serializer
 
 _DEFAULT_SCOPE = "memories:read memories:write"
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -291,7 +291,7 @@ class TestOAuthRegister:
         assert resp.status_code == 201
         data = resp.json()
         assert data["client_id"]
-        assert data["client_secret"] is None
+        assert "client_secret" not in data  # omitted for public clients (RFC 7591)
 
     def test_register_invalid_grant_type_returns_400(self, oauth_client):
         tc, *_ = oauth_client


### PR DESCRIPTION
## Summary

`mcp-remote` fails to connect with a Zod validation error:
```
"path": ["client_secret"],
"message": "Invalid input: expected string, received null"
```

Our DCR endpoint returns `"client_secret": null` for public clients. RFC 7591 §3.2.1 says the field should only be present for confidential clients — `mcp-remote`'s strict Zod schema rejects `null`.

Fix: use a `model_serializer` on `ClientRegistrationResponse` to drop the `client_secret` key entirely when it's `None`.

Closes #370

## Test plan
- `test_register_public_client` now asserts `"client_secret" not in data` (was `data["client_secret"] is None`)
- All 108 existing auth + model unit tests pass