### PR TITLE
docs: promote URL-based connector flow + add ChatGPT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 Shared persistent memory for AI agents — works with any MCP-compatible client. Free hosted service, no AWS account required.
 
-Hive is an MCP server that gives AI agents durable, shared memory across conversations. Connect any MCP-compatible client — Claude Code, Claude Desktop, Cursor, Continue, or custom agents — store and retrieve memories by key or tag, and manage everything through a web UI.
+Hive is an MCP server that gives AI agents durable, shared memory across conversations. Connect any MCP-compatible client — Claude Code, Claude Desktop, ChatGPT, Cursor, Continue, or custom agents — store and retrieve memories by key or tag, and manage everything through a web UI.
 
 **Hosted at [hive.warlordofmars.net](https://hive.warlordofmars.net) — sign in with Google, no setup required.**
 
@@ -53,7 +53,15 @@ Hive is an MCP server that gives AI agents durable, shared memory across convers
 }
 ```
 
-**Claude Desktop / any stdio-based client** — use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy:
+**Claude Desktop** / **ChatGPT** — open *Settings → Connectors* and add a custom MCP connector pointing at:
+
+```
+https://hive.warlordofmars.net/mcp
+```
+
+The browser handles OAuth on first use; no config file or local proxy required.
+
+**Older Claude Desktop builds (no Connectors UI)** or any other stdio-based client — fall back to [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy:
 
 ```json
 {

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -38,7 +38,7 @@ Up to approximately 380 KB of text per memory. This is enough for several pages 
 
 ### How long are tokens valid?
 
-Access tokens are valid for **1 hour** and refresh automatically in supported clients (Claude Code, Claude Desktop, claude.ai). Refresh tokens are valid for **30 days**.
+Access tokens are valid for **1 hour** and refresh automatically in supported clients (Claude Code, Claude Desktop, ChatGPT, claude.ai). Refresh tokens are valid for **30 days**.
 
 ---
 

--- a/docs-site/getting-started/connect-client.md
+++ b/docs-site/getting-started/connect-client.md
@@ -38,7 +38,21 @@ Restart Cursor. On first use it will open a browser window to complete the OAuth
 
 ## Claude Desktop
 
-Claude Desktop requires [mcp-remote](https://github.com/geelen/mcp-remote) as a local proxy. `npx` will install it automatically.
+Recent Claude Desktop versions support remote MCP servers as **Custom Connectors** — no config file or local proxy needed.
+
+1. Open Claude Desktop → **Settings → Connectors**.
+2. Click **Add custom connector**.
+3. Paste:
+
+   ```
+   https://hive.warlordofmars.net/mcp
+   ```
+
+4. Save. Claude Desktop opens your browser to complete OAuth — approve and you're connected.
+
+### Older Claude Desktop (pre-Connectors UI)
+
+If your build doesn't have the Connectors menu yet, fall back to the [mcp-remote](https://github.com/geelen/mcp-remote) helper.
 
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
@@ -54,6 +68,20 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 Restart Claude Desktop. On first use it will open a browser window to complete the OAuth flow.
+
+## ChatGPT
+
+ChatGPT supports remote MCP servers as **Apps** under Developer mode (eligibility varies by plan and may require enabling Developer mode in account settings).
+
+1. Open ChatGPT → **Settings → Connectors**.
+2. Click **Add → MCP server**.
+3. Paste:
+
+   ```
+   https://hive.warlordofmars.net/mcp
+   ```
+
+4. Save. ChatGPT opens an OAuth pop-up — approve and the connector stays available across sessions.
 
 ## Continue (VS Code / JetBrains)
 

--- a/docs-site/getting-started/quick-start.md
+++ b/docs-site/getting-started/quick-start.md
@@ -8,9 +8,16 @@ Go to [hive.warlordofmars.net](https://hive.warlordofmars.net) and sign in with 
 
 ## Step 2 — Connect your MCP client
 
-Add Hive to your MCP client config. The config depends on which client you use:
+Connect Hive to your MCP client. The exact path depends on the client:
 
 ::: code-group
+
+```text [Claude Desktop / ChatGPT]
+Settings → Connectors → Add custom connector
+(or Add → MCP server in ChatGPT)
+
+URL: https://hive.warlordofmars.net/mcp
+```
 
 ```json [Claude Code / Cursor]
 // ~/.claude/settings.json  (Claude Code)
@@ -25,8 +32,9 @@ Add Hive to your MCP client config. The config depends on which client you use:
 }
 ```
 
-```json [Claude Desktop]
+```json [Claude Desktop (legacy mcp-remote)]
 // ~/Library/Application Support/Claude/claude_desktop_config.json
+// Use this only if your Claude Desktop build pre-dates the Connectors UI.
 {
   "mcpServers": {
     "hive": {

--- a/docs-site/getting-started/what-is-hive.md
+++ b/docs-site/getting-started/what-is-hive.md
@@ -33,7 +33,7 @@ No copy-pasting context. No re-explaining your project each session. Your agent 
 | **Persistent storage** | Memories survive indefinitely across conversations |
 | **Semantic search** | Find memories by meaning using natural language |
 | **Tag-based organisation** | Group related memories with tags for easy retrieval |
-| **Multi-client** | Use Hive from Claude Code, Claude Desktop, Cursor, and more simultaneously |
+| **Multi-client** | Use Hive from Claude Code, Claude Desktop, ChatGPT, Cursor, and more simultaneously |
 | **Team sharing** | Multiple agents or team members can share a Hive instance |
 
 ## Who is it for?

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -21,7 +21,7 @@ features:
   - icon:
       svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/></svg>'
     title: Works with any MCP client
-    details: Claude Code, Claude Desktop, Cursor, Continue, claude.ai — if it supports MCP, it works with Hive.
+    details: Claude Code, Claude Desktop, ChatGPT, Cursor, Continue, claude.ai — if it supports MCP, it works with Hive.
   - icon:
       svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>'
     title: Semantic search

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -29,7 +29,16 @@ On first use Claude Code will open a browser window to complete the OAuth flow. 
 
 ## Claude Desktop
 
-Claude Desktop doesn't support HTTP MCP servers directly. Use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy — it handles DCR and the OAuth flow automatically.
+Recent Claude Desktop builds support remote MCP servers as **Custom Connectors** — no config file or local proxy required.
+
+1. Open Claude Desktop → **Settings → Connectors**.
+2. Click **Add custom connector**.
+3. Paste `https://hive.warlordofmars.net/mcp` and save.
+4. Approve the OAuth flow in the browser pop-up.
+
+### Older builds (pre-Connectors UI)
+
+Use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy — it handles DCR and the OAuth flow automatically.
 
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
@@ -45,6 +54,17 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 Restart Claude Desktop. On first use `mcp-remote` will open a browser window to complete the OAuth flow.
+
+---
+
+## ChatGPT
+
+ChatGPT supports remote MCP servers as **Apps** under Developer mode (eligibility varies by plan).
+
+1. Open ChatGPT → **Settings → Connectors**.
+2. Click **Add → MCP server**.
+3. Paste `https://hive.warlordofmars.net/mcp` and save.
+4. Approve the OAuth pop-up that follows.
 
 ---
 

--- a/ui/src/components/FaqPage.jsx
+++ b/ui/src/components/FaqPage.jsx
@@ -15,7 +15,7 @@ const FAQS = [
   },
   {
     q: "Which MCP clients are supported?",
-    a: "Any client that implements the Model Context Protocol works with Hive. Tested clients include Claude Code, Claude Desktop, Cursor, and Continue. If your client supports MCP, it will work.",
+    a: "Any client that implements the Model Context Protocol works with Hive. Tested clients include Claude Code, Claude Desktop, ChatGPT, Cursor, and Continue. If your client supports MCP, it will work.",
   },
   {
     q: "How do I delete my account or data?",

--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -15,7 +15,7 @@ const FEATURES = [
   {
     icon: Plug,
     title: "Works with any MCP client",
-    body: "Plug in to Claude Code, Claude Desktop, Cursor, Continue, or any client that speaks the Model Context Protocol.",
+    body: "Plug in to Claude Code, Claude Desktop, ChatGPT, Cursor, Continue, or any client that speaks the Model Context Protocol.",
   },
   {
     icon: Users,

--- a/ui/src/components/McpClientsPage.jsx
+++ b/ui/src/components/McpClientsPage.jsx
@@ -19,16 +19,15 @@ const CLIENTS = [
   },
   {
     name: "Claude Desktop",
-    description: "The Claude desktop app on Mac and Windows. Requires the mcp-remote helper to bridge to HTTP; npx installs it automatically.",
-    config: `{
-  "mcpServers": {
-    "hive": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://hive.warlordofmars.net/mcp"]
-    }
-  }
-}`,
-    configFile: "~/Library/Application Support/Claude/claude_desktop_config.json",
+    description: "The Claude desktop app on Mac and Windows. Add Hive via Settings → Connectors → Add custom connector and paste the URL — no config file or mcp-remote helper needed.",
+    config: `https://hive.warlordofmars.net/mcp`,
+    configFile: "Settings → Connectors → Add custom connector",
+  },
+  {
+    name: "ChatGPT",
+    description: "OpenAI's web client. Add Hive as a remote MCP App via Settings → Connectors (Developer mode required). OAuth happens in the browser.",
+    config: `https://hive.warlordofmars.net/mcp`,
+    configFile: "Settings → Connectors → Add → MCP server",
   },
   {
     name: "Cursor",

--- a/ui/src/components/McpClientsPage.test.jsx
+++ b/ui/src/components/McpClientsPage.test.jsx
@@ -35,13 +35,19 @@ describe("McpClientsPage", () => {
   it("renders config snippets for each client", async () => {
     const { container } = await act(async () => renderInRouter(<McpClientsPage />));
     const snippets = container.querySelectorAll("pre");
-    expect(snippets.length).toBe(4);
+    // Claude Code, Claude Desktop, ChatGPT, Cursor, Continue
+    expect(snippets.length).toBe(5);
   });
 
   it("renders Copy buttons", async () => {
     await act(async () => renderInRouter(<McpClientsPage />));
     const copyBtns = screen.getAllByText("Copy");
-    expect(copyBtns.length).toBe(4);
+    expect(copyBtns.length).toBe(5);
+  });
+
+  it("renders ChatGPT card", async () => {
+    await act(async () => renderInRouter(<McpClientsPage />));
+    expect(screen.getByText("ChatGPT")).toBeTruthy();
   });
 
   it("clicking Copy calls clipboard and shows Copied!", async () => {

--- a/ui/src/components/PricingPage.jsx
+++ b/ui/src/components/PricingPage.jsx
@@ -9,7 +9,7 @@ import { FREE_TIER_MEMORY_LIMIT } from "@/lib/limits";
 const INCLUDED = [
   `Up to ${FREE_TIER_MEMORY_LIMIT} memories`,
   "Semantic search across all memories",
-  "Works with Claude Code, Claude Desktop, Cursor, Continue, and any MCP client",
+  "Works with Claude Code, Claude Desktop, ChatGPT, Cursor, Continue, and any MCP client",
   "Multiple OAuth clients per account",
   "Activity log and memory browser UI",
   "OAuth 2.1 with PKCE — no shared secrets",

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -10,7 +10,9 @@ const STEP1_KEY = "hive_setup_step1_done";
 export default function SetupPanel() {
   const mcpUrl = import.meta.env.VITE_MCP_BASE ?? `${globalThis.location.origin}/mcp`;
   const [activeTab, setActiveTab] = useState("code");
+  const [desktopMode, setDesktopMode] = useState("url"); // "url" | "json"
   const [copied, setCopied] = useState(false);
+  const [urlCopied, setUrlCopied] = useState(false);
   const [step1Done, setStep1Done] = useState(() => !!localStorage.getItem(STEP1_KEY));
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null); // "ok" | "error"
@@ -72,6 +74,14 @@ export default function SetupPanel() {
     localStorage.setItem(STEP1_KEY, "1");
     setStep1Done(true);
     setTimeout(() => setCopied(false), 2000);
+  }
+
+  function handleCopyUrl() {
+    navigator.clipboard.writeText(mcpUrl);
+    setUrlCopied(true);
+    localStorage.setItem(STEP1_KEY, "1");
+    setStep1Done(true);
+    setTimeout(() => setUrlCopied(false), 2000);
   }
 
   async function handleDeleteAccount() {
@@ -147,7 +157,7 @@ export default function SetupPanel() {
           needed.
         </p>
 
-        <div className="flex gap-1 mb-0">
+        <div className="flex gap-1 mb-0 flex-wrap">
           <button className={tabClassName("code")} onClick={() => setActiveTab("code")}>
             Claude Code
           </button>
@@ -157,33 +167,51 @@ export default function SetupPanel() {
           <button className={tabClassName("desktop")} onClick={() => setActiveTab("desktop")}>
             Claude Desktop
           </button>
+          <button className={tabClassName("chatgpt")} onClick={() => setActiveTab("chatgpt")}>
+            ChatGPT
+          </button>
         </div>
 
         <div className="border border-[var(--border)] rounded-b rounded-tr p-3 bg-[var(--bg)]">
+          {(activeTab === "desktop" || activeTab === "chatgpt") && (
+            <DesktopOrChatgptInstructions
+              activeTab={activeTab}
+              desktopMode={desktopMode}
+              setDesktopMode={setDesktopMode}
+              mcpUrl={mcpUrl}
+              configs={configs}
+              urlCopied={urlCopied}
+              copied={copied}
+              handleCopy={handleCopy}
+              handleCopyUrl={handleCopyUrl}
+            />
+          )}
           {activeTab === "code" && (
-            <p className="mb-2 text-[var(--text-muted)] text-[13px]">
-              Add to <code>~/.claude/settings.json</code>:
-            </p>
+            <>
+              <p className="mb-2 text-[var(--text-muted)] text-[13px]">
+                Add to <code>~/.claude/settings.json</code>:
+              </p>
+              <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
+                {configs[activeTab]}
+              </pre>
+              <Button variant="secondary" className="mt-2" onClick={handleCopy}>
+                {copied ? "Copied!" : "Copy"}
+              </Button>
+            </>
           )}
           {activeTab === "cursor" && (
-            <p className="mb-2 text-[var(--text-muted)] text-[13px]">
-              Add to <code>~/.cursor/mcp.json</code> (create it if it doesn't exist):
-            </p>
+            <>
+              <p className="mb-2 text-[var(--text-muted)] text-[13px]">
+                Add to <code>~/.cursor/mcp.json</code> (create it if it doesn't exist):
+              </p>
+              <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
+                {configs[activeTab]}
+              </pre>
+              <Button variant="secondary" className="mt-2" onClick={handleCopy}>
+                {copied ? "Copied!" : "Copy"}
+              </Button>
+            </>
           )}
-          {activeTab === "desktop" && (
-            <p className="mb-2 text-[var(--text-muted)] text-[13px]">
-              Add to{" "}
-              <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>.
-              Requires <a href="https://github.com/geelen/mcp-remote" target="_blank" rel="noreferrer">mcp-remote</a> (
-              <code>npx</code> will install it automatically):
-            </p>
-          )}
-          <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
-            {configs[activeTab]}
-          </pre>
-          <Button variant="secondary" className="mt-2" onClick={handleCopy}>
-            {copied ? "Copied!" : "Copy"}
-          </Button>
         </div>
       </section>
 
@@ -195,7 +223,9 @@ export default function SetupPanel() {
         <p className="text-[var(--text-muted)] mb-3">
           {activeTab === "code" && "Open Claude Code. The next time you use a Hive memory tool, it will prompt you to authorise access via your browser. Complete the flow and you're done."}
           {activeTab === "cursor" && "Restart Cursor. On first use it will open a browser window to complete the OAuth flow. After authorising, the connection is maintained automatically."}
-          {activeTab === "desktop" && "Restart Claude Desktop. On first use it will open a browser window to complete the OAuth flow. After authorising, the connection is maintained automatically."}
+          {activeTab === "desktop" && desktopMode === "url" && "After saving the connector, Claude Desktop opens your browser to complete OAuth. Confirm access and you're connected."}
+          {activeTab === "desktop" && desktopMode === "json" && "Restart Claude Desktop. On first use it will open a browser window to complete the OAuth flow. After authorising, the connection is maintained automatically."}
+          {activeTab === "chatgpt" && "ChatGPT opens an OAuth pop-up the first time the connector is used. Approve access and the connection is kept open until you revoke it."}
         </p>
         <div className="flex items-center gap-3">
           <Button variant="secondary" onClick={handleTest} disabled={testing}>
@@ -307,6 +337,89 @@ export default function SetupPanel() {
         )}
       </section>
     </div>
+  );
+}
+
+function DesktopOrChatgptInstructions({
+  activeTab,
+  desktopMode,
+  setDesktopMode,
+  mcpUrl,
+  configs,
+  urlCopied,
+  copied,
+  handleCopy,
+  handleCopyUrl,
+}) {
+  const isChatgpt = activeTab === "chatgpt";
+  const showJsonForm = activeTab === "desktop" && desktopMode === "json";
+
+  if (showJsonForm) {
+    return (
+      <>
+        <p className="mb-2 text-[var(--text-muted)] text-[13px]">
+          Add to{" "}
+          <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>.
+          Requires <a href="https://github.com/geelen/mcp-remote" target="_blank" rel="noreferrer">mcp-remote</a> (
+          <code>npx</code> will install it automatically):
+        </p>
+        <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
+          {configs.desktop}
+        </pre>
+        <Button variant="secondary" className="mt-2" onClick={handleCopy}>
+          {copied ? "Copied!" : "Copy"}
+        </Button>
+        <button
+          type="button"
+          className="block mt-3 text-[13px] text-[var(--accent)] underline bg-transparent"
+          onClick={() => setDesktopMode("url")}
+        >
+          ← Back to the Custom Connector flow (recommended)
+        </button>
+      </>
+    );
+  }
+
+  const steps = isChatgpt
+    ? [
+        "Open ChatGPT → Settings → Connectors (Developer mode required).",
+        "Click Add → MCP server.",
+        "Paste the URL below, save, and approve the OAuth pop-up that follows.",
+      ]
+    : [
+        "Open Claude Desktop → Settings → Connectors.",
+        "Click Add custom connector.",
+        "Paste the URL below, save, and complete the browser OAuth flow.",
+      ];
+
+  return (
+    <>
+      <p className="mb-2 text-[var(--text-muted)] text-[13px]">
+        {isChatgpt
+          ? "Add Hive as a remote MCP App. ChatGPT handles OAuth in the browser — no config file needed."
+          : "Add Hive as a Custom Connector. Claude Desktop handles OAuth in the browser — no config file or mcp-remote helper needed."}
+      </p>
+      <ol className="list-decimal pl-5 mb-3 text-[13px] text-[var(--text)] space-y-1">
+        {steps.map((s) => (
+          <li key={s}>{s}</li>
+        ))}
+      </ol>
+      <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
+        {mcpUrl}
+      </pre>
+      <Button variant="secondary" className="mt-2" onClick={handleCopyUrl}>
+        {urlCopied ? "Copied!" : "Copy URL"}
+      </Button>
+      {!isChatgpt && (
+        <button
+          type="button"
+          className="block mt-3 text-[13px] text-[var(--text-muted)] underline bg-transparent"
+          onClick={() => setDesktopMode("json")}
+        >
+          Prefer JSON? (legacy mcp-remote setup)
+        </button>
+      )}
+    </>
   );
 }
 

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -56,11 +56,50 @@ describe("SetupPanel", () => {
     expect(document.body.textContent).toContain('"type": "http"');
   });
 
-  it("switches to Claude Desktop tab and shows mcp-remote config", async () => {
+  it("Claude Desktop tab leads with the Custom Connector URL flow", async () => {
     await act(async () => render(<SetupPanel />));
     fireEvent.click(screen.getByText("Claude Desktop"));
+    expect(document.body.textContent).toContain("Add custom connector");
+    expect(document.body.textContent).toContain("/mcp");
+    // The mcp-remote JSON config is hidden behind the legacy disclosure
+    expect(document.body.textContent).not.toContain('"command": "npx"');
+  });
+
+  it("Claude Desktop legacy disclosure reveals the mcp-remote JSON form", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText(/Prefer JSON/));
     expect(document.body.textContent).toContain("mcp-remote");
     expect(document.body.textContent).toContain('"command": "npx"');
+  });
+
+  it("ChatGPT tab shows the URL flow with the connector steps", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("ChatGPT"));
+    expect(document.body.textContent).toContain("Add → MCP server");
+    expect(document.body.textContent).toContain("/mcp");
+    expect(document.body.textContent).not.toContain('"command": "npx"');
+  });
+
+  it("Copy URL button copies the URL and marks step 1 done", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText("Copy URL"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("/mcp"),
+    );
+    expect(_storage["hive_setup_step1_done"]).toBe("1");
+  });
+
+  it("Copy URL shows Copied! and reverts after 2s", async () => {
+    vi.useFakeTimers();
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText("Copy URL"));
+    expect(screen.getByText("Copied!")).toBeTruthy();
+    act(() => vi.runAllTimers());
+    expect(screen.getByText("Copy URL")).toBeTruthy();
+    vi.useRealTimers();
   });
 
   it("shows Copy button initially", async () => {
@@ -90,11 +129,24 @@ describe("SetupPanel", () => {
     expect(document.body.textContent).toContain("/mcp");
   });
 
-  it("step 2 text updates when switching tabs", async () => {
+  it("step 2 text updates when switching tabs (Claude Desktop URL flow)", async () => {
     await act(async () => render(<SetupPanel />));
     expect(document.body.textContent).toContain("Claude Code");
     fireEvent.click(screen.getByText("Claude Desktop"));
+    expect(document.body.textContent).toContain("After saving the connector");
+  });
+
+  it("step 2 text updates for the Claude Desktop legacy JSON flow", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText(/Prefer JSON/));
     expect(document.body.textContent).toContain("Restart Claude Desktop");
+  });
+
+  it("step 2 text updates when switching to ChatGPT tab", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("ChatGPT"));
+    expect(document.body.textContent).toContain("ChatGPT opens an OAuth pop-up");
   });
 
   it("switching back to Claude Code tab restores http config", async () => {

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -102,6 +102,35 @@ describe("SetupPanel", () => {
     vi.useRealTimers();
   });
 
+  it("Cursor tab Copy uses the Cursor http config", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Cursor"));
+    fireEvent.click(screen.getByText("Copy"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('"type": "http"'),
+    );
+  });
+
+  it("Claude Desktop legacy JSON Copy uses the mcp-remote config", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText(/Prefer JSON/));
+    fireEvent.click(screen.getByText("Copy"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("mcp-remote"),
+    );
+  });
+
+  it("Back link from legacy JSON form returns to the URL flow", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText(/Prefer JSON/));
+    expect(document.body.textContent).toContain('"command": "npx"');
+    fireEvent.click(screen.getByText(/Back to the Custom Connector/));
+    expect(document.body.textContent).toContain("Add custom connector");
+    expect(document.body.textContent).not.toContain('"command": "npx"');
+  });
+
   it("shows Copy button initially", async () => {
     await act(async () => render(<SetupPanel />));
     expect(screen.getByText("Copy")).toBeTruthy();


### PR DESCRIPTION
Closes #409

## Summary

Two coordinated changes across the management UI, marketing site, docs site, and repo docs:

1. **Claude Desktop** — promote the Custom Connector URL flow (Settings → Connectors → Add custom connector + paste URL) to the primary recommendation. The `mcp-remote` JSON config drops to a clearly-labelled "Prefer JSON? (legacy)" disclosure on the SetupPanel tab and an "Older builds (pre-Connectors UI)" subsection in every doc.
2. **ChatGPT** is added as a newly supported client everywhere Claude Desktop / Cursor / Continue appear, with the Apps / Developer-mode connector instructions.

## Surfaces touched

- **`SetupPanel.jsx`** — new `chatgpt` tab, new `desktopMode` state for the URL ↔ JSON toggle, new Copy URL button, ChatGPT step-2 text, refactored to a small `DesktopOrChatgptInstructions` helper.
- **`McpClientsPage.jsx`** — Claude Desktop card rewritten for the connector flow, new ChatGPT card.
- **`HomePage.jsx`, `FaqPage.jsx`, `PricingPage.jsx`** — supported-clients lines now include ChatGPT.
- **`docs-site/getting-started/connect-client.md`** — Claude Desktop section leads with Custom Connectors, mcp-remote behind an "Older builds" subhead, new ChatGPT section.
- **`docs-site/getting-started/quick-start.md`** — code-group adds the URL flow as the lead tab; the Claude Desktop JSON form is now labelled `(legacy mcp-remote)`.
- **`docs-site/getting-started/what-is-hive.md`, `index.md`, `faq.md`** — supported-client lines updated.
- **`README.md`, `docs/mcp-setup.md`** — same: URL flow first, JSON as fallback, ChatGPT section.

## Tests

- New: ChatGPT tab renders, Custom Connector URL flow on Claude Desktop, legacy disclosure reveals JSON form, Copy URL writes URL to clipboard + marks step 1 done, Copied!→Copy URL state transition, ChatGPT step-2 text.
- Updated: `McpClientsPage` snippet count goes 4 → 5, plus a new `renders ChatGPT card` assertion.

`uv run inv pre-push` green (601 vitest + 538 pytest).

## Out of scope

- Removing the `mcp-remote` path entirely — it stays as the documented fallback for older Claude Desktop builds.
- Other clients beyond ChatGPT.
- Marketing accuracy audit was already done in #407 (this builds on those changes).