### PR TITLE
feat: add Terms of Service and Privacy Policy pages

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -12,6 +12,8 @@ import LogViewer from "./components/LogViewer.jsx";
 import ChangelogPage from "./components/ChangelogPage.jsx";
 import FaqPage from "./components/FaqPage.jsx";
 import HomePage from "./components/HomePage.jsx";
+import PrivacyPage from "./components/PrivacyPage.jsx";
+import TermsPage from "./components/TermsPage.jsx";
 import LoginPage from "./components/LoginPage.jsx";
 import McpClientsPage from "./components/McpClientsPage.jsx";
 import PricingPage from "./components/PricingPage.jsx";
@@ -249,6 +251,8 @@ export default function App() {
         <Route path="/clients" element={<McpClientsPage />} />
         <Route path="/changelog" element={<ChangelogPage />} />
         <Route path="/status" element={<StatusPage />} />
+        <Route path="/terms" element={<TermsPage />} />
+        <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/app" element={<AppShell />} />
         <Route path="/oauth/callback" element={<AuthCallback />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -63,6 +63,8 @@ export default function PageLayout({ children }) {
               <a href="/docs/" className="no-underline hover:text-[var(--text)] transition-colors">Docs</a>
               <a href="/changelog" className="no-underline hover:text-[var(--text)] transition-colors">Changelog</a>
               <a href="/status" className="no-underline hover:text-[var(--text)] transition-colors">Status</a>
+              <a href="/terms" className="no-underline hover:text-[var(--text)] transition-colors">Terms</a>
+              <a href="/privacy" className="no-underline hover:text-[var(--text)] transition-colors">Privacy</a>
             </div>
           </div>
           <p className="mt-6 text-[13px] text-[var(--text-muted)]">© 2026 Hive. Free to use.</p>

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -82,6 +82,15 @@ describe("PageLayout", () => {
     expect(screen.getAllByText("Clients").length).toBeGreaterThanOrEqual(1);
   });
 
+  it("renders footer Terms and Privacy links", async () => {
+    const { container } = await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    const footer = container.querySelector("footer");
+    expect(within(footer).getByText("Terms")).toBeTruthy();
+    expect(within(footer).getByText("Privacy")).toBeTruthy();
+  });
+
   it("active nav link has orange bottom border for current page", async () => {
     const { container } = await act(async () =>
       renderInRouter(<PageLayout><span /></PageLayout>, "/pricing")

--- a/ui/src/components/PrivacyPage.jsx
+++ b/ui/src/components/PrivacyPage.jsx
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import PageLayout from "@/components/PageLayout";
+
+function Section({ title, children }) {
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl font-bold mb-3">{title}</h2>
+      <div className="text-sm text-[var(--text-muted)] leading-relaxed space-y-3">{children}</div>
+    </section>
+  );
+}
+
+export default function PrivacyPage() {
+  return (
+    <PageLayout>
+      {/* Header */}
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">Privacy Policy</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[520px] mx-auto leading-relaxed">
+            Last updated: April 2026. We keep this short and specific to Hive.
+          </p>
+        </div>
+      </section>
+
+      {/* Body */}
+      <section className="py-16 px-8">
+        <div className="max-w-[720px] mx-auto">
+
+          <Section title="1. Who We Are">
+            <p>
+              Hive is a shared persistent memory service for AI agents and teams. The Service is
+              operated by John Carter. Questions about this policy can be sent to{" "}
+              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
+                privacy@hive.so
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section title="2. Data We Collect">
+            <p>We collect only what is necessary to operate the Service:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                <strong>Email address</strong> — collected when you sign in via Google OAuth.
+                Used to identify your account, scope your memories, and (rarely) contact you about
+                service changes.
+              </li>
+              <li>
+                <strong>Memories</strong> — the key/value pairs you or your AI agents store using
+                the MCP tools. These are the core data of the Service and belong to you.
+              </li>
+              <li>
+                <strong>Activity logs</strong> — timestamped records of MCP tool calls (e.g.
+                <code> remember</code>, <code>recall</code>) and management API requests. Retained
+                for 90 days. Used for debugging, abuse detection, and usage statistics shown in
+                your account.
+              </li>
+              <li>
+                <strong>Usage metrics</strong> — aggregate CloudWatch metrics (request counts,
+                error rates, latency) used to monitor service health. Not linked to individual
+                user identities.
+              </li>
+              <li>
+                <strong>OAuth tokens</strong> — access and refresh tokens issued to your
+                registered MCP clients. Stored encrypted in DynamoDB with a TTL; purged
+                automatically on expiry.
+              </li>
+            </ul>
+          </Section>
+
+          <Section title="3. How We Use Your Data">
+            <ul className="list-disc pl-5 space-y-1">
+              <li>To authenticate you and serve your memories to your AI agents.</li>
+              <li>To display your activity log and usage statistics in the management UI.</li>
+              <li>To detect and prevent abuse or policy violations.</li>
+              <li>To notify you of significant changes to the Service or these policies.</li>
+            </ul>
+            <p>
+              We do not sell, rent, or share your personal data with third parties for marketing
+              purposes.
+            </p>
+          </Section>
+
+          <Section title="4. Where Data Is Stored">
+            <p>
+              All data is stored in AWS DynamoDB (us-east-1 region) behind AWS Lambda with IAM
+              role-based access. Semantic search embeddings are stored in AWS S3 Vectors in the
+              same region. No data is replicated to other cloud providers or regions.
+            </p>
+            <p>
+              AWS is our sole infrastructure provider. Their data-processing terms apply to
+              data at rest and in transit within AWS services.
+            </p>
+          </Section>
+
+          <Section title="5. Cookies and Local Storage">
+            <p>
+              Hive does not use tracking cookies. The management UI stores a single item in your
+              browser's <code>localStorage</code>:
+            </p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                <code>hive_mgmt_token</code> — a signed JWT issued after you authenticate via
+                Google OAuth. Used to authorise API requests from the management UI. Expires
+                after 24 hours. Removed when you sign out.
+              </li>
+            </ul>
+            <p>
+              No third-party cookies are set on the management UI. The marketing site may set
+              cookies via Google Analytics (see section 6).
+            </p>
+          </Section>
+
+          <Section title="6. Google Analytics 4">
+            <p>
+              The Hive marketing site (hive.so and its sub-pages, including <code>/pricing</code>,
+              {" "}<code>/faq</code>, <code>/use-cases</code>, and <code>/docs</code>) uses Google
+              Analytics 4 (GA4) to measure page views and navigation events. GA4 may set cookies
+              in your browser and send anonymised usage data to Google.
+            </p>
+            <p>
+              The management UI (<code>/app</code>) does not send data to GA4.
+            </p>
+            <p>
+              You can opt out of GA4 tracking by enabling "Do Not Track" in your browser, using a
+              content blocker, or installing the{" "}
+              <a
+                href="https://tools.google.com/dlpage/gaoptout"
+                className="text-brand no-underline hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Google Analytics opt-out browser add-on
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section title="7. Google OAuth">
+            <p>
+              Sign-in is handled by Google OAuth 2.0. When you sign in, Google returns your
+              email address and a profile identifier to Hive. We do not request access to your
+              Google Drive, Gmail, contacts, or any other Google services. Google's own Privacy
+              Policy governs what Google collects during the OAuth flow.
+            </p>
+          </Section>
+
+          <Section title="8. Your Rights">
+            <p>Depending on your location, you may have rights under GDPR, CCPA, or similar laws:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li><strong>Access</strong> — request a copy of the data we hold about you.</li>
+              <li><strong>Correction</strong> — ask us to correct inaccurate data.</li>
+              <li>
+                <strong>Deletion</strong> — delete your account and all associated data at any
+                time using the <code>DELETE /api/account</code> API endpoint, or by contacting us.
+                We complete deletion requests within 30 days.
+              </li>
+              <li><strong>Portability</strong> — export your memories from the management UI.</li>
+              <li>
+                <strong>Objection</strong> — object to processing where we rely on legitimate
+                interests as a legal basis.
+              </li>
+            </ul>
+            <p>
+              To exercise any of these rights, email{" "}
+              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
+                privacy@hive.so
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section title="9. Data Retention">
+            <p>
+              Memories are retained until you delete them or delete your account. Activity logs
+              are retained for 90 days, after which they are automatically purged. OAuth tokens
+              are purged on expiry via DynamoDB TTL. Account deletion via{" "}
+              <code>DELETE /api/account</code> removes all data immediately; it may persist in
+              AWS DynamoDB point-in-time recovery backups for up to 35 days.
+            </p>
+          </Section>
+
+          <Section title="10. Changes to This Policy">
+            <p>
+              We may update this Privacy Policy periodically. Material changes will be announced
+              in the in-app changelog or by email. The "last updated" date at the top of this
+              page reflects the most recent revision.
+            </p>
+          </Section>
+
+          <Section title="11. Contact">
+            <p>
+              For privacy questions or to exercise your data rights, contact us at{" "}
+              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
+                privacy@hive.so
+              </a>
+              .
+            </p>
+          </Section>
+        </div>
+      </section>
+
+      {/* Footer CTA */}
+      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+        <p className="text-[var(--text-muted)] text-sm">
+          See also our{" "}
+          <a href="/terms" className="text-brand no-underline hover:underline">
+            Terms of Service →
+          </a>
+        </p>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/PrivacyPage.test.jsx
+++ b/ui/src/components/PrivacyPage.test.jsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PrivacyPage from "./PrivacyPage.jsx";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("PrivacyPage", () => {
+  it("renders the heading", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getAllByText(/Privacy Policy/).length).toBeGreaterThan(0);
+  });
+
+  it("renders the last-updated note", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getByText(/Last updated: April 2026/)).toBeTruthy();
+  });
+
+  it("renders all section headings", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getByText(/Who We Are/)).toBeTruthy();
+    expect(screen.getByText(/Data We Collect/)).toBeTruthy();
+    expect(screen.getByText(/How We Use Your Data/)).toBeTruthy();
+    expect(screen.getByText(/Where Data Is Stored/)).toBeTruthy();
+    expect(screen.getByText(/Cookies and Local Storage/)).toBeTruthy();
+    expect(screen.getAllByText(/Google Analytics 4/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Google OAuth/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Your Rights/)).toBeTruthy();
+    expect(screen.getByText(/Data Retention/)).toBeTruthy();
+    expect(screen.getByText(/Changes to This Policy/)).toBeTruthy();
+    expect(screen.getByText(/^11\. Contact/)).toBeTruthy();
+  });
+
+  it("discloses Google Analytics 4 usage", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getAllByText(/Google Analytics 4/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/GA4/).length).toBeGreaterThan(0);
+  });
+
+  it("discloses localStorage token usage", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getAllByText(/hive_mgmt_token/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/localStorage/).length).toBeGreaterThan(0);
+  });
+
+  it("mentions DynamoDB and AWS storage", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getAllByText(/DynamoDB/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/AWS/).length).toBeGreaterThan(0);
+  });
+
+  it("mentions the DELETE /api/account endpoint", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getAllByText(/DELETE \/api\/account/).length).toBeGreaterThan(0);
+  });
+
+  it("does not sell data to third parties", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getByText(/do not sell/)).toBeTruthy();
+  });
+
+  it("renders the Terms of Service footer link", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getAllByText(/Terms of Service/).length).toBeGreaterThan(0);
+  });
+
+  it("renders the privacy contact email", async () => {
+    await act(async () => renderInRouter(<PrivacyPage />));
+    expect(screen.getAllByText(/privacy@hive\.so/).length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/components/TermsPage.jsx
+++ b/ui/src/components/TermsPage.jsx
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import PageLayout from "@/components/PageLayout";
+
+function Section({ title, children }) {
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl font-bold mb-3">{title}</h2>
+      <div className="text-sm text-[var(--text-muted)] leading-relaxed space-y-3">{children}</div>
+    </section>
+  );
+}
+
+export default function TermsPage() {
+  return (
+    <PageLayout>
+      {/* Header */}
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">Terms of Service</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[520px] mx-auto leading-relaxed">
+            Last updated: April 2026. Please read these terms before using Hive.
+          </p>
+        </div>
+      </section>
+
+      {/* Body */}
+      <section className="py-16 px-8">
+        <div className="max-w-[720px] mx-auto">
+
+          <Section title="1. Acceptance of Terms">
+            <p>
+              By accessing or using Hive ("the Service"), you agree to be bound by these Terms of
+              Service. If you do not agree, you may not use the Service.
+            </p>
+          </Section>
+
+          <Section title="2. Acceptable Use">
+            <p>You may use Hive to store, retrieve, and manage memories for AI agents and
+            personal productivity. You agree not to:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Store content that is unlawful, abusive, or infringes third-party rights.</li>
+              <li>Attempt to circumvent authentication, rate limits, or access controls.</li>
+              <li>Use the Service to send spam, run denial-of-service attacks, or scrape data at
+                  scale in ways that degrade service quality for other users.</li>
+              <li>Reverse-engineer or resell access to the Service without prior written consent.</li>
+            </ul>
+            <p>
+              We reserve the right to suspend or terminate accounts that violate these rules.
+            </p>
+          </Section>
+
+          <Section title="3. What Hive Stores">
+            <p>When you use Hive, the following data is created and stored on your behalf:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li><strong>Memories</strong> — key/value pairs with optional tags that you or your
+                  AI agents write via the MCP tools (<code>remember</code>, <code>recall</code>,
+                  <code>list_memories</code>, <code>search_memories</code>).</li>
+              <li><strong>OAuth tokens</strong> — short-lived access tokens and refresh tokens
+                  issued to registered MCP clients. Tokens are stored in DynamoDB with a TTL and
+                  are automatically purged on expiry.</li>
+              <li><strong>Activity logs</strong> — timestamped records of MCP tool calls and
+                  management API requests, retained for 90 days for debugging and abuse detection.</li>
+              <li><strong>Account data</strong> — your email address collected via Google OAuth
+                  at sign-in, used to scope your memories and authenticate management UI access.</li>
+            </ul>
+          </Section>
+
+          <Section title="4. Data Retention and Deletion">
+            <p>
+              You may delete individual memories at any time from the Memory Browser in the
+              management UI.
+            </p>
+            <p>
+              To delete your account and all associated data (memories, tokens, activity logs,
+              and account record), use the <code>DELETE /api/account</code> endpoint (available
+              since the v0.19 release, implemented in issue #330). A successful call permanently
+              removes all data within seconds. We do not retain backups of deleted accounts beyond
+              standard AWS DynamoDB point-in-time recovery windows (35 days).
+            </p>
+            <p>
+              You may also contact us at the email listed in the Privacy Policy to request
+              deletion; we will complete it within 30 days.
+            </p>
+          </Section>
+
+          <Section title="5. Service Availability">
+            <p>
+              Hive is provided on a best-effort basis. We target high availability using AWS
+              Lambda and DynamoDB, but we make no uptime guarantee. Scheduled maintenance or
+              unexpected outages may occur. Memories are not lost during downtime.
+            </p>
+          </Section>
+
+          <Section title="6. Limitation of Liability">
+            <p>
+              To the fullest extent permitted by applicable law, Hive and its operators are not
+              liable for any indirect, incidental, special, consequential, or punitive damages,
+              including loss of data or profits, arising from your use of or inability to use the
+              Service.
+            </p>
+            <p>
+              Our total liability to you for any claim arising from these terms or the Service
+              shall not exceed the amount you paid us in the twelve months preceding the claim.
+              Because Hive is currently free, that amount is zero.
+            </p>
+          </Section>
+
+          <Section title="7. Intellectual Property">
+            <p>
+              Hive is open-source software. The content of your memories belongs to you. By
+              storing content in Hive you grant us a limited licence to host, transmit, and
+              process that content solely to provide the Service.
+            </p>
+          </Section>
+
+          <Section title="8. Changes to These Terms">
+            <p>
+              We may update these Terms from time to time. We will notify users of material
+              changes via the in-app changelog or email. Continued use of the Service after
+              notice constitutes acceptance of the updated Terms.
+            </p>
+          </Section>
+
+          <Section title="9. Governing Law">
+            <p>
+              These Terms are governed by and construed in accordance with the laws of the State
+              of California, United States, without regard to its conflict-of-law provisions. Any
+              disputes shall be resolved in the courts located in San Francisco County, California.
+            </p>
+          </Section>
+
+          <Section title="10. Contact">
+            <p>
+              Questions about these Terms? Email us at{" "}
+              <a href="mailto:hello@hive.so" className="text-brand no-underline hover:underline">
+                hello@hive.so
+              </a>
+              .
+            </p>
+          </Section>
+        </div>
+      </section>
+
+      {/* Footer CTA */}
+      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+        <p className="text-[var(--text-muted)] text-sm">
+          See also our{" "}
+          <a href="/privacy" className="text-brand no-underline hover:underline">
+            Privacy Policy →
+          </a>
+        </p>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/TermsPage.test.jsx
+++ b/ui/src/components/TermsPage.test.jsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import TermsPage from "./TermsPage.jsx";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+function renderInRouter(ui) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("TermsPage", () => {
+  it("renders the heading", async () => {
+    await act(async () => renderInRouter(<TermsPage />));
+    expect(screen.getAllByText(/Terms of Service/).length).toBeGreaterThan(0);
+  });
+
+  it("renders the last-updated note", async () => {
+    await act(async () => renderInRouter(<TermsPage />));
+    expect(screen.getByText(/Last updated: April 2026/)).toBeTruthy();
+  });
+
+  it("renders all section headings", async () => {
+    await act(async () => renderInRouter(<TermsPage />));
+    expect(screen.getByText(/Acceptance of Terms/)).toBeTruthy();
+    expect(screen.getByText(/Acceptable Use/)).toBeTruthy();
+    expect(screen.getByText(/What Hive Stores/)).toBeTruthy();
+    expect(screen.getByText(/Data Retention and Deletion/)).toBeTruthy();
+    expect(screen.getByText(/Service Availability/)).toBeTruthy();
+    expect(screen.getByText(/Limitation of Liability/)).toBeTruthy();
+    expect(screen.getByText(/Intellectual Property/)).toBeTruthy();
+    expect(screen.getByText(/Changes to These Terms/)).toBeTruthy();
+    expect(screen.getByText(/Governing Law/)).toBeTruthy();
+    expect(screen.getByText(/^10\. Contact/)).toBeTruthy();
+  });
+
+  it("mentions the DELETE /api/account endpoint", async () => {
+    await act(async () => renderInRouter(<TermsPage />));
+    expect(screen.getAllByText(/DELETE \/api\/account/).length).toBeGreaterThan(0);
+  });
+
+  it("mentions memories, OAuth tokens, and activity logs", async () => {
+    await act(async () => renderInRouter(<TermsPage />));
+    expect(screen.getAllByText(/Memories/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/OAuth tokens/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Activity logs/).length).toBeGreaterThan(0);
+  });
+
+  it("mentions California governing law", async () => {
+    await act(async () => renderInRouter(<TermsPage />));
+    expect(screen.getByText(/California/)).toBeTruthy();
+  });
+
+  it("renders the Privacy Policy footer link", async () => {
+    await act(async () => renderInRouter(<TermsPage />));
+    expect(screen.getAllByText(/Privacy Policy/).length).toBeGreaterThan(0);
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -208,14 +208,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.6.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
 ]
 
 [[package]]
@@ -2668,7 +2668,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2679,9 +2679,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -2754,11 +2754,11 @@ cryptography = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #368

## Summary

- Add `/terms` (TermsPage) covering acceptable use, what Hive stores (memories, OAuth tokens, activity logs), data retention/deletion via `DELETE /api/account`, limitation of liability, and California governing law
- Add `/privacy` (PrivacyPage) covering data collected (email via Google OAuth, memories, activity logs, usage metrics), DynamoDB/AWS storage, no third-party data selling, GA4 disclosure, `localStorage` token, user rights (access, deletion, portability), and contact info
- Wire `/terms` and `/privacy` routes in `App.jsx`
- Add Terms and Privacy links to `PageLayout` footer alongside existing links
- Co-located `TermsPage.test.jsx` and `PrivacyPage.test.jsx`; copyright headers on all new files
- Updated `PageLayout.test.jsx` to cover the new footer links; all 546 tests pass

## Approach

Pages follow the existing marketing-page pattern (wrapped in `PageLayout`, same section/heading structure as `FaqPage`). Content is Hive-specific placeholder copy matching the issue brief — no lorem ipsum. The `DELETE /api/account` endpoint from #330 is cited explicitly in both pages as the self-service deletion mechanism.