### PR TITLE
docs(changelog): retroactive entry for v0.20.0 + [Unreleased] section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Hive are documented here. Releases correspond to GitHub t
 
 See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) for full release notes generated from merged PRs.
 
+## [Unreleased]
+
+_Changes accumulated on `development` since v0.20.0. Will be rolled into v0.21.0._
+
+## v0.20.0 — 2026-04-17
+
+> **Note**: v0.20.0 was cut from a single PR that bypassed the normal release-branch workflow. The intended scope of this milestone (compliance work, accuracy audit, MCP annotations, etc.) was merged to `development` after the tag was already pushed and will ship in v0.21.0. This entry documents what actually shipped in v0.20.0. See #475 for the branch-protection follow-up to prevent this recurring.
+
+### Added
+
+- Terms of Service and Privacy Policy marketing pages (#401)
+
 ## v0.19.1 — 2026-04-13
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds a retroactive `CHANGELOG.md` entry for **v0.20.0** to match what was actually released, and introduces an `[Unreleased]` section as the landing zone for changes accumulating on `development` between tagged releases.

## Background

v0.20.0 was tagged on 2026-04-17 containing only #401 (Terms of Service and Privacy Policy pages). The release happened because that PR was merged directly to `main` instead of going through the documented `release/*` branch workflow in CLAUDE.md, so CI auto-tagged main and generated release notes from the single PR.

The intended scope of the `v0.20` milestone (GA4 cookie consent, GDPR export endpoint, CloudWatch alarms, security headers, MCP annotations, etc.) was merged to `development` **after** the tag was already pushed, and will ship in v0.21.0.

## Changes

- New `## [Unreleased]` section right below the intro — a single landing zone for dev-branch changes until the next cut
- New `## v0.20.0 — 2026-04-17` section documenting what actually shipped, with a pointer to #475 (the branch-protection follow-up)
- Existing v0.19.x entries left untouched

## Follow-ups tracked separately

- **#475** — branch-protection workflow to block non-`release/*`/`development` PRs from targeting `main`
- Milestone `v0.20` (in GitHub) will be renamed to `v0.21` since the remaining items never shipped in v0.20.0

## Test plan

- [x] Docs-only change; tests unaffected
- [ ] Reviewer confirms the narrative matches what actually happened

https://claude.ai/code/session_01CHZukppdQyVuVfG3cJb2xV