### PR TITLE
feat: add /subprocessors page for GDPR compliance

### DIFF
--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -14,7 +14,7 @@ Memories are never shared between accounts, and Hive does not use your data to t
 
 ### Where is my data stored?
 
-Data is stored on AWS infrastructure (DynamoDB, S3 Vectors) in the US East region. Data is encrypted at rest and in transit.
+Data is stored on AWS infrastructure (DynamoDB, S3 Vectors) in the US East region. Data is encrypted at rest and in transit. A full list of third parties that process data on our behalf — AWS, Google OAuth, and Google Analytics — is maintained on the [Subprocessors page](https://hive.warlordofmars.net/subprocessors).
 
 ### Can Anthropic or other AI providers see my memories?
 

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -13,6 +13,7 @@ import ChangelogPage from "./components/ChangelogPage.jsx";
 import FaqPage from "./components/FaqPage.jsx";
 import HomePage from "./components/HomePage.jsx";
 import PrivacyPage from "./components/PrivacyPage.jsx";
+import SubprocessorsPage from "./components/SubprocessorsPage.jsx";
 import TermsPage from "./components/TermsPage.jsx";
 import LoginPage from "./components/LoginPage.jsx";
 import McpClientsPage from "./components/McpClientsPage.jsx";
@@ -253,6 +254,7 @@ export default function App() {
         <Route path="/status" element={<StatusPage />} />
         <Route path="/terms" element={<TermsPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
+        <Route path="/subprocessors" element={<SubprocessorsPage />} />
         <Route path="/app" element={<AppShell />} />
         <Route path="/oauth/callback" element={<AuthCallback />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -73,6 +73,7 @@ export default function PageLayout({ children }) {
               <a href="/status" className="no-underline hover:text-[var(--text)] transition-colors">Status</a>
               <a href="/terms" className="no-underline hover:text-[var(--text)] transition-colors">Terms</a>
               <a href="/privacy" className="no-underline hover:text-[var(--text)] transition-colors">Privacy</a>
+              <a href="/subprocessors" className="no-underline hover:text-[var(--text)] transition-colors">Subprocessors</a>
               <a
                 href="#cookie-preferences"
                 onClick={handleReopenConsent}

--- a/ui/src/components/PrivacyPage.jsx
+++ b/ui/src/components/PrivacyPage.jsx
@@ -90,8 +90,13 @@ export default function PrivacyPage() {
               same region. No data is replicated to other cloud providers or regions.
             </p>
             <p>
-              AWS is our sole infrastructure provider. Their data-processing terms apply to
-              data at rest and in transit within AWS services.
+              AWS is our primary infrastructure provider. A full list of the third parties
+              that process data on our behalf (including AWS, Google OAuth, and Google
+              Analytics) is maintained on the{" "}
+              <a href="/subprocessors" className="text-brand no-underline hover:underline">
+                Subprocessors
+              </a>{" "}
+              page.
             </p>
           </Section>
 

--- a/ui/src/components/SubprocessorsPage.jsx
+++ b/ui/src/components/SubprocessorsPage.jsx
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import PageLayout from "@/components/PageLayout";
+
+const LAST_UPDATED = "April 2026";
+
+const SUBPROCESSORS = [
+  {
+    name: "Amazon Web Services",
+    services: "DynamoDB, Lambda, S3 Vectors, CloudFront, CloudWatch",
+    purpose: "Hosting, storage, compute, CDN, observability",
+    data: "User account, memories, OAuth clients, activity logs, request logs",
+    location: "us-east-1 (United States)",
+  },
+  {
+    name: "Google LLC",
+    services: "Google OAuth 2.0",
+    purpose: "Sign-in / identity verification for the management UI",
+    data: "Email address, Google profile identifier",
+    location: "Global",
+  },
+  {
+    name: "Google LLC",
+    services: "Google Analytics 4",
+    purpose: "Marketing-site usage analytics (opt-in only)",
+    data: "Pseudonymous usage data (page views, referrers, aggregated device info)",
+    location: "Global",
+  },
+];
+
+function Section({ title, children }) {
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl font-bold mb-3">{title}</h2>
+      <div className="text-sm text-[var(--text-muted)] leading-relaxed space-y-3">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export default function SubprocessorsPage() {
+  return (
+    <PageLayout>
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">Subprocessors</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[520px] mx-auto leading-relaxed">
+            Last updated: {LAST_UPDATED}. The third-party services Hive uses to
+            operate.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16 px-8">
+        <div className="max-w-[960px] mx-auto">
+          <Section title="Current subprocessors">
+            <p>
+              Hive engages the following third parties (subprocessors) to
+              process personal data on our behalf. Each entry lists the
+              categories of data they see and where they process it.
+            </p>
+            <div className="overflow-x-auto -mx-2">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="text-left border-b border-[var(--border)]">
+                    <th className="py-3 px-2 font-semibold text-[var(--text)]">
+                      Subprocessor
+                    </th>
+                    <th className="py-3 px-2 font-semibold text-[var(--text)]">
+                      Purpose
+                    </th>
+                    <th className="py-3 px-2 font-semibold text-[var(--text)]">
+                      Data processed
+                    </th>
+                    <th className="py-3 px-2 font-semibold text-[var(--text)]">
+                      Location
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {SUBPROCESSORS.map((s) => (
+                    <tr
+                      key={`${s.name}-${s.services}`}
+                      className="border-b border-[var(--border)] align-top"
+                    >
+                      <td className="py-3 px-2">
+                        <div className="text-[var(--text)] font-medium">
+                          {s.name}
+                        </div>
+                        <div className="text-[13px]">{s.services}</div>
+                      </td>
+                      <td className="py-3 px-2">{s.purpose}</td>
+                      <td className="py-3 px-2">{s.data}</td>
+                      <td className="py-3 px-2 whitespace-nowrap">
+                        {s.location}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Section>
+
+          <Section title="Notification of changes">
+            <p>
+              When we add or change subprocessors, we announce the update in the
+              in-app changelog. Paid enterprise customers (once available) will
+              receive at least 30 days' advance notice by email before any new
+              subprocessor is engaged, giving them time to object.
+            </p>
+          </Section>
+
+          <Section title="Where this fits">
+            <p>
+              This page is a living complement to our{" "}
+              <a
+                href="/privacy"
+                className="text-brand no-underline hover:underline"
+              >
+                Privacy Policy
+              </a>
+              . Section 4 of the Privacy Policy describes where data is stored
+              at a high level; this page enumerates the specific services
+              involved.
+            </p>
+          </Section>
+        </div>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/SubprocessorsPage.test.jsx
+++ b/ui/src/components/SubprocessorsPage.test.jsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import SubprocessorsPage from "./SubprocessorsPage.jsx";
+
+function renderInRouter() {
+  return render(
+    <MemoryRouter>
+      <SubprocessorsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("SubprocessorsPage", () => {
+  it("renders heading and last-updated date", async () => {
+    await act(async () => renderInRouter());
+    expect(screen.getByRole("heading", { name: "Subprocessors" })).toBeTruthy();
+    expect(screen.getByText(/Last updated: April 2026/)).toBeTruthy();
+  });
+
+  it("lists each current subprocessor in the table", async () => {
+    const { container } = await act(async () => renderInRouter());
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+    const tableBody = within(table);
+    // AWS + two Google entries expected
+    expect(tableBody.getAllByText("Amazon Web Services")).toHaveLength(1);
+    expect(tableBody.getAllByText("Google LLC").length).toBeGreaterThanOrEqual(2);
+    expect(
+      tableBody.getByText("Google OAuth 2.0"),
+    ).toBeTruthy();
+    expect(
+      tableBody.getByText("Google Analytics 4"),
+    ).toBeTruthy();
+    expect(
+      tableBody.getByText(/DynamoDB, Lambda/),
+    ).toBeTruthy();
+    expect(tableBody.getByText("us-east-1 (United States)")).toBeTruthy();
+  });
+
+  it("renders column headers", async () => {
+    await act(async () => renderInRouter());
+    expect(screen.getByText("Subprocessor")).toBeTruthy();
+    expect(screen.getByText("Purpose")).toBeTruthy();
+    expect(screen.getByText("Data processed")).toBeTruthy();
+    expect(screen.getByText("Location")).toBeTruthy();
+  });
+
+  it("includes the change-notification commitment", async () => {
+    await act(async () => renderInRouter());
+    expect(screen.getByText(/Notification of changes/)).toBeTruthy();
+    expect(screen.getByText(/30 days' advance notice/)).toBeTruthy();
+  });
+
+  it("links back to the Privacy Policy", async () => {
+    const { container } = await act(async () => renderInRouter());
+    const main = container.querySelector("main");
+    const link = within(main).getByText("Privacy Policy");
+    expect(link.getAttribute("href")).toBe("/privacy");
+  });
+});


### PR DESCRIPTION
Closes #442

## Summary

Publishes a dated `/subprocessors` page listing the third parties that process personal data on Hive's behalf, with the categories each sees and their processing location. Closes the GDPR-common gap where the Privacy Policy mentions AWS once but doesn't enumerate the actual services or the Google dependencies.

## Current entries

| Subprocessor | Services | Purpose | Data | Location |
| --- | --- | --- | --- | --- |
| Amazon Web Services | DynamoDB, Lambda, S3 Vectors, CloudFront, CloudWatch | Hosting, storage, compute, CDN, observability | Account, memories, clients, activity + request logs | us-east-1 (US) |
| Google LLC (OAuth) | Sign-in | Email + profile id | Global |
| Google LLC (Analytics 4) | Marketing-site usage analytics (opt-in) | Pseudonymous usage data | Global |

## Changes

- **New `SubprocessorsPage.jsx`** at `/subprocessors` with a responsive table, a `LAST_UPDATED` constant at the top of the file (single place to edit), a notification-of-changes clause (in-app changelog + 30-day email notice for paid enterprise customers once we have them), and a link back to the Privacy Policy.
- **New co-located test** covering heading, table contents, column headers, the notification clause, and the Privacy Policy backlink.
- **Footer link** added alongside Terms/Privacy.
- **Privacy §4** rewritten to cross-reference the new page instead of claiming "AWS is our sole infrastructure provider".
- **`docs-site/faq.md`** now points at the Subprocessors page from the "Where is my data stored?" answer.

## Tests

`uv run inv pre-push` green (594 vitest + 527 pytest).