### PR TITLE
docs(claude): halt autonomous agent when a release milestone drains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -702,6 +702,40 @@ If the pipeline fails:
 
 Only move to the next issue when the `development` pipeline is green.
 
+#### 9. Check if the milestone is drained
+
+After the development pipeline is green, check whether the closed issue's
+milestone still has any open, non-epic issues:
+
+```bash
+# Resolve the milestone number from the issue just closed (via gh)
+MILESTONE=$(gh issue view <number> --json milestone --jq '.milestone.title')
+
+# If the milestone exists and matches a release-milestone pattern (vX.Y),
+# count the open non-epic issues remaining in it
+if [[ -n "$MILESTONE" && "$MILESTONE" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+  REMAINING=$(gh issue list \
+    --milestone "$MILESTONE" \
+    --state open \
+    --json labels \
+    --jq '[.[] | select(.labels | map(.name) | contains(["epic"]) | not)] | length')
+
+  if [ "$REMAINING" -eq 0 ]; then
+    echo "HUMAN_INPUT_REQUIRED: Milestone $MILESTONE has no open issues — ready to cut release?"
+    exit 0   # stop; do not pick up the next issue
+  fi
+fi
+```
+
+If the release milestone is drained, stop and surface the sentinel so the
+operator can decide whether to cut the release first or continue draining
+from `Backlog`. Do **not** unilaterally create a release branch — releases
+are a human decision per §Releasing to production.
+
+If the milestone is non-release (e.g. `Backlog`, `MVP-hardening`), or the
+issue has no milestone, or there are still open non-epic items: skip this
+step and pick up the next issue normally.
+
 ### Keeping CLAUDE.md current
 
 If you discover that CLAUDE.md is missing information needed to work
@@ -736,6 +770,9 @@ Halt and wait for human input **only** in these situations:
 - A change requires modifying `infra/stacks/hive_stack.py` in a way that
   could affect production resources
 - The same CI check has failed 3 times without a clear fix
+- A release milestone (pattern `vX.Y`) drains to zero open non-epic issues —
+  stop after step 9 and surface so the user can decide whether to cut the
+  release before continuing
 
 In all other cases, make a judgment call and proceed.
 


### PR DESCRIPTION
## Summary

Adds a release-readiness stopping condition to the autonomous issue workflow so the agent doesn't silently plough through `Backlog` work while a shippable release sits uncut on `development`.

## Changes

Two edits to `CLAUDE.md` §Autonomous issue workflow:

1. **New step 9 — Check if the milestone is drained** (after step 8, Monitor development branch CI/CD post-merge). After each merge, the agent resolves the closed issue's milestone via `gh issue view`. If the milestone matches `vX.Y` and has zero open non-epic items, the agent emits `HUMAN_INPUT_REQUIRED: Milestone <name> has no open issues — ready to cut release?` and halts.
2. **New bullet on the `Stop and ask` list** naming this situation explicitly so operators reading that section see it.

## Failure modes prevented

- Agent drains `Backlog` instead of prompting you to cut v0.21 when its work is done
- Agent picks up a low-priority item *right* as a release window opens, causing a forced context switch

## Scope limits

- Only triggers for release milestones (semver pattern `vX.Y`)
- Hardening buckets (e.g. `MVP-hardening`) and `Backlog` are ignored — draining those is expected, not a release signal
- Epics don't count against the open-count (they stay open across releases)
- The agent does **not** unilaterally create a release branch — that's still a human decision per §Releasing to production. Stop and surface, nothing more.

## Why not auto-merge

Touches `## Autonomous issue workflow` and the `Stop and ask` list — both covered by the "requires human review" rule in CLAUDE.md §Keeping CLAUDE.md current.

## Follow-up (separate issue)

A GitHub Action that watches for empty release milestones outside of agent sessions — fires on issue-close, posts to a tracking issue when a milestone drains. Belt-and-braces for the case where you're off for a week and Dependabot PRs drain the remainder. Filing next.

## Test plan

- [x] Docs-only change; lint + typecheck + tests unaffected
- [ ] Reviewer confirms the pattern-matching (`vX.Y`) matches intent — excludes `Backlog`, `MVP-hardening`, and any custom theme milestones

https://claude.ai/code/session_01CHZukppdQyVuVfG3cJb2xV