### PR TITLE
fix: replace hive.so with warlordofmars.net in Privacy/Terms

### DIFF
--- a/ui/src/components/PrivacyPage.jsx
+++ b/ui/src/components/PrivacyPage.jsx
@@ -31,9 +31,9 @@ export default function PrivacyPage() {
           <Section title="1. Who We Are">
             <p>
               Hive is a shared persistent memory service for AI agents and teams. The Service is
-              operated by John Carter. Questions about this policy can be sent to{" "}
-              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
-                privacy@hive.so
+              operated by warlordofmars. Questions about this policy can be sent to{" "}
+              <a href="mailto:privacy@warlordofmars.net" className="text-brand no-underline hover:underline">
+                privacy@warlordofmars.net
               </a>
               .
             </p>
@@ -115,7 +115,7 @@ export default function PrivacyPage() {
 
           <Section title="6. Google Analytics 4">
             <p>
-              The Hive marketing site (hive.so and its sub-pages, including <code>/pricing</code>,
+              The Hive marketing site (hive.warlordofmars.net and its sub-pages, including <code>/pricing</code>,
               {" "}<code>/faq</code>, <code>/use-cases</code>, and <code>/docs</code>) uses Google
               Analytics 4 (GA4) to measure page views and navigation events. GA4 may set cookies
               in your browser and send anonymised usage data to Google.
@@ -165,8 +165,8 @@ export default function PrivacyPage() {
             </ul>
             <p>
               To exercise any of these rights, email{" "}
-              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
-                privacy@hive.so
+              <a href="mailto:privacy@warlordofmars.net" className="text-brand no-underline hover:underline">
+                privacy@warlordofmars.net
               </a>
               .
             </p>
@@ -193,8 +193,8 @@ export default function PrivacyPage() {
           <Section title="11. Contact">
             <p>
               For privacy questions or to exercise your data rights, contact us at{" "}
-              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
-                privacy@hive.so
+              <a href="mailto:privacy@warlordofmars.net" className="text-brand no-underline hover:underline">
+                privacy@warlordofmars.net
               </a>
               .
             </p>

--- a/ui/src/components/PrivacyPage.test.jsx
+++ b/ui/src/components/PrivacyPage.test.jsx
@@ -74,6 +74,6 @@ describe("PrivacyPage", () => {
 
   it("renders the privacy contact email", async () => {
     await act(async () => renderInRouter(<PrivacyPage />));
-    expect(screen.getAllByText(/privacy@hive\.so/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/privacy@warlordofmars\.net/).length).toBeGreaterThan(0);
   });
 });

--- a/ui/src/components/TermsPage.jsx
+++ b/ui/src/components/TermsPage.jsx
@@ -133,8 +133,8 @@ export default function TermsPage() {
           <Section title="10. Contact">
             <p>
               Questions about these Terms? Email us at{" "}
-              <a href="mailto:hello@hive.so" className="text-brand no-underline hover:underline">
-                hello@hive.so
+              <a href="mailto:hello@warlordofmars.net" className="text-brand no-underline hover:underline">
+                hello@warlordofmars.net
               </a>
               .
             </p>


### PR DESCRIPTION
Closes #405

## Summary

Hive doesn't own `hive.so` — the Privacy Policy and Terms of Service pages listed `privacy@hive.so` / `hello@hive.so` and mentioned `hive.so` as the marketing-site domain, leaving any GDPR/CCPA request (or just a support question) routed into a black hole. Replaced with addresses on a domain we actually control (`warlordofmars.net`).

## Changes

- `PrivacyPage.jsx` — 3× `privacy@hive.so` (sections 1, 8, 11) → `privacy@warlordofmars.net` (both visible text and `mailto:` href).
- `PrivacyPage.jsx` (section 6) — marketing-site domain reference `hive.so` → `hive.warlordofmars.net` to match the actual deployed domain.
- `PrivacyPage.jsx` (section 1) — operator identification: *"operated by John Carter"* → *"operated by warlordofmars"* (Option 2 from the issue — keeps the personal handle without publishing a legal name; open to switching to Option 3 if you'd rather drop the name entirely).
- `TermsPage.jsx` — `hello@hive.so` → `hello@warlordofmars.net`.
- `PrivacyPage.test.jsx` — assertion updated to match new email string.

## Tests

Vitest + pytest green via `uv run inv pre-push`.

## Out of scope

- Copyright headers (`// Copyright (c) 2026 John Carter ...`) left alone per the issue — those are legal copyright notices and not user-facing.