### PR TITLE
chore(ci): main-branch guard against feature PRs to main

### DIFF
--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -1,0 +1,25 @@
+name: Main branch guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-source-branch:
+    name: check-source-branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject PRs not from release/* or development
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$HEAD_REF" == "development" ]] || [[ "$HEAD_REF" == release/* ]]; then
+            echo "✓ PR from $HEAD_REF — allowed"
+            exit 0
+          fi
+          echo "::error::PRs to main must come from 'development' or 'release/*' branches (got: $HEAD_REF)"
+          echo "See CLAUDE.md §Releasing to production for the correct flow."
+          exit 1


### PR DESCRIPTION
Closes #475

## Summary

New `.github/workflows/main-branch-guard.yml` that runs on every PR targeting `main` and fails the `check-source-branch` job unless the PR's head ref is `development` or matches `release/*`. Closes the loophole that let v0.20.0 ship from a feature branch directly into `main` and bypass the release workflow documented in `CLAUDE.md`.

## Behaviour

| PR direction | Result |
| --- | --- |
| `feat/*` → `main` | ❌ fails — `::error::PRs to main must come from 'development' or 'release/*' branches` |
| `fix/*` → `main` | ❌ fails (same) |
| `release/v1.2.3` → `main` | ✓ passes |
| `development` → `main` (back-merge / hotfix) | ✓ passes |
| Any branch → `development` | not affected — workflow only triggers when `main` is the base |

## Required follow-up — repo settings (one-time)

The workflow doesn't enforce itself; it has to be wired in as a required status check. After this merges:

1. **Settings → Branches → Branch protection rules → `main`**
2. Under *"Require status checks to pass before merging"*, add **`check-source-branch`** (the job name) to the required-checks list.
3. Make sure *"Do not allow bypassing the above settings"* is on so admins can't sidestep it either.

I can't make those clicks from a PR — flagging here so it doesn't fall through the cracks.

## Out of scope

- Signed commits / required reviewers — separate hardening.
- Blocking direct `git push` to `main` — already covered by the existing branch protection's "Require pull request before merging".

## Tests

Workflow itself can only be exercised by opening a non-compliant PR to `main`, which we explicitly don't want to do here. The shell logic is small and self-evident; CI's existing YAML-lint will catch syntax issues.