### PR TITLE
fix: correct free-tier limit copy on pricing and FAQ pages

### DIFF
--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -30,7 +30,7 @@ All memories, OAuth clients, tokens, and activity log entries associated with yo
 
 ### How many memories can I store?
 
-There is currently no hard limit on the number of memories per account. Very large memory stores (tens of thousands of memories) may affect search and retrieval performance.
+Free accounts can store up to 500 memories. Once you reach the limit, new `remember` calls are rejected until you delete existing memories. Large memory stores may also affect search and retrieval performance.
 
 ### How large can a memory value be?
 

--- a/ui/src/components/FaqPage.jsx
+++ b/ui/src/components/FaqPage.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import PageLayout from "@/components/PageLayout";
+import { FREE_TIER_MEMORY_LIMIT } from "@/lib/limits";
 
 const FAQS = [
   {
@@ -10,7 +11,7 @@ const FAQS = [
   },
   {
     q: "What are the usage limits?",
-    a: "There are no hard limits on the number of memories or API calls during the free period. We reserve the right to introduce fair-use limits in future to ensure service quality for all users — we'll give plenty of notice before doing so.",
+    a: `Free accounts can store up to ${FREE_TIER_MEMORY_LIMIT} memories. Once you reach the limit, new memories are rejected until you delete existing ones. Additional rate limits may apply to prevent abuse. We'll communicate any changes to these limits with plenty of notice.`,
   },
   {
     q: "Which MCP clients are supported?",

--- a/ui/src/components/FaqPage.test.jsx
+++ b/ui/src/components/FaqPage.test.jsx
@@ -56,7 +56,7 @@ describe("FaqPage", () => {
     fireEvent.click(screen.getByText(/Is my data private/));
     fireEvent.click(screen.getByText(/What are the usage limits/));
     expect(screen.getByText(/Your memories are scoped to your account/)).toBeTruthy();
-    expect(screen.getByText(/no hard limits/)).toBeTruthy();
+    expect(screen.getByText(/up to 500 memories/)).toBeTruthy();
   });
 
   it("renders docs link", async () => {

--- a/ui/src/components/PricingPage.jsx
+++ b/ui/src/components/PricingPage.jsx
@@ -4,9 +4,10 @@ import { Check } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import PageLayout from "@/components/PageLayout";
+import { FREE_TIER_MEMORY_LIMIT } from "@/lib/limits";
 
 const INCLUDED = [
-  "Unlimited memories",
+  `Up to ${FREE_TIER_MEMORY_LIMIT} memories`,
   "Semantic search across all memories",
   "Works with Claude Code, Claude Desktop, Cursor, Continue, and any MCP client",
   "Multiple OAuth clients per account",

--- a/ui/src/components/PricingPage.test.jsx
+++ b/ui/src/components/PricingPage.test.jsx
@@ -32,7 +32,7 @@ describe("PricingPage", () => {
 
   it("renders all included features", async () => {
     await act(async () => renderInRouter(<PricingPage />));
-    expect(screen.getByText(/Unlimited memories/)).toBeTruthy();
+    expect(screen.getByText(/Up to 500 memories/)).toBeTruthy();
     expect(screen.getByText(/Semantic search/)).toBeTruthy();
     expect(screen.getAllByText(/No credit card required/i).length).toBeGreaterThanOrEqual(1);
   });

--- a/ui/src/lib/limits.js
+++ b/ui/src/lib/limits.js
@@ -1,0 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+// Free tier quotas surfaced in marketing copy. Must stay in sync with
+// DEFAULT_QUOTA_MAX_MEMORIES in src/hive/quota.py.
+export const FREE_TIER_MEMORY_LIMIT = 500;


### PR DESCRIPTION
Closes #364

## Summary

Pricing + FAQ pages previously claimed *"Unlimited memories"* and *"no hard limits on the number of memories"*, but the free-tier quota system enforces a 500-memory cap (`DEFAULT_QUOTA_MAX_MEMORIES` in `src/hive/quota.py`). Over-quota `remember()` calls return an error — this PR makes the marketing copy match reality.

## Approach

- New `ui/src/lib/limits.js` exports `FREE_TIER_MEMORY_LIMIT = 500` — single source for the marketing copy, with a comment pointing at the Python default it shadows.
- Pricing page features list now reads `"Up to 500 memories"` (interpolated from the constant).
- FAQ page answer for *"What are the usage limits?"* rewritten to explicitly state the 500-memory cap and describe what happens when you hit it.
- `docs-site/faq.md` updated to match.
- Tests updated to assert the new copy.

Chose Option A from the issue ("show the actual limit") over Option B ("framed as generous but bounded") — the extra rewording of Option B feels evasive given the issue's framing. Happy to reframe if you'd prefer.

## Test plan

- Vitest: updated `PricingPage.test.jsx` and `FaqPage.test.jsx` to match new strings.
- Full `uv run inv pre-push` green (546 vitest + 481 pytest).