### PR TITLE
feat: add filter_tags param to search_memories

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -667,6 +667,11 @@ async def search_memories(
         "Minimum similarity score (0.0–1.0). Results below this threshold are "
         "excluded. None disables filtering.",
     ] = None,
+    filter_tags: Annotated[
+        list[str] | None,
+        "Optional list of tags. Only memories carrying ALL of the given tags "
+        "are returned. None disables filtering.",
+    ] = None,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Search memories by semantic similarity to a natural language query.
@@ -678,9 +683,14 @@ async def search_memories(
     storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     top_k = max(1, min(top_k, 50))
     threshold = max(0.0, min(1.0, min_score)) if min_score is not None else None
+    required_tags = set(filter_tags) if filter_tags else None
+
+    # When post-filtering by tags, request the full cap from the vector store
+    # so we have headroom to still return up to top_k matches after filtering.
+    search_top_k = 50 if required_tags else top_k
 
     try:
-        pairs = _vector_store().search(query, client_id, top_k=top_k)
+        pairs = _vector_store().search(query, client_id, top_k=search_top_k)
     except VectorIndexNotFoundError:
         return {"items": [], "count": 0, "query": query}
     except Exception:
@@ -691,6 +701,11 @@ async def search_memories(
         pairs = [(mid, score) for mid, score in pairs if score >= threshold]
 
     results = storage.hydrate_memory_ids(pairs)
+
+    if required_tags:
+        results = [(m, s) for m, s in results if required_tags.issubset(m.tags)]
+
+    results = results[:top_k]
 
     storage.log_event(
         ActivityEvent(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -806,6 +806,81 @@ class TestSearchMemories:
 
         assert result == {"items": [], "count": 0, "query": "q"}
 
+    async def test_filter_tags_requires_all_tags(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "alpha", ["x", "y"], ctx=ctx)
+        await remember("b", "beta", ["x"], ctx=ctx)
+        await remember("c", "gamma", ["y"], ctx=ctx)
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        c = storage.get_memory_by_key("c")
+        mock_vs = _make_mock_vector_store(
+            [(a.memory_id, 0.9), (b.memory_id, 0.8), (c.memory_id, 0.7)]
+        )
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", filter_tags=["x", "y"], ctx=ctx)
+
+        # Only "a" has both x and y
+        assert [item["key"] for item in result["items"]] == ["a"]
+        assert result["count"] == 1
+
+    async def test_filter_tags_none_returns_all(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "v", ["x"], ctx=ctx)
+        a = storage.get_memory_by_key("a")
+        mock_vs = _make_mock_vector_store([(a.memory_id, 0.9)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", ctx=ctx)
+
+        assert result["count"] == 1
+
+    async def test_filter_tags_requests_wider_candidate_pool(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import search_memories
+
+        _, _, jwt = server_env
+        mock_vs = _make_mock_vector_store([])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await search_memories("q", top_k=5, filter_tags=["x"], ctx=_make_ctx(jwt))
+
+        # When filter_tags is set, the vector search asks for the cap (50) so
+        # we can still return up to top_k matches after post-filtering.
+        assert mock_vs.search.call_args.kwargs["top_k"] == 50
+
+    async def test_filter_tags_trims_to_top_k_after_filter(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        for i in range(5):
+            await remember(f"k{i}", f"v{i}", ["x"], ctx=ctx)
+        mems = [storage.get_memory_by_key(f"k{i}") for i in range(5)]
+        mock_vs = _make_mock_vector_store(
+            [(m.memory_id, 0.9 - i * 0.1) for i, m in enumerate(mems)]
+        )
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", top_k=2, filter_tags=["x"], ctx=ctx)
+
+        assert result["count"] == 2
+        assert [item["key"] for item in result["items"]] == ["k0", "k1"]
+
     async def test_min_score_clamped_to_unit_interval(self, server_env):
         from unittest.mock import patch
 


### PR DESCRIPTION
Closes #377

## Summary

Adds an optional `filter_tags: list[str] | None` parameter to `search_memories`, letting callers narrow a semantic search to memories carrying a specific tag set. Complements `min_score` from #378.

## Decisions

- **AND semantics** — the param name is `filter_tags` (filter = narrow) and AND is the usual expectation when callers list constraints. OR can be approximated by separate calls if needed. Happy to switch to OR or add an `all_of`/`any_of` flavour if you'd prefer.
- **top_k refers to post-filter count** — when `filter_tags` is set, the vector store is asked for the full 50-result cap so post-filter trimming can still surface up to `top_k` matches. When unset, behaviour is unchanged (`top_k` passed through).
- **Post-filter, not pushed into the vector query** — S3 Vectors' metadata filtering isn't wired up here yet; this is a Python filter on hydrated memories. Keeps the change self-contained; can move it into the vector layer later without touching the public API.

## Tests

- `test_filter_tags_requires_all_tags` — memory with `{x, y}` passes; memories with only `x` or only `y` are excluded.
- `test_filter_tags_none_returns_all` — param defaulting to `None` preserves current behaviour.
- `test_filter_tags_requests_wider_candidate_pool` — asserts the vector store is called with `top_k=50` when filtering.
- `test_filter_tags_trims_to_top_k_after_filter` — trims to the requested `top_k` after filtering, preserving score order.

`uv run inv pre-push` green (547 vitest + 489 pytest).