### PR TITLE
chore(ci): enforce status/priority/size labels on issues linked from PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something isn't working as expected
-labels: ["bug"]
+labels: ["bug", "status:ready"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an improvement or new capability
-labels: ["enhancement"]
+labels: ["enhancement", "status:ready"]
 body:
   - type: textarea
     id: problem

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,54 @@
+name: Issue label check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  check-issue-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract linked issue and verify required labels
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Find "Closes #NNN" (or Fixes / Resolves) in PR body or title.
+          # Accepts the GitHub-recognised forms:
+          #   Closes #123, Fixes #123, Resolves #123 (case-insensitive).
+          ISSUE_NUM=$(printf '%s\n%s' "$PR_TITLE" "$PR_BODY" \
+            | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+' \
+            | head -1 \
+            | grep -oE '[0-9]+' || true)
+
+          if [ -z "$ISSUE_NUM" ]; then
+            echo "::notice::No linked issue found (PR body/title contains no 'Closes #N'). Skipping label check."
+            exit 0
+          fi
+
+          echo "Linked issue: #$ISSUE_NUM"
+
+          LABELS=$(gh api "repos/$REPO/issues/$ISSUE_NUM" --jq '[.labels[].name] | join(",")')
+          echo "Labels on issue #$ISSUE_NUM: $LABELS"
+
+          MISSING=()
+          echo "$LABELS" | grep -qE '(^|,)status:' || MISSING+=("status:*")
+          echo "$LABELS" | grep -qE '(^|,)priority:' || MISSING+=("priority:p0|p1|p2|p3")
+          echo "$LABELS" | grep -qE '(^|,)size:' || MISSING+=("size:xs|s|m|l|xl")
+
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::Issue #$ISSUE_NUM is missing required labels: ${MISSING[*]}"
+            echo "Add status, priority, and size labels to the issue before merging this PR."
+            exit 1
+          fi
+
+          echo "::notice::Issue #$ISSUE_NUM has all required label categories."


### PR DESCRIPTION
## Summary

Enforces the new backlog label taxonomy (`status:*`, `priority:p*`, `size:*`) so autonomous agents and humans can trust the metadata.

## Changes

1. **`.github/ISSUE_TEMPLATE/bug_report.yml`** — default labels now include `status:ready`
2. **`.github/ISSUE_TEMPLATE/feature_request.yml`** — same
3. **`.github/workflows/label-check.yml`** — new workflow that:
   - Runs on `pull_request` (opened/edited/synchronize/reopened)
   - Extracts the linked issue number from `Closes #N` / `Fixes #N` / `Resolves #N` in the PR title or body
   - Fetches the issue's labels via `gh api`
   - Fails the check if the issue is missing any of `status:*`, `priority:*`, `size:*`
   - **Skips** (exit 0) for PRs without a linked issue — housekeeping PRs like this one don't fail

## Why this matters

Pairs with #461 (CLAUDE.md selection algorithm). The algorithm assumes every `status:ready` issue also has a priority and a size label; this check backs that assumption at merge time so a stray half-labelled issue can't slip in.

## Out of scope

- Dropdown-driven priority/size selection in the issue template — issue forms can't natively translate dropdown values to labels; a follow-up workflow could do it but isn't blocking
- Backfilling labels on existing issues — already done for all 58 open issues in the prior session

## Test plan

- [x] This PR has no `Closes #N` → label-check skips and passes (verifies the no-link branch)
- [ ] Next feature PR with `Closes #NNN` where the issue has all three label categories → label-check passes
- [ ] Next feature PR where the linked issue is missing e.g. `priority:*` → label-check fails with a clear message
- [x] Lint + typecheck + tests unaffected (pure CI/template changes)

https://claude.ai/code/session_01CHZukppdQyVuVfG3cJb2xV