### PR TITLE
feat: enforce max value size on remember tool

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -45,6 +45,13 @@ logger = get_logger("hive.server")
 
 _MEMORIES_READ_SCOPE = "memories:read"
 
+DEFAULT_MAX_VALUE_BYTES = 10 * 1024
+
+
+def _max_value_bytes() -> int:
+    """Max UTF-8 byte size of a memory value. Configurable via HIVE_MAX_VALUE_BYTES."""
+    return int(os.environ.get("HIVE_MAX_VALUE_BYTES", str(DEFAULT_MAX_VALUE_BYTES)))
+
 
 class HiveTokenVerifier(TokenVerifier):
     """Wraps Hive token validation for FastMCP's built-in auth middleware.
@@ -182,7 +189,11 @@ def _vector_store() -> VectorStore:
 @mcp.tool()
 async def remember(
     key: Annotated[str, "Unique key to store the memory under"],
-    value: Annotated[str, "Content of the memory"],
+    value: Annotated[
+        str,
+        f"Content of the memory. Maximum {_max_value_bytes()} bytes (UTF-8 encoded); "
+        "configurable via HIVE_MAX_VALUE_BYTES.",
+    ],
     tags: Annotated[list[str] | None, "Optional tags for categorisation"] = None,
     ttl_seconds: Annotated[
         int | None, "Seconds until the memory expires. None = never expires."
@@ -192,6 +203,13 @@ async def remember(
     """Store or update a memory with optional tags and optional TTL."""
     t0 = time.monotonic()
     storage, client_id = _auth(ctx, required_scope="memories:write")
+
+    limit = _max_value_bytes()
+    actual = len(value.encode("utf-8"))
+    if actual > limit:
+        await emit_metric("ToolErrors", operation="remember")
+        raise ToolError(f"Value exceeds maximum size of {limit} bytes ({actual} bytes provided)")
+
     tags = tags or []
     expires_at = (
         datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -188,6 +188,52 @@ class TestRemember:
         ):
             await remember("big-key", "x" * 1000, [], ctx=_make_ctx(jwt))
 
+    async def test_value_at_limit_succeeds(self, server_env):
+        from hive.server import DEFAULT_MAX_VALUE_BYTES, remember
+
+        storage, _, jwt = server_env
+        value = "x" * DEFAULT_MAX_VALUE_BYTES
+        result = await remember("at-limit-key", value, [], ctx=_make_ctx(jwt))
+        assert result == "Stored memory 'at-limit-key'."
+
+    async def test_value_over_limit_raises_tool_error(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import DEFAULT_MAX_VALUE_BYTES, remember
+
+        _, _, jwt = server_env
+        actual = DEFAULT_MAX_VALUE_BYTES + 1
+        expected = f"Value exceeds maximum size of {DEFAULT_MAX_VALUE_BYTES} bytes ({actual} bytes provided)"
+        with pytest.raises(ToolError) as exc_info:
+            await remember("over-limit-key", "x" * actual, [], ctx=_make_ctx(jwt))
+        assert str(exc_info.value) == expected
+
+    async def test_value_size_counts_utf8_bytes_not_chars(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        _, _, jwt = server_env
+        # "€" is 3 bytes in UTF-8, so 5 chars = 15 bytes — exceeds 10 byte limit
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("HIVE_MAX_VALUE_BYTES", "10")
+            with pytest.raises(ToolError, match="15 bytes provided"):
+                await remember("euro-key", "€€€€€", [], ctx=_make_ctx(jwt))
+
+    async def test_value_size_limit_env_override(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        _, _, jwt = server_env
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("HIVE_MAX_VALUE_BYTES", "5")
+            with pytest.raises(ToolError, match="maximum size of 5 bytes"):
+                await remember("custom-limit-key", "x" * 6, [], ctx=_make_ctx(jwt))
+            # within the override limit is fine
+            result = await remember("within-key", "x" * 5, [], ctx=_make_ctx(jwt))
+            assert result == "Stored memory 'within-key'."
+
     async def test_remember_with_ttl_sets_expires_at(self, server_env):
         storage, client_id, jwt = server_env
         from hive.server import remember


### PR DESCRIPTION
Closes #390

## Summary

Adds a configurable UTF-8 byte-size limit to the `remember` MCP tool.
Values exceeding the limit are rejected with a `ToolError` *before*
any storage or quota work happens, so agents get a clear, self-describing
error instead of silent failure or a cryptic `ValidationException` from
DynamoDB.

## Approach

- New `DEFAULT_MAX_VALUE_BYTES = 10 * 1024` and `_max_value_bytes()`
  helper in `server.py`, configurable via `HIVE_MAX_VALUE_BYTES`.
- Pre-write check in `remember()`:
  `len(value.encode("utf-8")) > limit` → `ToolError` with
  `"Value exceeds maximum size of {limit} bytes ({actual} bytes provided)"`.
- Emits the existing `ToolErrors` metric (operation=remember) on rejection
  for observability parity with other failure paths.
- Limit is surfaced in the `value` parameter's `Annotated` description so
  MCP clients see it in tool discovery metadata.
- Kept scope tight to `remember` per the issue; did not touch
  `restore_memory` or the FastAPI `/memories` path (that already returns
  413 via the existing `put_memory` size catch).

## Tests

- `test_value_at_limit_succeeds` — boundary value (exactly the limit) stores OK.
- `test_value_over_limit_raises_tool_error` — limit + 1 bytes raises
  with the exact documented message.
- `test_value_size_counts_utf8_bytes_not_chars` — multibyte chars are
  counted as bytes, not characters.
- `test_value_size_limit_env_override` — `HIVE_MAX_VALUE_BYTES` override
  is respected for both rejection and success paths.