### PR TITLE
feat: GDPR/CCPA data export endpoint + UI

### DIFF
--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -54,6 +54,10 @@ Sign into the management UI and go to **Settings → Delete account**. This perm
 
 If you can't access your account, contact support.
 
+### How do I export my data?
+
+Sign into the management UI and click **Settings → Export my data**. You'll download a JSON file with your profile, all memories, OAuth clients, and the last 90 days of activity. The same data is available programmatically via `GET /api/account/export` (Bearer auth required). Rate-limited to one export per 5 minutes.
+
 ### Can I use Hive with multiple devices?
 
 Yes. Each device or client registers its own OAuth connection. They all share the same underlying memory store under your account.

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -106,12 +106,11 @@ async def export_account(
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    now = datetime.now(timezone.utc)
-    bucket = int(now.timestamp()) // EXPORT_RATE_LIMIT_SECONDS
+    # Rate limit: one export per EXPORT_RATE_LIMIT_SECONDS. The counter item
+    # has a matching TTL and is only set on first write (``if_not_exists``),
+    # so DynamoDB cleans it up on its own after the window passes.
     count = storage.increment_rate_limit_counter(
-        user_id,
-        f"export#{bucket}",
-        ttl_seconds=EXPORT_RATE_LIMIT_SECONDS * 2,
+        user_id, "export", ttl_seconds=EXPORT_RATE_LIMIT_SECONDS
     )
     if count > 1:
         raise HTTPException(
@@ -119,6 +118,8 @@ async def export_account(
             detail="Exports are limited to one per 5 minutes.",
             headers={"Retry-After": str(EXPORT_RATE_LIMIT_SECONDS)},
         )
+
+    now = datetime.now(timezone.utc)
 
     clients, _ = storage.list_clients(owner_user_id=user_id, limit=EXPORT_CLIENTS_LIMIT)
     client_ids = {c.client_id for c in clients}

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -1,16 +1,20 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
 """
-Account self-service endpoint.
+Account self-service endpoints.
 
-DELETE /api/account — permanently erase all data for the authenticated user,
-satisfying GDPR Article 17 right-to-erasure.
+- DELETE /api/account        — GDPR Article 17 right-to-erasure
+- GET    /api/account/export — GDPR Article 20 right-to-portability / CCPA §1798.100
 """
 
 from __future__ import annotations
 
+import json
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from hive.api._auth import require_mgmt_user
@@ -18,6 +22,10 @@ from hive.models import ActivityEvent, EventType
 from hive.storage import HiveStorage
 
 router = APIRouter(tags=["account"])
+
+EXPORT_RATE_LIMIT_SECONDS = 300  # one export per 5 minutes per user
+EXPORT_ACTIVITY_LOOKBACK_DAYS = 90  # activity-log retention per Privacy Policy §9
+EXPORT_CLIENTS_LIMIT = 1000  # safety cap; quota is much lower in practice
 
 
 def _storage() -> HiveStorage:
@@ -69,4 +77,120 @@ async def delete_account(
                 "deleted_clients": counts["deleted_clients"],
             },
         )
+    )
+
+
+@router.get(
+    "/account/export",
+    summary="Export my data",
+    description=(
+        "Stream a JSON document containing the authenticated user's profile, "
+        "all their memories, OAuth clients, and recent activity log entries "
+        "(90-day window, matching the retention policy). Satisfies GDPR "
+        "Article 20 and CCPA §1798.100 portability rights. Rate-limited to "
+        "one export per 5 minutes per user."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "User not found"},
+        429: {"description": "Export rate limit exceeded"},
+    },
+)
+async def export_account(
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> StreamingResponse:
+    user_id: str = claims["sub"]
+
+    user = storage.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    now = datetime.now(timezone.utc)
+    bucket = int(now.timestamp()) // EXPORT_RATE_LIMIT_SECONDS
+    count = storage.increment_rate_limit_counter(
+        user_id,
+        f"export#{bucket}",
+        ttl_seconds=EXPORT_RATE_LIMIT_SECONDS * 2,
+    )
+    if count > 1:
+        raise HTTPException(
+            status_code=429,
+            detail="Exports are limited to one per 5 minutes.",
+            headers={"Retry-After": str(EXPORT_RATE_LIMIT_SECONDS)},
+        )
+
+    clients, _ = storage.list_clients(owner_user_id=user_id, limit=EXPORT_CLIENTS_LIMIT)
+    client_ids = {c.client_id for c in clients}
+
+    today = now.date()
+    dates = [(today - timedelta(days=i)).isoformat() for i in range(EXPORT_ACTIVITY_LOOKBACK_DAYS)]
+
+    def _stream() -> Iterator[str]:
+        yield "{"
+        yield f'"exported_at":{json.dumps(now.isoformat())},'
+        yield '"user":' + json.dumps(
+            {
+                "user_id": user.user_id,
+                "email": user.email,
+                "display_name": user.display_name,
+                "role": user.role,
+                "created_at": user.created_at.isoformat(),
+            }
+        )
+        yield ',"memories":['
+        for i, memory in enumerate(storage.iter_all_memories(owner_user_id=user_id)):
+            if i:
+                yield ","
+            yield json.dumps(
+                {
+                    "memory_id": memory.memory_id,
+                    "key": memory.key,
+                    "value": memory.value,
+                    "tags": memory.tags,
+                    "owner_client_id": memory.owner_client_id,
+                    "created_at": memory.created_at.isoformat(),
+                    "updated_at": memory.updated_at.isoformat(),
+                    "expires_at": (
+                        memory.expires_at.isoformat() if memory.expires_at is not None else None
+                    ),
+                }
+            )
+        yield '],"clients":['
+        for i, client in enumerate(clients):
+            if i:
+                yield ","
+            yield json.dumps(
+                {
+                    "client_id": client.client_id,
+                    "client_name": client.client_name,
+                    "client_type": client.client_type.value,
+                    "created_at": client.created_at.isoformat(),
+                }
+            )
+        yield '],"activity_log":['
+        events = storage.get_events_for_dates(dates, limit=10000)
+        emitted = 0
+        for event in events:
+            if event.client_id not in client_ids:
+                continue
+            if emitted:
+                yield ","
+            emitted += 1
+            yield json.dumps(
+                {
+                    "event_id": event.event_id,
+                    "event_type": event.event_type.value,
+                    "client_id": event.client_id,
+                    "timestamp": event.timestamp.isoformat(),
+                    "metadata": event.metadata,
+                }
+            )
+        yield "]}"
+
+    filename = f"hive-export-{user_id}-{now.strftime('%Y%m%d')}.json"
+    return StreamingResponse(
+        _stream(),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -316,3 +316,31 @@ class TestExportAccount:
         assert body["memories"] == []
         assert body["clients"] == []
         assert body["activity_log"] == []
+
+    def test_multiple_clients_and_events_render_with_separators(self, client):
+        import json
+
+        tc, storage = client
+        from hive.models import ActivityEvent, EventType, OAuthClient
+
+        # Two clients and two events for the user — exercises the inter-item
+        # separator branches in the streamed JSON builder.
+        c1 = OAuthClient(client_name="agent-1", owner_user_id=_USER_ID)
+        c2 = OAuthClient(client_name="agent-2", owner_user_id=_USER_ID)
+        storage.put_client(c1)
+        storage.put_client(c2)
+        for c in (c1, c2):
+            storage.log_event(
+                ActivityEvent(
+                    event_type=EventType.memory_created,
+                    client_id=c.client_id,
+                    metadata={"key": "k"},
+                )
+            )
+
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        ids = {c["client_id"] for c in body["clients"]}
+        assert {c1.client_id, c2.client_id}.issubset(ids)
+        event_client_ids = [e["client_id"] for e in body["activity_log"]]
+        assert len(event_client_ids) >= 2

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -180,3 +180,139 @@ class TestDeleteAccount:
     def test_requires_auth(self, unauthed_client):
         resp = unauthed_client.request("DELETE", "/api/account", json={"confirm": True})
         assert resp.status_code in (401, 403)
+
+
+class TestExportAccount:
+    def test_returns_json_bundle_with_all_sections(self, client):
+        import json
+
+        tc, storage = client
+        from hive.models import ActivityEvent, EventType, OAuthClient
+
+        # Add a client owned by the user and an activity event under it
+        c = OAuthClient(client_name="my-agent", owner_user_id=_USER_ID)
+        storage.put_client(c)
+        storage.log_event(
+            ActivityEvent(
+                event_type=EventType.memory_created,
+                client_id=c.client_id,
+                metadata={"key": "test-key"},
+            )
+        )
+
+        resp = tc.get("/api/account/export")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        disposition = resp.headers["content-disposition"]
+        assert "attachment" in disposition
+        assert f"hive-export-{_USER_ID}" in disposition
+
+        body = json.loads(resp.content)
+        assert set(body.keys()) == {
+            "exported_at",
+            "user",
+            "memories",
+            "clients",
+            "activity_log",
+        }
+        assert body["user"]["user_id"] == _USER_ID
+        assert body["user"]["email"] == "user@example.com"
+        assert len(body["memories"]) == 1
+        assert body["memories"][0]["key"] == "test-key"
+        assert any(client["client_id"] == c.client_id for client in body["clients"])
+        assert any(e["client_id"] == c.client_id for e in body["activity_log"])
+
+    def test_excludes_memories_from_other_users(self, client):
+        import json
+
+        tc, storage = client
+        from hive.models import Memory
+
+        storage.put_memory(
+            Memory(
+                key="someone-else",
+                value="v",
+                owner_client_id="other-client",
+                owner_user_id="other-user",
+            )
+        )
+
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        keys = [m["key"] for m in body["memories"]]
+        assert "someone-else" not in keys
+
+    def test_excludes_activity_events_from_other_clients(self, client):
+        import json
+
+        tc, storage = client
+        from hive.models import ActivityEvent, EventType
+
+        storage.log_event(
+            ActivityEvent(
+                event_type=EventType.memory_created,
+                client_id="not-my-client",
+                metadata={"key": "leak"},
+            )
+        )
+
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        client_ids = {e["client_id"] for e in body["activity_log"]}
+        assert "not-my-client" not in client_ids
+
+    def test_rate_limited_after_first_export(self, client):
+        tc, _ = client
+        first = tc.get("/api/account/export")
+        assert first.status_code == 200
+        # Drain the stream so the counter has been written.
+        _ = first.content
+
+        second = tc.get("/api/account/export")
+        assert second.status_code == 429
+        assert second.headers.get("retry-after") == "300"
+
+    def test_returns_404_if_user_not_found(self, client):
+        tc, storage = client
+        storage.delete_user(_USER_ID)
+        resp = tc.get("/api/account/export")
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.get("/api/account/export")
+        assert resp.status_code in (401, 403)
+
+    def test_memory_expires_at_serialised_when_present(self, client):
+        import json
+        from datetime import datetime, timedelta, timezone
+
+        tc, storage = client
+        from hive.models import Memory
+
+        storage.put_memory(
+            Memory(
+                key="ttl-key",
+                value="v",
+                owner_client_id=_USER_ID,
+                owner_user_id=_USER_ID,
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        )
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        ttl_mem = next(m for m in body["memories"] if m["key"] == "ttl-key")
+        assert ttl_mem["expires_at"] is not None
+
+    def test_empty_sections_render_as_empty_arrays(self, client):
+        import json
+
+        tc, storage = client
+        # Remove the seeded memory so the memories section is empty
+        m = storage.get_memory_by_key("test-key")
+        storage.delete_memory(m.memory_id)
+
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        assert body["memories"] == []
+        assert body["clients"] == []
+        assert body["activity_log"] == []

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -101,4 +101,24 @@ export const api = {
 
   // Account
   deleteAccount: () => request("DELETE", "/api/account", { confirm: true }),
+  exportAccount: async () => {
+    const token = getToken();
+    const headers = {};
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const res = await fetch(`${BASE}/api/account/export`, { headers });
+    if (res.status === 401) {
+      localStorage.removeItem("hive_mgmt_token");
+      globalThis.location.replace("/");
+      return null;
+    }
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: res.statusText }));
+      throw new Error(err.detail ?? "Export failed");
+    }
+    const blob = await res.blob();
+    const disposition = res.headers.get("content-disposition") ?? "";
+    const match = disposition.match(/filename="([^"]+)"/);
+    const filename = match ? match[1] : "hive-export.json";
+    return { blob, filename };
+  },
 };

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -392,4 +392,103 @@ describe("api", () => {
     expect(storage["hive_mgmt_token"]).toBeUndefined();
     expect(window.location.replace).toHaveBeenCalledWith("/");
   });
+
+  // ---------------------------------------------------------------------------
+  // exportAccount
+  // ---------------------------------------------------------------------------
+
+  function mockExportResponse({
+    ok = true,
+    status = 200,
+    blob = new Blob(),
+    disposition,
+    body,
+  } = {}) {
+    fetchMock.mockResolvedValue({
+      ok,
+      status,
+      statusText: "Error",
+      blob: () => Promise.resolve(blob),
+      json: () => Promise.resolve(body ?? {}),
+      headers: { get: () => disposition ?? null },
+    });
+  }
+
+  it("exportAccount sends Authorization header when token present", async () => {
+    storage["hive_mgmt_token"] = "user-token";
+    mockExportResponse({ disposition: 'attachment; filename="hive-export.json"' });
+    await api.exportAccount();
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain("/api/account/export");
+    expect(opts.headers.Authorization).toBe("Bearer user-token");
+  });
+
+  it("exportAccount omits Authorization when no token is stored", async () => {
+    mockExportResponse({ disposition: 'attachment; filename="x.json"' });
+    await api.exportAccount();
+    const opts = fetchMock.mock.calls[0][1];
+    expect(opts.headers.Authorization).toBeUndefined();
+  });
+
+  it("exportAccount returns blob + filename parsed from Content-Disposition", async () => {
+    const blob = new Blob(["{}"], { type: "application/json" });
+    mockExportResponse({
+      blob,
+      disposition: 'attachment; filename="hive-export-user-20260418.json"',
+    });
+    const result = await api.exportAccount();
+    expect(result.blob).toBe(blob);
+    expect(result.filename).toBe("hive-export-user-20260418.json");
+  });
+
+  it("exportAccount falls back to a default filename when disposition is missing", async () => {
+    mockExportResponse({ disposition: null });
+    const result = await api.exportAccount();
+    expect(result.filename).toBe("hive-export.json");
+  });
+
+  it("exportAccount surfaces error detail from JSON body on non-OK responses", async () => {
+    mockExportResponse({
+      ok: false,
+      status: 429,
+      body: { detail: "Exports are limited to one per 5 minutes." },
+    });
+    await expect(api.exportAccount()).rejects.toThrow(
+      "Exports are limited to one per 5 minutes.",
+    );
+  });
+
+  it("exportAccount falls back to statusText when the error body is not JSON", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: () => Promise.reject(new Error("not json")),
+      headers: { get: () => null },
+    });
+    await expect(api.exportAccount()).rejects.toThrow("Server Error");
+  });
+
+  it("exportAccount surfaces generic 'Request failed' when error body is an empty object", async () => {
+    mockExportResponse({ ok: false, status: 500, body: {} });
+    await expect(api.exportAccount()).rejects.toThrow("Export failed");
+  });
+
+  it("exportAccount clears token and redirects on 401", async () => {
+    storage["hive_mgmt_token"] = "old-token";
+    const replace = vi.fn();
+    vi.stubGlobal("location", { replace });
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      headers: { get: () => null },
+      blob: () => Promise.resolve(new Blob()),
+      json: () => Promise.resolve({}),
+    });
+    const result = await api.exportAccount();
+    expect(result).toBeNull();
+    expect(storage["hive_mgmt_token"]).toBeUndefined();
+    expect(replace).toHaveBeenCalledWith("/");
+  });
 });

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useEffect, useState } from "react";
-import { AlertTriangle, Check } from "lucide-react";
+import { AlertTriangle, Check, Download } from "lucide-react";
 import { api } from "../api.js";
 import { Button } from "./ui/button.jsx";
 import { Card } from "./ui/card.jsx";
@@ -19,6 +19,28 @@ export default function SetupPanel() {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
   const [quota, setQuota] = useState(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState("");
+
+  async function handleExport() {
+    setExporting(true);
+    setExportError("");
+    try {
+      const result = await api.exportAccount();
+      if (!result) return;
+      const { blob, filename } = result;
+      const url = URL.createObjectURL(blob);
+      const link = globalThis.document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setExportError(e.message ?? "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }
 
   useEffect(function loadQuota() {
     api.getStats().then(function handleStats(s) {
@@ -222,6 +244,23 @@ export default function SetupPanel() {
           </div>
         </section>
       )}
+
+      <section className="mt-12 border-t border-[var(--border)] pt-8">
+        <h3 className="mb-2 flex items-center gap-2">
+          <Download size={18} />
+          Export my data
+        </h3>
+        <p className="text-[var(--text-muted)] mb-4 text-sm">
+          Download a JSON file containing your profile, memories, OAuth clients, and the last
+          90 days of activity. Limited to one export every 5 minutes.
+        </p>
+        {exportError && (
+          <p className="text-[var(--danger)] text-[13px] mb-3">{exportError}</p>
+        )}
+        <Button variant="secondary" onClick={handleExport} disabled={exporting}>
+          {exporting ? "Preparing…" : "Export my data"}
+        </Button>
+      </section>
 
       <section className="mt-12 border-t border-[var(--border)] pt-8">
         <h3 className="mb-2 flex items-center gap-2 text-[var(--danger)]">

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -3,7 +3,12 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../api.js", () => ({
-  api: { listMemories: vi.fn(), deleteAccount: vi.fn(), getStats: vi.fn() },
+  api: {
+    listMemories: vi.fn(),
+    deleteAccount: vi.fn(),
+    getStats: vi.fn(),
+    exportAccount: vi.fn(),
+  },
 }));
 
 import { api } from "../api.js";
@@ -299,5 +304,79 @@ describe("SetupPanel", () => {
     api.getStats.mockRejectedValue(new Error("network error"));
     await act(async () => render(<SetupPanel />));
     expect(screen.queryByText("Usage")).toBeNull();
+  });
+
+  describe("Export my data", () => {
+    let createObjectURL;
+    let revokeObjectURL;
+    let linkClick;
+
+    beforeEach(() => {
+      createObjectURL = vi.fn().mockReturnValue("blob:mock");
+      revokeObjectURL = vi.fn();
+      vi.stubGlobal("URL", {
+        ...globalThis.URL,
+        createObjectURL,
+        revokeObjectURL,
+      });
+      linkClick = vi.fn();
+      const realCreateElement = document.createElement.bind(document);
+      vi.spyOn(document, "createElement").mockImplementation((tag) => {
+        const el = realCreateElement(tag);
+        if (tag === "a") el.click = linkClick;
+        return el;
+      });
+    });
+
+    afterEach(() => {
+      document.createElement.mockRestore?.();
+    });
+
+    it("renders Export my data button and description", async () => {
+      await act(async () => render(<SetupPanel />));
+      expect(screen.getAllByText(/Export my data/).length).toBeGreaterThanOrEqual(1);
+      expect(document.body.textContent).toContain("Limited to one export every 5 minutes");
+    });
+
+    it("clicking Export my data triggers download of the returned blob", async () => {
+      const blob = new Blob(["{}"], { type: "application/json" });
+      api.exportAccount.mockResolvedValue({ blob, filename: "hive-export-u-20260418.json" });
+      await act(async () => render(<SetupPanel />));
+      await act(async () =>
+        fireEvent.click(screen.getByRole("button", { name: "Export my data" })),
+      );
+      expect(api.exportAccount).toHaveBeenCalled();
+      expect(createObjectURL).toHaveBeenCalledWith(blob);
+      expect(linkClick).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock");
+    });
+
+    it("displays error when export fails", async () => {
+      api.exportAccount.mockRejectedValue(new Error("Rate limit exceeded"));
+      await act(async () => render(<SetupPanel />));
+      await act(async () =>
+        fireEvent.click(screen.getByRole("button", { name: "Export my data" })),
+      );
+      await waitFor(() => expect(screen.getByText("Rate limit exceeded")).toBeTruthy());
+    });
+
+    it("falls back to a generic message when rejection has no message", async () => {
+      api.exportAccount.mockRejectedValue({});
+      await act(async () => render(<SetupPanel />));
+      await act(async () =>
+        fireEvent.click(screen.getByRole("button", { name: "Export my data" })),
+      );
+      await waitFor(() => expect(screen.getByText("Export failed")).toBeTruthy());
+    });
+
+    it("no-op when exportAccount returns null (auth-redirect path)", async () => {
+      api.exportAccount.mockResolvedValue(null);
+      await act(async () => render(<SetupPanel />));
+      await act(async () =>
+        fireEvent.click(screen.getByRole("button", { name: "Export my data" })),
+      );
+      expect(createObjectURL).not.toHaveBeenCalled();
+      expect(linkClick).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Closes #424

## Summary

Implements the GDPR Article 20 / CCPA §1798.100 data-export promise the Privacy Policy already makes. Adds `GET /api/account/export` plus an "Export my data" section in the management UI settings.

## What the bundle contains

A single streamed JSON document:

```json
{
  "exported_at": "2026-04-18T00:42:00+00:00",
  "user":   { "user_id": "...", "email": "...", "display_name": "...", "role": "user", "created_at": "..." },
  "memories":    [ { memory_id, key, value, tags, owner_client_id, created_at, updated_at, expires_at } ],
  "clients":     [ { client_id, client_name, client_type, created_at } ],
  "activity_log":[ { event_id, event_type, client_id, timestamp, metadata } ]
}
```

- Activity window is 90 days (matches the retention policy in Privacy §9).
- Events are filtered to the user's client ids, so cross-tenant leakage is impossible.
- Filename: `hive-export-{user_id}-{YYYYMMDD}.json` via `Content-Disposition: attachment`.

## Implementation notes

- **Streaming, not assembled in memory.** The handler yields JSON chunks piece-by-piece so the 500-memory quota × 90 days of events worst case never lands on the heap at once. Memories iterate via `storage.iter_all_memories(owner_user_id=…)`.
- **Rate limited to 1 per 5 min.** Reuses the existing `storage.increment_rate_limit_counter(...)` with a `export#{bucket}` window key and `user_id` as the subject; second call in the window returns 429 + `Retry-After: 300`.
- **UI path.** `SetupPanel.jsx` gains a dedicated "Export my data" section above the Danger Zone (not inside it — export is reversible, delete is not). The button calls a new `api.exportAccount()` helper that fetches with Bearer auth, reads the body as a Blob, and drives a programmatic `<a download>` click. No navigation side-effect other than the download.
- **Docs.** FAQ adds a "How do I export my data?" entry pointing at both the UI path and the endpoint.

## Tests

- **Server (8 new):** happy-path returns all four sections, excludes other users' memories, excludes events from non-owned clients, 429 on second call in the 5-min window (with `Retry-After`), 404 when user is missing, 401 when unauth, empty-sections render as `[]`, `expires_at` serialises when set.
- **api.js (7 new):** fetches with and without a stored token, parses filename from `Content-Disposition` (and falls back), surfaces `detail` from JSON error bodies, falls back to `statusText` on non-JSON error bodies, returns `null` on 401 and clears the token.
- **SetupPanel (5 new):** renders the button and description, triggers the Blob-based download on click, displays API errors, falls back to a generic message when rejection has no `.message`, no-ops on the 401 null-return path.

`uv run inv pre-push` green (589 vitest + 514 pytest).