### PR TITLE
chore: auto-merge passing Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,16 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #419

## Summary

Adds a workflow that enables squash auto-merge on every PR opened by `dependabot[bot]`. GitHub then merges automatically once all required checks pass. If CI fails, the PR stays open for manual review — same safety net as today.

Pairs with #410 (daily pip/npm cadence) so the queue drains continuously instead of piling up week-to-week.

## Safety

- `dependabot.yml` groups updates per ecosystem and ignores semver-major bumps for npm + `aws-cdk-lib`, so no surprise API breakage.
- CI is the usual strict gate (lint, types, unit + integration, frontend, coverage ≥100%, Trivy, SonarCloud).
- `dependabot[bot]` is the only actor the workflow fires for — human PRs stay manual.
- Workflow uses only built-ins (`gh pr merge`, ubuntu-latest runner label), so there's nothing third-party to pin to a SHA per CLAUDE.md conventions.

## Acceptance check

First Dependabot PR after this merges will either:
- merge automatically on green CI (expected), or
- remain open if CI fails — we can eyeball the next one to confirm.