### PR TITLE
feat: add min_score threshold to search_memories

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -634,6 +634,11 @@ async def summarize_context(
 async def search_memories(
     query: Annotated[str, "Natural language search query"],
     top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 10,
+    min_score: Annotated[
+        float | None,
+        "Minimum similarity score (0.0–1.0). Results below this threshold are "
+        "excluded. None disables filtering.",
+    ] = None,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Search memories by semantic similarity to a natural language query.
@@ -644,6 +649,7 @@ async def search_memories(
     t0 = time.monotonic()
     storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     top_k = max(1, min(top_k, 50))
+    threshold = max(0.0, min(1.0, min_score)) if min_score is not None else None
 
     try:
         pairs = _vector_store().search(query, client_id, top_k=top_k)
@@ -652,6 +658,9 @@ async def search_memories(
     except Exception:
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
         return {"items": [], "count": 0, "query": query}
+
+    if threshold is not None:
+        pairs = [(mid, score) for mid, score in pairs if score >= threshold]
 
     results = storage.hydrate_memory_ids(pairs)
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -703,6 +703,83 @@ class TestSearchMemories:
         with pytest.raises(ToolError, match="Insufficient scope"):
             await search_memories("q", ctx=_make_ctx(write_only_jwt))
 
+    async def test_min_score_filters_low_ranked_results(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("hi-key", "high match", ["t"], ctx=ctx)
+        await remember("lo-key", "low match", ["t"], ctx=ctx)
+        hi = storage.get_memory_by_key("hi-key")
+        lo = storage.get_memory_by_key("lo-key")
+        mock_vs = _make_mock_vector_store([(hi.memory_id, 0.9), (lo.memory_id, 0.3)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("anything", min_score=0.5, ctx=ctx)
+
+        assert result["count"] == 1
+        assert [item["key"] for item in result["items"]] == ["hi-key"]
+
+    async def test_min_score_none_returns_all(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "a", ["t"], ctx=ctx)
+        await remember("b", "b", ["t"], ctx=ctx)
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        mock_vs = _make_mock_vector_store([(a.memory_id, 0.9), (b.memory_id, 0.05)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", ctx=ctx)
+
+        assert result["count"] == 2
+
+    async def test_min_score_all_below_threshold_returns_empty(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("only-key", "v", ["t"], ctx=ctx)
+        m = storage.get_memory_by_key("only-key")
+        mock_vs = _make_mock_vector_store([(m.memory_id, 0.2)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", min_score=0.9, ctx=ctx)
+
+        assert result == {"items": [], "count": 0, "query": "q"}
+
+    async def test_min_score_clamped_to_unit_interval(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("key", "v", ["t"], ctx=ctx)
+        m = storage.get_memory_by_key("key")
+        mock_vs = _make_mock_vector_store([(m.memory_id, 1.0)])
+
+        # min_score > 1.0 gets clamped to 1.0; a perfect score still matches
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", min_score=5.0, ctx=ctx)
+
+        assert result["count"] == 1
+
+        # min_score < 0.0 gets clamped to 0.0; everything passes
+        mock_vs2 = _make_mock_vector_store([(m.memory_id, 0.0)])
+        with patch("hive.server._vector_store", return_value=mock_vs2):
+            result = await search_memories("q", min_score=-1.0, ctx=ctx)
+
+        assert result["count"] == 1
+
     async def test_remember_dual_writes_to_vector_store(self, server_env):
         """remember() calls upsert_memory on the VectorStore for new memories."""
         from unittest.mock import MagicMock, patch


### PR DESCRIPTION
Closes #378

## Summary

Adds an optional `min_score` parameter to `search_memories` so callers can set a confidence floor and avoid getting weakly-related matches back as "top results".

## Approach

- New `min_score: float | None = None` parameter, clamped to `[0.0, 1.0]` when non-None.
- Filter is applied to the `(memory_id, score)` pairs **before** hydration so we don't pay DynamoDB lookups for results we're about to drop.
- `count` in the response reflects the post-filter length (per acceptance criteria).
- When every result falls below the threshold, returns an empty `items` list — no "least bad match" fallback.

## Tests

- `test_min_score_filters_low_ranked_results` — mixed scores, only those ≥ threshold survive.
- `test_min_score_none_returns_all` — absence of the param preserves existing behaviour.
- `test_min_score_all_below_threshold_returns_empty` — empty response when every pair is below the floor.
- `test_min_score_clamped_to_unit_interval` — values outside [0, 1] are clamped.

`uv run inv pre-push` green (547 vitest + 482 pytest).

## Test plan

- [ ] e2e verification on deployed dev env via `tests/e2e/test_mcp_e2e.py` — flagged in the issue's acceptance criteria, but the current e2e suite doesn't cover `search_memories` with a score floor; the CI `development` pipeline will still run the existing e2e coverage.