### PR TITLE
feat: add MCP tool annotations + titles to all tools

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -188,7 +188,10 @@ def _vector_store() -> VectorStore:
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Ping",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def ping(ctx: Context | None = None) -> str:
     """Lightweight health check — returns 'ok' when the Bearer token is valid.
 
@@ -200,7 +203,15 @@ async def ping(ctx: Context | None = None) -> str:
     return "ok"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Remember",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
 async def remember(
     key: Annotated[str, "Unique key to store the memory under"],
     value: Annotated[
@@ -312,7 +323,15 @@ async def remember(
     return f"{action} memory '{key}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Remember if absent",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
 async def remember_if_absent(
     key: Annotated[str, "Unique key to store the memory under"],
     value: Annotated[
@@ -413,7 +432,10 @@ async def remember_if_absent(
     return f"Stored memory '{key}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Recall",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def recall(
     key: Annotated[str, "Key of the memory to retrieve"],
     ctx: Context | None = None,
@@ -460,7 +482,15 @@ async def recall(
     return memory.value
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Forget",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
 async def forget(
     key: Annotated[str, "Key of the memory to delete"],
     ctx: Context | None = None,
@@ -512,7 +542,15 @@ async def forget(
     return f"Deleted memory '{key}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Forget all (by tag)",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    },
+)
 async def forget_all(
     tag: Annotated[str, "Tag of the memories to delete"],
     ctx: Context | None = None,
@@ -550,7 +588,10 @@ async def forget_all(
     return f"Deleted {deleted} memories with tag '{tag}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Memory history",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def memory_history(
     key: Annotated[str, "Key of the memory to retrieve history for"],
     ctx: Context | None = None,
@@ -582,7 +623,15 @@ async def memory_history(
     ]
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Restore memory",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    },
+)
 async def restore_memory(
     key: Annotated[str, "Key of the memory to restore"],
     version_timestamp: Annotated[str, "Version timestamp to restore (from memory_history)"],
@@ -621,7 +670,10 @@ async def restore_memory(
     return f"Restored memory '{key}' to version '{version_timestamp}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List memories",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def list_memories(
     tag: Annotated[str, "Tag to filter memories by"],
     limit: Annotated[int, "Maximum number of memories to return (1–500)"] = 100,
@@ -674,7 +726,10 @@ async def list_memories(
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List tags",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     """List all distinct tags currently in use across the caller's memories.
 
@@ -701,7 +756,10 @@ async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     return {"tags": tags, "count": len(tags)}
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Summarise context",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def summarize_context(
     topic: Annotated[str, "Topic or tag to summarise memories about"],
     ctx: Context | None = None,
@@ -767,7 +825,10 @@ async def summarize_context(
     return "\n".join(lines)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Search memories",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def search_memories(
     query: Annotated[str, "Natural language search query"],
     top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 10,
@@ -850,7 +911,10 @@ async def search_memories(
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Relate memories",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def relate_memories(
     key: Annotated[str, "Key of the memory to find relations for"],
     top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 5,

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1376,6 +1376,42 @@ class TestRestoreMemory:
 # ---------------------------------------------------------------------------
 
 
+class TestMcpToolAnnotations:
+    """Every exposed MCP tool should carry a user-friendly title and
+    annotations that let consent-aware clients (Claude Desktop, Claude Code)
+    render destructive operations differently from read-only ones.
+    """
+
+    @pytest.mark.parametrize(
+        "tool_name,title,read_only,destructive",
+        [
+            ("ping", "Ping", True, None),
+            ("remember", "Remember", False, False),
+            ("remember_if_absent", "Remember if absent", False, False),
+            ("recall", "Recall", True, None),
+            ("forget", "Forget", False, True),
+            ("forget_all", "Forget all (by tag)", False, True),
+            ("memory_history", "Memory history", True, None),
+            ("restore_memory", "Restore memory", False, False),
+            ("list_memories", "List memories", True, None),
+            ("list_tags", "List tags", True, None),
+            ("summarize_context", "Summarise context", True, None),
+            ("search_memories", "Search memories", True, None),
+            ("relate_memories", "Relate memories", True, None),
+        ],
+    )
+    async def test_title_and_hints(self, tool_name, title, read_only, destructive):
+        from hive.server import mcp
+
+        tool = await mcp.get_tool(tool_name)
+        assert tool.title == title
+        assert tool.annotations.readOnlyHint is read_only
+        # destructiveHint is only set when meaningful.
+        assert tool.annotations.destructiveHint is destructive
+        # Every Hive tool is closed-world (our DynamoDB only).
+        assert tool.annotations.openWorldHint is False
+
+
 class TestHiveTokenVerifier:
     async def test_valid_token_returns_access_token(self, server_env):
         from hive.server import HiveTokenVerifier


### PR DESCRIPTION
Closes #450

## Summary

Every `@mcp.tool` now advertises a user-friendly title and the MCP 1.0 tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`). Clients that honour these hints (Claude Desktop, Claude Code) can:
- Auto-approve read-only tools (`recall`, `list_memories`, `list_tags`, `search_memories`, `summarize_context`, `memory_history`, `relate_memories`, `ping`) without prompting.
- Confirm before destructive calls (`forget`, `forget_all`).
- Cache idempotent results where appropriate.

## The matrix applied

| Tool | title | readOnly | destructive | idempotent | openWorld |
| --- | --- | --- | --- | --- | --- |
| `ping` | Ping | ✓ | — | ✓ | false |
| `remember` | Remember | — | false | ✓ | false |
| `remember_if_absent` | Remember if absent | — | false | ✓ | false |
| `recall` | Recall | ✓ | — | ✓ | false |
| `forget` | Forget | — | **✓** | ✓ | false |
| `forget_all` | Forget all (by tag) | — | **✓** | — | false |
| `memory_history` | Memory history | ✓ | — | ✓ | false |
| `restore_memory` | Restore memory | — | false | — | false |
| `list_memories` | List memories | ✓ | — | ✓ | false |
| `list_tags` | List tags | ✓ | — | ✓ | false |
| `summarize_context` | Summarise context | ✓ | — | ✓ | false |
| `search_memories` | Search memories | ✓ | — | ✓ | false |
| `relate_memories` | Relate memories | ✓ | — | ✓ | false |

All tools are `openWorldHint: false` because Hive only touches its own DynamoDB.

## Tests

New parametrised `TestMcpToolAnnotations` asserts the title and the expected hint values for every registered tool — so if we add a tool later and forget to annotate it, CI fails.

`uv run inv pre-push` green (589 vitest + 527 pytest).