### PR TITLE
feat: add relate_memories MCP tool

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -749,6 +749,72 @@ async def search_memories(
     }
 
 
+@mcp.tool()
+async def relate_memories(
+    key: Annotated[str, "Key of the memory to find relations for"],
+    top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 5,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Return memories most semantically similar to the one at ``key``.
+
+    The source memory's value is used as the vector search query and the
+    source memory itself is excluded from the results.  ``score`` ranges
+    from 0.0 to 1.0 where higher means more semantically similar.
+    """
+    t0 = time.monotonic()
+    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    top_k = max(1, min(top_k, 50))
+
+    memory = storage.get_memory_by_key(key)
+    if memory is None:
+        raise ToolError(f"No memory found for key '{key}'.")
+
+    try:
+        # Fetch top_k+1 so that dropping the source still leaves up to top_k.
+        pairs = _vector_store().search(memory.value, client_id, top_k=top_k + 1)
+    except VectorIndexNotFoundError:
+        return {"items": [], "count": 0, "key": key}
+    except Exception:
+        logger.warning("Vector search failed (non-fatal)", exc_info=True)
+        return {"items": [], "count": 0, "key": key}
+
+    pairs = [(mid, score) for mid, score in pairs if mid != memory.memory_id][:top_k]
+    results = storage.hydrate_memory_ids(pairs)
+
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_searched,
+            client_id=client_id,
+            metadata={"key": key, "result_count": len(results), "related_to": memory.memory_id},
+        )
+    )
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "Related memories for '%s', %d result(s)",
+        key,
+        len(results),
+        extra={
+            "tool": "relate_memories",
+            "duration_ms": duration_ms,
+            "status": "success",
+        },
+    )
+    await emit_metric("ToolInvocations", operation="relate_memories")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="relate_memories",
+    )
+    return {
+        "items": [
+            MemorySearchResult.from_memory_and_score(m, score).model_dump() for m, score in results
+        ],
+        "count": len(results),
+        "key": key,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Entry points
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1018,6 +1018,124 @@ class TestSearchMemories:
 
 
 # ---------------------------------------------------------------------------
+# relate_memories
+# ---------------------------------------------------------------------------
+
+
+class TestRelateMemories:
+    async def test_returns_related_with_source_excluded(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import relate_memories, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("source", "about cats and dogs", ["t"], ctx=ctx)
+        await remember("a", "cats are great pets", ["t"], ctx=ctx)
+        await remember("b", "dogs are great pets", ["t"], ctx=ctx)
+        src = storage.get_memory_by_key("source")
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        # Vector store also ranks the source highly; relate_memories must drop it.
+        mock_vs = _make_mock_vector_store(
+            [(src.memory_id, 0.99), (a.memory_id, 0.9), (b.memory_id, 0.8)]
+        )
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await relate_memories("source", top_k=2, ctx=ctx)
+
+        keys = [item["key"] for item in result["items"]]
+        assert keys == ["a", "b"]
+        assert result["count"] == 2
+        assert result["key"] == "source"
+
+    async def test_uses_source_value_as_query(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import relate_memories, remember
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("source", "unique search phrase", [], ctx=ctx)
+        mock_vs = _make_mock_vector_store([])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await relate_memories("source", ctx=ctx)
+
+        assert mock_vs.search.call_args.args[0] == "unique search phrase"
+        # top_k+1 requested so the source-memory drop still leaves headroom.
+        assert mock_vs.search.call_args.kwargs["top_k"] == 6
+
+    async def test_missing_key_raises_tool_error(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import relate_memories
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="No memory found"):
+            await relate_memories("nonexistent", ctx=_make_ctx(jwt))
+
+    async def test_returns_empty_when_no_index(self, server_env):
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import relate_memories, remember
+        from hive.vector_store import VectorIndexNotFoundError
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("src", "v", [], ctx=ctx)
+        mock_vs = MagicMock()
+        mock_vs.search.side_effect = VectorIndexNotFoundError("no index")
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await relate_memories("src", ctx=ctx)
+
+        assert result == {"items": [], "count": 0, "key": "src"}
+
+    async def test_returns_empty_on_vector_error(self, server_env):
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import relate_memories, remember
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("src", "v", [], ctx=ctx)
+        mock_vs = MagicMock()
+        mock_vs.search.side_effect = RuntimeError("bedrock down")
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await relate_memories("src", ctx=ctx)
+
+        assert result == {"items": [], "count": 0, "key": "src"}
+
+    async def test_top_k_clamped(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import relate_memories, remember
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("src", "v", [], ctx=ctx)
+        mock_vs = _make_mock_vector_store([])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await relate_memories("src", top_k=999, ctx=ctx)
+
+        # 50 cap + 1 headroom
+        assert mock_vs.search.call_args.kwargs["top_k"] == 51
+
+    async def test_requires_read_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import relate_memories
+
+        storage, _, _ = server_env
+        write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await relate_memories("any", ctx=_make_ctx(write_only_jwt))
+
+
+# ---------------------------------------------------------------------------
 # forget_all
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #381

## Summary

New `relate_memories(key, top_k=5)` MCP tool: given a memory key, return the N memories most semantically similar to it. Enables knowledge-graph-style traversal ("what else do I know that's connected to this?") without needing a natural-language query.

## Implementation

- Fetch the source memory by key (`ToolError` if missing).
- Use the source memory's `value` as the vector search query.
- Request `top_k + 1` candidates so dropping the source still leaves room for `top_k` results.
- Filter the source's own `memory_id` out of the returned pairs, trim to `top_k`, hydrate.
- Response shape mirrors `search_memories`: `{ items: [...], count, key }` (uses `key` in place of `query` since the source's key is what disambiguates the call).
- `VectorIndexNotFoundError` + unexpected vector errors degrade to an empty result, matching `search_memories`.
- Emits the standard `ToolInvocations` + `StorageLatencyMs` metrics and a `memory_searched` activity event with a `related_to` tag in the metadata.

## Tests

7 new cases covering: the happy path with source exclusion, the source value becoming the query, the `top_k+1` request sizing, missing-key → `ToolError`, `VectorIndexNotFoundError` → empty, unexpected vector error → empty, `top_k` clamped at 50 (vector call sees 51), and read-scope enforcement.

`uv run inv pre-push` green (551 vitest + 498 pytest).