### PR TITLE
feat: add Open Graph and Twitter Card meta tags

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -15,7 +15,41 @@ export default defineConfig({
         url: `docs/${item.url.replace(/^\//, "")}`,
       })),
   },
-  head: [["link", { rel: "icon", type: "image/svg+xml", href: "/docs/favicon.svg" }]],
+  head: [
+    ["link", { rel: "icon", type: "image/svg+xml", href: "/docs/favicon.svg" }],
+    ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:site_name", content: "Hive" }],
+    ["meta", { property: "og:title", content: "Hive Docs — Shared Memory for Claude Agents" }],
+    [
+      "meta",
+      {
+        property: "og:description",
+        content: "Documentation for Hive, a shared persistent memory service for Claude agents and teams.",
+      },
+    ],
+    ["meta", { property: "og:url", content: "https://hive.warlordofmars.net/docs/" }],
+    [
+      "meta",
+      { property: "og:image", content: "https://hive.warlordofmars.net/social-preview.png" },
+    ],
+    ["meta", { property: "og:image:width", content: "1200" }],
+    ["meta", { property: "og:image:height", content: "630" }],
+    ["meta", { property: "og:image:alt", content: "Hive — Shared Memory for Claude Agents" }],
+    ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    ["meta", { name: "twitter:title", content: "Hive Docs — Shared Memory for Claude Agents" }],
+    [
+      "meta",
+      {
+        name: "twitter:description",
+        content: "Documentation for Hive, a shared persistent memory service for Claude agents and teams.",
+      },
+    ],
+    [
+      "meta",
+      { name: "twitter:image", content: "https://hive.warlordofmars.net/social-preview.png" },
+    ],
+    ["meta", { name: "twitter:image:alt", content: "Hive — Shared Memory for Claude Agents" }],
+  ],
 
   themeConfig: {
     logo: { src: "/logo.svg", alt: "Hive" },

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,10 +4,26 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hive — Shared Memory</title>
+    <meta name="description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Hive" />
     <meta property="og:title" content="Hive — Shared Memory for Claude Agents" />
     <meta property="og:description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
+    <meta property="og:url" content="https://hive.warlordofmars.net/" />
     <meta property="og:image" content="https://hive.warlordofmars.net/social-preview.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Hive — Shared Memory for Claude Agents" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Hive — Shared Memory for Claude Agents" />
+    <meta name="twitter:description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
+    <meta name="twitter:image" content="https://hive.warlordofmars.net/social-preview.png" />
+    <meta name="twitter:image:alt" content="Hive — Shared Memory for Claude Agents" />
     <!-- Google Analytics 4 — only injected when VITE_GA_MEASUREMENT_ID is set at build time -->
     <script>
       (function () {


### PR DESCRIPTION
Closes #422

## Summary

Adds full Open Graph + Twitter Card metadata to both the marketing SPA and the docs site so links shared in Slack, Discord, Twitter/X, LinkedIn, iMessage, etc. render a real preview card instead of the current degraded/blank state.

## Changes

- **`ui/index.html`** — promoted the existing partial OG tags to a complete set: `og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image` (+ dimensions + alt), plus the full Twitter Card set (`summary_large_image`, title, description, image, alt). Added a plain `<meta name="description">` for search engines while we were in there.
- **`docs-site/.vitepress/config.mjs`** — same tag set added to VitePress's `head` config, titled/described for the docs.
- Both reference the existing `/social-preview.png` asset (1200×630).

## Design decision

Social-media crawlers (Slack, Twitter, LinkedIn, Discord) don't execute JavaScript — they fetch raw HTML. That means `react-helmet-async` for per-page tags on the SPA would add a runtime dependency without solving the actual problem (the crawler would still only see the static `index.html` tags). The sitewide static set covers 100% of the real use case; per-page overrides can be revisited if/when deep marketing pages need distinct previews.

VitePress pre-renders docs pages to static HTML at build time, so per-page overrides via frontmatter would work there — left as a follow-up.

## Verification

- `npm run build` in `docs-site/` — output HTML contains the new tags.
- `uv run inv pre-push` green.
- Post-deploy, verify with `curl -s https://hive.warlordofmars.net/ | grep -E 'og:|twitter:'`.