### PR TITLE
feat: GA4 cookie consent banner for GDPR/CCPA compliance

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -24,14 +24,21 @@
     <meta name="twitter:description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
     <meta name="twitter:image" content="https://hive.warlordofmars.net/social-preview.png" />
     <meta name="twitter:image:alt" content="Hive — Shared Memory for Claude Agents" />
-    <!-- Google Analytics 4 — only injected when VITE_GA_MEASUREMENT_ID is set at build time -->
+    <!-- Google Analytics 4 — gated on the consent banner. Only loads when
+         VITE_GA_MEASUREMENT_ID is set AND the visitor has opted in. -->
     <script>
       (function () {
         var id = "%VITE_GA_MEASUREMENT_ID%";
         if (!id) return;
+        try {
+          if (localStorage.getItem("hive_ga_consent") !== "accept") return;
+        } catch (e) {
+          return;
+        }
         var s = document.createElement("script");
         s.src = "https://www.googletagmanager.com/gtag/js?id=" + id;
         s.async = true;
+        s.dataset.hiveGa = "1";
         document.head.appendChild(s);
         window.dataLayer = window.dataLayer || [];
         function gtag() { window.dataLayer.push(arguments); }

--- a/ui/src/analytics.js
+++ b/ui/src/analytics.js
@@ -4,13 +4,19 @@
  * Thin wrapper around gtag. All functions are no-ops when:
  *   - running in local dev (import.meta.env.DEV)
  *   - VITE_GA_MEASUREMENT_ID is not set
+ *   - the visitor has not opted in via the consent banner
  */
 
+import { hasAcceptedConsent } from "./lib/consent.js";
+
 const ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
-const enabled = !import.meta.env.DEV && !!ID;
+
+function enabled() {
+  return !import.meta.env.DEV && !!ID && hasAcceptedConsent();
+}
 
 export function trackPageView(path) {
-  if (!enabled) return;
+  if (!enabled()) return;
   globalThis.gtag?.("event", "page_view", {
     page_path: path,
     send_to: ID,
@@ -18,6 +24,6 @@ export function trackPageView(path) {
 }
 
 export function trackEvent(name, params = {}) {
-  if (!enabled) return;
+  if (!enabled()) return;
   globalThis.gtag?.("event", name, { ...params, send_to: ID });
 }

--- a/ui/src/analytics.test.js
+++ b/ui/src/analytics.test.js
@@ -56,11 +56,13 @@ describe("analytics (GA enabled — production with ID)", () => {
     vi.resetModules();
     vi.stubEnv("DEV", false);
     vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    localStorage.setItem("hive_ga_consent", "accept");
     window.gtag = vi.fn();
   });
 
   afterEach(() => {
     delete window.gtag;
+    localStorage.clear();
     vi.unstubAllEnvs();
   });
 
@@ -100,5 +102,41 @@ describe("analytics (GA enabled — production with ID)", () => {
     delete window.gtag;
     const { trackEvent } = await import("./analytics.js");
     expect(() => trackEvent("cta_click")).not.toThrow();
+  });
+});
+
+describe("analytics (GA gated on consent)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("DEV", false);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    localStorage.clear();
+    window.gtag = vi.fn();
+  });
+
+  afterEach(() => {
+    delete window.gtag;
+    localStorage.clear();
+    vi.unstubAllEnvs();
+  });
+
+  it("trackPageView is a no-op when no consent is stored", async () => {
+    const { trackPageView } = await import("./analytics.js");
+    trackPageView("/pricing");
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+
+  it("trackPageView is a no-op when consent is rejected", async () => {
+    localStorage.setItem("hive_ga_consent", "reject");
+    const { trackPageView } = await import("./analytics.js");
+    trackPageView("/pricing");
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+
+  it("trackEvent is a no-op when consent is rejected", async () => {
+    localStorage.setItem("hive_ga_consent", "reject");
+    const { trackEvent } = await import("./analytics.js");
+    trackEvent("cta_click");
+    expect(window.gtag).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/components/ConsentBanner.jsx
+++ b/ui/src/components/ConsentBanner.jsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  CONSENT_RESET_EVENT,
+  getConsent,
+  loadGtag,
+  setConsent,
+} from "@/lib/consent";
+
+export default function ConsentBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(function subscribeToResetEvent() {
+    if (getConsent() === null) setVisible(true);
+    function onReset() {
+      setVisible(true);
+    }
+    globalThis.addEventListener(CONSENT_RESET_EVENT, onReset);
+    return function cleanup() {
+      globalThis.removeEventListener(CONSENT_RESET_EVENT, onReset);
+    };
+  }, []);
+
+  function handleAccept() {
+    setConsent("accept");
+    loadGtag(import.meta.env.VITE_GA_MEASUREMENT_ID);
+    setVisible(false);
+  }
+
+  function handleReject() {
+    setConsent("reject");
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Cookie consent"
+      className="fixed bottom-4 left-4 right-4 sm:left-auto sm:right-4 sm:max-w-[420px] bg-[var(--surface)] border border-[var(--border)] rounded-[var(--radius)] shadow-lg p-4 z-50"
+    >
+      <p className="text-sm text-[var(--text)] mb-3">
+        We use Google Analytics to understand how visitors use the marketing
+        site. No tracking happens until you choose. See the{" "}
+        <a
+          href="/privacy"
+          className="text-[var(--accent)] underline"
+        >
+          Privacy Policy
+        </a>{" "}
+        for details.
+      </p>
+      <div className="flex gap-2">
+        <Button variant="brand" size="sm" onClick={handleAccept}>
+          Accept
+        </Button>
+        <Button variant="secondary" size="sm" onClick={handleReject}>
+          Reject
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/ConsentBanner.test.jsx
+++ b/ui/src/components/ConsentBanner.test.jsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import ConsentBanner from "./ConsentBanner.jsx";
+import { CONSENT_KEY, CONSENT_RESET_EVENT } from "../lib/consent.js";
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <ConsentBanner />
+    </MemoryRouter>,
+  );
+}
+
+describe("ConsentBanner", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.querySelectorAll("script[data-hive-ga]").forEach((s) => s.remove());
+    delete globalThis.gtag;
+    delete globalThis.dataLayer;
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TESTID");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("renders on first visit when no choice is stored", async () => {
+    await act(async () => renderBanner());
+    expect(screen.getByRole("dialog", { name: "Cookie consent" })).toBeTruthy();
+    expect(screen.getByText("Accept")).toBeTruthy();
+    expect(screen.getByText("Reject")).toBeTruthy();
+  });
+
+  it("is hidden when consent was already accepted", async () => {
+    localStorage.setItem(CONSENT_KEY, "accept");
+    await act(async () => renderBanner());
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+  });
+
+  it("is hidden when consent was already rejected", async () => {
+    localStorage.setItem(CONSENT_KEY, "reject");
+    await act(async () => renderBanner());
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+  });
+
+  it("Accept stores consent, loads gtag, and hides the banner", async () => {
+    await act(async () => renderBanner());
+    fireEvent.click(screen.getByText("Accept"));
+    expect(localStorage.getItem(CONSENT_KEY)).toBe("accept");
+    expect(document.querySelector("script[data-hive-ga]")).not.toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+  });
+
+  it("Reject stores consent, does not load gtag, and hides the banner", async () => {
+    await act(async () => renderBanner());
+    fireEvent.click(screen.getByText("Reject"));
+    expect(localStorage.getItem(CONSENT_KEY)).toBe("reject");
+    expect(document.querySelector("script[data-hive-ga]")).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+  });
+
+  it("re-shows the banner when the reset event fires", async () => {
+    localStorage.setItem(CONSENT_KEY, "reject");
+    await act(async () => renderBanner());
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+    await act(async () => {
+      globalThis.dispatchEvent(new CustomEvent(CONSENT_RESET_EVENT));
+    });
+    expect(screen.getByRole("dialog", { name: "Cookie consent" })).toBeTruthy();
+  });
+
+  it("links to the Privacy Policy", async () => {
+    await act(async () => renderBanner());
+    const link = screen.getByText("Privacy Policy");
+    expect(link.getAttribute("href")).toBe("/privacy");
+  });
+});

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -2,8 +2,16 @@
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import ConsentBanner from "@/components/ConsentBanner";
+import { CONSENT_RESET_EVENT, clearConsent } from "@/lib/consent";
 
 const NAV_LINK_BASE = "text-sm no-underline hover:text-white transition-colors";
+
+function handleReopenConsent(e) {
+  e.preventDefault();
+  clearConsent();
+  globalThis.dispatchEvent(new CustomEvent(CONSENT_RESET_EVENT));
+}
 
 export default function PageLayout({ children }) {
   const navigate = useNavigate();
@@ -65,11 +73,19 @@ export default function PageLayout({ children }) {
               <a href="/status" className="no-underline hover:text-[var(--text)] transition-colors">Status</a>
               <a href="/terms" className="no-underline hover:text-[var(--text)] transition-colors">Terms</a>
               <a href="/privacy" className="no-underline hover:text-[var(--text)] transition-colors">Privacy</a>
+              <a
+                href="#cookie-preferences"
+                onClick={handleReopenConsent}
+                className="no-underline hover:text-[var(--text)] transition-colors"
+              >
+                Cookie preferences
+              </a>
             </div>
           </div>
           <p className="mt-6 text-[13px] text-[var(--text-muted)]">© 2026 Hive. Free to use.</p>
         </div>
       </footer>
+      <ConsentBanner />
     </div>
   );
 }

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -117,4 +117,34 @@ describe("PageLayout", () => {
     expect(btn.className).toContain("border-white/60");
     expect(btn.className).toContain("marketing-signin-btn");
   });
+
+  it("mounts the consent banner when no consent has been stored", async () => {
+    localStorage.removeItem("hive_ga_consent");
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    expect(screen.getByRole("dialog", { name: "Cookie consent" })).toBeTruthy();
+  });
+
+  it("renders Cookie preferences footer link", async () => {
+    const { container } = await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    const footer = container.querySelector("footer");
+    expect(within(footer).getByText("Cookie preferences")).toBeTruthy();
+  });
+
+  it("Cookie preferences click clears stored consent and re-shows the banner", async () => {
+    localStorage.setItem("hive_ga_consent", "reject");
+    const { container } = await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    // Banner hidden while consent is stored.
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+    const footer = container.querySelector("footer");
+    const link = within(footer).getByText("Cookie preferences");
+    await act(async () => fireEvent.click(link));
+    expect(localStorage.getItem("hive_ga_consent")).toBeNull();
+    expect(screen.getByRole("dialog", { name: "Cookie consent" })).toBeTruthy();
+  });
 });

--- a/ui/src/components/PrivacyPage.jsx
+++ b/ui/src/components/PrivacyPage.jsx
@@ -117,14 +117,17 @@ export default function PrivacyPage() {
             <p>
               The Hive marketing site (hive.warlordofmars.net and its sub-pages, including <code>/pricing</code>,
               {" "}<code>/faq</code>, <code>/use-cases</code>, and <code>/docs</code>) uses Google
-              Analytics 4 (GA4) to measure page views and navigation events. GA4 may set cookies
-              in your browser and send anonymised usage data to Google.
+              Analytics 4 (GA4) to measure page views and navigation events.
             </p>
             <p>
-              The management UI (<code>/app</code>) does not send data to GA4.
+              GA4 is <strong>opt-in</strong>: we show a consent banner on your first visit with
+              equal-prominence Accept and Reject buttons. No GA4 script loads and no data is sent
+              to Google until you click Accept. You can change your choice at any time via the
+              <strong> Cookie preferences </strong>link in the footer. The management UI
+              (<code>/app</code>) never sends data to GA4, regardless of your choice.
             </p>
             <p>
-              You can opt out of GA4 tracking by enabling "Do Not Track" in your browser, using a
+              You can also opt out at the browser level by enabling "Do Not Track", using a
               content blocker, or installing the{" "}
               <a
                 href="https://tools.google.com/dlpage/gaoptout"

--- a/ui/src/lib/consent.js
+++ b/ui/src/lib/consent.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+
+/**
+ * GA4 consent utilities. The marketing site must not load Google Analytics
+ * before the visitor has explicitly opted in (GDPR/CCPA). Both this module
+ * and the inline bootstrap in index.html gate on the `hive_ga_consent`
+ * localStorage key.
+ */
+
+export const CONSENT_KEY = "hive_ga_consent";
+export const CONSENT_RESET_EVENT = "hive:consent-reset";
+
+export function getConsent() {
+  try {
+    return globalThis.localStorage?.getItem(CONSENT_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function setConsent(value) {
+  try {
+    globalThis.localStorage?.setItem(CONSENT_KEY, value);
+  } catch {
+    /* private browsing / SSR — silently ignore */
+  }
+}
+
+export function clearConsent() {
+  try {
+    globalThis.localStorage?.removeItem(CONSENT_KEY);
+  } catch {
+    /* private browsing / SSR — silently ignore */
+  }
+}
+
+export function hasAcceptedConsent() {
+  return getConsent() === "accept";
+}
+
+export function loadGtag(measurementId) {
+  if (!measurementId) return;
+  const doc = globalThis.document;
+  if (!doc) return;
+  if (doc.querySelector("script[data-hive-ga]")) return;
+  const s = doc.createElement("script");
+  s.src = "https://www.googletagmanager.com/gtag/js?id=" + measurementId;
+  s.async = true;
+  s.dataset.hiveGa = "1";
+  doc.head.appendChild(s);
+  globalThis.dataLayer = globalThis.dataLayer || [];
+  function gtag() {
+    globalThis.dataLayer.push(arguments);
+  }
+  globalThis.gtag = gtag;
+  gtag("js", new Date());
+  gtag("config", measurementId, { send_page_view: false });
+}

--- a/ui/src/lib/consent.test.js
+++ b/ui/src/lib/consent.test.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CONSENT_KEY,
+  CONSENT_RESET_EVENT,
+  clearConsent,
+  getConsent,
+  hasAcceptedConsent,
+  loadGtag,
+  setConsent,
+} from "./consent.js";
+
+describe("consent utilities", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("getConsent returns null when unset", () => {
+    expect(getConsent()).toBeNull();
+  });
+
+  it("setConsent/getConsent round-trip", () => {
+    setConsent("accept");
+    expect(getConsent()).toBe("accept");
+  });
+
+  it("clearConsent removes the stored value", () => {
+    setConsent("reject");
+    clearConsent();
+    expect(getConsent()).toBeNull();
+  });
+
+  it("hasAcceptedConsent is true only for 'accept'", () => {
+    expect(hasAcceptedConsent()).toBe(false);
+    setConsent("reject");
+    expect(hasAcceptedConsent()).toBe(false);
+    setConsent("accept");
+    expect(hasAcceptedConsent()).toBe(true);
+  });
+
+  it("swallows localStorage errors from get", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(getConsent()).toBeNull();
+  });
+
+  it("swallows localStorage errors from set", () => {
+    vi.stubGlobal("localStorage", {
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(() => setConsent("accept")).not.toThrow();
+  });
+
+  it("swallows localStorage errors from remove", () => {
+    vi.stubGlobal("localStorage", {
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(() => clearConsent()).not.toThrow();
+  });
+
+  it("CONSENT_KEY and CONSENT_RESET_EVENT are stable strings", () => {
+    expect(CONSENT_KEY).toBe("hive_ga_consent");
+    expect(CONSENT_RESET_EVENT).toBe("hive:consent-reset");
+  });
+
+  describe("loadGtag", () => {
+    beforeEach(() => {
+      document
+        .querySelectorAll("script[data-hive-ga]")
+        .forEach((s) => s.remove());
+      delete globalThis.gtag;
+      delete globalThis.dataLayer;
+    });
+
+    it("is a no-op when no measurement id is given", () => {
+      loadGtag("");
+      expect(document.querySelector("script[data-hive-ga]")).toBeNull();
+    });
+
+    it("injects the gtag script and initialises gtag()", () => {
+      loadGtag("G-TESTID");
+      const s = document.querySelector("script[data-hive-ga]");
+      expect(s).not.toBeNull();
+      expect(s.src).toContain("googletagmanager.com/gtag/js?id=G-TESTID");
+      expect(typeof globalThis.gtag).toBe("function");
+      expect(Array.isArray(globalThis.dataLayer)).toBe(true);
+    });
+
+    it("does not inject the script twice", () => {
+      loadGtag("G-TESTID");
+      loadGtag("G-TESTID");
+      expect(document.querySelectorAll("script[data-hive-ga]")).toHaveLength(1);
+    });
+
+    it("is a no-op when document is missing", () => {
+      vi.stubGlobal("document", undefined);
+      expect(() => loadGtag("G-TESTID")).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Closes #414

## Summary

Adds a GA4 opt-in consent banner so the marketing site stops loading Google Analytics before the visitor has explicitly consented — closing the GDPR/UK-GDPR/CCPA compliance gap called out in the issue.

## What changes for visitors

- On first visit to any marketing page, a modest banner appears at the bottom-right with **Accept** and **Reject** buttons of equal prominence (ICO/EDPB requirement — no dark patterns).
- Until a choice is made, **no GA4 script loads** and no gtag calls fire. Confirmed locally via both the inline bootstrap in `index.html` and the `analytics.js` wrapper.
- Choice is persisted in `localStorage` under `hive_ga_consent`.
- A new **Cookie preferences** link in the marketing footer clears the stored choice and re-shows the banner.
- The management UI at `/app` is untouched — PageLayout is marketing-only so the banner never mounts there.

## What changes in code

- New `ui/src/lib/consent.js` — shared helpers (`getConsent`, `setConsent`, `clearConsent`, `hasAcceptedConsent`, `loadGtag`) plus the `CONSENT_KEY` and `CONSENT_RESET_EVENT` constants. Dynamic `loadGtag` mirrors the inline bootstrap so the Accept handler can install GA4 without a page reload.
- New `ConsentBanner.jsx` with seven vitest cases: first-visit display, hidden on accept/reject, Accept loads the gtag script + stores consent, Reject stores consent without loading anything, reset event re-shows the banner, Privacy Policy link.
- `analytics.js` — `enabled` now also requires `hasAcceptedConsent()`. Existing tests updated to stub consent when they need the enabled path; added a new describe block for the gated-on-consent case.
- `ui/index.html` — inline GA bootstrap wrapped in a `localStorage.getItem("hive_ga_consent") === "accept"` gate with a try/catch for private-browsing safety. Also tags the injected `<script>` with `data-hive-ga` so we never inject twice.
- `PageLayout.jsx` — mounts `<ConsentBanner />` and adds the Cookie preferences footer link. Three new tests cover the mount, the link presence, and the reset flow.
- `PrivacyPage.jsx` §6 rewritten to describe the opt-in mechanism and point at the footer link.

## Verification

- `uv run inv pre-push` green (576 vitest + 506 pytest).
- Post-deploy manual check: with an empty `localStorage`, open devtools Network tab on `hive.warlordofmars.net/` — no requests to `google-analytics.com` / `googletagmanager.com` should appear until you click Accept.

## Out of scope

- Region detection (EU-vs-rest) — per the issue, simpler to show the banner to all visitors and let them choose.
- Full consent management platform — lightweight in-house banner is enough at current scale.