### PR TITLE
chore: add robots.txt and sitemap.xml for marketing + docs sites

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -5,6 +5,16 @@ export default defineConfig({
   title: "Hive Docs",
   description: "Shared persistent memory for AI agents — documentation",
   cleanUrls: true,
+  sitemap: {
+    hostname: "https://hive.warlordofmars.net",
+    // VitePress drops `base` from the item URL when writing the sitemap,
+    // so prepend it here to match the deployed path at /docs/.
+    transformItems: (items) =>
+      items.map((item) => ({
+        ...item,
+        url: `docs/${item.url.replace(/^\//, "")}`,
+      })),
+  },
   head: [["link", { rel: "icon", type: "image/svg+xml", href: "/docs/favicon.svg" }]],
 
   themeConfig: {

--- a/ui/public/robots.txt
+++ b/ui/public/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Allow: /
+Allow: /docs/
+Disallow: /app
+Disallow: /auth/
+Disallow: /oauth/
+Disallow: /mcp
+Disallow: /api/
+
+Sitemap: https://hive.warlordofmars.net/sitemap.xml
+Sitemap: https://hive.warlordofmars.net/docs/sitemap.xml

--- a/ui/public/sitemap.xml
+++ b/ui/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://hive.warlordofmars.net/</loc></url>
+  <url><loc>https://hive.warlordofmars.net/pricing</loc></url>
+  <url><loc>https://hive.warlordofmars.net/faq</loc></url>
+  <url><loc>https://hive.warlordofmars.net/use-cases</loc></url>
+  <url><loc>https://hive.warlordofmars.net/clients</loc></url>
+  <url><loc>https://hive.warlordofmars.net/changelog</loc></url>
+  <url><loc>https://hive.warlordofmars.net/status</loc></url>
+  <url><loc>https://hive.warlordofmars.net/terms</loc></url>
+  <url><loc>https://hive.warlordofmars.net/privacy</loc></url>
+</urlset>


### PR DESCRIPTION
Closes #423

## Summary

Adds `robots.txt` + two sitemaps so search engines can discover Hive's public pages and know what's off-limits (the management UI, OAuth callbacks, MCP/API endpoints).

## Changes

- **`ui/public/robots.txt`** — allows `/` and `/docs/`, disallows `/app`, `/auth/`, `/oauth/`, `/mcp`, `/api/`. Advertises both sitemaps (SPA + docs).
- **`ui/public/sitemap.xml`** — static handwritten sitemap listing the 9 public React Router routes (home, pricing, faq, use-cases, clients, changelog, status, terms, privacy). Stable set, easy to grep when routes change.
- **`docs-site/.vitepress/config.mjs`** — enables VitePress's built-in sitemap generator (generates `/docs/sitemap.xml` at build time, one entry per `.md` page). Includes a `transformItems` hook because VitePress drops `base` (`/docs/`) from the sitemap URLs; the hook re-prepends it so loc URLs resolve to the actual deployed paths.

Verified locally: `npm run build` in `docs-site/` produces a sitemap with `loc` URLs of the form `https://hive.warlordofmars.net/docs/concepts/...`.

## Out of scope / deferred

- **Playwright assertions** for `/robots.txt` and `/sitemap.xml` — the existing e2e suite doesn't assert on static asset responses; a follow-up can add them alongside broader static-asset smoke tests.
- **`lastmod` from git history** — the `<lastmod>` field is optional ("where practical" in the issue), and adding it here would add complexity without much search-engine benefit given how frequently the site deploys.
- **Sitemap index file** — using two separate `Sitemap:` lines in `robots.txt` is simpler and equally valid per the sitemaps.org spec.

## Tests

`uv run inv pre-push` green. `npm run build` in `docs-site/` produces the expected sitemap.