### PR TITLE
chore: bump Dependabot pip + npm schedules to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
     groups:
       python-deps:
         patterns: ["*"]
@@ -17,8 +16,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
     groups:
       npm-deps:
         patterns: ["*"]


### PR DESCRIPTION
Closes #410

## Summary

Bumps Dependabot pip and npm schedules from `weekly` (Mondays) to `daily`. GitHub Actions stays on weekly — those versions move slowly and we pin to SHAs anyway, so daily would be pure noise.

## Safety notes

- Grouped PRs (`patterns: ["*"]`) unchanged → max 1 PR per ecosystem per run.
- Semver-major ignores unchanged → no surprise major bumps.
- The `day: "monday"` key is dropped for the daily schedules (it's only valid on weekly).

## Tests

No code changes — `.github/dependabot.yml` is consumed by GitHub's Dependabot, not exercised by the test suite. Lint + format check clean.