### PR TITLE
feat: add list_tags MCP tool for tag discovery

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -11,6 +11,7 @@ Tools:
   recall(key)                 — retrieve a memory by key
   forget(key)                 — delete a memory by key
   list_memories(tag)          — list memories by tag
+  list_tags()                 — list distinct tags for the caller's memories
   summarize_context(topic)    — synthesise memories into a summary
 """
 
@@ -562,6 +563,33 @@ async def list_memories(
     if next_cursor:
         result["next_cursor"] = next_cursor
     return result
+
+
+@mcp.tool()
+async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
+    """List all distinct tags currently in use across the caller's memories.
+
+    Returns tags sorted alphabetically. Useful for discovering the tag
+    namespace of an existing memory corpus before calling `list_memories`.
+    """
+    t0 = time.monotonic()
+    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    tags = storage.list_distinct_tags(client_id)
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "Listed %d distinct tags",
+        len(tags),
+        extra={
+            "tool": "list_tags",
+            "duration_ms": duration_ms,
+            "status": "success",
+        },
+    )
+    await emit_metric("ToolInvocations", operation="list_tags")
+    await emit_metric(
+        "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="list_tags"
+    )
+    return {"tags": tags, "count": len(tags)}
 
 
 @mcp.tool()

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -202,6 +202,34 @@ class HiveStorage:
                 results.append((memory, score))
         return results
 
+    def list_distinct_tags(self, client_id: str) -> list[str]:
+        """Return the sorted set of distinct tags on memories owned by ``client_id``.
+
+        Scans the TagIndex GSI (scope is limited to tag items — the base table
+        is never scanned) filtering on ``owner_client_id`` and projecting only
+        the ``GSI2PK`` attribute, which carries the ``TAG#{name}`` marker.
+        """
+        tags: set[str] = set()
+        start_key: dict[str, Any] | None = None
+        while True:
+            kwargs: dict[str, Any] = {
+                "IndexName": "TagIndex",
+                "FilterExpression": "owner_client_id = :cid",
+                "ExpressionAttributeValues": {":cid": client_id},
+                "ProjectionExpression": "GSI2PK",
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            resp = self.table.scan(**kwargs)
+            for item in resp.get("Items", []):
+                gsi_pk = item.get("GSI2PK", "")
+                if gsi_pk.startswith("TAG#"):
+                    tags.add(gsi_pk[len("TAG#") :])
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                break
+        return sorted(tags)
+
     def list_memories_by_tag(
         self,
         tag: str,

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -369,6 +369,56 @@ class TestListMemories:
 
 
 # ---------------------------------------------------------------------------
+# list_tags
+# ---------------------------------------------------------------------------
+
+
+class TestListTags:
+    async def test_returns_sorted_distinct_tags(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_tags, remember
+
+        ctx = _make_ctx(jwt)
+        await remember("a", "1", ["zebra", "alpha"], ctx=ctx)
+        await remember("b", "2", ["alpha", "mango"], ctx=ctx)
+        await remember("c", "3", [], ctx=ctx)
+
+        result = await list_tags(ctx=ctx)
+        assert result == {"tags": ["alpha", "mango", "zebra"], "count": 3}
+
+    async def test_empty_when_no_memories(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_tags
+
+        result = await list_tags(ctx=_make_ctx(jwt))
+        assert result == {"tags": [], "count": 0}
+
+    async def test_scoped_to_caller_client(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.models import Memory
+        from hive.server import list_tags, remember
+
+        await remember("mine", "v", ["owned"], ctx=_make_ctx(jwt))
+        # Write a memory belonging to a different client directly so we bypass auth
+        storage.put_memory(
+            Memory(key="theirs", value="v", tags=["not-mine"], owner_client_id="other-client")
+        )
+
+        result = await list_tags(ctx=_make_ctx(jwt))
+        assert result["tags"] == ["owned"]
+
+    async def test_requires_read_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import list_tags
+
+        storage, _, _ = server_env
+        write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await list_tags(ctx=_make_ctx(write_only_jwt))
+
+
+# ---------------------------------------------------------------------------
 # summarize_context
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -152,6 +152,20 @@ class TestMemoryStorage:
     def test_list_distinct_tags_empty_when_no_memories(self, storage):
         assert storage.list_distinct_tags("c1") == []
 
+    def test_list_distinct_tags_follows_scan_pages(self, storage):
+        from unittest.mock import patch
+
+        responses = iter(
+            [
+                {"Items": [{"GSI2PK": "TAG#alpha"}], "LastEvaluatedKey": {"PK": "x"}},
+                {"Items": [{"GSI2PK": "TAG#beta"}, {"GSI2PK": "NOT_A_TAG"}]},
+            ]
+        )
+        with patch.object(storage.table, "scan", side_effect=lambda **_kw: next(responses)):
+            result = storage.list_distinct_tags("c1")
+
+        assert result == ["alpha", "beta"]
+
     def test_update_replaces_tags(self, storage):
         m = Memory(key="k", value="v", tags=["old"], owner_client_id="c1")
         storage.put_memory(m)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -132,6 +132,26 @@ class TestMemoryStorage:
         keys_z = {m.key for m in tagged_z}
         assert keys_z == {"b", "c"}
 
+    def test_list_distinct_tags_returns_sorted_unique(self, storage):
+        for m in [
+            Memory(key="a", value="1", tags=["zebra", "alpha"], owner_client_id="c1"),
+            Memory(key="b", value="2", tags=["alpha", "mango"], owner_client_id="c1"),
+            Memory(key="c", value="3", tags=[], owner_client_id="c1"),
+        ]:
+            storage.put_memory(m)
+
+        assert storage.list_distinct_tags("c1") == ["alpha", "mango", "zebra"]
+
+    def test_list_distinct_tags_scoped_to_client(self, storage):
+        storage.put_memory(Memory(key="a", value="1", tags=["mine"], owner_client_id="c1"))
+        storage.put_memory(Memory(key="b", value="2", tags=["theirs"], owner_client_id="c2"))
+
+        assert storage.list_distinct_tags("c1") == ["mine"]
+        assert storage.list_distinct_tags("c2") == ["theirs"]
+
+    def test_list_distinct_tags_empty_when_no_memories(self, storage):
+        assert storage.list_distinct_tags("c1") == []
+
     def test_update_replaces_tags(self, storage):
         m = Memory(key="k", value="v", tags=["old"], owner_client_id="c1")
         storage.put_memory(m)


### PR DESCRIPTION
Closes #393

## Summary

Adds a `list_tags` MCP tool so agents can discover the tag namespace of an existing memory corpus without already knowing what tags exist. Returns `{"tags": [...], "count": N}` with tags sorted alphabetically.

## Approach

- **New `HiveStorage.list_distinct_tags(client_id)`** — scans the `TagIndex` GSI (not the base table), filtering on `owner_client_id` and projecting only `GSI2PK` (which carries the `TAG#{name}` marker). Dedupes via a Python `set` and returns sorted.
- **New `list_tags` MCP tool** — requires `memories:read`, calls the storage method, emits the standard `ToolInvocations` and `StorageLatencyMs` metrics.
- No activity-log event — tag discovery is pure metadata, no memory content touched, and there's no existing `tags_listed` event type. Happy to add one if you'd rather.
- **Pagination intentionally deferred** — the issue calls it out as optional for the initial cut; can add `limit` + `cursor` later if tag counts blow up.

## Out of scope

- The issue mentions the `MemoryBrowser` tag autocomplete could call a new `GET /api/tags` management endpoint once this lands. Left for a follow-up so this PR stays focused on the MCP surface.

## Tests

- `test_list_distinct_tags_returns_sorted_unique` — covers the sort + dedupe guarantee.
- `test_list_distinct_tags_scoped_to_client` — two clients' tags don't leak.
- `test_list_distinct_tags_empty_when_no_memories` — empty-set path.
- Server-level: four tests covering happy path, empty, cross-client isolation, and read-scope enforcement.

`uv run inv pre-push` green (547 vitest + 485 pytest).