### PR TITLE
feat: add ping MCP tool for connectivity and auth health checks

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -6,6 +6,7 @@ All tools validate the OAuth 2.1 Bearer token passed in the MCP request
 context before performing any storage operation.
 
 Tools:
+  ping()                      — health check (auth-only, no storage access)
   remember(key, value, tags)  — store a memory
   recall(key)                 — retrieve a memory by key
   forget(key)                 — delete a memory by key
@@ -184,6 +185,18 @@ def _vector_store() -> VectorStore:
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def ping(ctx: Context | None = None) -> str:
+    """Lightweight health check — returns 'ok' when the Bearer token is valid.
+
+    Performs no storage reads or writes. A successful call confirms both
+    connectivity to the MCP server and that the caller's token is still valid.
+    """
+    _auth(ctx)
+    await emit_metric("ToolInvocations", operation="ping")
+    return "ok"
 
 
 @mcp.tool()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -115,6 +115,30 @@ def server_env():
 
 
 # ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+
+
+class TestPing:
+    async def test_returns_ok_for_valid_token(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import ping
+
+        result = await ping(ctx=_make_ctx(jwt))
+        assert result == "ok"
+
+    async def test_missing_auth_raises_tool_error(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import ping
+
+        ctx = MagicMock()
+        ctx.request_context.meta = {}
+        with pytest.raises(ToolError, match="Unauthorized"):
+            await ping(ctx=ctx)
+
+
+# ---------------------------------------------------------------------------
 # remember
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #389

## Summary

Adds a minimal `ping` MCP tool — takes no parameters, performs no storage work, returns the string `"ok"` when the Bearer token validates. A successful call confirms both connectivity to the MCP server and that the caller's token is still valid.

## Approach

- Added `ping` at the top of the tools section in `src/hive/server.py`.
- Calls the existing `_auth(ctx)` with `required_scope=None` — any valid token passes, regardless of read/write scope, matching the issue's "auth is still required" requirement.
- Emits the standard `ToolInvocations` metric (operation=`ping`) for observability parity with other tools.
- No DynamoDB reads or writes beyond what `_auth` already does to validate the token (rate-limit check + scope parse).
- Updated the module docstring's Tools: section to list it.

## Tests

- `test_returns_ok_for_valid_token` — successful case.
- `test_missing_auth_raises_tool_error` — unauthorised call raises `ToolError`.

Full `uv run inv pre-push` green.