### PR TITLE
docs: publish recommended key naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ AI agents are stateless — every new conversation starts blank. Hive gives them
 
 Multiple agents or team members connect with their own OAuth clients, so you can track who stored what and revoke access individually.
 
+Keys are opaque to the server, but a structured convention like `{domain}:{entity-type}/{entity-id}:{attribute}` (e.g. `project:task/42:summary`) keeps memory stores organised and collision-free as they grow. See the [key naming conventions](https://hive.warlordofmars.net/docs/concepts/key-conventions) docs page for details.
+
 ## Architecture
 
 Hive is a serverless, AWS-native stack deployed on Lambda + DynamoDB behind CloudFront:

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -53,6 +53,7 @@ export default defineConfig({
         items: [
           { text: "How memory scoping works", link: "/concepts/memory-scoping" },
           { text: "Tags and organisation", link: "/concepts/tags" },
+          { text: "Key naming conventions", link: "/concepts/key-conventions" },
         ],
       },
       {

--- a/docs-site/concepts/key-conventions.md
+++ b/docs-site/concepts/key-conventions.md
@@ -1,0 +1,45 @@
+# Key naming conventions
+
+Hive stores memories under a **key** you choose. The server doesn't enforce any structure on that key — any non-empty string works. But keys left to grow organically become chaotic and collision-prone fast, and renaming them later is painful once a client has thousands.
+
+This page describes the recommended convention. It's a guideline, not a rule; adopt as much or as little as suits your agent.
+
+## The convention
+
+```text
+{domain}:{entity-type}/{entity-id}:{attribute}
+```
+
+- **domain** — top-level namespace (e.g. `project`, `user`, `session`, `team`, `global`)
+- **entity-type/entity-id** — identifies a specific thing (optional, omit for domain-wide memories)
+- **attribute** — what the value contains (e.g. `summary`, `preferences`, `context`)
+
+Lowercase, hyphens within segments, colons as separators, `/` between an entity type and its id.
+
+## Examples
+
+| Key | Meaning |
+|---|---|
+| `project:task/42:summary` | Summary of task 42 in the project domain |
+| `user:profile/alice:preferences` | Alice's user preferences |
+| `session:current:context` | Context for the current session |
+| `team:shared:coding-guidelines` | Team-wide coding guidelines |
+| `global:env:database-schema` | A globally-shared piece of context |
+
+## Why this works
+
+- **Collision-resistant.** Two different domains never share a key space.
+- **Queryable by prefix.** Pairs well with `list_memories` and `search_memories` when you want everything under `project:task/42`.
+- **Readable.** An operator browsing the Memory Browser can tell what each memory is for at a glance.
+- **Extensible.** Adding a new domain or attribute never forces a rename of existing keys.
+
+## Tips
+
+- Prefer a fixed, small set of domains per agent — don't invent a new one for every memory.
+- Keep `entity-id` stable for the life of the entity (a database id works well; a slug is fine if it never changes).
+- Use `tags` for cross-cutting groupings ("decision", "open-question") rather than stuffing them into the key.
+- When in doubt, start simple (`domain:attribute`) and add structure only when a real collision shows up.
+
+## What Hive does not enforce
+
+The server accepts any key. This convention lives in your agent's system prompt or tool-use instructions — it's your choice how strictly to follow it. Hive may introduce opt-in key validation in a future release.

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -190,6 +190,29 @@ export default function SetupPanel() {
         </div>
       </section>
 
+      <section className="mt-12 border-t border-[var(--border)] pt-8">
+        <h3 className="mb-3">Tip — naming your memories</h3>
+        <p className="text-[var(--text-muted)] mb-3 text-sm">
+          Keys are free-form, but a structured scheme keeps your store organised as it grows.
+          We recommend:
+        </p>
+        <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)] mb-3">
+          {"{domain}:{entity-type}/{entity-id}:{attribute}\n\nproject:task/42:summary\nuser:profile/alice:preferences\nsession:current:context"}
+        </pre>
+        <p className="text-[var(--text-muted)] text-sm">
+          See the{" "}
+          <a
+            href="/docs/concepts/key-conventions"
+            target="_blank"
+            rel="noreferrer"
+            className="text-[var(--accent)] underline"
+          >
+            key naming conventions
+          </a>{" "}
+          docs for the full guide.
+        </p>
+      </section>
+
       {quota && (
         <section className="mt-12 border-t border-[var(--border)] pt-8">
           <h3 className="mb-4">Usage</h3>

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -287,6 +287,14 @@ describe("SetupPanel", () => {
     expect(bars.length).toBeGreaterThan(0);
   });
 
+  it("renders key naming convention tip with example and docs link", async () => {
+    await act(async () => render(<SetupPanel />));
+    expect(screen.getByText(/Tip — naming your memories/)).toBeTruthy();
+    expect(document.body.textContent).toContain("project:task/42:summary");
+    const docsLink = screen.getByText(/key naming conventions/);
+    expect(docsLink.getAttribute("href")).toBe("/docs/concepts/key-conventions");
+  });
+
   it("hides Usage section when getStats rejects", async () => {
     api.getStats.mockRejectedValue(new Error("network error"));
     await act(async () => render(<SetupPanel />));


### PR DESCRIPTION
Closes #398

## Summary

Publishes the recommended memory-key naming convention so agents produce structured, collision-resistant key spaces from day one instead of discovering they needed a scheme only after thousands of keys are already in the wild.

## Approach

- **New `docs-site/concepts/key-conventions.md`** — explains the `{domain}:{entity-type}/{entity-id}:{attribute}` shape, gives five real examples, the reasoning (collision-resistance, prefix queries, readability), and practical tips. Ends with an explicit note that Hive does not enforce any of this — it's a recommendation.
- **Sidebar wiring** — added to the Concepts group in `.vitepress/config.mjs`.
- **README** — one paragraph under the MCP Tools table pointing at the new page, with a short inline example.
- **SetupPanel (first-run wizard)** — new "Tip — naming your memories" section with a compact code block showing the pattern and three examples, plus a link to the full docs page.

Took the issue's proposed convention as-is since the issue frames it as the starting point for discussion and nothing in the codebase conflicts with it. If you'd prefer different examples or a looser phrasing, happy to iterate.

## Test plan

- New vitest case asserts the SetupPanel renders the tip heading, the `project:task/42:summary` example, and the link to `/docs/concepts/key-conventions`.
- Built the docs site locally (`npm run build` in `docs-site/`) — page renders, no broken links, sidebar shows the new entry.
- Full `uv run inv pre-push` green (547 vitest + 481 pytest).