### PR TITLE
feat: surface owner_client_id in list/search results + memory browser

### DIFF
--- a/docs-site/ui-guide/memory-browser.md
+++ b/docs-site/ui-guide/memory-browser.md
@@ -12,6 +12,7 @@ Your memories are listed in the main panel. Each card shows:
 - The memory **key**
 - A preview of the **value** (first 160 characters)
 - Any **tags** attached to the memory
+- A **by {client name}** badge attributing the memory to the OAuth client that created it (falls back to the client id when the name has been deleted)
 
 ## Searching memories
 

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -785,6 +785,7 @@ class MemorySearchResult(BaseModel):
     key: str
     value: str
     tags: list[str]
+    owner_client_id: str | None
     score: float  # cosine similarity (0.0–1.0); higher = more relevant
     created_at: datetime
     updated_at: datetime
@@ -796,6 +797,7 @@ class MemorySearchResult(BaseModel):
             key=m.key,
             value=m.value,
             tags=m.tags,
+            owner_client_id=m.owner_client_id,
             score=score,
             created_at=m.created_at,
             updated_at=m.updated_at,

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -556,7 +556,15 @@ async def list_memories(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="list_memories"
     )
     result: dict[str, Any] = {
-        "items": [{"key": m.key, "value": m.value, "tags": m.tags} for m in memories],
+        "items": [
+            {
+                "key": m.key,
+                "value": m.value,
+                "tags": m.tags,
+                "owner_client_id": m.owner_client_id,
+            }
+            for m in memories
+        ],
         "count": len(memories),
         "has_more": next_cursor is not None,
     }

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -358,6 +358,8 @@ class TestListMemories:
         keys = [m["key"] for m in result["items"]]
         assert "lst-a" in keys
         assert "lst-b" not in keys
+        # Agent attribution is surfaced on every item.
+        assert result["items"][0]["owner_client_id"] == client_id
 
     async def test_list_empty_tag_returns_empty(self, server_env):
         _, _, jwt = server_env
@@ -713,6 +715,7 @@ class TestSearchMemories:
         item = result["items"][0]
         assert item["key"] == "search-key"
         assert item["score"] == 0.88
+        assert item["owner_client_id"] == client_id
 
     async def test_returns_empty_when_no_index(self, server_env):
         from unittest.mock import patch

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -187,6 +187,19 @@ export default function MemoryBrowser() {
   const [versionsLoading, setVersionsLoading] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [pendingDelete, setPendingDelete] = useState(null);
+  const [clientNameById, setClientNameById] = useState({});
+
+  useEffect(function loadClientNames() {
+    api.listClients()
+      .then(function handleClients(data) {
+        const map = {};
+        for (const c of data.items ?? []) {
+          map[c.client_id] = c.client_name;
+        }
+        setClientNameById(map);
+      })
+      .catch(function ignore() {});
+  }, []);
   const searchDebounceRef = useRef(null);
   const listRef = useRef(null);
 
@@ -448,13 +461,18 @@ export default function MemoryBrowser() {
                 onKeyDown={(e) => handleCardKeyDown(e, m)}
               >
                 <div className="flex-1">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <strong>{m.key}</strong>
                     {m.score !== undefined && (
                       <Badge>{Math.round(m.score * 100)}% match</Badge>
                     )}
                     {m.expires_at && (
                       <Badge className="border-[var(--amber)] text-[var(--amber)]">Expires {new Date(m.expires_at).toLocaleDateString()}</Badge>
+                    )}
+                    {m.owner_client_id && (
+                      <Badge className="text-[var(--text-muted)]">
+                        by {clientNameById[m.owner_client_id] ?? m.owner_client_id}
+                      </Badge>
                     )}
                   </div>
                   <p className="mt-1 text-[var(--text-muted)] text-[13px] whitespace-pre-wrap">

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -249,7 +249,8 @@ describe("MemoryBrowser", () => {
     vi.clearAllMocks();
     api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
     api.searchMemories.mockResolvedValue({ items: [], count: 0 });
-    api.listClients.mockResolvedValue({ items: [] });
+    // Default to a shape without `items` so the `?? []` fallback is exercised.
+    api.listClients.mockResolvedValue({});
   });
 
   afterEach(() => {

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -12,6 +12,7 @@ vi.mock("../api.js", () => ({
     deleteMemory: vi.fn(),
     listMemoryVersions: vi.fn(),
     restoreMemoryVersion: vi.fn(),
+    listClients: vi.fn(),
   },
 }));
 
@@ -248,6 +249,7 @@ describe("MemoryBrowser", () => {
     vi.clearAllMocks();
     api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
     api.searchMemories.mockResolvedValue({ items: [], count: 0 });
+    api.listClients.mockResolvedValue({ items: [] });
   });
 
   afterEach(() => {
@@ -1017,5 +1019,48 @@ describe("MemoryBrowser", () => {
     fireEvent.click(getCard());
     expect(screen.queryByText("History: test-key")).toBeNull();
     expect(screen.getByText("Edit: test-key")).toBeTruthy();
+  });
+
+  it("renders attribution badge with client name when client is known", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ owner_client_id: "client-123" })],
+      next_cursor: null,
+    });
+    api.listClients.mockResolvedValue({
+      items: [{ client_id: "client-123", client_name: "My Agent" }],
+    });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => expect(screen.getByText("by My Agent")).toBeTruthy());
+  });
+
+  it("falls back to client id when name is not yet loaded", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ owner_client_id: "client-xyz" })],
+      next_cursor: null,
+    });
+    api.listClients.mockResolvedValue({ items: [] });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => expect(screen.getByText("by client-xyz")).toBeTruthy());
+  });
+
+  it("omits attribution badge when owner_client_id is missing", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory()],
+      next_cursor: null,
+    });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    expect(screen.queryByText(/^by /)).toBeNull();
+  });
+
+  it("swallows listClients errors and still renders memories", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listClients.mockRejectedValue(new Error("network"));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
   });
 });


### PR DESCRIPTION
Closes #382

## Summary

`Memory.owner_client_id` has been stored for a while, but nothing ever surfaced it. This PR propagates the field through the MCP surfaces and renders attribution in the memory browser.

## Changes

- **`MemorySearchResult`** (`src/hive/models.py`) — new `owner_client_id: str | None` field; `from_memory_and_score` populates it.
- **`list_memories` MCP tool** — response items now include `owner_client_id`.
- **`MemoryBrowser.jsx`** — loads the clients list once on mount and caches a `client_id → client_name` map. Each memory card renders a **"by {client_name}"** badge when `owner_client_id` is set, falling back to the raw id when the client has been deleted.
- **Tests** — server-level assertions on the new field in both list and search responses; four new vitest cases cover the badge with a known client, the id fallback, the no-id case, and `listClients` errors being swallowed non-fatally.
- **Docs** — `ui-guide/memory-browser.md` lists the new card element.

## Out of scope (per issue)

- Filtering by client in the UI — separate issue if we want it.
- Broader namespacing work — tracked in #386.

## Tests

`uv run inv pre-push` green (551 vitest + 491 pytest).