### PR TITLE
release: v0.21.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something isn't working as expected
-labels: ["bug"]
+labels: ["bug", "status:ready"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an improvement or new capability
-labels: ["enhancement"]
+labels: ["enhancement", "status:ready"]
 body:
   - type: textarea
     id: problem

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
     groups:
       python-deps:
         patterns: ["*"]
@@ -17,8 +16,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
     groups:
       npm-deps:
         patterns: ["*"]

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,16 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,54 @@
+name: Issue label check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  check-issue-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract linked issue and verify required labels
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Find "Closes #NNN" (or Fixes / Resolves) in PR body or title.
+          # Accepts the GitHub-recognised forms:
+          #   Closes #123, Fixes #123, Resolves #123 (case-insensitive).
+          ISSUE_NUM=$(printf '%s\n%s' "$PR_TITLE" "$PR_BODY" \
+            | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+' \
+            | head -1 \
+            | grep -oE '[0-9]+' || true)
+
+          if [ -z "$ISSUE_NUM" ]; then
+            echo "::notice::No linked issue found (PR body/title contains no 'Closes #N'). Skipping label check."
+            exit 0
+          fi
+
+          echo "Linked issue: #$ISSUE_NUM"
+
+          LABELS=$(gh api "repos/$REPO/issues/$ISSUE_NUM" --jq '[.labels[].name] | join(",")')
+          echo "Labels on issue #$ISSUE_NUM: $LABELS"
+
+          MISSING=()
+          echo "$LABELS" | grep -qE '(^|,)status:' || MISSING+=("status:*")
+          echo "$LABELS" | grep -qE '(^|,)priority:' || MISSING+=("priority:p0|p1|p2|p3")
+          echo "$LABELS" | grep -qE '(^|,)size:' || MISSING+=("size:xs|s|m|l|xl")
+
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::Issue #$ISSUE_NUM is missing required labels: ${MISSING[*]}"
+            echo "Add status, priority, and size labels to the issue before merging this PR."
+            exit 1
+          fi
+
+          echo "::notice::Issue #$ISSUE_NUM has all required label categories."

--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -1,0 +1,25 @@
+name: Main branch guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-source-branch:
+    name: check-source-branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject PRs not from release/* or development
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$HEAD_REF" == "development" ]] || [[ "$HEAD_REF" == release/* ]]; then
+            echo "✓ PR from $HEAD_REF — allowed"
+            exit 0
+          fi
+          echo "::error::PRs to main must come from 'development' or 'release/*' branches (got: $HEAD_REF)"
+          echo "See CLAUDE.md §Releasing to production for the correct flow."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,56 @@ See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) f
 
 ## [Unreleased]
 
-_Changes accumulated on `development` since v0.20.0. Will be rolled into v0.21.0._
+_Changes accumulated on `development` since v0.21.0. Will be rolled into the next release._
+
+## v0.21.0 — 2026-04-18
+
+### Added
+
+#### MCP surface
+
+- New `ping` tool for connectivity and auth health checks (#411)
+- New `list_tags` tool for tag-space discovery (#415)
+- New `relate_memories(key, top_k)` tool — semantic traversal from a memory to its nearest neighbours (#465)
+- New `remember_if_absent(key, value, tags?, ttl_seconds?)` — conditional write only when the key doesn't already exist (#466)
+- `search_memories` gained `min_score` (score threshold) and `filter_tags` (tag-intersection filter) parameters (#412, #444)
+- `remember` enforces a UTF-8 byte-size cap on `value` (default 10 KB, configurable via `HIVE_MAX_VALUE_BYTES`) (#403)
+- Every tool now advertises title + `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` so capable clients can auto-approve read-only calls and confirm destructive ones (#469)
+- `list_memories` and `search_memories` responses now include `owner_client_id`; the memory browser renders a "by {client name}" attribution badge on every card (#463)
+
+#### Compliance & privacy
+
+- GDPR Article 20 / CCPA §1798.100 data export: `GET /api/account/export` streams a JSON bundle with the user's profile, memories, OAuth clients, and the last 90 days of activity; rate-limited to one export per 5 min (#468)
+- Opt-in GA4 cookie consent banner — no tracking script loads until the visitor clicks Accept; choice persisted in `localStorage`, revocable via a footer "Cookie preferences" link (#467)
+- New `/subprocessors` page listing AWS, Google OAuth, and Google Analytics with purpose, data categories, and location; cross-linked from Privacy §4 and the FAQ (#470)
+
+#### Infrastructure, security, & observability
+
+- CloudFront response-headers policy: HSTS, `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, and a `Content-Security-Policy-Report-Only` draft; enforcing CSP tracked separately (#473)
+- New CloudWatch alarms: Lambda throttles (MCP + API), DynamoDB user errors, and Bearer-token auth failures; every prod alarm now pages both on firing and on recovery (OK actions); first-deploy runbook documents the SNS subscription flow (#474)
+- Backup / restore runbook for prod DynamoDB PITR recovery — when-to, pre-flight, restore, swap, validation, cleanup, post-mortem template, and annual drill guidance (#478)
+- SEO: `robots.txt` + `sitemap.xml` for marketing SPA + VitePress-generated docs sitemap (#443)
+- Open Graph + Twitter Card metadata across marketing and docs pages so shared links render proper preview cards (#455)
+
+#### Dev experience & CI
+
+- Key-naming conventions docs page with the recommended `{domain}:{entity-type}/{entity-id}:{attribute}` pattern and examples (#408)
+- `main`-branch guard: PRs to `main` from anything other than `development` or `release/*` fail a required status check, preventing another v0.20.0-style release-bypass (#477)
+- Dependabot now runs daily for pip and npm (github-actions stays weekly) and passing Dependabot PRs auto-merge (#432, #445)
+- ChatGPT joins the supported-clients list everywhere; Claude Desktop setup now leads with the Custom Connector URL flow (mcp-remote JSON kept as a legacy fallback) (#485)
+
+### Fixed
+
+- Pricing page claimed "unlimited memories" while the free-tier quota is 500 (#404)
+- Privacy Policy / Terms referenced `privacy@hive.so` and `hello@hive.so` on a domain we don't own; switched to `@warlordofmars.net` (#431)
+- Marketing home page's "3-step setup" described a flow that doesn't exist ("register a client", "one-line snippet"); rewritten to match `SetupPanel` and the docs, including the browser-OAuth step (#471)
+
+### Meta
+
+- CLAUDE.md: deterministic selection algorithm for the autonomous issue queue (#461)
+- CLAUDE.md: label taxonomy (status / priority / size / area) and milestone policy; enforced at PR merge via `label-check.yml` (#462, #464)
+- CLAUDE.md: autonomous agent halts and surfaces `HUMAN_INPUT_REQUIRED` when the active release milestone drains (#483)
+- CHANGELOG: retroactive v0.20.0 entry documenting what actually shipped there (#476)
 
 ## v0.20.0 — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Hive are documented here. Releases correspond to GitHub t
 
 See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) for full release notes generated from merged PRs.
 
+## [Unreleased]
+
+_Changes accumulated on `development` since v0.20.0. Will be rolled into v0.21.0._
+
+## v0.20.0 — 2026-04-17
+
+> **Note**: v0.20.0 was cut from a single PR that bypassed the normal release-branch workflow. The intended scope of this milestone (compliance work, accuracy audit, MCP annotations, etc.) was merged to `development` after the tag was already pushed and will ship in v0.21.0. This entry documents what actually shipped in v0.20.0. See #475 for the branch-protection follow-up to prevent this recurring.
+
+### Added
+
+- Terms of Service and Privacy Policy marketing pages (#401)
+
 ## v0.19.1 — 2026-04-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,10 +466,60 @@ calls and document them in the PR description.
 When given one or more GitHub issue numbers, process them **sequentially**.
 Complete the full cycle for each issue before starting the next.
 
+When given no specific issue number, use the selection algorithm in §0 to
+pick the next one from the queue.
+
 When processing a batch of issues, after completing each issue cycle
 successfully, append the issue number to `.autonomous-progress` in the
 repo root. This allows an interrupted batch to be resumed by checking
 which issues are already recorded there.
+
+#### 0. Pick the next issue (if none was given)
+
+Every open issue should carry three metadata labels:
+
+- **Status** — `status:ready`, `status:blocked`, `status:design-needed`,
+  or `status:needs-info`
+- **Priority** — `priority:p0` (ship this week) through `priority:p3`
+  (someday-maybe)
+- **Size** — `size:xs` (<1h), `size:s` (half-day), `size:m` (1–2 days),
+  `size:l` (3–5 days), `size:xl` (epic; break down before picking up)
+
+Pick the next issue using this deterministic queue:
+
+1. **Filter** to issues matching ALL of:
+   - `state:open`
+   - `status:ready` (exclude `status:blocked`, `status:design-needed`,
+     `status:needs-info`)
+   - no assignee (not already being worked on)
+   - not labelled `epic` (those are tracking issues, not implementation work)
+
+2. **Sort** by priority descending: `p0` > `p1` > `p2` > `p3`.
+   Missing priority label → treat as `p3`.
+
+3. **Break priority ties** by size ascending (smallest first):
+   `xs` > `s` > `m` > `l` > `xl`. Missing size label → treat as `m`.
+
+4. **Break remaining ties** by issue number ascending (oldest first).
+
+Saved GitHub query for the top of the queue:
+
+```
+is:issue is:open no:assignee label:status:ready -label:epic
+```
+
+Sort the result by label priority manually (GitHub search doesn't sort by
+label precedence).
+
+**Never pick** issues labelled `status:design-needed` or `status:needs-info`.
+If you believe one of those issues is actually ready, state the case in a
+comment and ask for the label to be changed — do not proceed unilaterally.
+
+**Never pick** `size:xl` issues. Ask the user to break them into smaller
+issues first.
+
+**Never pick** issues from the "Stop and ask" list below, even if labelled
+`status:ready`.
 
 #### 1. Understand the issue
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,3 +748,85 @@ In all other cases, make a judgment call and proceed.
 - Use `pip` or `requirements.txt` — always use `uv`
 - Skip `inv pre-push` before creating a PR
 - Pin GitHub Actions to mutable version tags — use full commit SHAs
+
+## Backlog labels and milestones
+
+The selection algorithm in §Autonomous issue workflow §0 assumes every
+open implementation issue carries status + priority + size + area labels.
+This section defines the taxonomy and the creation rules that keep the
+queue trustworthy.
+
+### Status (one, required)
+
+- `status:ready` — fully scoped, queue-eligible
+- `status:blocked` — depends on another issue; body must name the blocker
+  with `Blocked by #N`. Not queue-eligible
+- `status:design-needed` — needs a decision before implementation. Not
+  queue-eligible
+- `status:needs-info` — waiting on reporter/user. Not queue-eligible
+
+### Priority (one, required)
+
+- `priority:p0` — compliance, security, or outage-adjacent; ship this week
+- `priority:p1` — ship this quarter
+- `priority:p2` — ship eventually; useful but not urgent
+- `priority:p3` — someday-maybe
+
+### Size (one, required)
+
+- `size:xs` — less than 1 hour
+- `size:s` — half a day
+- `size:m` — 1–2 days
+- `size:l` — 3–5 days
+- `size:xl` — a week or more; must be broken down before the agent picks
+  it up
+
+### Area (one or more, required)
+
+`ui`, `ux`, `a11y`, `api`, `mcp`, `auth`, `infra`, `ci`, `dx`, `sdk`,
+`security`, `compliance`, `docs`, `design`, `performance`, `observability`,
+`marketing`, `seo`, `growth`, `ops`, `reliability`.
+
+### Special labels
+
+- `epic` — tracking issue with sub-issue checklist; never queue-eligible
+- `bug` / `enhancement` / `chore` — issue type
+
+### Issue creation rules
+
+When filing a new issue:
+
+1. Use the GitHub issue template (defaults to `status:ready`)
+2. Add a `priority:*` label and a `size:*` label before leaving the page
+3. Add at least one area label
+4. If the issue is part of an existing epic, add `Part of #NNN` to the
+   body so the epic's checklist stays linked
+5. If the issue depends on another, add `Blocked by #NNN` to the body and
+   apply `status:blocked`
+
+The `label-check.yml` workflow enforces status + priority + size at PR
+merge time for any PR that contains `Closes #NNN`.
+
+### Milestones
+
+Keep **three** active milestones at any time — no more:
+
+1. **Current release** (e.g. `v0.20`) — what ships next
+2. **Themed hardening bucket** (e.g. `MVP-hardening`) — ship-blocking work
+   that's too large for the current release
+3. **`Backlog`** — accepted but unscheduled p2/p3 work
+
+Epics are **not** milestoned — they span multiple releases.
+
+Do not create future release milestones in advance; they become stockpiles
+and degrade the "what's next" signal. When the current release closes,
+create the next one and promote items from the hardening bucket.
+
+### Triage cadence (human, not agent)
+
+- **Weekly** — glance at issues created in the last 7 days; fix any
+  missing priority / size / area labels
+- **Monthly** — review the hardening bucket and promote shippable items
+  into the current release
+- **Quarterly** — review `priority:p3` and `status:design-needed` issues;
+  promote, rescope, or close. Don't let them rot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -702,6 +702,40 @@ If the pipeline fails:
 
 Only move to the next issue when the `development` pipeline is green.
 
+#### 9. Check if the milestone is drained
+
+After the development pipeline is green, check whether the closed issue's
+milestone still has any open, non-epic issues:
+
+```bash
+# Resolve the milestone number from the issue just closed (via gh)
+MILESTONE=$(gh issue view <number> --json milestone --jq '.milestone.title')
+
+# If the milestone exists and matches a release-milestone pattern (vX.Y),
+# count the open non-epic issues remaining in it
+if [[ -n "$MILESTONE" && "$MILESTONE" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+  REMAINING=$(gh issue list \
+    --milestone "$MILESTONE" \
+    --state open \
+    --json labels \
+    --jq '[.[] | select(.labels | map(.name) | contains(["epic"]) | not)] | length')
+
+  if [ "$REMAINING" -eq 0 ]; then
+    echo "HUMAN_INPUT_REQUIRED: Milestone $MILESTONE has no open issues — ready to cut release?"
+    exit 0   # stop; do not pick up the next issue
+  fi
+fi
+```
+
+If the release milestone is drained, stop and surface the sentinel so the
+operator can decide whether to cut the release first or continue draining
+from `Backlog`. Do **not** unilaterally create a release branch — releases
+are a human decision per §Releasing to production.
+
+If the milestone is non-release (e.g. `Backlog`, `MVP-hardening`), or the
+issue has no milestone, or there are still open non-epic items: skip this
+step and pick up the next issue normally.
+
 ### Keeping CLAUDE.md current
 
 If you discover that CLAUDE.md is missing information needed to work
@@ -736,6 +770,9 @@ Halt and wait for human input **only** in these situations:
 - A change requires modifying `infra/stacks/hive_stack.py` in a way that
   could affect production resources
 - The same CI check has failed 3 times without a clear fix
+- A release milestone (pattern `vX.Y`) drains to zero open non-epic issues —
+  stop after step 9 and surface so the user can decide whether to cut the
+  release before continuing
 
 In all other cases, make a judgment call and proceed.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 Shared persistent memory for AI agents — works with any MCP-compatible client. Free hosted service, no AWS account required.
 
-Hive is an MCP server that gives AI agents durable, shared memory across conversations. Connect any MCP-compatible client — Claude Code, Claude Desktop, Cursor, Continue, or custom agents — store and retrieve memories by key or tag, and manage everything through a web UI.
+Hive is an MCP server that gives AI agents durable, shared memory across conversations. Connect any MCP-compatible client — Claude Code, Claude Desktop, ChatGPT, Cursor, Continue, or custom agents — store and retrieve memories by key or tag, and manage everything through a web UI.
 
 **Hosted at [hive.warlordofmars.net](https://hive.warlordofmars.net) — sign in with Google, no setup required.**
 
@@ -53,7 +53,15 @@ Hive is an MCP server that gives AI agents durable, shared memory across convers
 }
 ```
 
-**Claude Desktop / any stdio-based client** — use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy:
+**Claude Desktop** / **ChatGPT** — open *Settings → Connectors* and add a custom MCP connector pointing at:
+
+```
+https://hive.warlordofmars.net/mcp
+```
+
+The browser handles OAuth on first use; no config file or local proxy required.
+
+**Older Claude Desktop builds (no Connectors UI)** or any other stdio-based client — fall back to [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ AI agents are stateless — every new conversation starts blank. Hive gives them
 
 Multiple agents or team members connect with their own OAuth clients, so you can track who stored what and revoke access individually.
 
+Keys are opaque to the server, but a structured convention like `{domain}:{entity-type}/{entity-id}:{attribute}` (e.g. `project:task/42:summary`) keeps memory stores organised and collision-free as they grow. See the [key naming conventions](https://hive.warlordofmars.net/docs/concepts/key-conventions) docs page for details.
+
 ## Architecture
 
 Hive is a serverless, AWS-native stack deployed on Lambda + DynamoDB behind CloudFront:

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -15,7 +15,41 @@ export default defineConfig({
         url: `docs/${item.url.replace(/^\//, "")}`,
       })),
   },
-  head: [["link", { rel: "icon", type: "image/svg+xml", href: "/docs/favicon.svg" }]],
+  head: [
+    ["link", { rel: "icon", type: "image/svg+xml", href: "/docs/favicon.svg" }],
+    ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:site_name", content: "Hive" }],
+    ["meta", { property: "og:title", content: "Hive Docs — Shared Memory for Claude Agents" }],
+    [
+      "meta",
+      {
+        property: "og:description",
+        content: "Documentation for Hive, a shared persistent memory service for Claude agents and teams.",
+      },
+    ],
+    ["meta", { property: "og:url", content: "https://hive.warlordofmars.net/docs/" }],
+    [
+      "meta",
+      { property: "og:image", content: "https://hive.warlordofmars.net/social-preview.png" },
+    ],
+    ["meta", { property: "og:image:width", content: "1200" }],
+    ["meta", { property: "og:image:height", content: "630" }],
+    ["meta", { property: "og:image:alt", content: "Hive — Shared Memory for Claude Agents" }],
+    ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    ["meta", { name: "twitter:title", content: "Hive Docs — Shared Memory for Claude Agents" }],
+    [
+      "meta",
+      {
+        name: "twitter:description",
+        content: "Documentation for Hive, a shared persistent memory service for Claude agents and teams.",
+      },
+    ],
+    [
+      "meta",
+      { name: "twitter:image", content: "https://hive.warlordofmars.net/social-preview.png" },
+    ],
+    ["meta", { name: "twitter:image:alt", content: "Hive — Shared Memory for Claude Agents" }],
+  ],
 
   themeConfig: {
     logo: { src: "/logo.svg", alt: "Hive" },

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -5,6 +5,16 @@ export default defineConfig({
   title: "Hive Docs",
   description: "Shared persistent memory for AI agents — documentation",
   cleanUrls: true,
+  sitemap: {
+    hostname: "https://hive.warlordofmars.net",
+    // VitePress drops `base` from the item URL when writing the sitemap,
+    // so prepend it here to match the deployed path at /docs/.
+    transformItems: (items) =>
+      items.map((item) => ({
+        ...item,
+        url: `docs/${item.url.replace(/^\//, "")}`,
+      })),
+  },
   head: [["link", { rel: "icon", type: "image/svg+xml", href: "/docs/favicon.svg" }]],
 
   themeConfig: {

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -53,6 +53,7 @@ export default defineConfig({
         items: [
           { text: "How memory scoping works", link: "/concepts/memory-scoping" },
           { text: "Tags and organisation", link: "/concepts/tags" },
+          { text: "Key naming conventions", link: "/concepts/key-conventions" },
         ],
       },
       {

--- a/docs-site/concepts/key-conventions.md
+++ b/docs-site/concepts/key-conventions.md
@@ -1,0 +1,45 @@
+# Key naming conventions
+
+Hive stores memories under a **key** you choose. The server doesn't enforce any structure on that key — any non-empty string works. But keys left to grow organically become chaotic and collision-prone fast, and renaming them later is painful once a client has thousands.
+
+This page describes the recommended convention. It's a guideline, not a rule; adopt as much or as little as suits your agent.
+
+## The convention
+
+```text
+{domain}:{entity-type}/{entity-id}:{attribute}
+```
+
+- **domain** — top-level namespace (e.g. `project`, `user`, `session`, `team`, `global`)
+- **entity-type/entity-id** — identifies a specific thing (optional, omit for domain-wide memories)
+- **attribute** — what the value contains (e.g. `summary`, `preferences`, `context`)
+
+Lowercase, hyphens within segments, colons as separators, `/` between an entity type and its id.
+
+## Examples
+
+| Key | Meaning |
+|---|---|
+| `project:task/42:summary` | Summary of task 42 in the project domain |
+| `user:profile/alice:preferences` | Alice's user preferences |
+| `session:current:context` | Context for the current session |
+| `team:shared:coding-guidelines` | Team-wide coding guidelines |
+| `global:env:database-schema` | A globally-shared piece of context |
+
+## Why this works
+
+- **Collision-resistant.** Two different domains never share a key space.
+- **Queryable by prefix.** Pairs well with `list_memories` and `search_memories` when you want everything under `project:task/42`.
+- **Readable.** An operator browsing the Memory Browser can tell what each memory is for at a glance.
+- **Extensible.** Adding a new domain or attribute never forces a rename of existing keys.
+
+## Tips
+
+- Prefer a fixed, small set of domains per agent — don't invent a new one for every memory.
+- Keep `entity-id` stable for the life of the entity (a database id works well; a slug is fine if it never changes).
+- Use `tags` for cross-cutting groupings ("decision", "open-question") rather than stuffing them into the key.
+- When in doubt, start simple (`domain:attribute`) and add structure only when a real collision shows up.
+
+## What Hive does not enforce
+
+The server accepts any key. This convention lives in your agent's system prompt or tool-use instructions — it's your choice how strictly to follow it. Hive may introduce opt-in key validation in a future release.

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -14,7 +14,7 @@ Memories are never shared between accounts, and Hive does not use your data to t
 
 ### Where is my data stored?
 
-Data is stored on AWS infrastructure (DynamoDB, S3 Vectors) in the US East region. Data is encrypted at rest and in transit.
+Data is stored on AWS infrastructure (DynamoDB, S3 Vectors) in the US East region. Data is encrypted at rest and in transit. A full list of third parties that process data on our behalf — AWS, Google OAuth, and Google Analytics — is maintained on the [Subprocessors page](https://hive.warlordofmars.net/subprocessors).
 
 ### Can Anthropic or other AI providers see my memories?
 

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -30,7 +30,7 @@ All memories, OAuth clients, tokens, and activity log entries associated with yo
 
 ### How many memories can I store?
 
-There is currently no hard limit on the number of memories per account. Very large memory stores (tens of thousands of memories) may affect search and retrieval performance.
+Free accounts can store up to 500 memories. Once you reach the limit, new `remember` calls are rejected until you delete existing memories. Large memory stores may also affect search and retrieval performance.
 
 ### How large can a memory value be?
 

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -54,6 +54,10 @@ Sign into the management UI and go to **Settings → Delete account**. This perm
 
 If you can't access your account, contact support.
 
+### How do I export my data?
+
+Sign into the management UI and click **Settings → Export my data**. You'll download a JSON file with your profile, all memories, OAuth clients, and the last 90 days of activity. The same data is available programmatically via `GET /api/account/export` (Bearer auth required). Rate-limited to one export per 5 minutes.
+
 ### Can I use Hive with multiple devices?
 
 Yes. Each device or client registers its own OAuth connection. They all share the same underlying memory store under your account.

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -38,7 +38,7 @@ Up to approximately 380 KB of text per memory. This is enough for several pages 
 
 ### How long are tokens valid?
 
-Access tokens are valid for **1 hour** and refresh automatically in supported clients (Claude Code, Claude Desktop, claude.ai). Refresh tokens are valid for **30 days**.
+Access tokens are valid for **1 hour** and refresh automatically in supported clients (Claude Code, Claude Desktop, ChatGPT, claude.ai). Refresh tokens are valid for **30 days**.
 
 ---
 

--- a/docs-site/getting-started/connect-client.md
+++ b/docs-site/getting-started/connect-client.md
@@ -38,7 +38,21 @@ Restart Cursor. On first use it will open a browser window to complete the OAuth
 
 ## Claude Desktop
 
-Claude Desktop requires [mcp-remote](https://github.com/geelen/mcp-remote) as a local proxy. `npx` will install it automatically.
+Recent Claude Desktop versions support remote MCP servers as **Custom Connectors** — no config file or local proxy needed.
+
+1. Open Claude Desktop → **Settings → Connectors**.
+2. Click **Add custom connector**.
+3. Paste:
+
+   ```
+   https://hive.warlordofmars.net/mcp
+   ```
+
+4. Save. Claude Desktop opens your browser to complete OAuth — approve and you're connected.
+
+### Older Claude Desktop (pre-Connectors UI)
+
+If your build doesn't have the Connectors menu yet, fall back to the [mcp-remote](https://github.com/geelen/mcp-remote) helper.
 
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
@@ -54,6 +68,20 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 Restart Claude Desktop. On first use it will open a browser window to complete the OAuth flow.
+
+## ChatGPT
+
+ChatGPT supports remote MCP servers as **Apps** under Developer mode (eligibility varies by plan and may require enabling Developer mode in account settings).
+
+1. Open ChatGPT → **Settings → Connectors**.
+2. Click **Add → MCP server**.
+3. Paste:
+
+   ```
+   https://hive.warlordofmars.net/mcp
+   ```
+
+4. Save. ChatGPT opens an OAuth pop-up — approve and the connector stays available across sessions.
 
 ## Continue (VS Code / JetBrains)
 

--- a/docs-site/getting-started/quick-start.md
+++ b/docs-site/getting-started/quick-start.md
@@ -8,9 +8,16 @@ Go to [hive.warlordofmars.net](https://hive.warlordofmars.net) and sign in with 
 
 ## Step 2 — Connect your MCP client
 
-Add Hive to your MCP client config. The config depends on which client you use:
+Connect Hive to your MCP client. The exact path depends on the client:
 
 ::: code-group
+
+```text [Claude Desktop / ChatGPT]
+Settings → Connectors → Add custom connector
+(or Add → MCP server in ChatGPT)
+
+URL: https://hive.warlordofmars.net/mcp
+```
 
 ```json [Claude Code / Cursor]
 // ~/.claude/settings.json  (Claude Code)
@@ -25,8 +32,9 @@ Add Hive to your MCP client config. The config depends on which client you use:
 }
 ```
 
-```json [Claude Desktop]
+```json [Claude Desktop (legacy mcp-remote)]
 // ~/Library/Application Support/Claude/claude_desktop_config.json
+// Use this only if your Claude Desktop build pre-dates the Connectors UI.
 {
   "mcpServers": {
     "hive": {

--- a/docs-site/getting-started/what-is-hive.md
+++ b/docs-site/getting-started/what-is-hive.md
@@ -33,7 +33,7 @@ No copy-pasting context. No re-explaining your project each session. Your agent 
 | **Persistent storage** | Memories survive indefinitely across conversations |
 | **Semantic search** | Find memories by meaning using natural language |
 | **Tag-based organisation** | Group related memories with tags for easy retrieval |
-| **Multi-client** | Use Hive from Claude Code, Claude Desktop, Cursor, and more simultaneously |
+| **Multi-client** | Use Hive from Claude Code, Claude Desktop, ChatGPT, Cursor, and more simultaneously |
 | **Team sharing** | Multiple agents or team members can share a Hive instance |
 
 ## Who is it for?

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -21,7 +21,7 @@ features:
   - icon:
       svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/></svg>'
     title: Works with any MCP client
-    details: Claude Code, Claude Desktop, Cursor, Continue, claude.ai — if it supports MCP, it works with Hive.
+    details: Claude Code, Claude Desktop, ChatGPT, Cursor, Continue, claude.ai — if it supports MCP, it works with Hive.
   - icon:
       svg: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>'
     title: Semantic search

--- a/docs-site/ui-guide/memory-browser.md
+++ b/docs-site/ui-guide/memory-browser.md
@@ -12,6 +12,7 @@ Your memories are listed in the main panel. Each card shows:
 - The memory **key**
 - A preview of the **value** (first 160 characters)
 - Any **tags** attached to the memory
+- A **by {client name}** badge attributing the memory to the OAuth client that created it (falls back to the client id when the name has been deleted)
 
 ## Searching memories
 

--- a/docs/alarms.md
+++ b/docs/alarms.md
@@ -1,0 +1,175 @@
+# Alarm runbook
+
+Hive ships with a set of CloudWatch alarms that page the operator via SNS
+when something goes wrong. This page lists every alarm, what it means,
+and the first things to check when it fires.
+
+## First-deploy: subscribing to alerts
+
+On the first deploy of a new environment, the SNS topic exists but has
+**no subscribers**. Alarms fire into the void until you subscribe.
+
+1. Set the alarm-recipient email in SSM:
+
+   ```bash
+   aws ssm put-parameter \
+     --name /hive/prod/alarm-email \
+     --value "you@example.com" \
+     --type String \
+     --overwrite
+   ```
+
+2. Subscribe the SNS topic to that email:
+
+   ```bash
+   EMAIL=$(aws ssm get-parameter --name /hive/prod/alarm-email \
+             --query 'Parameter.Value' --output text)
+   TOPIC_ARN=$(aws cloudformation describe-stack-resource \
+                 --stack-name HiveStack \
+                 --logical-resource-id AlarmTopic \
+                 --query 'StackResourceDetail.PhysicalResourceId' \
+                 --output text)
+   aws sns subscribe \
+     --topic-arn "$TOPIC_ARN" \
+     --protocol email \
+     --notification-endpoint "$EMAIL"
+   ```
+
+3. Confirm the subscription from the confirmation email AWS sends.
+
+Every alarm wires both `alarm_action` and `ok_action` to the same topic,
+so you'll get both "firing" and "recovered" emails.
+
+## Alarms
+
+### `Hive-{env}-McpErrorRate` / `Hive-{env}-ApiErrorRate`
+
+Fires when **Lambda error rate exceeds 5 %** for 2 of 3 × 5-minute windows.
+
+First checks:
+
+- Recent deploys in `#deploys` and on the `development`/`main` CI runs — any
+  failure you missed?
+- `Dashboard → MCP/API Lambda → Invocations & Errors` chart — is it a spike
+  or sustained?
+- `aws logs tail /aws/lambda/hive-mcp-fn` (or `-api-fn`) — read the most
+  recent stack trace.
+
+### `Hive-{env}-McpP99Duration`
+
+MCP Lambda p99 latency > 25 s over 2 × 5 min. **Timeout canary** — if this
+fires we're very close to the 30 s Lambda cutoff.
+
+First checks:
+
+- DynamoDB throttles (`Hive-{env}-DdbThrottles`). Throttles + slow Lambda
+  usually move together.
+- S3 Vectors health — semantic search is the slowest call in `remember`.
+- Any recent change to `hive.storage` or `vector_store` that could hot-
+  path a new scan.
+
+### `Hive-{env}-McpP95Latency`
+
+MCP p95 > 2000 ms over a 1-hour window. **SLO breach** — slower than what
+we promise to users. Usually a leading indicator for `McpP99Duration`.
+
+### `Hive-{env}-McpThrottles` / `Hive-{env}-ApiThrottles`
+
+Any Lambda throttle in a 5-minute window. Reserved concurrency may be too
+low, or a noisy client is hammering one endpoint.
+
+First checks:
+
+- `aws lambda get-function-concurrency --function-name <fn>` — does it
+  match the expected config?
+- Identify the client via `/api/activity?limit=200` — is one `client_id`
+  dominating?
+- If sustained: temporarily raise reserved concurrency and open a ticket
+  to investigate.
+
+### `Hive-{env}-DdbThrottles`
+
+Any DynamoDB throttle in 5 min. We're pay-per-request so this shouldn't
+happen unless we're hot-partitioning (all traffic to one `PK`).
+
+First checks:
+
+- `AWS/DynamoDB` → `ReadThrottleEvents` + `WriteThrottleEvents` per
+  `TableName` — which op is throttling?
+- Activity log: is there a bug writing many items to one `PK` (the
+  `LOG#{date}#{hour}` partition is the most common offender — see
+  `storage.py` sharding comment).
+
+### `Hive-{env}-DdbUserErrors`
+
+> 10 `AWS/DynamoDB` `UserErrors` in 5 min. Conditional-check failures,
+ValidationException, etc.
+
+First checks:
+
+- Tail the Lambda log for `botocore.exceptions.ClientError` — which
+  item / condition is failing?
+- `ConditionalCheckFailed` is expected for optimistic writes; a spike
+  usually means concurrent writers to the same key.
+- Schema mismatch after a migration? Check the latest CloudFormation
+  deploy diff.
+
+### `Hive-{env}-CloudFront5xx`
+
+CloudFront 5xx rate > 1 % over 5 min. Upstream Lambda is likely the
+cause; check the MCP/API error alarms first.
+
+### `Hive-{env}-ToolErrors`
+
+Custom `Hive/ToolErrors` EMF metric exceeds 10 in 5 min for 2 of 3
+windows. Fires when MCP tools return `ToolError` (quota, size limit,
+storage error).
+
+First checks:
+
+- Which `operation` dimension is spiking? (Dashboard → Custom metrics).
+- `remember` spikes are usually quota or size-limit hits — check
+  `check_memory_quota` + `HIVE_MAX_VALUE_BYTES`.
+- `recall` / `forget` spikes are usually "not found" — a client using
+  stale keys.
+
+### `Hive-{env}-StorageLatencyHigh`
+
+`Hive/StorageLatencyMs` p99 > 2000 ms for 2 × 5 min. DynamoDB's own slow
+path (not Lambda overhead).
+
+First checks:
+
+- Paginated tag queries (`list_memories`, `forget_all`) — large tags can
+  sweep many pages.
+- Vector store `upsert_memory` failures that cause `put_memory` to retry.
+
+### `Hive-{env}-AuthFailures`
+
+Bearer token rejections (`Hive/TokenValidationFailures`) > 10 in 5 min
+for 2 of 3 windows.
+
+First checks:
+
+- One client that just rotated its key and hasn't updated the config?
+- Credential leak — scan recent activity for unusual client IDs / IP
+  ranges (see `api/logs` CloudWatch log viewer).
+- If sustained and multi-client, consider temporarily tightening WAF
+  rate limits.
+
+### `Hive-{env}-McpFastBurn` / `McpSlowBurn` / `ApiFastBurn` / `ApiSlowBurn`
+
+SLO burn-rate alarms. Fast burn = 5× error budget over 1 hour, slow burn
+= 2× over 6 hours. See [Google SRE workbook — burn-rate alerts](
+https://sre.google/workbook/alerting-on-slos/) for the methodology.
+
+Treat these like the plain error-rate alarms but with more urgency — they
+mean the error budget will run out within hours if nothing changes.
+
+## Adding a new alarm
+
+1. Declare the `cw.Alarm` in `infra/stacks/hive_stack.py`.
+2. Call `_notify(alarm)` to wire both alarm + OK actions in prod.
+3. Add it to the dashboard (`HiveDashboard` widgets) so it's visible
+   even when it isn't firing.
+4. Add an entry to this runbook.

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -29,7 +29,16 @@ On first use Claude Code will open a browser window to complete the OAuth flow. 
 
 ## Claude Desktop
 
-Claude Desktop doesn't support HTTP MCP servers directly. Use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy — it handles DCR and the OAuth flow automatically.
+Recent Claude Desktop builds support remote MCP servers as **Custom Connectors** — no config file or local proxy required.
+
+1. Open Claude Desktop → **Settings → Connectors**.
+2. Click **Add custom connector**.
+3. Paste `https://hive.warlordofmars.net/mcp` and save.
+4. Approve the OAuth flow in the browser pop-up.
+
+### Older builds (pre-Connectors UI)
+
+Use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local proxy — it handles DCR and the OAuth flow automatically.
 
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
@@ -45,6 +54,17 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 Restart Claude Desktop. On first use `mcp-remote` will open a browser window to complete the OAuth flow.
+
+---
+
+## ChatGPT
+
+ChatGPT supports remote MCP servers as **Apps** under Developer mode (eligibility varies by plan).
+
+1. Open ChatGPT → **Settings → Connectors**.
+2. Click **Add → MCP server**.
+3. Paste `https://hive.warlordofmars.net/mcp` and save.
+4. Approve the OAuth pop-up that follows.
 
 ---
 

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,216 @@
+# Backup & restore runbook
+
+How to recover Hive's DynamoDB data when something has gone catastrophically
+wrong. Read this before you need it.
+
+## When to use this
+
+- **Data corruption** — bad code wrote bad data; recent state is wrong.
+- **Accidental delete** — `inv` task or admin script wiped real data.
+- **Ransomware / hostile actor** — attacker scrubbed or encrypted the table.
+- **Region failure** — `us-east-1` is unavailable and won't be back soon.
+
+If the issue is *latency*, *errors*, or *one bad record*, this runbook is
+overkill — see `docs/alarms.md` first.
+
+## What you have to work with
+
+- DynamoDB **Point-in-time recovery** (PITR) is enabled on the prod
+  `hive` table (`infra/stacks/hive_stack.py` →
+  `point_in_time_recovery_enabled=is_prod`). PITR retains a continuous
+  recovery window of **35 days**.
+- A weekly restore drill (`.github/workflows/backup-test.yml`) PITR-restores
+  to a temp table, validates row count > 0, deletes the temp table. If
+  it fails, an issue with `reliability` label is opened automatically.
+- `inv export` / `inv import` produce JSONL dumps for ad-hoc backups —
+  use when you need a portable copy outside AWS.
+
+## Pre-flight (≤ 10 min)
+
+1. **Notify** — drop a note in the ops channel. State the symptom and an
+   ETA for next status update (15 min is reasonable; resist
+   under-promising).
+2. **Freeze writes** to limit blast radius:
+
+   ```bash
+   aws lambda put-function-concurrency \
+     --function-name hive-mcp-fn \
+     --reserved-concurrent-executions 0
+   aws lambda put-function-concurrency \
+     --function-name hive-api-fn \
+     --reserved-concurrent-executions 0
+   ```
+
+   This 200's all incoming requests with throttling but keeps the
+   stack intact — operators and admins can still inspect via the AWS
+   console.
+3. **Capture the symptom.** Screenshot the dashboard, save a sample of
+   the bad data, copy any error stack traces. You'll want this for the
+   post-mortem.
+
+## PITR restore
+
+1. **Pick the restore time.** Aim for the latest moment *before* the
+   corruption. PITR resolution is one second.
+
+   ```bash
+   # Example: restore to the state at 13:42 UTC today
+   RESTORE_TIME=2026-04-18T13:42:00Z
+   ```
+
+2. **Restore to a new table.** Never restore in-place — you want the
+   bad table preserved for forensics.
+
+   ```bash
+   RESTORE_TABLE=hive-restore-$(date -u +%Y%m%d-%H%M)
+   aws dynamodb restore-table-to-point-in-time \
+     --source-table-name hive \
+     --target-table-name "$RESTORE_TABLE" \
+     --restore-date-time "$RESTORE_TIME"
+   ```
+
+   If you can't pick a precise moment, use `--use-latest-restorable-time`
+   instead of `--restore-date-time`.
+
+3. **Wait for `ACTIVE`.** Restores take 5–30 min depending on table size.
+
+   ```bash
+   aws dynamodb wait table-exists --table-name "$RESTORE_TABLE"
+   aws dynamodb describe-table --table-name "$RESTORE_TABLE" \
+     --query 'Table.TableStatus' --output text
+   # Expect: ACTIVE
+   ```
+
+4. **Spot-check the restored data.** Run a few targeted queries to
+   confirm the bad data is gone and the good data is back.
+
+   ```bash
+   # Example: pull a memory you know existed before the incident
+   aws dynamodb get-item --table-name "$RESTORE_TABLE" \
+     --key '{"PK": {"S": "MEMORY#known-id"}, "SK": {"S": "META"}}'
+   ```
+
+## Swap procedure
+
+The Lambda environment variable `HIVE_TABLE_NAME` controls which table
+the app reads/writes. Swap it to the restored table.
+
+1. **Update CDK** — set the table name override in
+   `infra/stacks/hive_stack.py` (or temporarily via Lambda env var).
+   Cleanest path is a one-line CDK change + redeploy:
+
+   ```python
+   # Temporary override — reset after data is migrated back
+   table_name = "hive-restore-20260418-1342"  # was: "hive"
+   ```
+
+2. **Deploy:**
+
+   ```bash
+   uv run inv deploy --env prod
+   ```
+
+3. **Lift the write freeze** by setting concurrency back to its prior
+   value (or removing the limit):
+
+   ```bash
+   aws lambda delete-function-concurrency --function-name hive-mcp-fn
+   aws lambda delete-function-concurrency --function-name hive-api-fn
+   ```
+
+## Validation
+
+1. **Smoke-test the API:**
+
+   ```bash
+   curl -s https://hive.warlordofmars.net/health
+   # Expect: 200 OK
+   ```
+
+2. **Smoke-test MCP tools** with a known-good token:
+
+   ```bash
+   # Set $TOKEN to a working API key
+   curl -s -X POST https://hive.warlordofmars.net/mcp \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ping"}}'
+   # Expect: "result": {"content": [{"text": "ok"}]}
+   ```
+
+3. **Watch CloudWatch.** The CloudFront 5xx, MCP/API error-rate, and
+   DDB throttle alarms should all stay quiet for at least 15 minutes
+   after the swap. See `docs/alarms.md` for what each one means.
+
+4. **Verify a real user flow.** Sign in to the management UI and
+   confirm your memories appear, you can `recall` one, and the
+   activity log shows recent events.
+
+## Cleanup (24–48 h after restore)
+
+Don't rush this — the original table is your evidence and your
+fallback if the restore turns out to be incomplete.
+
+1. **Migrate any writes** that hit the restored table back to a
+   permanent table named `hive` (the original convention). Easiest
+   path: rename the restored table by exporting + reimporting under
+   the canonical name, then update the Lambda env back to `"hive"`.
+2. **Delete the corrupt table** *only after* the restore has been
+   running cleanly for at least 24 h:
+
+   ```bash
+   aws dynamodb delete-table --table-name hive  # the corrupt one
+   ```
+
+   (If the rename in step 1 already used the `hive` name, this means
+   deleting the temp table whose data you migrated out of.)
+3. **Re-enable PITR** on the new permanent table — it isn't
+   automatically inherited from the source on restore:
+
+   ```bash
+   aws dynamodb update-continuous-backups \
+     --table-name hive \
+     --point-in-time-recovery-specification PointInTimeRecoveryEnabled=true
+   ```
+
+   In CDK this is the `point_in_time_recovery_enabled=is_prod`
+   parameter; redeploying after the rename should re-apply it
+   automatically.
+
+## Post-mortem
+
+After the dust settles, file a follow-up issue (label `reliability`)
+with:
+
+- **Timeline** — when corruption started, when noticed, when restored,
+  when validated.
+- **Root cause** — what wrote the bad data; what (if anything) failed
+  to catch it.
+- **Customer impact** — how many users affected, what they saw,
+  whether anyone needs to be notified directly.
+- **Action items** — what to add to the test suite, the alarm set,
+  the runbook, or the deploy gate so this is harder to do again.
+
+A template file lives at `docs/runbooks/postmortem-template.md` (TODO
+— file alongside this runbook in a follow-up).
+
+## Annual restore drill
+
+Restoring under pressure is the wrong time to discover that the
+runbook drifted. Once a year (calendar reminder for the operator),
+follow this entire runbook end-to-end against a non-prod environment:
+
+- File a tracking issue: `chore: annual restore drill — 20YY`.
+- Run through every step. Time each one.
+- Update this runbook for anything that was unclear, missing, or
+  changed. CDK / API surface drift is the common culprit.
+- Close the tracking issue with a short summary (drill duration,
+  things to fix, follow-up issues filed).
+
+## Related
+
+- `docs/alarms.md` — CloudWatch alarms that surface backup/restore
+  health.
+- `.github/workflows/backup-test.yml` — weekly automated PITR
+  restore + validation.
+- `infra/stacks/hive_stack.py` — DynamoDB table and PITR config.

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -498,12 +498,71 @@ class HiveStack(cdk.Stack):
             custom_headers=origin_verify_header,
         )
 
+        # ----------------------------------------------------------------
+        # CloudFront response headers — security hardening
+        #
+        # CSP ships in Report-Only mode first; browser console surfaces
+        # violations without breaking the site. Flip to enforcing in a
+        # follow-up once logs are clean for ~1 week.
+        # ----------------------------------------------------------------
+        csp_report_only = (
+            "default-src 'self'; "
+            "script-src 'self' https://www.googletagmanager.com; "
+            "connect-src 'self' https://www.google-analytics.com "
+            "https://hive.warlordofmars.net; "
+            "img-src 'self' data: https://www.google-analytics.com; "
+            "style-src 'self' 'unsafe-inline'; "
+            "frame-ancestors 'none'; "
+            "base-uri 'self'; "
+            "form-action 'self';"
+        )
+        security_headers_policy = cloudfront.ResponseHeadersPolicy(
+            self,
+            "HiveSecurityHeadersPolicy",
+            response_headers_policy_name=f"hive-security-headers-{env_name}",
+            comment="Hive security response headers (HSTS, CSP-RO, frame/referrer/permissions)",
+            security_headers_behavior=cloudfront.ResponseSecurityHeadersBehavior(
+                strict_transport_security=cloudfront.ResponseHeadersStrictTransportSecurity(
+                    access_control_max_age=cdk.Duration.seconds(31536000),
+                    include_subdomains=True,
+                    preload=True,
+                    override=True,
+                ),
+                content_type_options=cloudfront.ResponseHeadersContentTypeOptions(
+                    override=True,
+                ),
+                frame_options=cloudfront.ResponseHeadersFrameOptions(
+                    frame_option=cloudfront.HeadersFrameOption.DENY,
+                    override=True,
+                ),
+                referrer_policy=cloudfront.ResponseHeadersReferrerPolicy(
+                    referrer_policy=cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+                    override=True,
+                ),
+            ),
+            custom_headers_behavior=cloudfront.ResponseCustomHeadersBehavior(
+                custom_headers=[
+                    cloudfront.ResponseCustomHeader(
+                        header="Permissions-Policy",
+                        value="camera=(), microphone=(), geolocation=(), payment=()",
+                        override=True,
+                    ),
+                    cloudfront.ResponseCustomHeader(
+                        header="Content-Security-Policy-Report-Only",
+                        value=csp_report_only,
+                        override=True,
+                    ),
+                ],
+            ),
+        )
+
         api_behavior = cloudfront.BehaviorOptions(
             origin=api_cf_origin,
             viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
             origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
             allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
+            response_headers_policy=security_headers_policy,
         )
         mcp_behavior = cloudfront.BehaviorOptions(
             origin=mcp_cf_origin,
@@ -511,6 +570,7 @@ class HiveStack(cdk.Stack):
             cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
             origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
             allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
+            response_headers_policy=security_headers_policy,
         )
 
         # ----------------------------------------------------------------
@@ -714,6 +774,7 @@ function handler(event) {
             origin=ui_s3_origin,
             viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             cache_policy=cloudfront.CachePolicy.CACHING_OPTIMIZED,
+            response_headers_policy=security_headers_policy,
             function_associations=[
                 cloudfront.FunctionAssociation(
                     function=docs_rewrite_fn,
@@ -729,6 +790,7 @@ function handler(event) {
                 origin=ui_s3_origin,
                 viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                 cache_policy=cloudfront.CachePolicy.CACHING_OPTIMIZED,
+                response_headers_policy=security_headers_policy,
             ),
             additional_behaviors={
                 "/api/*": api_behavior,
@@ -739,12 +801,14 @@ function handler(event) {
                     viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                     cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
                     origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+                    response_headers_policy=security_headers_policy,
                 ),
                 "/health": cloudfront.BehaviorOptions(
                     origin=api_cf_origin,
                     viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                     cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
                     origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+                    response_headers_policy=security_headers_policy,
                 ),
                 "/mcp*": mcp_behavior,
                 "/docs*": docs_behavior,

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -39,6 +39,7 @@ from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_s3_deployment as s3deploy
 from aws_cdk import aws_s3vectors as s3vectors
 from aws_cdk import aws_sns as sns
+from aws_cdk import aws_sns_subscriptions as sns_subs
 from aws_cdk import aws_ssm as ssm
 from aws_cdk import aws_wafv2 as wafv2
 from constructs import Construct
@@ -188,6 +189,20 @@ class HiveStack(cdk.Stack):
             tier=ssm.ParameterTier.STANDARD,
         )
         origin_verify_param.apply_removal_policy(cdk.RemovalPolicy.RETAIN)
+
+        # Email address that receives CloudWatch alarm + recovery notifications.
+        # Set the parameter value in SSM after first deploy, then confirm the
+        # auto-created SNS subscription from your inbox. See
+        # docs-site/ops/alarms.md for the first-deploy checklist.
+        alarm_email_param = ssm.StringParameter(
+            self,
+            "AlarmEmail",
+            parameter_name=_ssm_path("alarm-email"),
+            string_value="CHANGE_ME_ON_FIRST_DEPLOY",
+            description=f"Recipient for CloudWatch alarm notifications ({env_name})",
+            tier=ssm.ParameterTier.STANDARD,
+        )
+        alarm_email_param.apply_removal_policy(cdk.RemovalPolicy.RETAIN)
 
         # ----------------------------------------------------------------
         # Shared Lambda code (Docker-bundled at cdk deploy time)
@@ -1007,12 +1022,21 @@ function handler(event) {
         _API_ERROR_BUDGET_PCT = 1.0
 
         # SNS topic for alarm notifications — prod only gets an email subscription
-        # (subscription address can be set via the console after first deploy).
+        # (subscription address lives in SSM /hive/{env}/alarm-email; set it
+        # post-deploy, then run `aws sns subscribe --protocol email ...`).
         alarm_topic = sns.Topic(
             self,
             "AlarmTopic",
             display_name=f"Hive alarms ({env_name})",
         )
+
+        def _notify(alarm: cw.Alarm) -> cw.Alarm:
+            """Attach SNS alarm + OK actions (prod only), so recovery also pages."""
+            if is_prod:
+                action = cw_actions.SnsAction(alarm_topic)
+                alarm.add_alarm_action(action)
+                alarm.add_ok_action(action)
+            return alarm
 
         def _error_rate_alarm(
             construct_id: str,
@@ -1042,9 +1066,7 @@ function handler(event) {
                 treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
                 alarm_description=f"Hive {label} error rate > 5% ({env_name})",
             )
-            if is_prod:
-                alarm.add_alarm_action(cw_actions.SnsAction(alarm_topic))
-            return alarm
+            return _notify(alarm)
 
         mcp_error_alarm = _error_rate_alarm("McpErrorRateAlarm", mcp_fn, "MCP")
         api_error_alarm = _error_rate_alarm("ApiErrorRateAlarm", api_fn, "API")
@@ -1064,8 +1086,7 @@ function handler(event) {
             treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
             alarm_description=f"Hive MCP P99 duration > 25s ({env_name})",
         )
-        if is_prod:
-            mcp_p99_alarm.add_alarm_action(cw_actions.SnsAction(alarm_topic))
+        _notify(mcp_p99_alarm)
 
         # DynamoDB throttle alarm: any throttled requests over 5 min
         ddb_throttle_alarm = cw.Alarm(
@@ -1085,8 +1106,7 @@ function handler(event) {
             treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
             alarm_description=f"Hive DynamoDB throttled requests > 0 ({env_name})",
         )
-        if is_prod:
-            ddb_throttle_alarm.add_alarm_action(cw_actions.SnsAction(alarm_topic))
+        _notify(ddb_throttle_alarm)
 
         # CloudFront 5xx error rate alarm: > 1% over 5 min
         cf_5xx_alarm = cw.Alarm(
@@ -1109,8 +1129,7 @@ function handler(event) {
             treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
             alarm_description=f"Hive CloudFront 5xx rate > 1% ({env_name})",
         )
-        if is_prod:
-            cf_5xx_alarm.add_alarm_action(cw_actions.SnsAction(alarm_topic))
+        _notify(cf_5xx_alarm)
 
         # Custom EMF metric alarms
         tool_errors_alarm = cw.Alarm(
@@ -1131,8 +1150,7 @@ function handler(event) {
             treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
             alarm_description=f"Hive tool errors > 10 in 5 min ({env_name})",
         )
-        if is_prod:
-            tool_errors_alarm.add_alarm_action(cw_actions.SnsAction(alarm_topic))
+        _notify(tool_errors_alarm)
 
         storage_latency_alarm = cw.Alarm(
             self,
@@ -1152,8 +1170,75 @@ function handler(event) {
             treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
             alarm_description=f"Hive storage latency p99 > 2000ms ({env_name})",
         )
-        if is_prod:
-            storage_latency_alarm.add_alarm_action(cw_actions.SnsAction(alarm_topic))
+        _notify(storage_latency_alarm)
+
+        # Lambda throttles — any throttled invocation is a capacity issue to
+        # investigate immediately; no tolerance.
+        def _throttle_alarm(construct_id: str, fn: lambda_.Function, label: str) -> cw.Alarm:
+            alarm = cw.Alarm(
+                self,
+                construct_id,
+                alarm_name=f"Hive-{env_name}-{construct_id.removesuffix('Alarm')}",
+                metric=fn.metric_throttles(
+                    period=cdk.Duration.minutes(5), statistic="Sum"
+                ),
+                threshold=0,
+                evaluation_periods=1,
+                comparison_operator=cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
+                treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+                alarm_description=f"Hive {label} Lambda throttles > 0 ({env_name})",
+            )
+            return _notify(alarm)
+
+        mcp_throttles_alarm = _throttle_alarm("McpThrottlesAlarm", mcp_fn, "MCP")
+        api_throttles_alarm = _throttle_alarm("ApiThrottlesAlarm", api_fn, "API")
+
+        # DynamoDB user errors — 4xx-class failures from the SDK (validation,
+        # ConditionalCheckFailed, etc.). A small rate is normal (optimistic
+        # writes race); > 10 in 5 min usually means a bug or a misconfigured
+        # client.
+        ddb_user_errors_alarm = cw.Alarm(
+            self,
+            "DdbUserErrorsAlarm",
+            alarm_name=f"Hive-{env_name}-DdbUserErrors",
+            metric=cw.Metric(
+                namespace="AWS/DynamoDB",
+                metric_name="UserErrors",
+                dimensions_map={"TableName": table.table_name},
+                period=cdk.Duration.minutes(5),
+                statistic="Sum",
+            ),
+            threshold=10,
+            evaluation_periods=1,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+            alarm_description=f"Hive DynamoDB user errors > 10 in 5 min ({env_name})",
+        )
+        _notify(ddb_user_errors_alarm)
+
+        # Business metric: Bearer-token rejections from the existing
+        # `TokenValidationFailures` EMF metric. Spike usually means a
+        # credential leak or a misconfigured client — investigate before it
+        # triggers rate-limiter churn.
+        auth_failures_alarm = cw.Alarm(
+            self,
+            "AuthFailuresAlarm",
+            alarm_name=f"Hive-{env_name}-AuthFailures",
+            metric=cw.Metric(
+                namespace="Hive",
+                metric_name="TokenValidationFailures",
+                dimensions_map={"Environment": env_name},
+                period=cdk.Duration.minutes(5),
+                statistic="Sum",
+            ),
+            threshold=10,
+            evaluation_periods=2,
+            datapoints_to_alarm=2,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+            alarm_description=f"Hive auth failures > 10 in 5 min ({env_name})",
+        )
+        _notify(auth_failures_alarm)
 
         # SLO burn rate alarms
         # Fast burn (>5×): error rate exceeds 5 × error_budget over 1 hour
@@ -1197,9 +1282,7 @@ function handler(event) {
                     f"over {window_minutes}m (budget={error_budget_pct}% × {burn_multiplier}×) ({env_name})"
                 ),
             )
-            if is_prod:
-                alarm.add_alarm_action(cw_actions.SnsAction(alarm_topic))
-            return alarm
+            return _notify(alarm)
 
         mcp_fast_burn_alarm = _burn_rate_alarm(
             "McpFastBurnAlarm", mcp_fn, "MCP", _MCP_ERROR_BUDGET_PCT, 5, 60
@@ -1229,8 +1312,7 @@ function handler(event) {
             treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
             alarm_description=f"Hive MCP p95 latency > 2000ms over 1h (SLO breach) ({env_name})",
         )
-        if is_prod:
-            mcp_p95_latency_alarm.add_alarm_action(cw_actions.SnsAction(alarm_topic))
+        _notify(mcp_p95_latency_alarm)
 
         # Dashboard
         dashboard = cw.Dashboard(

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -1,16 +1,20 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
 """
-Account self-service endpoint.
+Account self-service endpoints.
 
-DELETE /api/account — permanently erase all data for the authenticated user,
-satisfying GDPR Article 17 right-to-erasure.
+- DELETE /api/account        — GDPR Article 17 right-to-erasure
+- GET    /api/account/export — GDPR Article 20 right-to-portability / CCPA §1798.100
 """
 
 from __future__ import annotations
 
+import json
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from hive.api._auth import require_mgmt_user
@@ -18,6 +22,10 @@ from hive.models import ActivityEvent, EventType
 from hive.storage import HiveStorage
 
 router = APIRouter(tags=["account"])
+
+EXPORT_RATE_LIMIT_SECONDS = 300  # one export per 5 minutes per user
+EXPORT_ACTIVITY_LOOKBACK_DAYS = 90  # activity-log retention per Privacy Policy §9
+EXPORT_CLIENTS_LIMIT = 1000  # safety cap; quota is much lower in practice
 
 
 def _storage() -> HiveStorage:
@@ -69,4 +77,121 @@ async def delete_account(
                 "deleted_clients": counts["deleted_clients"],
             },
         )
+    )
+
+
+@router.get(
+    "/account/export",
+    summary="Export my data",
+    description=(
+        "Stream a JSON document containing the authenticated user's profile, "
+        "all their memories, OAuth clients, and recent activity log entries "
+        "(90-day window, matching the retention policy). Satisfies GDPR "
+        "Article 20 and CCPA §1798.100 portability rights. Rate-limited to "
+        "one export per 5 minutes per user."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": "User not found"},
+        429: {"description": "Export rate limit exceeded"},
+    },
+)
+async def export_account(
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> StreamingResponse:
+    user_id: str = claims["sub"]
+
+    user = storage.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Rate limit: one export per EXPORT_RATE_LIMIT_SECONDS. The counter item
+    # has a matching TTL and is only set on first write (``if_not_exists``),
+    # so DynamoDB cleans it up on its own after the window passes.
+    count = storage.increment_rate_limit_counter(
+        user_id, "export", ttl_seconds=EXPORT_RATE_LIMIT_SECONDS
+    )
+    if count > 1:
+        raise HTTPException(
+            status_code=429,
+            detail="Exports are limited to one per 5 minutes.",
+            headers={"Retry-After": str(EXPORT_RATE_LIMIT_SECONDS)},
+        )
+
+    now = datetime.now(timezone.utc)
+
+    clients, _ = storage.list_clients(owner_user_id=user_id, limit=EXPORT_CLIENTS_LIMIT)
+    client_ids = {c.client_id for c in clients}
+
+    today = now.date()
+    dates = [(today - timedelta(days=i)).isoformat() for i in range(EXPORT_ACTIVITY_LOOKBACK_DAYS)]
+
+    def _stream() -> Iterator[str]:
+        yield "{"
+        yield f'"exported_at":{json.dumps(now.isoformat())},'
+        yield '"user":' + json.dumps(
+            {
+                "user_id": user.user_id,
+                "email": user.email,
+                "display_name": user.display_name,
+                "role": user.role,
+                "created_at": user.created_at.isoformat(),
+            }
+        )
+        yield ',"memories":['
+        for i, memory in enumerate(storage.iter_all_memories(owner_user_id=user_id)):
+            if i:
+                yield ","
+            yield json.dumps(
+                {
+                    "memory_id": memory.memory_id,
+                    "key": memory.key,
+                    "value": memory.value,
+                    "tags": memory.tags,
+                    "owner_client_id": memory.owner_client_id,
+                    "created_at": memory.created_at.isoformat(),
+                    "updated_at": memory.updated_at.isoformat(),
+                    "expires_at": (
+                        memory.expires_at.isoformat() if memory.expires_at is not None else None
+                    ),
+                }
+            )
+        yield '],"clients":['
+        for i, client in enumerate(clients):
+            if i:
+                yield ","
+            yield json.dumps(
+                {
+                    "client_id": client.client_id,
+                    "client_name": client.client_name,
+                    "client_type": client.client_type.value,
+                    "created_at": client.created_at.isoformat(),
+                }
+            )
+        yield '],"activity_log":['
+        events = storage.get_events_for_dates(dates, limit=10000)
+        emitted = 0
+        for event in events:
+            if event.client_id not in client_ids:
+                continue
+            if emitted:
+                yield ","
+            emitted += 1
+            yield json.dumps(
+                {
+                    "event_id": event.event_id,
+                    "event_type": event.event_type.value,
+                    "client_id": event.client_id,
+                    "timestamp": event.timestamp.isoformat(),
+                    "metadata": event.metadata,
+                }
+            )
+        yield "]}"
+
+    filename = f"hive-export-{user_id}-{now.strftime('%Y%m%d')}.json"
+    return StreamingResponse(
+        _stream(),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -785,6 +785,7 @@ class MemorySearchResult(BaseModel):
     key: str
     value: str
     tags: list[str]
+    owner_client_id: str | None
     score: float  # cosine similarity (0.0–1.0); higher = more relevant
     created_at: datetime
     updated_at: datetime
@@ -796,6 +797,7 @@ class MemorySearchResult(BaseModel):
             key=m.key,
             value=m.value,
             tags=m.tags,
+            owner_client_id=m.owner_client_id,
             score=score,
             created_at=m.created_at,
             updated_at=m.updated_at,

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -749,6 +749,72 @@ async def search_memories(
     }
 
 
+@mcp.tool()
+async def relate_memories(
+    key: Annotated[str, "Key of the memory to find relations for"],
+    top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 5,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Return memories most semantically similar to the one at ``key``.
+
+    The source memory's value is used as the vector search query and the
+    source memory itself is excluded from the results.  ``score`` ranges
+    from 0.0 to 1.0 where higher means more semantically similar.
+    """
+    t0 = time.monotonic()
+    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    top_k = max(1, min(top_k, 50))
+
+    memory = storage.get_memory_by_key(key)
+    if memory is None:
+        raise ToolError(f"No memory found for key '{key}'.")
+
+    try:
+        # Fetch top_k+1 so that dropping the source still leaves up to top_k.
+        pairs = _vector_store().search(memory.value, client_id, top_k=top_k + 1)
+    except VectorIndexNotFoundError:
+        return {"items": [], "count": 0, "key": key}
+    except Exception:
+        logger.warning("Vector search failed (non-fatal)", exc_info=True)
+        return {"items": [], "count": 0, "key": key}
+
+    pairs = [(mid, score) for mid, score in pairs if mid != memory.memory_id][:top_k]
+    results = storage.hydrate_memory_ids(pairs)
+
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_searched,
+            client_id=client_id,
+            metadata={"key": key, "result_count": len(results), "related_to": memory.memory_id},
+        )
+    )
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "Related memories for '%s', %d result(s)",
+        key,
+        len(results),
+        extra={
+            "tool": "relate_memories",
+            "duration_ms": duration_ms,
+            "status": "success",
+        },
+    )
+    await emit_metric("ToolInvocations", operation="relate_memories")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="relate_memories",
+    )
+    return {
+        "items": [
+            MemorySearchResult.from_memory_and_score(m, score).model_dump() for m, score in results
+        ],
+        "count": len(results),
+        "key": key,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Entry points
 # ---------------------------------------------------------------------------

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -188,7 +188,10 @@ def _vector_store() -> VectorStore:
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Ping",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def ping(ctx: Context | None = None) -> str:
     """Lightweight health check — returns 'ok' when the Bearer token is valid.
 
@@ -200,7 +203,15 @@ async def ping(ctx: Context | None = None) -> str:
     return "ok"
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Remember",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
 async def remember(
     key: Annotated[str, "Unique key to store the memory under"],
     value: Annotated[
@@ -312,7 +323,15 @@ async def remember(
     return f"{action} memory '{key}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Remember if absent",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
 async def remember_if_absent(
     key: Annotated[str, "Unique key to store the memory under"],
     value: Annotated[
@@ -413,7 +432,10 @@ async def remember_if_absent(
     return f"Stored memory '{key}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Recall",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def recall(
     key: Annotated[str, "Key of the memory to retrieve"],
     ctx: Context | None = None,
@@ -460,7 +482,15 @@ async def recall(
     return memory.value
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Forget",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
 async def forget(
     key: Annotated[str, "Key of the memory to delete"],
     ctx: Context | None = None,
@@ -512,7 +542,15 @@ async def forget(
     return f"Deleted memory '{key}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Forget all (by tag)",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    },
+)
 async def forget_all(
     tag: Annotated[str, "Tag of the memories to delete"],
     ctx: Context | None = None,
@@ -550,7 +588,10 @@ async def forget_all(
     return f"Deleted {deleted} memories with tag '{tag}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Memory history",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def memory_history(
     key: Annotated[str, "Key of the memory to retrieve history for"],
     ctx: Context | None = None,
@@ -582,7 +623,15 @@ async def memory_history(
     ]
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Restore memory",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    },
+)
 async def restore_memory(
     key: Annotated[str, "Key of the memory to restore"],
     version_timestamp: Annotated[str, "Version timestamp to restore (from memory_history)"],
@@ -621,7 +670,10 @@ async def restore_memory(
     return f"Restored memory '{key}' to version '{version_timestamp}'."
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List memories",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def list_memories(
     tag: Annotated[str, "Tag to filter memories by"],
     limit: Annotated[int, "Maximum number of memories to return (1–500)"] = 100,
@@ -674,7 +726,10 @@ async def list_memories(
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    title="List tags",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     """List all distinct tags currently in use across the caller's memories.
 
@@ -701,7 +756,10 @@ async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     return {"tags": tags, "count": len(tags)}
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Summarise context",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def summarize_context(
     topic: Annotated[str, "Topic or tag to summarise memories about"],
     ctx: Context | None = None,
@@ -767,7 +825,10 @@ async def summarize_context(
     return "\n".join(lines)
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Search memories",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def search_memories(
     query: Annotated[str, "Natural language search query"],
     top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 10,
@@ -850,7 +911,10 @@ async def search_memories(
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    title="Relate memories",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
 async def relate_memories(
     key: Annotated[str, "Key of the memory to find relations for"],
     top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 5,

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -45,6 +45,13 @@ logger = get_logger("hive.server")
 
 _MEMORIES_READ_SCOPE = "memories:read"
 
+DEFAULT_MAX_VALUE_BYTES = 10 * 1024
+
+
+def _max_value_bytes() -> int:
+    """Max UTF-8 byte size of a memory value. Configurable via HIVE_MAX_VALUE_BYTES."""
+    return int(os.environ.get("HIVE_MAX_VALUE_BYTES", str(DEFAULT_MAX_VALUE_BYTES)))
+
 
 class HiveTokenVerifier(TokenVerifier):
     """Wraps Hive token validation for FastMCP's built-in auth middleware.
@@ -182,7 +189,11 @@ def _vector_store() -> VectorStore:
 @mcp.tool()
 async def remember(
     key: Annotated[str, "Unique key to store the memory under"],
-    value: Annotated[str, "Content of the memory"],
+    value: Annotated[
+        str,
+        f"Content of the memory. Maximum {_max_value_bytes()} bytes (UTF-8 encoded); "
+        "configurable via HIVE_MAX_VALUE_BYTES.",
+    ],
     tags: Annotated[list[str] | None, "Optional tags for categorisation"] = None,
     ttl_seconds: Annotated[
         int | None, "Seconds until the memory expires. None = never expires."
@@ -192,6 +203,13 @@ async def remember(
     """Store or update a memory with optional tags and optional TTL."""
     t0 = time.monotonic()
     storage, client_id = _auth(ctx, required_scope="memories:write")
+
+    limit = _max_value_bytes()
+    actual = len(value.encode("utf-8"))
+    if actual > limit:
+        await emit_metric("ToolErrors", operation="remember")
+        raise ToolError(f"Value exceeds maximum size of {limit} bytes ({actual} bytes provided)")
+
     tags = tags or []
     expires_at = (
         datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -556,7 +556,15 @@ async def list_memories(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="list_memories"
     )
     result: dict[str, Any] = {
-        "items": [{"key": m.key, "value": m.value, "tags": m.tags} for m in memories],
+        "items": [
+            {
+                "key": m.key,
+                "value": m.value,
+                "tags": m.tags,
+                "owner_client_id": m.owner_client_id,
+            }
+            for m in memories
+        ],
         "count": len(memories),
         "has_more": next_cursor is not None,
     }

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -634,6 +634,11 @@ async def summarize_context(
 async def search_memories(
     query: Annotated[str, "Natural language search query"],
     top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 10,
+    min_score: Annotated[
+        float | None,
+        "Minimum similarity score (0.0–1.0). Results below this threshold are "
+        "excluded. None disables filtering.",
+    ] = None,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Search memories by semantic similarity to a natural language query.
@@ -644,6 +649,7 @@ async def search_memories(
     t0 = time.monotonic()
     storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     top_k = max(1, min(top_k, 50))
+    threshold = max(0.0, min(1.0, min_score)) if min_score is not None else None
 
     try:
         pairs = _vector_store().search(query, client_id, top_k=top_k)
@@ -652,6 +658,9 @@ async def search_memories(
     except Exception:
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
         return {"items": [], "count": 0, "query": query}
+
+    if threshold is not None:
+        pairs = [(mid, score) for mid, score in pairs if score >= threshold]
 
     results = storage.hydrate_memory_ids(pairs)
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -11,6 +11,7 @@ Tools:
   recall(key)                 — retrieve a memory by key
   forget(key)                 — delete a memory by key
   list_memories(tag)          — list memories by tag
+  list_tags()                 — list distinct tags for the caller's memories
   summarize_context(topic)    — synthesise memories into a summary
 """
 
@@ -562,6 +563,33 @@ async def list_memories(
     if next_cursor:
         result["next_cursor"] = next_cursor
     return result
+
+
+@mcp.tool()
+async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
+    """List all distinct tags currently in use across the caller's memories.
+
+    Returns tags sorted alphabetically. Useful for discovering the tag
+    namespace of an existing memory corpus before calling `list_memories`.
+    """
+    t0 = time.monotonic()
+    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    tags = storage.list_distinct_tags(client_id)
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "Listed %d distinct tags",
+        len(tags),
+        extra={
+            "tool": "list_tags",
+            "duration_ms": duration_ms,
+            "status": "success",
+        },
+    )
+    await emit_metric("ToolInvocations", operation="list_tags")
+    await emit_metric(
+        "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="list_tags"
+    )
+    return {"tags": tags, "count": len(tags)}
 
 
 @mcp.tool()

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -124,7 +124,7 @@ mcp = FastMCP(
 # ---------------------------------------------------------------------------
 
 
-def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple[HiveStorage, str]:
+async def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple[HiveStorage, str]:
     """Validate Bearer token; return (storage, client_id).
 
     Reads the Authorization header from the HTTP request when running under
@@ -133,6 +133,8 @@ def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple[HiveS
     context (request_id, client_id).
 
     If required_scope is given, raises ToolError if the token lacks that scope.
+    Emits the ``TokenValidationFailures`` metric on auth rejection so the
+    CloudWatch AuthFailures alarm has something to fire on.
     """
     storage = HiveStorage()
     auth_header: str | None = None
@@ -165,6 +167,7 @@ def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple[HiveS
     try:
         token = validate_bearer_token(auth_header, storage)
     except ValueError as exc:
+        await emit_metric("TokenValidationFailures")
         raise ToolError(f"Unauthorized: {exc}") from exc
 
     if required_scope and required_scope not in set(token.scope.split()):
@@ -198,7 +201,7 @@ async def ping(ctx: Context | None = None) -> str:
     Performs no storage reads or writes. A successful call confirms both
     connectivity to the MCP server and that the caller's token is still valid.
     """
-    _auth(ctx)
+    await _auth(ctx)
     await emit_metric("ToolInvocations", operation="ping")
     return "ok"
 
@@ -227,7 +230,7 @@ async def remember(
 ) -> str:
     """Store or update a memory with optional tags and optional TTL."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope="memories:write")
+    storage, client_id = await _auth(ctx, required_scope="memories:write")
 
     limit = _max_value_bytes()
     actual = len(value.encode("utf-8"))
@@ -355,7 +358,7 @@ async def remember_if_absent(
     strict DynamoDB-level atomicity is tracked in #391.
     """
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope="memories:write")
+    storage, client_id = await _auth(ctx, required_scope="memories:write")
 
     limit = _max_value_bytes()
     actual = len(value.encode("utf-8"))
@@ -442,7 +445,7 @@ async def recall(
 ) -> str:
     """Retrieve a memory by its key."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
 
     memory = storage.get_memory_by_key(key)
     if memory is None:
@@ -497,7 +500,7 @@ async def forget(
 ) -> str:
     """Delete a memory by its key."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope="memories:write")
+    storage, client_id = await _auth(ctx, required_scope="memories:write")
 
     existing = storage.get_memory_by_key(key)
     if existing is None:
@@ -557,7 +560,7 @@ async def forget_all(
 ) -> str:
     """Delete all memories that have the given tag."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope="memories:write")
+    storage, client_id = await _auth(ctx, required_scope="memories:write")
 
     deleted = storage.delete_memories_by_tag(tag)
     storage.log_event(
@@ -598,7 +601,7 @@ async def memory_history(
 ) -> list[dict[str, Any]]:
     """Return the version history of a memory (previous values before each overwrite)."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope="memories:read")
+    storage, client_id = await _auth(ctx, required_scope="memories:read")
 
     memory = storage.get_memory_by_key(key)
     if memory is None:
@@ -639,7 +642,7 @@ async def restore_memory(
 ) -> str:
     """Restore a memory to a previous version."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope="memories:write")
+    storage, client_id = await _auth(ctx, required_scope="memories:write")
 
     memory = storage.get_memory_by_key(key)
     if memory is None:
@@ -682,7 +685,7 @@ async def list_memories(
 ) -> dict[str, Any]:
     """List memories that have a specific tag, with optional pagination."""
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
 
     limit = max(1, min(limit, 500))
     memories, next_cursor = storage.list_memories_by_tag(tag, limit=limit, cursor=cursor)
@@ -737,7 +740,7 @@ async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     namespace of an existing memory corpus before calling `list_memories`.
     """
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     tags = storage.list_distinct_tags(client_id)
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -771,7 +774,7 @@ async def summarize_context(
     memory and then provides a combined overview paragraph.
     """
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
 
     memories, _ = storage.list_memories_by_tag(topic, limit=500)
 
@@ -850,7 +853,7 @@ async def search_memories(
     where higher means more semantically similar to the query.
     """
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     top_k = max(1, min(top_k, 50))
     threshold = max(0.0, min(1.0, min_score)) if min_score is not None else None
     required_tags = set(filter_tags) if filter_tags else None
@@ -927,7 +930,7 @@ async def relate_memories(
     from 0.0 to 1.0 where higher means more semantically similar.
     """
     t0 = time.monotonic()
-    storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     top_k = max(1, min(top_k, 50))
 
     memory = storage.get_memory_by_key(key)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -313,6 +313,107 @@ async def remember(
 
 
 @mcp.tool()
+async def remember_if_absent(
+    key: Annotated[str, "Unique key to store the memory under"],
+    value: Annotated[
+        str,
+        f"Content of the memory. Maximum {_max_value_bytes()} bytes (UTF-8 encoded); "
+        "configurable via HIVE_MAX_VALUE_BYTES.",
+    ],
+    tags: Annotated[list[str] | None, "Optional tags for categorisation"] = None,
+    ttl_seconds: Annotated[
+        int | None, "Seconds until the memory expires. None = never expires."
+    ] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Store a memory **only if** no memory with the given key already exists.
+
+    Returns "Stored memory '{key}'." on write, or
+    "Memory '{key}' already exists — not overwritten." on skip.
+
+    Uses a read-then-write check. Two concurrent callers with the same key
+    can still race in the narrow window between the read and the write;
+    strict DynamoDB-level atomicity is tracked in #391.
+    """
+    t0 = time.monotonic()
+    storage, client_id = _auth(ctx, required_scope="memories:write")
+
+    limit = _max_value_bytes()
+    actual = len(value.encode("utf-8"))
+    if actual > limit:
+        await emit_metric("ToolErrors", operation="remember_if_absent")
+        raise ToolError(f"Value exceeds maximum size of {limit} bytes ({actual} bytes provided)")
+
+    tags = tags or []
+    expires_at = (
+        datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
+        if ttl_seconds is not None
+        else None
+    )
+
+    existing = storage.get_memory_by_key(key)
+    if existing:
+        duration_ms = int((time.monotonic() - t0) * 1000)
+        logger.info(
+            "Memory '%s' already exists — not overwritten",
+            key,
+            extra={
+                "tool": "remember_if_absent",
+                "duration_ms": duration_ms,
+                "status": "skipped",
+            },
+        )
+        await emit_metric("ToolInvocations", operation="remember_if_absent")
+        return f"Memory '{key}' already exists — not overwritten."
+
+    client = storage.get_client(client_id)
+    owner_user_id = client.owner_user_id if client else None
+    try:
+        check_memory_quota(owner_user_id, storage)
+    except QuotaExceeded as exc:
+        raise ToolError(exc.detail) from exc
+
+    memory = Memory(
+        key=key, value=value, tags=tags, owner_client_id=client_id, expires_at=expires_at
+    )
+    try:
+        storage.put_memory(memory)
+    except ValueError as exc:
+        await emit_metric("ToolErrors", operation="remember_if_absent")
+        raise ToolError(str(exc)) from exc
+    try:
+        _vector_store().upsert_memory(memory)
+    except Exception:
+        logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
+
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_created,
+            client_id=client_id,
+            metadata={"key": key, "tags": tags},
+        )
+    )
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "Stored memory '%s' (if_absent)",
+        key,
+        extra={
+            "tool": "remember_if_absent",
+            "duration_ms": duration_ms,
+            "status": "success",
+        },
+    )
+    await emit_metric("ToolInvocations", operation="remember_if_absent")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="remember_if_absent",
+    )
+    return f"Stored memory '{key}'."
+
+
+@mcp.tool()
 async def recall(
     key: Annotated[str, "Key of the memory to retrieve"],
     ctx: Context | None = None,

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -6,6 +6,7 @@ All tools validate the OAuth 2.1 Bearer token passed in the MCP request
 context before performing any storage operation.
 
 Tools:
+  ping()                      — health check (auth-only, no storage access)
   remember(key, value, tags)  — store a memory
   recall(key)                 — retrieve a memory by key
   forget(key)                 — delete a memory by key
@@ -184,6 +185,18 @@ def _vector_store() -> VectorStore:
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def ping(ctx: Context | None = None) -> str:
+    """Lightweight health check — returns 'ok' when the Bearer token is valid.
+
+    Performs no storage reads or writes. A successful call confirms both
+    connectivity to the MCP server and that the caller's token is still valid.
+    """
+    _auth(ctx)
+    await emit_metric("ToolInvocations", operation="ping")
+    return "ok"
 
 
 @mcp.tool()

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -667,6 +667,11 @@ async def search_memories(
         "Minimum similarity score (0.0–1.0). Results below this threshold are "
         "excluded. None disables filtering.",
     ] = None,
+    filter_tags: Annotated[
+        list[str] | None,
+        "Optional list of tags. Only memories carrying ALL of the given tags "
+        "are returned. None disables filtering.",
+    ] = None,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Search memories by semantic similarity to a natural language query.
@@ -678,9 +683,14 @@ async def search_memories(
     storage, client_id = _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     top_k = max(1, min(top_k, 50))
     threshold = max(0.0, min(1.0, min_score)) if min_score is not None else None
+    required_tags = set(filter_tags) if filter_tags else None
+
+    # When post-filtering by tags, request the full cap from the vector store
+    # so we have headroom to still return up to top_k matches after filtering.
+    search_top_k = 50 if required_tags else top_k
 
     try:
-        pairs = _vector_store().search(query, client_id, top_k=top_k)
+        pairs = _vector_store().search(query, client_id, top_k=search_top_k)
     except VectorIndexNotFoundError:
         return {"items": [], "count": 0, "query": query}
     except Exception:
@@ -691,6 +701,11 @@ async def search_memories(
         pairs = [(mid, score) for mid, score in pairs if score >= threshold]
 
     results = storage.hydrate_memory_ids(pairs)
+
+    if required_tags:
+        results = [(m, s) for m, s in results if required_tags.issubset(m.tags)]
+
+    results = results[:top_k]
 
     storage.log_event(
         ActivityEvent(

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -202,6 +202,34 @@ class HiveStorage:
                 results.append((memory, score))
         return results
 
+    def list_distinct_tags(self, client_id: str) -> list[str]:
+        """Return the sorted set of distinct tags on memories owned by ``client_id``.
+
+        Scans the TagIndex GSI (scope is limited to tag items — the base table
+        is never scanned) filtering on ``owner_client_id`` and projecting only
+        the ``GSI2PK`` attribute, which carries the ``TAG#{name}`` marker.
+        """
+        tags: set[str] = set()
+        start_key: dict[str, Any] | None = None
+        while True:
+            kwargs: dict[str, Any] = {
+                "IndexName": "TagIndex",
+                "FilterExpression": "owner_client_id = :cid",
+                "ExpressionAttributeValues": {":cid": client_id},
+                "ProjectionExpression": "GSI2PK",
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            resp = self.table.scan(**kwargs)
+            for item in resp.get("Items", []):
+                gsi_pk = item.get("GSI2PK", "")
+                if gsi_pk.startswith("TAG#"):
+                    tags.add(gsi_pk[len("TAG#") :])
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                break
+        return sorted(tags)
+
     def list_memories_by_tag(
         self,
         tag: str,

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -180,3 +180,167 @@ class TestDeleteAccount:
     def test_requires_auth(self, unauthed_client):
         resp = unauthed_client.request("DELETE", "/api/account", json={"confirm": True})
         assert resp.status_code in (401, 403)
+
+
+class TestExportAccount:
+    def test_returns_json_bundle_with_all_sections(self, client):
+        import json
+
+        tc, storage = client
+        from hive.models import ActivityEvent, EventType, OAuthClient
+
+        # Add a client owned by the user and an activity event under it
+        c = OAuthClient(client_name="my-agent", owner_user_id=_USER_ID)
+        storage.put_client(c)
+        storage.log_event(
+            ActivityEvent(
+                event_type=EventType.memory_created,
+                client_id=c.client_id,
+                metadata={"key": "test-key"},
+            )
+        )
+
+        resp = tc.get("/api/account/export")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        disposition = resp.headers["content-disposition"]
+        assert "attachment" in disposition
+        assert f"hive-export-{_USER_ID}" in disposition
+
+        body = json.loads(resp.content)
+        assert set(body.keys()) == {
+            "exported_at",
+            "user",
+            "memories",
+            "clients",
+            "activity_log",
+        }
+        assert body["user"]["user_id"] == _USER_ID
+        assert body["user"]["email"] == "user@example.com"
+        assert len(body["memories"]) == 1
+        assert body["memories"][0]["key"] == "test-key"
+        assert any(client["client_id"] == c.client_id for client in body["clients"])
+        assert any(e["client_id"] == c.client_id for e in body["activity_log"])
+
+    def test_excludes_memories_from_other_users(self, client):
+        import json
+
+        tc, storage = client
+        from hive.models import Memory
+
+        storage.put_memory(
+            Memory(
+                key="someone-else",
+                value="v",
+                owner_client_id="other-client",
+                owner_user_id="other-user",
+            )
+        )
+
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        keys = [m["key"] for m in body["memories"]]
+        assert "someone-else" not in keys
+
+    def test_excludes_activity_events_from_other_clients(self, client):
+        import json
+
+        tc, storage = client
+        from hive.models import ActivityEvent, EventType
+
+        storage.log_event(
+            ActivityEvent(
+                event_type=EventType.memory_created,
+                client_id="not-my-client",
+                metadata={"key": "leak"},
+            )
+        )
+
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        client_ids = {e["client_id"] for e in body["activity_log"]}
+        assert "not-my-client" not in client_ids
+
+    def test_rate_limited_after_first_export(self, client):
+        tc, _ = client
+        first = tc.get("/api/account/export")
+        assert first.status_code == 200
+        # Drain the stream so the counter has been written.
+        _ = first.content
+
+        second = tc.get("/api/account/export")
+        assert second.status_code == 429
+        assert second.headers.get("retry-after") == "300"
+
+    def test_returns_404_if_user_not_found(self, client):
+        tc, storage = client
+        storage.delete_user(_USER_ID)
+        resp = tc.get("/api/account/export")
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.get("/api/account/export")
+        assert resp.status_code in (401, 403)
+
+    def test_memory_expires_at_serialised_when_present(self, client):
+        import json
+        from datetime import datetime, timedelta, timezone
+
+        tc, storage = client
+        from hive.models import Memory
+
+        storage.put_memory(
+            Memory(
+                key="ttl-key",
+                value="v",
+                owner_client_id=_USER_ID,
+                owner_user_id=_USER_ID,
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        )
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        ttl_mem = next(m for m in body["memories"] if m["key"] == "ttl-key")
+        assert ttl_mem["expires_at"] is not None
+
+    def test_empty_sections_render_as_empty_arrays(self, client):
+        import json
+
+        tc, storage = client
+        # Remove the seeded memory so the memories section is empty
+        m = storage.get_memory_by_key("test-key")
+        storage.delete_memory(m.memory_id)
+
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        assert body["memories"] == []
+        assert body["clients"] == []
+        assert body["activity_log"] == []
+
+    def test_multiple_clients_and_events_render_with_separators(self, client):
+        import json
+
+        tc, storage = client
+        from hive.models import ActivityEvent, EventType, OAuthClient
+
+        # Two clients and two events for the user — exercises the inter-item
+        # separator branches in the streamed JSON builder.
+        c1 = OAuthClient(client_name="agent-1", owner_user_id=_USER_ID)
+        c2 = OAuthClient(client_name="agent-2", owner_user_id=_USER_ID)
+        storage.put_client(c1)
+        storage.put_client(c2)
+        for c in (c1, c2):
+            storage.log_event(
+                ActivityEvent(
+                    event_type=EventType.memory_created,
+                    client_id=c.client_id,
+                    metadata={"key": "k"},
+                )
+            )
+
+        resp = tc.get("/api/account/export")
+        body = json.loads(resp.content)
+        ids = {c["client_id"] for c in body["clients"]}
+        assert {c1.client_id, c2.client_id}.issubset(ids)
+        event_client_ids = [e["client_id"] for e in body["activity_log"]]
+        assert len(event_client_ids) >= 2

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -175,7 +175,7 @@ class TestCheckRateLimit:
 class TestMcpRateLimitIntegration:
     """Verify _auth() in server.py raises ToolError on rate limit exceeded."""
 
-    def test_mcp_auth_raises_tool_error_on_rate_limit(self):
+    async def test_mcp_auth_raises_tool_error_on_rate_limit(self):
         from fastmcp.exceptions import ToolError
 
         from hive.rate_limiter import RateLimitExceeded
@@ -195,7 +195,7 @@ class TestMcpRateLimitIntegration:
             from hive.server import _auth
 
             with pytest.raises(ToolError) as exc_info:
-                _auth(None, required_scope="memories:read")
+                await _auth(None, required_scope="memories:read")
             assert "Rate limit exceeded" in str(exc_info.value)
             assert "45" in str(exc_info.value)
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -369,6 +369,56 @@ class TestListMemories:
 
 
 # ---------------------------------------------------------------------------
+# list_tags
+# ---------------------------------------------------------------------------
+
+
+class TestListTags:
+    async def test_returns_sorted_distinct_tags(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_tags, remember
+
+        ctx = _make_ctx(jwt)
+        await remember("a", "1", ["zebra", "alpha"], ctx=ctx)
+        await remember("b", "2", ["alpha", "mango"], ctx=ctx)
+        await remember("c", "3", [], ctx=ctx)
+
+        result = await list_tags(ctx=ctx)
+        assert result == {"tags": ["alpha", "mango", "zebra"], "count": 3}
+
+    async def test_empty_when_no_memories(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_tags
+
+        result = await list_tags(ctx=_make_ctx(jwt))
+        assert result == {"tags": [], "count": 0}
+
+    async def test_scoped_to_caller_client(self, server_env):
+        storage, client_id, jwt = server_env
+        from hive.models import Memory
+        from hive.server import list_tags, remember
+
+        await remember("mine", "v", ["owned"], ctx=_make_ctx(jwt))
+        # Write a memory belonging to a different client directly so we bypass auth
+        storage.put_memory(
+            Memory(key="theirs", value="v", tags=["not-mine"], owner_client_id="other-client")
+        )
+
+        result = await list_tags(ctx=_make_ctx(jwt))
+        assert result["tags"] == ["owned"]
+
+    async def test_requires_read_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import list_tags
+
+        storage, _, _ = server_env
+        write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await list_tags(ctx=_make_ctx(write_only_jwt))
+
+
+# ---------------------------------------------------------------------------
 # summarize_context
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1018,6 +1018,124 @@ class TestSearchMemories:
 
 
 # ---------------------------------------------------------------------------
+# relate_memories
+# ---------------------------------------------------------------------------
+
+
+class TestRelateMemories:
+    async def test_returns_related_with_source_excluded(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import relate_memories, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("source", "about cats and dogs", ["t"], ctx=ctx)
+        await remember("a", "cats are great pets", ["t"], ctx=ctx)
+        await remember("b", "dogs are great pets", ["t"], ctx=ctx)
+        src = storage.get_memory_by_key("source")
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        # Vector store also ranks the source highly; relate_memories must drop it.
+        mock_vs = _make_mock_vector_store(
+            [(src.memory_id, 0.99), (a.memory_id, 0.9), (b.memory_id, 0.8)]
+        )
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await relate_memories("source", top_k=2, ctx=ctx)
+
+        keys = [item["key"] for item in result["items"]]
+        assert keys == ["a", "b"]
+        assert result["count"] == 2
+        assert result["key"] == "source"
+
+    async def test_uses_source_value_as_query(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import relate_memories, remember
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("source", "unique search phrase", [], ctx=ctx)
+        mock_vs = _make_mock_vector_store([])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await relate_memories("source", ctx=ctx)
+
+        assert mock_vs.search.call_args.args[0] == "unique search phrase"
+        # top_k+1 requested so the source-memory drop still leaves headroom.
+        assert mock_vs.search.call_args.kwargs["top_k"] == 6
+
+    async def test_missing_key_raises_tool_error(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import relate_memories
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="No memory found"):
+            await relate_memories("nonexistent", ctx=_make_ctx(jwt))
+
+    async def test_returns_empty_when_no_index(self, server_env):
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import relate_memories, remember
+        from hive.vector_store import VectorIndexNotFoundError
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("src", "v", [], ctx=ctx)
+        mock_vs = MagicMock()
+        mock_vs.search.side_effect = VectorIndexNotFoundError("no index")
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await relate_memories("src", ctx=ctx)
+
+        assert result == {"items": [], "count": 0, "key": "src"}
+
+    async def test_returns_empty_on_vector_error(self, server_env):
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import relate_memories, remember
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("src", "v", [], ctx=ctx)
+        mock_vs = MagicMock()
+        mock_vs.search.side_effect = RuntimeError("bedrock down")
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await relate_memories("src", ctx=ctx)
+
+        assert result == {"items": [], "count": 0, "key": "src"}
+
+    async def test_top_k_clamped(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import relate_memories, remember
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("src", "v", [], ctx=ctx)
+        mock_vs = _make_mock_vector_store([])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await relate_memories("src", top_k=999, ctx=ctx)
+
+        # 50 cap + 1 headroom
+        assert mock_vs.search.call_args.kwargs["top_k"] == 51
+
+    async def test_requires_read_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import relate_memories
+
+        storage, _, _ = server_env
+        write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await relate_memories("any", ctx=_make_ctx(write_only_jwt))
+
+
+# ---------------------------------------------------------------------------
 # forget_all
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -137,6 +137,26 @@ class TestPing:
         with pytest.raises(ToolError, match="Unauthorized"):
             await ping(ctx=ctx)
 
+    async def test_auth_rejection_emits_token_validation_failure_metric(self, server_env):
+        """The AuthFailures CloudWatch alarm watches TokenValidationFailures —
+        make sure the MCP auth path actually emits it on rejection."""
+        from unittest.mock import AsyncMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import ping
+
+        ctx = MagicMock()
+        ctx.request_context.meta = {"Authorization": "Bearer totally-bogus"}
+        mock_emit = AsyncMock()
+        with (
+            patch("hive.server.emit_metric", mock_emit),
+            pytest.raises(ToolError, match="Unauthorized"),
+        ):
+            await ping(ctx=ctx)
+        names_emitted = [call.args[0] for call in mock_emit.call_args_list]
+        assert "TokenValidationFailures" in names_emitted
+
 
 # ---------------------------------------------------------------------------
 # remember

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -188,6 +188,52 @@ class TestRemember:
         ):
             await remember("big-key", "x" * 1000, [], ctx=_make_ctx(jwt))
 
+    async def test_value_at_limit_succeeds(self, server_env):
+        from hive.server import DEFAULT_MAX_VALUE_BYTES, remember
+
+        storage, _, jwt = server_env
+        value = "x" * DEFAULT_MAX_VALUE_BYTES
+        result = await remember("at-limit-key", value, [], ctx=_make_ctx(jwt))
+        assert result == "Stored memory 'at-limit-key'."
+
+    async def test_value_over_limit_raises_tool_error(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import DEFAULT_MAX_VALUE_BYTES, remember
+
+        _, _, jwt = server_env
+        actual = DEFAULT_MAX_VALUE_BYTES + 1
+        expected = f"Value exceeds maximum size of {DEFAULT_MAX_VALUE_BYTES} bytes ({actual} bytes provided)"
+        with pytest.raises(ToolError) as exc_info:
+            await remember("over-limit-key", "x" * actual, [], ctx=_make_ctx(jwt))
+        assert str(exc_info.value) == expected
+
+    async def test_value_size_counts_utf8_bytes_not_chars(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        _, _, jwt = server_env
+        # "€" is 3 bytes in UTF-8, so 5 chars = 15 bytes — exceeds 10 byte limit
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("HIVE_MAX_VALUE_BYTES", "10")
+            with pytest.raises(ToolError, match="15 bytes provided"):
+                await remember("euro-key", "€€€€€", [], ctx=_make_ctx(jwt))
+
+    async def test_value_size_limit_env_override(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        _, _, jwt = server_env
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("HIVE_MAX_VALUE_BYTES", "5")
+            with pytest.raises(ToolError, match="maximum size of 5 bytes"):
+                await remember("custom-limit-key", "x" * 6, [], ctx=_make_ctx(jwt))
+            # within the override limit is fine
+            result = await remember("within-key", "x" * 5, [], ctx=_make_ctx(jwt))
+            assert result == "Stored memory 'within-key'."
+
     async def test_remember_with_ttl_sets_expires_at(self, server_env):
         storage, client_id, jwt = server_env
         from hive.server import remember

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1376,6 +1376,42 @@ class TestRestoreMemory:
 # ---------------------------------------------------------------------------
 
 
+class TestMcpToolAnnotations:
+    """Every exposed MCP tool should carry a user-friendly title and
+    annotations that let consent-aware clients (Claude Desktop, Claude Code)
+    render destructive operations differently from read-only ones.
+    """
+
+    @pytest.mark.parametrize(
+        "tool_name,title,read_only,destructive",
+        [
+            ("ping", "Ping", True, None),
+            ("remember", "Remember", False, False),
+            ("remember_if_absent", "Remember if absent", False, False),
+            ("recall", "Recall", True, None),
+            ("forget", "Forget", False, True),
+            ("forget_all", "Forget all (by tag)", False, True),
+            ("memory_history", "Memory history", True, None),
+            ("restore_memory", "Restore memory", False, False),
+            ("list_memories", "List memories", True, None),
+            ("list_tags", "List tags", True, None),
+            ("summarize_context", "Summarise context", True, None),
+            ("search_memories", "Search memories", True, None),
+            ("relate_memories", "Relate memories", True, None),
+        ],
+    )
+    async def test_title_and_hints(self, tool_name, title, read_only, destructive):
+        from hive.server import mcp
+
+        tool = await mcp.get_tool(tool_name)
+        assert tool.title == title
+        assert tool.annotations.readOnlyHint is read_only
+        # destructiveHint is only set when meaningful.
+        assert tool.annotations.destructiveHint is destructive
+        # Every Hive tool is closed-world (our DynamoDB only).
+        assert tool.annotations.openWorldHint is False
+
+
 class TestHiveTokenVerifier:
     async def test_valid_token_returns_access_token(self, server_env):
         from hive.server import HiveTokenVerifier

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -293,6 +293,111 @@ class TestRemember:
 
 
 # ---------------------------------------------------------------------------
+# remember_if_absent
+# ---------------------------------------------------------------------------
+
+
+class TestRememberIfAbsent:
+    async def test_writes_when_key_absent(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import remember_if_absent
+
+        result = await remember_if_absent("ifa-new", "v", ["t"], ctx=_make_ctx(jwt))
+        assert result == "Stored memory 'ifa-new'."
+        m = storage.get_memory_by_key("ifa-new")
+        assert m is not None
+        assert m.value == "v"
+
+    async def test_skips_when_key_exists(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import remember, remember_if_absent
+
+        await remember("ifa-dupe", "original", ["old"], ctx=_make_ctx(jwt))
+        result = await remember_if_absent("ifa-dupe", "new-value", ["new"], ctx=_make_ctx(jwt))
+        assert result == "Memory 'ifa-dupe' already exists — not overwritten."
+        m = storage.get_memory_by_key("ifa-dupe")
+        assert m.value == "original"
+        assert set(m.tags) == {"old"}
+
+    async def test_sets_ttl_when_writing(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import remember_if_absent
+
+        await remember_if_absent("ifa-ttl", "v", [], ttl_seconds=3600, ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("ifa-ttl")
+        assert m.expires_at is not None
+
+    async def test_oversized_value_raises(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import DEFAULT_MAX_VALUE_BYTES, remember_if_absent
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="exceeds maximum size"):
+            await remember_if_absent(
+                "ifa-big", "x" * (DEFAULT_MAX_VALUE_BYTES + 1), ctx=_make_ctx(jwt)
+            )
+
+    async def test_storage_value_error_becomes_tool_error(self, server_env):
+        from unittest.mock import patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_if_absent
+
+        storage, _, jwt = server_env
+        with (
+            patch.object(storage.__class__, "get_memory_by_key", return_value=None),
+            patch.object(
+                storage.__class__,
+                "put_memory",
+                side_effect=ValueError("Memory value is too large"),
+            ),
+            pytest.raises(ToolError, match="too large"),
+        ):
+            await remember_if_absent("ifa-err", "v", ctx=_make_ctx(jwt))
+
+    async def test_quota_exceeded_becomes_tool_error(self, server_env):
+        from unittest.mock import patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.quota import QuotaExceeded
+        from hive.server import remember_if_absent
+
+        _, _, jwt = server_env
+        with (
+            patch("hive.server.check_memory_quota", side_effect=QuotaExceeded("quota full")),
+            pytest.raises(ToolError, match="quota full"),
+        ):
+            await remember_if_absent("ifa-q", "v", ctx=_make_ctx(jwt))
+
+    async def test_vector_upsert_failure_is_non_fatal(self, server_env):
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import remember_if_absent
+
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+        mock_vs.upsert_memory.side_effect = RuntimeError("bedrock down")
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await remember_if_absent("ifa-vs-fail", "v", ctx=_make_ctx(jwt))
+
+        assert result == "Stored memory 'ifa-vs-fail'."
+
+    async def test_requires_write_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_if_absent
+
+        storage, _, _ = server_env
+        read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await remember_if_absent("ifa-scope", "v", ctx=_make_ctx(read_only_jwt))
+
+
+# ---------------------------------------------------------------------------
 # recall
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -806,6 +806,81 @@ class TestSearchMemories:
 
         assert result == {"items": [], "count": 0, "query": "q"}
 
+    async def test_filter_tags_requires_all_tags(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "alpha", ["x", "y"], ctx=ctx)
+        await remember("b", "beta", ["x"], ctx=ctx)
+        await remember("c", "gamma", ["y"], ctx=ctx)
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        c = storage.get_memory_by_key("c")
+        mock_vs = _make_mock_vector_store(
+            [(a.memory_id, 0.9), (b.memory_id, 0.8), (c.memory_id, 0.7)]
+        )
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", filter_tags=["x", "y"], ctx=ctx)
+
+        # Only "a" has both x and y
+        assert [item["key"] for item in result["items"]] == ["a"]
+        assert result["count"] == 1
+
+    async def test_filter_tags_none_returns_all(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "v", ["x"], ctx=ctx)
+        a = storage.get_memory_by_key("a")
+        mock_vs = _make_mock_vector_store([(a.memory_id, 0.9)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", ctx=ctx)
+
+        assert result["count"] == 1
+
+    async def test_filter_tags_requests_wider_candidate_pool(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import search_memories
+
+        _, _, jwt = server_env
+        mock_vs = _make_mock_vector_store([])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await search_memories("q", top_k=5, filter_tags=["x"], ctx=_make_ctx(jwt))
+
+        # When filter_tags is set, the vector search asks for the cap (50) so
+        # we can still return up to top_k matches after post-filtering.
+        assert mock_vs.search.call_args.kwargs["top_k"] == 50
+
+    async def test_filter_tags_trims_to_top_k_after_filter(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        for i in range(5):
+            await remember(f"k{i}", f"v{i}", ["x"], ctx=ctx)
+        mems = [storage.get_memory_by_key(f"k{i}") for i in range(5)]
+        mock_vs = _make_mock_vector_store(
+            [(m.memory_id, 0.9 - i * 0.1) for i, m in enumerate(mems)]
+        )
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", top_k=2, filter_tags=["x"], ctx=ctx)
+
+        assert result["count"] == 2
+        assert [item["key"] for item in result["items"]] == ["k0", "k1"]
+
     async def test_min_score_clamped_to_unit_interval(self, server_env):
         from unittest.mock import patch
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -115,6 +115,30 @@ def server_env():
 
 
 # ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+
+
+class TestPing:
+    async def test_returns_ok_for_valid_token(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import ping
+
+        result = await ping(ctx=_make_ctx(jwt))
+        assert result == "ok"
+
+    async def test_missing_auth_raises_tool_error(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import ping
+
+        ctx = MagicMock()
+        ctx.request_context.meta = {}
+        with pytest.raises(ToolError, match="Unauthorized"):
+            await ping(ctx=ctx)
+
+
+# ---------------------------------------------------------------------------
 # remember
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -703,6 +703,83 @@ class TestSearchMemories:
         with pytest.raises(ToolError, match="Insufficient scope"):
             await search_memories("q", ctx=_make_ctx(write_only_jwt))
 
+    async def test_min_score_filters_low_ranked_results(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("hi-key", "high match", ["t"], ctx=ctx)
+        await remember("lo-key", "low match", ["t"], ctx=ctx)
+        hi = storage.get_memory_by_key("hi-key")
+        lo = storage.get_memory_by_key("lo-key")
+        mock_vs = _make_mock_vector_store([(hi.memory_id, 0.9), (lo.memory_id, 0.3)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("anything", min_score=0.5, ctx=ctx)
+
+        assert result["count"] == 1
+        assert [item["key"] for item in result["items"]] == ["hi-key"]
+
+    async def test_min_score_none_returns_all(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "a", ["t"], ctx=ctx)
+        await remember("b", "b", ["t"], ctx=ctx)
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        mock_vs = _make_mock_vector_store([(a.memory_id, 0.9), (b.memory_id, 0.05)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", ctx=ctx)
+
+        assert result["count"] == 2
+
+    async def test_min_score_all_below_threshold_returns_empty(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("only-key", "v", ["t"], ctx=ctx)
+        m = storage.get_memory_by_key("only-key")
+        mock_vs = _make_mock_vector_store([(m.memory_id, 0.2)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", min_score=0.9, ctx=ctx)
+
+        assert result == {"items": [], "count": 0, "query": "q"}
+
+    async def test_min_score_clamped_to_unit_interval(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("key", "v", ["t"], ctx=ctx)
+        m = storage.get_memory_by_key("key")
+        mock_vs = _make_mock_vector_store([(m.memory_id, 1.0)])
+
+        # min_score > 1.0 gets clamped to 1.0; a perfect score still matches
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("q", min_score=5.0, ctx=ctx)
+
+        assert result["count"] == 1
+
+        # min_score < 0.0 gets clamped to 0.0; everything passes
+        mock_vs2 = _make_mock_vector_store([(m.memory_id, 0.0)])
+        with patch("hive.server._vector_store", return_value=mock_vs2):
+            result = await search_memories("q", min_score=-1.0, ctx=ctx)
+
+        assert result["count"] == 1
+
     async def test_remember_dual_writes_to_vector_store(self, server_env):
         """remember() calls upsert_memory on the VectorStore for new memories."""
         from unittest.mock import MagicMock, patch

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -358,6 +358,8 @@ class TestListMemories:
         keys = [m["key"] for m in result["items"]]
         assert "lst-a" in keys
         assert "lst-b" not in keys
+        # Agent attribution is surfaced on every item.
+        assert result["items"][0]["owner_client_id"] == client_id
 
     async def test_list_empty_tag_returns_empty(self, server_env):
         _, _, jwt = server_env
@@ -713,6 +715,7 @@ class TestSearchMemories:
         item = result["items"][0]
         assert item["key"] == "search-key"
         assert item["score"] == 0.88
+        assert item["owner_client_id"] == client_id
 
     async def test_returns_empty_when_no_index(self, server_env):
         from unittest.mock import patch

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -132,6 +132,40 @@ class TestMemoryStorage:
         keys_z = {m.key for m in tagged_z}
         assert keys_z == {"b", "c"}
 
+    def test_list_distinct_tags_returns_sorted_unique(self, storage):
+        for m in [
+            Memory(key="a", value="1", tags=["zebra", "alpha"], owner_client_id="c1"),
+            Memory(key="b", value="2", tags=["alpha", "mango"], owner_client_id="c1"),
+            Memory(key="c", value="3", tags=[], owner_client_id="c1"),
+        ]:
+            storage.put_memory(m)
+
+        assert storage.list_distinct_tags("c1") == ["alpha", "mango", "zebra"]
+
+    def test_list_distinct_tags_scoped_to_client(self, storage):
+        storage.put_memory(Memory(key="a", value="1", tags=["mine"], owner_client_id="c1"))
+        storage.put_memory(Memory(key="b", value="2", tags=["theirs"], owner_client_id="c2"))
+
+        assert storage.list_distinct_tags("c1") == ["mine"]
+        assert storage.list_distinct_tags("c2") == ["theirs"]
+
+    def test_list_distinct_tags_empty_when_no_memories(self, storage):
+        assert storage.list_distinct_tags("c1") == []
+
+    def test_list_distinct_tags_follows_scan_pages(self, storage):
+        from unittest.mock import patch
+
+        responses = iter(
+            [
+                {"Items": [{"GSI2PK": "TAG#alpha"}], "LastEvaluatedKey": {"PK": "x"}},
+                {"Items": [{"GSI2PK": "TAG#beta"}, {"GSI2PK": "NOT_A_TAG"}]},
+            ]
+        )
+        with patch.object(storage.table, "scan", side_effect=lambda **_kw: next(responses)):
+            result = storage.list_distinct_tags("c1")
+
+        assert result == ["alpha", "beta"]
+
     def test_update_replaces_tags(self, storage):
         m = Memory(key="k", value="v", tags=["old"], owner_client_id="c1")
         storage.put_memory(m)

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,10 +4,26 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hive — Shared Memory</title>
+    <meta name="description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Hive" />
     <meta property="og:title" content="Hive — Shared Memory for Claude Agents" />
     <meta property="og:description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
+    <meta property="og:url" content="https://hive.warlordofmars.net/" />
     <meta property="og:image" content="https://hive.warlordofmars.net/social-preview.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Hive — Shared Memory for Claude Agents" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Hive — Shared Memory for Claude Agents" />
+    <meta name="twitter:description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
+    <meta name="twitter:image" content="https://hive.warlordofmars.net/social-preview.png" />
+    <meta name="twitter:image:alt" content="Hive — Shared Memory for Claude Agents" />
     <!-- Google Analytics 4 — only injected when VITE_GA_MEASUREMENT_ID is set at build time -->
     <script>
       (function () {

--- a/ui/index.html
+++ b/ui/index.html
@@ -24,14 +24,21 @@
     <meta name="twitter:description" content="Persistent, shared memory for Claude agents and teams. Free hosted service." />
     <meta name="twitter:image" content="https://hive.warlordofmars.net/social-preview.png" />
     <meta name="twitter:image:alt" content="Hive — Shared Memory for Claude Agents" />
-    <!-- Google Analytics 4 — only injected when VITE_GA_MEASUREMENT_ID is set at build time -->
+    <!-- Google Analytics 4 — gated on the consent banner. Only loads when
+         VITE_GA_MEASUREMENT_ID is set AND the visitor has opted in. -->
     <script>
       (function () {
         var id = "%VITE_GA_MEASUREMENT_ID%";
         if (!id) return;
+        try {
+          if (localStorage.getItem("hive_ga_consent") !== "accept") return;
+        } catch (e) {
+          return;
+        }
         var s = document.createElement("script");
         s.src = "https://www.googletagmanager.com/gtag/js?id=" + id;
         s.async = true;
+        s.dataset.hiveGa = "1";
         document.head.appendChild(s);
         window.dataLayer = window.dataLayer || [];
         function gtag() { window.dataLayer.push(arguments); }

--- a/ui/public/robots.txt
+++ b/ui/public/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Allow: /
+Allow: /docs/
+Disallow: /app
+Disallow: /auth/
+Disallow: /oauth/
+Disallow: /mcp
+Disallow: /api/
+
+Sitemap: https://hive.warlordofmars.net/sitemap.xml
+Sitemap: https://hive.warlordofmars.net/docs/sitemap.xml

--- a/ui/public/sitemap.xml
+++ b/ui/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://hive.warlordofmars.net/</loc></url>
+  <url><loc>https://hive.warlordofmars.net/pricing</loc></url>
+  <url><loc>https://hive.warlordofmars.net/faq</loc></url>
+  <url><loc>https://hive.warlordofmars.net/use-cases</loc></url>
+  <url><loc>https://hive.warlordofmars.net/clients</loc></url>
+  <url><loc>https://hive.warlordofmars.net/changelog</loc></url>
+  <url><loc>https://hive.warlordofmars.net/status</loc></url>
+  <url><loc>https://hive.warlordofmars.net/terms</loc></url>
+  <url><loc>https://hive.warlordofmars.net/privacy</loc></url>
+</urlset>

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -13,6 +13,7 @@ import ChangelogPage from "./components/ChangelogPage.jsx";
 import FaqPage from "./components/FaqPage.jsx";
 import HomePage from "./components/HomePage.jsx";
 import PrivacyPage from "./components/PrivacyPage.jsx";
+import SubprocessorsPage from "./components/SubprocessorsPage.jsx";
 import TermsPage from "./components/TermsPage.jsx";
 import LoginPage from "./components/LoginPage.jsx";
 import McpClientsPage from "./components/McpClientsPage.jsx";
@@ -253,6 +254,7 @@ export default function App() {
         <Route path="/status" element={<StatusPage />} />
         <Route path="/terms" element={<TermsPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
+        <Route path="/subprocessors" element={<SubprocessorsPage />} />
         <Route path="/app" element={<AppShell />} />
         <Route path="/oauth/callback" element={<AuthCallback />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/ui/src/analytics.js
+++ b/ui/src/analytics.js
@@ -4,13 +4,19 @@
  * Thin wrapper around gtag. All functions are no-ops when:
  *   - running in local dev (import.meta.env.DEV)
  *   - VITE_GA_MEASUREMENT_ID is not set
+ *   - the visitor has not opted in via the consent banner
  */
 
+import { hasAcceptedConsent } from "./lib/consent.js";
+
 const ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
-const enabled = !import.meta.env.DEV && !!ID;
+
+function enabled() {
+  return !import.meta.env.DEV && !!ID && hasAcceptedConsent();
+}
 
 export function trackPageView(path) {
-  if (!enabled) return;
+  if (!enabled()) return;
   globalThis.gtag?.("event", "page_view", {
     page_path: path,
     send_to: ID,
@@ -18,6 +24,6 @@ export function trackPageView(path) {
 }
 
 export function trackEvent(name, params = {}) {
-  if (!enabled) return;
+  if (!enabled()) return;
   globalThis.gtag?.("event", name, { ...params, send_to: ID });
 }

--- a/ui/src/analytics.test.js
+++ b/ui/src/analytics.test.js
@@ -56,11 +56,13 @@ describe("analytics (GA enabled — production with ID)", () => {
     vi.resetModules();
     vi.stubEnv("DEV", false);
     vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    localStorage.setItem("hive_ga_consent", "accept");
     window.gtag = vi.fn();
   });
 
   afterEach(() => {
     delete window.gtag;
+    localStorage.clear();
     vi.unstubAllEnvs();
   });
 
@@ -100,5 +102,41 @@ describe("analytics (GA enabled — production with ID)", () => {
     delete window.gtag;
     const { trackEvent } = await import("./analytics.js");
     expect(() => trackEvent("cta_click")).not.toThrow();
+  });
+});
+
+describe("analytics (GA gated on consent)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("DEV", false);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    localStorage.clear();
+    window.gtag = vi.fn();
+  });
+
+  afterEach(() => {
+    delete window.gtag;
+    localStorage.clear();
+    vi.unstubAllEnvs();
+  });
+
+  it("trackPageView is a no-op when no consent is stored", async () => {
+    const { trackPageView } = await import("./analytics.js");
+    trackPageView("/pricing");
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+
+  it("trackPageView is a no-op when consent is rejected", async () => {
+    localStorage.setItem("hive_ga_consent", "reject");
+    const { trackPageView } = await import("./analytics.js");
+    trackPageView("/pricing");
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+
+  it("trackEvent is a no-op when consent is rejected", async () => {
+    localStorage.setItem("hive_ga_consent", "reject");
+    const { trackEvent } = await import("./analytics.js");
+    trackEvent("cta_click");
+    expect(window.gtag).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -101,4 +101,24 @@ export const api = {
 
   // Account
   deleteAccount: () => request("DELETE", "/api/account", { confirm: true }),
+  exportAccount: async () => {
+    const token = getToken();
+    const headers = {};
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const res = await fetch(`${BASE}/api/account/export`, { headers });
+    if (res.status === 401) {
+      localStorage.removeItem("hive_mgmt_token");
+      globalThis.location.replace("/");
+      return null;
+    }
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: res.statusText }));
+      throw new Error(err.detail ?? "Export failed");
+    }
+    const blob = await res.blob();
+    const disposition = res.headers.get("content-disposition") ?? "";
+    const match = disposition.match(/filename="([^"]+)"/);
+    const filename = match ? match[1] : "hive-export.json";
+    return { blob, filename };
+  },
 };

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -392,4 +392,103 @@ describe("api", () => {
     expect(storage["hive_mgmt_token"]).toBeUndefined();
     expect(window.location.replace).toHaveBeenCalledWith("/");
   });
+
+  // ---------------------------------------------------------------------------
+  // exportAccount
+  // ---------------------------------------------------------------------------
+
+  function mockExportResponse({
+    ok = true,
+    status = 200,
+    blob = new Blob(),
+    disposition,
+    body,
+  } = {}) {
+    fetchMock.mockResolvedValue({
+      ok,
+      status,
+      statusText: "Error",
+      blob: () => Promise.resolve(blob),
+      json: () => Promise.resolve(body ?? {}),
+      headers: { get: () => disposition ?? null },
+    });
+  }
+
+  it("exportAccount sends Authorization header when token present", async () => {
+    storage["hive_mgmt_token"] = "user-token";
+    mockExportResponse({ disposition: 'attachment; filename="hive-export.json"' });
+    await api.exportAccount();
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain("/api/account/export");
+    expect(opts.headers.Authorization).toBe("Bearer user-token");
+  });
+
+  it("exportAccount omits Authorization when no token is stored", async () => {
+    mockExportResponse({ disposition: 'attachment; filename="x.json"' });
+    await api.exportAccount();
+    const opts = fetchMock.mock.calls[0][1];
+    expect(opts.headers.Authorization).toBeUndefined();
+  });
+
+  it("exportAccount returns blob + filename parsed from Content-Disposition", async () => {
+    const blob = new Blob(["{}"], { type: "application/json" });
+    mockExportResponse({
+      blob,
+      disposition: 'attachment; filename="hive-export-user-20260418.json"',
+    });
+    const result = await api.exportAccount();
+    expect(result.blob).toBe(blob);
+    expect(result.filename).toBe("hive-export-user-20260418.json");
+  });
+
+  it("exportAccount falls back to a default filename when disposition is missing", async () => {
+    mockExportResponse({ disposition: null });
+    const result = await api.exportAccount();
+    expect(result.filename).toBe("hive-export.json");
+  });
+
+  it("exportAccount surfaces error detail from JSON body on non-OK responses", async () => {
+    mockExportResponse({
+      ok: false,
+      status: 429,
+      body: { detail: "Exports are limited to one per 5 minutes." },
+    });
+    await expect(api.exportAccount()).rejects.toThrow(
+      "Exports are limited to one per 5 minutes.",
+    );
+  });
+
+  it("exportAccount falls back to statusText when the error body is not JSON", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: () => Promise.reject(new Error("not json")),
+      headers: { get: () => null },
+    });
+    await expect(api.exportAccount()).rejects.toThrow("Server Error");
+  });
+
+  it("exportAccount surfaces generic 'Request failed' when error body is an empty object", async () => {
+    mockExportResponse({ ok: false, status: 500, body: {} });
+    await expect(api.exportAccount()).rejects.toThrow("Export failed");
+  });
+
+  it("exportAccount clears token and redirects on 401", async () => {
+    storage["hive_mgmt_token"] = "old-token";
+    const replace = vi.fn();
+    vi.stubGlobal("location", { replace });
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      headers: { get: () => null },
+      blob: () => Promise.resolve(new Blob()),
+      json: () => Promise.resolve({}),
+    });
+    const result = await api.exportAccount();
+    expect(result).toBeNull();
+    expect(storage["hive_mgmt_token"]).toBeUndefined();
+    expect(replace).toHaveBeenCalledWith("/");
+  });
 });

--- a/ui/src/components/ConsentBanner.jsx
+++ b/ui/src/components/ConsentBanner.jsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  CONSENT_RESET_EVENT,
+  getConsent,
+  loadGtag,
+  setConsent,
+} from "@/lib/consent";
+
+export default function ConsentBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(function subscribeToResetEvent() {
+    if (getConsent() === null) setVisible(true);
+    function onReset() {
+      setVisible(true);
+    }
+    globalThis.addEventListener(CONSENT_RESET_EVENT, onReset);
+    return function cleanup() {
+      globalThis.removeEventListener(CONSENT_RESET_EVENT, onReset);
+    };
+  }, []);
+
+  function handleAccept() {
+    setConsent("accept");
+    loadGtag(import.meta.env.VITE_GA_MEASUREMENT_ID);
+    setVisible(false);
+  }
+
+  function handleReject() {
+    setConsent("reject");
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Cookie consent"
+      className="fixed bottom-4 left-4 right-4 sm:left-auto sm:right-4 sm:max-w-[420px] bg-[var(--surface)] border border-[var(--border)] rounded-[var(--radius)] shadow-lg p-4 z-50"
+    >
+      <p className="text-sm text-[var(--text)] mb-3">
+        We use Google Analytics to understand how visitors use the marketing
+        site. No tracking happens until you choose. See the{" "}
+        <a
+          href="/privacy"
+          className="text-[var(--accent)] underline"
+        >
+          Privacy Policy
+        </a>{" "}
+        for details.
+      </p>
+      <div className="flex gap-2">
+        <Button variant="brand" size="sm" onClick={handleAccept}>
+          Accept
+        </Button>
+        <Button variant="secondary" size="sm" onClick={handleReject}>
+          Reject
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/ConsentBanner.test.jsx
+++ b/ui/src/components/ConsentBanner.test.jsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import ConsentBanner from "./ConsentBanner.jsx";
+import { CONSENT_KEY, CONSENT_RESET_EVENT } from "../lib/consent.js";
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <ConsentBanner />
+    </MemoryRouter>,
+  );
+}
+
+describe("ConsentBanner", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.querySelectorAll("script[data-hive-ga]").forEach((s) => s.remove());
+    delete globalThis.gtag;
+    delete globalThis.dataLayer;
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TESTID");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("renders on first visit when no choice is stored", async () => {
+    await act(async () => renderBanner());
+    expect(screen.getByRole("dialog", { name: "Cookie consent" })).toBeTruthy();
+    expect(screen.getByText("Accept")).toBeTruthy();
+    expect(screen.getByText("Reject")).toBeTruthy();
+  });
+
+  it("is hidden when consent was already accepted", async () => {
+    localStorage.setItem(CONSENT_KEY, "accept");
+    await act(async () => renderBanner());
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+  });
+
+  it("is hidden when consent was already rejected", async () => {
+    localStorage.setItem(CONSENT_KEY, "reject");
+    await act(async () => renderBanner());
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+  });
+
+  it("Accept stores consent, loads gtag, and hides the banner", async () => {
+    await act(async () => renderBanner());
+    fireEvent.click(screen.getByText("Accept"));
+    expect(localStorage.getItem(CONSENT_KEY)).toBe("accept");
+    expect(document.querySelector("script[data-hive-ga]")).not.toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+  });
+
+  it("Reject stores consent, does not load gtag, and hides the banner", async () => {
+    await act(async () => renderBanner());
+    fireEvent.click(screen.getByText("Reject"));
+    expect(localStorage.getItem(CONSENT_KEY)).toBe("reject");
+    expect(document.querySelector("script[data-hive-ga]")).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+  });
+
+  it("re-shows the banner when the reset event fires", async () => {
+    localStorage.setItem(CONSENT_KEY, "reject");
+    await act(async () => renderBanner());
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+    await act(async () => {
+      globalThis.dispatchEvent(new CustomEvent(CONSENT_RESET_EVENT));
+    });
+    expect(screen.getByRole("dialog", { name: "Cookie consent" })).toBeTruthy();
+  });
+
+  it("links to the Privacy Policy", async () => {
+    await act(async () => renderBanner());
+    const link = screen.getByText("Privacy Policy");
+    expect(link.getAttribute("href")).toBe("/privacy");
+  });
+});

--- a/ui/src/components/FaqPage.jsx
+++ b/ui/src/components/FaqPage.jsx
@@ -31,7 +31,7 @@ const FAQS = [
   },
   {
     q: "How do I connect my MCP client?",
-    a: "Sign in, register a client in the management UI, and copy the one-line config snippet into your MCP client's configuration file. Full step-by-step instructions are in the docs.",
+    a: "Sign in and open the Setup tab. Copy the config snippet (a short JSON block) into your MCP client's config file. The first time your client uses a Hive tool it opens a browser window to complete OAuth — after that the connection is maintained automatically. Full step-by-step instructions are in the docs.",
   },
   {
     q: "Does Hive work offline or self-hosted?",

--- a/ui/src/components/FaqPage.jsx
+++ b/ui/src/components/FaqPage.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import PageLayout from "@/components/PageLayout";
+import { FREE_TIER_MEMORY_LIMIT } from "@/lib/limits";
 
 const FAQS = [
   {
@@ -10,7 +11,7 @@ const FAQS = [
   },
   {
     q: "What are the usage limits?",
-    a: "There are no hard limits on the number of memories or API calls during the free period. We reserve the right to introduce fair-use limits in future to ensure service quality for all users — we'll give plenty of notice before doing so.",
+    a: `Free accounts can store up to ${FREE_TIER_MEMORY_LIMIT} memories. Once you reach the limit, new memories are rejected until you delete existing ones. Additional rate limits may apply to prevent abuse. We'll communicate any changes to these limits with plenty of notice.`,
   },
   {
     q: "Which MCP clients are supported?",

--- a/ui/src/components/FaqPage.jsx
+++ b/ui/src/components/FaqPage.jsx
@@ -15,7 +15,7 @@ const FAQS = [
   },
   {
     q: "Which MCP clients are supported?",
-    a: "Any client that implements the Model Context Protocol works with Hive. Tested clients include Claude Code, Claude Desktop, Cursor, and Continue. If your client supports MCP, it will work.",
+    a: "Any client that implements the Model Context Protocol works with Hive. Tested clients include Claude Code, Claude Desktop, ChatGPT, Cursor, and Continue. If your client supports MCP, it will work.",
   },
   {
     q: "How do I delete my account or data?",

--- a/ui/src/components/FaqPage.test.jsx
+++ b/ui/src/components/FaqPage.test.jsx
@@ -56,7 +56,7 @@ describe("FaqPage", () => {
     fireEvent.click(screen.getByText(/Is my data private/));
     fireEvent.click(screen.getByText(/What are the usage limits/));
     expect(screen.getByText(/Your memories are scoped to your account/)).toBeTruthy();
-    expect(screen.getByText(/no hard limits/)).toBeTruthy();
+    expect(screen.getByText(/up to 500 memories/)).toBeTruthy();
   });
 
   it("renders docs link", async () => {

--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -37,8 +37,8 @@ const HOW_IT_WORKS = [
   },
   {
     step: "2",
-    title: "Register an MCP client",
-    body: "Give your agent a name and copy the one-line config snippet into your MCP client.",
+    title: "Connect your MCP client",
+    body: "Paste Hive's config snippet into your client. On first use your browser opens once to approve access — after that it's automatic.",
   },
   {
     step: "3",

--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -15,7 +15,7 @@ const FEATURES = [
   {
     icon: Plug,
     title: "Works with any MCP client",
-    body: "Plug in to Claude Code, Claude Desktop, Cursor, Continue, or any client that speaks the Model Context Protocol.",
+    body: "Plug in to Claude Code, Claude Desktop, ChatGPT, Cursor, Continue, or any client that speaks the Model Context Protocol.",
   },
   {
     icon: Users,

--- a/ui/src/components/HomePage.test.jsx
+++ b/ui/src/components/HomePage.test.jsx
@@ -44,7 +44,7 @@ describe("HomePage", () => {
   it("renders all how-it-works steps", async () => {
     await act(async () => renderInRouter(<HomePage />));
     expect(screen.getByText(/Sign in with Google/)).toBeTruthy();
-    expect(screen.getByText(/Register an MCP client/)).toBeTruthy();
+    expect(screen.getByText(/Connect your MCP client/)).toBeTruthy();
     expect(screen.getByText(/Start remembering/)).toBeTruthy();
   });
 

--- a/ui/src/components/McpClientsPage.jsx
+++ b/ui/src/components/McpClientsPage.jsx
@@ -19,16 +19,15 @@ const CLIENTS = [
   },
   {
     name: "Claude Desktop",
-    description: "The Claude desktop app on Mac and Windows. Requires the mcp-remote helper to bridge to HTTP; npx installs it automatically.",
-    config: `{
-  "mcpServers": {
-    "hive": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://hive.warlordofmars.net/mcp"]
-    }
-  }
-}`,
-    configFile: "~/Library/Application Support/Claude/claude_desktop_config.json",
+    description: "The Claude desktop app on Mac and Windows. Add Hive via Settings → Connectors → Add custom connector and paste the URL — no config file or mcp-remote helper needed.",
+    config: `https://hive.warlordofmars.net/mcp`,
+    configFile: "Settings → Connectors → Add custom connector",
+  },
+  {
+    name: "ChatGPT",
+    description: "OpenAI's web client. Add Hive as a remote MCP App via Settings → Connectors (Developer mode required). OAuth happens in the browser.",
+    config: `https://hive.warlordofmars.net/mcp`,
+    configFile: "Settings → Connectors → Add → MCP server",
   },
   {
     name: "Cursor",

--- a/ui/src/components/McpClientsPage.jsx
+++ b/ui/src/components/McpClientsPage.jsx
@@ -6,7 +6,7 @@ import PageLayout from "@/components/PageLayout";
 const CLIENTS = [
   {
     name: "Claude Code",
-    description: "Anthropic's official CLI for Claude. Add Hive as an MCP server in your project or global config.",
+    description: "Anthropic's official CLI for Claude. Add Hive to your global settings (or a project's .mcp.json).",
     config: `{
   "mcpServers": {
     "hive": {
@@ -15,24 +15,24 @@ const CLIENTS = [
     }
   }
 }`,
-    configFile: "~/.claude/claude_desktop_config.json or .mcp.json",
+    configFile: "~/.claude/settings.json (or .mcp.json)",
   },
   {
     name: "Claude Desktop",
-    description: "The Claude desktop app on Mac and Windows. Add Hive to your MCP server list in settings.",
+    description: "The Claude desktop app on Mac and Windows. Requires the mcp-remote helper to bridge to HTTP; npx installs it automatically.",
     config: `{
   "mcpServers": {
     "hive": {
-      "type": "http",
-      "url": "https://hive.warlordofmars.net/mcp"
+      "command": "npx",
+      "args": ["mcp-remote", "https://hive.warlordofmars.net/mcp"]
     }
   }
 }`,
-    configFile: "Claude Desktop → Settings → MCP Servers",
+    configFile: "~/Library/Application Support/Claude/claude_desktop_config.json",
   },
   {
     name: "Cursor",
-    description: "The AI-first code editor. Add Hive as an MCP server in your Cursor settings.",
+    description: "The AI-first code editor. Add Hive as an MCP server in your Cursor config.",
     config: `{
   "mcpServers": {
     "hive": {
@@ -46,19 +46,13 @@ const CLIENTS = [
   {
     name: "Continue",
     description: "The open-source AI code assistant for VS Code and JetBrains. Add Hive in your Continue config.",
-    config: `{
-  "experimental": {
-    "modelContextProtocolServers": [
-      {
-        "transport": {
-          "type": "http",
-          "url": "https://hive.warlordofmars.net/mcp"
-        }
-      }
-    ]
-  }
-}`,
-    configFile: "~/.continue/config.json",
+    config: `mcpServers:
+  - name: hive
+    command: npx
+    args:
+      - mcp-remote
+      - https://hive.warlordofmars.net/mcp`,
+    configFile: "~/.continue/config.yaml",
   },
 ];
 

--- a/ui/src/components/McpClientsPage.test.jsx
+++ b/ui/src/components/McpClientsPage.test.jsx
@@ -35,13 +35,19 @@ describe("McpClientsPage", () => {
   it("renders config snippets for each client", async () => {
     const { container } = await act(async () => renderInRouter(<McpClientsPage />));
     const snippets = container.querySelectorAll("pre");
-    expect(snippets.length).toBe(4);
+    // Claude Code, Claude Desktop, ChatGPT, Cursor, Continue
+    expect(snippets.length).toBe(5);
   });
 
   it("renders Copy buttons", async () => {
     await act(async () => renderInRouter(<McpClientsPage />));
     const copyBtns = screen.getAllByText("Copy");
-    expect(copyBtns.length).toBe(4);
+    expect(copyBtns.length).toBe(5);
+  });
+
+  it("renders ChatGPT card", async () => {
+    await act(async () => renderInRouter(<McpClientsPage />));
+    expect(screen.getByText("ChatGPT")).toBeTruthy();
   });
 
   it("clicking Copy calls clipboard and shows Copied!", async () => {

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -187,6 +187,19 @@ export default function MemoryBrowser() {
   const [versionsLoading, setVersionsLoading] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [pendingDelete, setPendingDelete] = useState(null);
+  const [clientNameById, setClientNameById] = useState({});
+
+  useEffect(function loadClientNames() {
+    api.listClients()
+      .then(function handleClients(data) {
+        const map = {};
+        for (const c of data.items ?? []) {
+          map[c.client_id] = c.client_name;
+        }
+        setClientNameById(map);
+      })
+      .catch(function ignore() {});
+  }, []);
   const searchDebounceRef = useRef(null);
   const listRef = useRef(null);
 
@@ -448,13 +461,18 @@ export default function MemoryBrowser() {
                 onKeyDown={(e) => handleCardKeyDown(e, m)}
               >
                 <div className="flex-1">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <strong>{m.key}</strong>
                     {m.score !== undefined && (
                       <Badge>{Math.round(m.score * 100)}% match</Badge>
                     )}
                     {m.expires_at && (
                       <Badge className="border-[var(--amber)] text-[var(--amber)]">Expires {new Date(m.expires_at).toLocaleDateString()}</Badge>
+                    )}
+                    {m.owner_client_id && (
+                      <Badge className="text-[var(--text-muted)]">
+                        by {clientNameById[m.owner_client_id] ?? m.owner_client_id}
+                      </Badge>
                     )}
                   </div>
                   <p className="mt-1 text-[var(--text-muted)] text-[13px] whitespace-pre-wrap">

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -12,6 +12,7 @@ vi.mock("../api.js", () => ({
     deleteMemory: vi.fn(),
     listMemoryVersions: vi.fn(),
     restoreMemoryVersion: vi.fn(),
+    listClients: vi.fn(),
   },
 }));
 
@@ -248,6 +249,8 @@ describe("MemoryBrowser", () => {
     vi.clearAllMocks();
     api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
     api.searchMemories.mockResolvedValue({ items: [], count: 0 });
+    // Default to a shape without `items` so the `?? []` fallback is exercised.
+    api.listClients.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -1017,5 +1020,48 @@ describe("MemoryBrowser", () => {
     fireEvent.click(getCard());
     expect(screen.queryByText("History: test-key")).toBeNull();
     expect(screen.getByText("Edit: test-key")).toBeTruthy();
+  });
+
+  it("renders attribution badge with client name when client is known", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ owner_client_id: "client-123" })],
+      next_cursor: null,
+    });
+    api.listClients.mockResolvedValue({
+      items: [{ client_id: "client-123", client_name: "My Agent" }],
+    });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => expect(screen.getByText("by My Agent")).toBeTruthy());
+  });
+
+  it("falls back to client id when name is not yet loaded", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ owner_client_id: "client-xyz" })],
+      next_cursor: null,
+    });
+    api.listClients.mockResolvedValue({ items: [] });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => expect(screen.getByText("by client-xyz")).toBeTruthy());
+  });
+
+  it("omits attribution badge when owner_client_id is missing", async () => {
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory()],
+      next_cursor: null,
+    });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    expect(screen.queryByText(/^by /)).toBeNull();
+  });
+
+  it("swallows listClients errors and still renders memories", async () => {
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+    api.listClients.mockRejectedValue(new Error("network"));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
   });
 });

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -2,8 +2,16 @@
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import ConsentBanner from "@/components/ConsentBanner";
+import { CONSENT_RESET_EVENT, clearConsent } from "@/lib/consent";
 
 const NAV_LINK_BASE = "text-sm no-underline hover:text-white transition-colors";
+
+function handleReopenConsent(e) {
+  e.preventDefault();
+  clearConsent();
+  globalThis.dispatchEvent(new CustomEvent(CONSENT_RESET_EVENT));
+}
 
 export default function PageLayout({ children }) {
   const navigate = useNavigate();
@@ -65,11 +73,19 @@ export default function PageLayout({ children }) {
               <a href="/status" className="no-underline hover:text-[var(--text)] transition-colors">Status</a>
               <a href="/terms" className="no-underline hover:text-[var(--text)] transition-colors">Terms</a>
               <a href="/privacy" className="no-underline hover:text-[var(--text)] transition-colors">Privacy</a>
+              <a
+                href="#cookie-preferences"
+                onClick={handleReopenConsent}
+                className="no-underline hover:text-[var(--text)] transition-colors"
+              >
+                Cookie preferences
+              </a>
             </div>
           </div>
           <p className="mt-6 text-[13px] text-[var(--text-muted)]">© 2026 Hive. Free to use.</p>
         </div>
       </footer>
+      <ConsentBanner />
     </div>
   );
 }

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -73,6 +73,7 @@ export default function PageLayout({ children }) {
               <a href="/status" className="no-underline hover:text-[var(--text)] transition-colors">Status</a>
               <a href="/terms" className="no-underline hover:text-[var(--text)] transition-colors">Terms</a>
               <a href="/privacy" className="no-underline hover:text-[var(--text)] transition-colors">Privacy</a>
+              <a href="/subprocessors" className="no-underline hover:text-[var(--text)] transition-colors">Subprocessors</a>
               <a
                 href="#cookie-preferences"
                 onClick={handleReopenConsent}

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -117,4 +117,34 @@ describe("PageLayout", () => {
     expect(btn.className).toContain("border-white/60");
     expect(btn.className).toContain("marketing-signin-btn");
   });
+
+  it("mounts the consent banner when no consent has been stored", async () => {
+    localStorage.removeItem("hive_ga_consent");
+    await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    expect(screen.getByRole("dialog", { name: "Cookie consent" })).toBeTruthy();
+  });
+
+  it("renders Cookie preferences footer link", async () => {
+    const { container } = await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    const footer = container.querySelector("footer");
+    expect(within(footer).getByText("Cookie preferences")).toBeTruthy();
+  });
+
+  it("Cookie preferences click clears stored consent and re-shows the banner", async () => {
+    localStorage.setItem("hive_ga_consent", "reject");
+    const { container } = await act(async () =>
+      renderInRouter(<PageLayout><span /></PageLayout>)
+    );
+    // Banner hidden while consent is stored.
+    expect(screen.queryByRole("dialog", { name: "Cookie consent" })).toBeNull();
+    const footer = container.querySelector("footer");
+    const link = within(footer).getByText("Cookie preferences");
+    await act(async () => fireEvent.click(link));
+    expect(localStorage.getItem("hive_ga_consent")).toBeNull();
+    expect(screen.getByRole("dialog", { name: "Cookie consent" })).toBeTruthy();
+  });
 });

--- a/ui/src/components/PricingPage.jsx
+++ b/ui/src/components/PricingPage.jsx
@@ -4,9 +4,10 @@ import { Check } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import PageLayout from "@/components/PageLayout";
+import { FREE_TIER_MEMORY_LIMIT } from "@/lib/limits";
 
 const INCLUDED = [
-  "Unlimited memories",
+  `Up to ${FREE_TIER_MEMORY_LIMIT} memories`,
   "Semantic search across all memories",
   "Works with Claude Code, Claude Desktop, Cursor, Continue, and any MCP client",
   "Multiple OAuth clients per account",

--- a/ui/src/components/PricingPage.jsx
+++ b/ui/src/components/PricingPage.jsx
@@ -9,7 +9,7 @@ import { FREE_TIER_MEMORY_LIMIT } from "@/lib/limits";
 const INCLUDED = [
   `Up to ${FREE_TIER_MEMORY_LIMIT} memories`,
   "Semantic search across all memories",
-  "Works with Claude Code, Claude Desktop, Cursor, Continue, and any MCP client",
+  "Works with Claude Code, Claude Desktop, ChatGPT, Cursor, Continue, and any MCP client",
   "Multiple OAuth clients per account",
   "Activity log and memory browser UI",
   "OAuth 2.1 with PKCE — no shared secrets",

--- a/ui/src/components/PricingPage.test.jsx
+++ b/ui/src/components/PricingPage.test.jsx
@@ -32,7 +32,7 @@ describe("PricingPage", () => {
 
   it("renders all included features", async () => {
     await act(async () => renderInRouter(<PricingPage />));
-    expect(screen.getByText(/Unlimited memories/)).toBeTruthy();
+    expect(screen.getByText(/Up to 500 memories/)).toBeTruthy();
     expect(screen.getByText(/Semantic search/)).toBeTruthy();
     expect(screen.getAllByText(/No credit card required/i).length).toBeGreaterThanOrEqual(1);
   });

--- a/ui/src/components/PrivacyPage.jsx
+++ b/ui/src/components/PrivacyPage.jsx
@@ -90,8 +90,13 @@ export default function PrivacyPage() {
               same region. No data is replicated to other cloud providers or regions.
             </p>
             <p>
-              AWS is our sole infrastructure provider. Their data-processing terms apply to
-              data at rest and in transit within AWS services.
+              AWS is our primary infrastructure provider. A full list of the third parties
+              that process data on our behalf (including AWS, Google OAuth, and Google
+              Analytics) is maintained on the{" "}
+              <a href="/subprocessors" className="text-brand no-underline hover:underline">
+                Subprocessors
+              </a>{" "}
+              page.
             </p>
           </Section>
 

--- a/ui/src/components/PrivacyPage.jsx
+++ b/ui/src/components/PrivacyPage.jsx
@@ -117,14 +117,17 @@ export default function PrivacyPage() {
             <p>
               The Hive marketing site (hive.warlordofmars.net and its sub-pages, including <code>/pricing</code>,
               {" "}<code>/faq</code>, <code>/use-cases</code>, and <code>/docs</code>) uses Google
-              Analytics 4 (GA4) to measure page views and navigation events. GA4 may set cookies
-              in your browser and send anonymised usage data to Google.
+              Analytics 4 (GA4) to measure page views and navigation events.
             </p>
             <p>
-              The management UI (<code>/app</code>) does not send data to GA4.
+              GA4 is <strong>opt-in</strong>: we show a consent banner on your first visit with
+              equal-prominence Accept and Reject buttons. No GA4 script loads and no data is sent
+              to Google until you click Accept. You can change your choice at any time via the
+              <strong> Cookie preferences </strong>link in the footer. The management UI
+              (<code>/app</code>) never sends data to GA4, regardless of your choice.
             </p>
             <p>
-              You can opt out of GA4 tracking by enabling "Do Not Track" in your browser, using a
+              You can also opt out at the browser level by enabling "Do Not Track", using a
               content blocker, or installing the{" "}
               <a
                 href="https://tools.google.com/dlpage/gaoptout"

--- a/ui/src/components/PrivacyPage.jsx
+++ b/ui/src/components/PrivacyPage.jsx
@@ -31,9 +31,9 @@ export default function PrivacyPage() {
           <Section title="1. Who We Are">
             <p>
               Hive is a shared persistent memory service for AI agents and teams. The Service is
-              operated by John Carter. Questions about this policy can be sent to{" "}
-              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
-                privacy@hive.so
+              operated by warlordofmars. Questions about this policy can be sent to{" "}
+              <a href="mailto:privacy@warlordofmars.net" className="text-brand no-underline hover:underline">
+                privacy@warlordofmars.net
               </a>
               .
             </p>
@@ -115,7 +115,7 @@ export default function PrivacyPage() {
 
           <Section title="6. Google Analytics 4">
             <p>
-              The Hive marketing site (hive.so and its sub-pages, including <code>/pricing</code>,
+              The Hive marketing site (hive.warlordofmars.net and its sub-pages, including <code>/pricing</code>,
               {" "}<code>/faq</code>, <code>/use-cases</code>, and <code>/docs</code>) uses Google
               Analytics 4 (GA4) to measure page views and navigation events. GA4 may set cookies
               in your browser and send anonymised usage data to Google.
@@ -165,8 +165,8 @@ export default function PrivacyPage() {
             </ul>
             <p>
               To exercise any of these rights, email{" "}
-              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
-                privacy@hive.so
+              <a href="mailto:privacy@warlordofmars.net" className="text-brand no-underline hover:underline">
+                privacy@warlordofmars.net
               </a>
               .
             </p>
@@ -193,8 +193,8 @@ export default function PrivacyPage() {
           <Section title="11. Contact">
             <p>
               For privacy questions or to exercise your data rights, contact us at{" "}
-              <a href="mailto:privacy@hive.so" className="text-brand no-underline hover:underline">
-                privacy@hive.so
+              <a href="mailto:privacy@warlordofmars.net" className="text-brand no-underline hover:underline">
+                privacy@warlordofmars.net
               </a>
               .
             </p>

--- a/ui/src/components/PrivacyPage.test.jsx
+++ b/ui/src/components/PrivacyPage.test.jsx
@@ -74,6 +74,6 @@ describe("PrivacyPage", () => {
 
   it("renders the privacy contact email", async () => {
     await act(async () => renderInRouter(<PrivacyPage />));
-    expect(screen.getAllByText(/privacy@hive\.so/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/privacy@warlordofmars\.net/).length).toBeGreaterThan(0);
   });
 });

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useEffect, useState } from "react";
-import { AlertTriangle, Check } from "lucide-react";
+import { AlertTriangle, Check, Download } from "lucide-react";
 import { api } from "../api.js";
 import { Button } from "./ui/button.jsx";
 import { Card } from "./ui/card.jsx";
@@ -19,6 +19,28 @@ export default function SetupPanel() {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
   const [quota, setQuota] = useState(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState("");
+
+  async function handleExport() {
+    setExporting(true);
+    setExportError("");
+    try {
+      const result = await api.exportAccount();
+      if (!result) return;
+      const { blob, filename } = result;
+      const url = URL.createObjectURL(blob);
+      const link = globalThis.document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setExportError(e.message ?? "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }
 
   useEffect(function loadQuota() {
     api.getStats().then(function handleStats(s) {
@@ -222,6 +244,23 @@ export default function SetupPanel() {
           </div>
         </section>
       )}
+
+      <section className="mt-12 border-t border-[var(--border)] pt-8">
+        <h3 className="mb-2 flex items-center gap-2">
+          <Download size={18} />
+          Export my data
+        </h3>
+        <p className="text-[var(--text-muted)] mb-4 text-sm">
+          Download a JSON file containing your profile, memories, OAuth clients, and the last
+          90 days of activity. Limited to one export every 5 minutes.
+        </p>
+        {exportError && (
+          <p className="text-[var(--danger)] text-[13px] mb-3">{exportError}</p>
+        )}
+        <Button variant="secondary" onClick={handleExport} disabled={exporting}>
+          {exporting ? "Preparing…" : "Export my data"}
+        </Button>
+      </section>
 
       <section className="mt-12 border-t border-[var(--border)] pt-8">
         <h3 className="mb-2 flex items-center gap-2 text-[var(--danger)]">

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -190,6 +190,29 @@ export default function SetupPanel() {
         </div>
       </section>
 
+      <section className="mt-12 border-t border-[var(--border)] pt-8">
+        <h3 className="mb-3">Tip — naming your memories</h3>
+        <p className="text-[var(--text-muted)] mb-3 text-sm">
+          Keys are free-form, but a structured scheme keeps your store organised as it grows.
+          We recommend:
+        </p>
+        <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)] mb-3">
+          {"{domain}:{entity-type}/{entity-id}:{attribute}\n\nproject:task/42:summary\nuser:profile/alice:preferences\nsession:current:context"}
+        </pre>
+        <p className="text-[var(--text-muted)] text-sm">
+          See the{" "}
+          <a
+            href="/docs/concepts/key-conventions"
+            target="_blank"
+            rel="noreferrer"
+            className="text-[var(--accent)] underline"
+          >
+            key naming conventions
+          </a>{" "}
+          docs for the full guide.
+        </p>
+      </section>
+
       {quota && (
         <section className="mt-12 border-t border-[var(--border)] pt-8">
           <h3 className="mb-4">Usage</h3>

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -10,7 +10,9 @@ const STEP1_KEY = "hive_setup_step1_done";
 export default function SetupPanel() {
   const mcpUrl = import.meta.env.VITE_MCP_BASE ?? `${globalThis.location.origin}/mcp`;
   const [activeTab, setActiveTab] = useState("code");
+  const [desktopMode, setDesktopMode] = useState("url"); // "url" | "json"
   const [copied, setCopied] = useState(false);
+  const [urlCopied, setUrlCopied] = useState(false);
   const [step1Done, setStep1Done] = useState(() => !!localStorage.getItem(STEP1_KEY));
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null); // "ok" | "error"
@@ -72,6 +74,14 @@ export default function SetupPanel() {
     localStorage.setItem(STEP1_KEY, "1");
     setStep1Done(true);
     setTimeout(() => setCopied(false), 2000);
+  }
+
+  function handleCopyUrl() {
+    navigator.clipboard.writeText(mcpUrl);
+    setUrlCopied(true);
+    localStorage.setItem(STEP1_KEY, "1");
+    setStep1Done(true);
+    setTimeout(() => setUrlCopied(false), 2000);
   }
 
   async function handleDeleteAccount() {
@@ -147,7 +157,7 @@ export default function SetupPanel() {
           needed.
         </p>
 
-        <div className="flex gap-1 mb-0">
+        <div className="flex gap-1 mb-0 flex-wrap">
           <button className={tabClassName("code")} onClick={() => setActiveTab("code")}>
             Claude Code
           </button>
@@ -157,33 +167,51 @@ export default function SetupPanel() {
           <button className={tabClassName("desktop")} onClick={() => setActiveTab("desktop")}>
             Claude Desktop
           </button>
+          <button className={tabClassName("chatgpt")} onClick={() => setActiveTab("chatgpt")}>
+            ChatGPT
+          </button>
         </div>
 
         <div className="border border-[var(--border)] rounded-b rounded-tr p-3 bg-[var(--bg)]">
+          {(activeTab === "desktop" || activeTab === "chatgpt") && (
+            <DesktopOrChatgptInstructions
+              activeTab={activeTab}
+              desktopMode={desktopMode}
+              setDesktopMode={setDesktopMode}
+              mcpUrl={mcpUrl}
+              configs={configs}
+              urlCopied={urlCopied}
+              copied={copied}
+              handleCopy={handleCopy}
+              handleCopyUrl={handleCopyUrl}
+            />
+          )}
           {activeTab === "code" && (
-            <p className="mb-2 text-[var(--text-muted)] text-[13px]">
-              Add to <code>~/.claude/settings.json</code>:
-            </p>
+            <>
+              <p className="mb-2 text-[var(--text-muted)] text-[13px]">
+                Add to <code>~/.claude/settings.json</code>:
+              </p>
+              <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
+                {configs[activeTab]}
+              </pre>
+              <Button variant="secondary" className="mt-2" onClick={handleCopy}>
+                {copied ? "Copied!" : "Copy"}
+              </Button>
+            </>
           )}
           {activeTab === "cursor" && (
-            <p className="mb-2 text-[var(--text-muted)] text-[13px]">
-              Add to <code>~/.cursor/mcp.json</code> (create it if it doesn't exist):
-            </p>
+            <>
+              <p className="mb-2 text-[var(--text-muted)] text-[13px]">
+                Add to <code>~/.cursor/mcp.json</code> (create it if it doesn't exist):
+              </p>
+              <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
+                {configs[activeTab]}
+              </pre>
+              <Button variant="secondary" className="mt-2" onClick={handleCopy}>
+                {copied ? "Copied!" : "Copy"}
+              </Button>
+            </>
           )}
-          {activeTab === "desktop" && (
-            <p className="mb-2 text-[var(--text-muted)] text-[13px]">
-              Add to{" "}
-              <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>.
-              Requires <a href="https://github.com/geelen/mcp-remote" target="_blank" rel="noreferrer">mcp-remote</a> (
-              <code>npx</code> will install it automatically):
-            </p>
-          )}
-          <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
-            {configs[activeTab]}
-          </pre>
-          <Button variant="secondary" className="mt-2" onClick={handleCopy}>
-            {copied ? "Copied!" : "Copy"}
-          </Button>
         </div>
       </section>
 
@@ -195,7 +223,9 @@ export default function SetupPanel() {
         <p className="text-[var(--text-muted)] mb-3">
           {activeTab === "code" && "Open Claude Code. The next time you use a Hive memory tool, it will prompt you to authorise access via your browser. Complete the flow and you're done."}
           {activeTab === "cursor" && "Restart Cursor. On first use it will open a browser window to complete the OAuth flow. After authorising, the connection is maintained automatically."}
-          {activeTab === "desktop" && "Restart Claude Desktop. On first use it will open a browser window to complete the OAuth flow. After authorising, the connection is maintained automatically."}
+          {activeTab === "desktop" && desktopMode === "url" && "After saving the connector, Claude Desktop opens your browser to complete OAuth. Confirm access and you're connected."}
+          {activeTab === "desktop" && desktopMode === "json" && "Restart Claude Desktop. On first use it will open a browser window to complete the OAuth flow. After authorising, the connection is maintained automatically."}
+          {activeTab === "chatgpt" && "ChatGPT opens an OAuth pop-up the first time the connector is used. Approve access and the connection is kept open until you revoke it."}
         </p>
         <div className="flex items-center gap-3">
           <Button variant="secondary" onClick={handleTest} disabled={testing}>
@@ -307,6 +337,89 @@ export default function SetupPanel() {
         )}
       </section>
     </div>
+  );
+}
+
+function DesktopOrChatgptInstructions({
+  activeTab,
+  desktopMode,
+  setDesktopMode,
+  mcpUrl,
+  configs,
+  urlCopied,
+  copied,
+  handleCopy,
+  handleCopyUrl,
+}) {
+  const isChatgpt = activeTab === "chatgpt";
+  const showJsonForm = activeTab === "desktop" && desktopMode === "json";
+
+  if (showJsonForm) {
+    return (
+      <>
+        <p className="mb-2 text-[var(--text-muted)] text-[13px]">
+          Add to{" "}
+          <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>.
+          Requires <a href="https://github.com/geelen/mcp-remote" target="_blank" rel="noreferrer">mcp-remote</a> (
+          <code>npx</code> will install it automatically):
+        </p>
+        <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
+          {configs.desktop}
+        </pre>
+        <Button variant="secondary" className="mt-2" onClick={handleCopy}>
+          {copied ? "Copied!" : "Copy"}
+        </Button>
+        <button
+          type="button"
+          className="block mt-3 text-[13px] text-[var(--accent)] underline bg-transparent"
+          onClick={() => setDesktopMode("url")}
+        >
+          ← Back to the Custom Connector flow (recommended)
+        </button>
+      </>
+    );
+  }
+
+  const steps = isChatgpt
+    ? [
+        "Open ChatGPT → Settings → Connectors (Developer mode required).",
+        "Click Add → MCP server.",
+        "Paste the URL below, save, and approve the OAuth pop-up that follows.",
+      ]
+    : [
+        "Open Claude Desktop → Settings → Connectors.",
+        "Click Add custom connector.",
+        "Paste the URL below, save, and complete the browser OAuth flow.",
+      ];
+
+  return (
+    <>
+      <p className="mb-2 text-[var(--text-muted)] text-[13px]">
+        {isChatgpt
+          ? "Add Hive as a remote MCP App. ChatGPT handles OAuth in the browser — no config file needed."
+          : "Add Hive as a Custom Connector. Claude Desktop handles OAuth in the browser — no config file or mcp-remote helper needed."}
+      </p>
+      <ol className="list-decimal pl-5 mb-3 text-[13px] text-[var(--text)] space-y-1">
+        {steps.map((s) => (
+          <li key={s}>{s}</li>
+        ))}
+      </ol>
+      <pre className="bg-[var(--surface)] border border-[var(--border)] rounded p-3 text-[13px] overflow-x-auto text-[var(--text)]">
+        {mcpUrl}
+      </pre>
+      <Button variant="secondary" className="mt-2" onClick={handleCopyUrl}>
+        {urlCopied ? "Copied!" : "Copy URL"}
+      </Button>
+      {!isChatgpt && (
+        <button
+          type="button"
+          className="block mt-3 text-[13px] text-[var(--text-muted)] underline bg-transparent"
+          onClick={() => setDesktopMode("json")}
+        >
+          Prefer JSON? (legacy mcp-remote setup)
+        </button>
+      )}
+    </>
   );
 }
 

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -287,6 +287,14 @@ describe("SetupPanel", () => {
     expect(bars.length).toBeGreaterThan(0);
   });
 
+  it("renders key naming convention tip with example and docs link", async () => {
+    await act(async () => render(<SetupPanel />));
+    expect(screen.getByText(/Tip — naming your memories/)).toBeTruthy();
+    expect(document.body.textContent).toContain("project:task/42:summary");
+    const docsLink = screen.getByText(/key naming conventions/);
+    expect(docsLink.getAttribute("href")).toBe("/docs/concepts/key-conventions");
+  });
+
   it("hides Usage section when getStats rejects", async () => {
     api.getStats.mockRejectedValue(new Error("network error"));
     await act(async () => render(<SetupPanel />));

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -56,11 +56,79 @@ describe("SetupPanel", () => {
     expect(document.body.textContent).toContain('"type": "http"');
   });
 
-  it("switches to Claude Desktop tab and shows mcp-remote config", async () => {
+  it("Claude Desktop tab leads with the Custom Connector URL flow", async () => {
     await act(async () => render(<SetupPanel />));
     fireEvent.click(screen.getByText("Claude Desktop"));
+    expect(document.body.textContent).toContain("Add custom connector");
+    expect(document.body.textContent).toContain("/mcp");
+    // The mcp-remote JSON config is hidden behind the legacy disclosure
+    expect(document.body.textContent).not.toContain('"command": "npx"');
+  });
+
+  it("Claude Desktop legacy disclosure reveals the mcp-remote JSON form", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText(/Prefer JSON/));
     expect(document.body.textContent).toContain("mcp-remote");
     expect(document.body.textContent).toContain('"command": "npx"');
+  });
+
+  it("ChatGPT tab shows the URL flow with the connector steps", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("ChatGPT"));
+    expect(document.body.textContent).toContain("Add → MCP server");
+    expect(document.body.textContent).toContain("/mcp");
+    expect(document.body.textContent).not.toContain('"command": "npx"');
+  });
+
+  it("Copy URL button copies the URL and marks step 1 done", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText("Copy URL"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("/mcp"),
+    );
+    expect(_storage["hive_setup_step1_done"]).toBe("1");
+  });
+
+  it("Copy URL shows Copied! and reverts after 2s", async () => {
+    vi.useFakeTimers();
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText("Copy URL"));
+    expect(screen.getByText("Copied!")).toBeTruthy();
+    act(() => vi.runAllTimers());
+    expect(screen.getByText("Copy URL")).toBeTruthy();
+    vi.useRealTimers();
+  });
+
+  it("Cursor tab Copy uses the Cursor http config", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Cursor"));
+    fireEvent.click(screen.getByText("Copy"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('"type": "http"'),
+    );
+  });
+
+  it("Claude Desktop legacy JSON Copy uses the mcp-remote config", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText(/Prefer JSON/));
+    fireEvent.click(screen.getByText("Copy"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("mcp-remote"),
+    );
+  });
+
+  it("Back link from legacy JSON form returns to the URL flow", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText(/Prefer JSON/));
+    expect(document.body.textContent).toContain('"command": "npx"');
+    fireEvent.click(screen.getByText(/Back to the Custom Connector/));
+    expect(document.body.textContent).toContain("Add custom connector");
+    expect(document.body.textContent).not.toContain('"command": "npx"');
   });
 
   it("shows Copy button initially", async () => {
@@ -90,11 +158,24 @@ describe("SetupPanel", () => {
     expect(document.body.textContent).toContain("/mcp");
   });
 
-  it("step 2 text updates when switching tabs", async () => {
+  it("step 2 text updates when switching tabs (Claude Desktop URL flow)", async () => {
     await act(async () => render(<SetupPanel />));
     expect(document.body.textContent).toContain("Claude Code");
     fireEvent.click(screen.getByText("Claude Desktop"));
+    expect(document.body.textContent).toContain("After saving the connector");
+  });
+
+  it("step 2 text updates for the Claude Desktop legacy JSON flow", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("Claude Desktop"));
+    fireEvent.click(screen.getByText(/Prefer JSON/));
     expect(document.body.textContent).toContain("Restart Claude Desktop");
+  });
+
+  it("step 2 text updates when switching to ChatGPT tab", async () => {
+    await act(async () => render(<SetupPanel />));
+    fireEvent.click(screen.getByText("ChatGPT"));
+    expect(document.body.textContent).toContain("ChatGPT opens an OAuth pop-up");
   });
 
   it("switching back to Claude Code tab restores http config", async () => {

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -3,7 +3,12 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../api.js", () => ({
-  api: { listMemories: vi.fn(), deleteAccount: vi.fn(), getStats: vi.fn() },
+  api: {
+    listMemories: vi.fn(),
+    deleteAccount: vi.fn(),
+    getStats: vi.fn(),
+    exportAccount: vi.fn(),
+  },
 }));
 
 import { api } from "../api.js";
@@ -299,5 +304,79 @@ describe("SetupPanel", () => {
     api.getStats.mockRejectedValue(new Error("network error"));
     await act(async () => render(<SetupPanel />));
     expect(screen.queryByText("Usage")).toBeNull();
+  });
+
+  describe("Export my data", () => {
+    let createObjectURL;
+    let revokeObjectURL;
+    let linkClick;
+
+    beforeEach(() => {
+      createObjectURL = vi.fn().mockReturnValue("blob:mock");
+      revokeObjectURL = vi.fn();
+      vi.stubGlobal("URL", {
+        ...globalThis.URL,
+        createObjectURL,
+        revokeObjectURL,
+      });
+      linkClick = vi.fn();
+      const realCreateElement = document.createElement.bind(document);
+      vi.spyOn(document, "createElement").mockImplementation((tag) => {
+        const el = realCreateElement(tag);
+        if (tag === "a") el.click = linkClick;
+        return el;
+      });
+    });
+
+    afterEach(() => {
+      document.createElement.mockRestore?.();
+    });
+
+    it("renders Export my data button and description", async () => {
+      await act(async () => render(<SetupPanel />));
+      expect(screen.getAllByText(/Export my data/).length).toBeGreaterThanOrEqual(1);
+      expect(document.body.textContent).toContain("Limited to one export every 5 minutes");
+    });
+
+    it("clicking Export my data triggers download of the returned blob", async () => {
+      const blob = new Blob(["{}"], { type: "application/json" });
+      api.exportAccount.mockResolvedValue({ blob, filename: "hive-export-u-20260418.json" });
+      await act(async () => render(<SetupPanel />));
+      await act(async () =>
+        fireEvent.click(screen.getByRole("button", { name: "Export my data" })),
+      );
+      expect(api.exportAccount).toHaveBeenCalled();
+      expect(createObjectURL).toHaveBeenCalledWith(blob);
+      expect(linkClick).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock");
+    });
+
+    it("displays error when export fails", async () => {
+      api.exportAccount.mockRejectedValue(new Error("Rate limit exceeded"));
+      await act(async () => render(<SetupPanel />));
+      await act(async () =>
+        fireEvent.click(screen.getByRole("button", { name: "Export my data" })),
+      );
+      await waitFor(() => expect(screen.getByText("Rate limit exceeded")).toBeTruthy());
+    });
+
+    it("falls back to a generic message when rejection has no message", async () => {
+      api.exportAccount.mockRejectedValue({});
+      await act(async () => render(<SetupPanel />));
+      await act(async () =>
+        fireEvent.click(screen.getByRole("button", { name: "Export my data" })),
+      );
+      await waitFor(() => expect(screen.getByText("Export failed")).toBeTruthy());
+    });
+
+    it("no-op when exportAccount returns null (auth-redirect path)", async () => {
+      api.exportAccount.mockResolvedValue(null);
+      await act(async () => render(<SetupPanel />));
+      await act(async () =>
+        fireEvent.click(screen.getByRole("button", { name: "Export my data" })),
+      );
+      expect(createObjectURL).not.toHaveBeenCalled();
+      expect(linkClick).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ui/src/components/SubprocessorsPage.jsx
+++ b/ui/src/components/SubprocessorsPage.jsx
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import PageLayout from "@/components/PageLayout";
+
+const LAST_UPDATED = "April 2026";
+
+const SUBPROCESSORS = [
+  {
+    name: "Amazon Web Services",
+    services: "DynamoDB, Lambda, S3 Vectors, CloudFront, CloudWatch",
+    purpose: "Hosting, storage, compute, CDN, observability",
+    data: "User account, memories, OAuth clients, activity logs, request logs",
+    location: "us-east-1 (United States)",
+  },
+  {
+    name: "Google LLC",
+    services: "Google OAuth 2.0",
+    purpose: "Sign-in / identity verification for the management UI",
+    data: "Email address, Google profile identifier",
+    location: "Global",
+  },
+  {
+    name: "Google LLC",
+    services: "Google Analytics 4",
+    purpose: "Marketing-site usage analytics (opt-in only)",
+    data: "Pseudonymous usage data (page views, referrers, aggregated device info)",
+    location: "Global",
+  },
+];
+
+function Section({ title, children }) {
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl font-bold mb-3">{title}</h2>
+      <div className="text-sm text-[var(--text-muted)] leading-relaxed space-y-3">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export default function SubprocessorsPage() {
+  return (
+    <PageLayout>
+      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+        <div className="max-w-[1100px] mx-auto">
+          <h1 className="text-[2.5rem] font-extrabold mb-4">Subprocessors</h1>
+          <p className="text-[var(--text-muted)] text-lg max-w-[520px] mx-auto leading-relaxed">
+            Last updated: {LAST_UPDATED}. The third-party services Hive uses to
+            operate.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16 px-8">
+        <div className="max-w-[960px] mx-auto">
+          <Section title="Current subprocessors">
+            <p>
+              Hive engages the following third parties (subprocessors) to
+              process personal data on our behalf. Each entry lists the
+              categories of data they see and where they process it.
+            </p>
+            <div className="overflow-x-auto -mx-2">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="text-left border-b border-[var(--border)]">
+                    <th className="py-3 px-2 font-semibold text-[var(--text)]">
+                      Subprocessor
+                    </th>
+                    <th className="py-3 px-2 font-semibold text-[var(--text)]">
+                      Purpose
+                    </th>
+                    <th className="py-3 px-2 font-semibold text-[var(--text)]">
+                      Data processed
+                    </th>
+                    <th className="py-3 px-2 font-semibold text-[var(--text)]">
+                      Location
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {SUBPROCESSORS.map((s) => (
+                    <tr
+                      key={`${s.name}-${s.services}`}
+                      className="border-b border-[var(--border)] align-top"
+                    >
+                      <td className="py-3 px-2">
+                        <div className="text-[var(--text)] font-medium">
+                          {s.name}
+                        </div>
+                        <div className="text-[13px]">{s.services}</div>
+                      </td>
+                      <td className="py-3 px-2">{s.purpose}</td>
+                      <td className="py-3 px-2">{s.data}</td>
+                      <td className="py-3 px-2 whitespace-nowrap">
+                        {s.location}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Section>
+
+          <Section title="Notification of changes">
+            <p>
+              When we add or change subprocessors, we announce the update in the
+              in-app changelog. Paid enterprise customers (once available) will
+              receive at least 30 days' advance notice by email before any new
+              subprocessor is engaged, giving them time to object.
+            </p>
+          </Section>
+
+          <Section title="Where this fits">
+            <p>
+              This page is a living complement to our{" "}
+              <a
+                href="/privacy"
+                className="text-brand no-underline hover:underline"
+              >
+                Privacy Policy
+              </a>
+              . Section 4 of the Privacy Policy describes where data is stored
+              at a high level; this page enumerates the specific services
+              involved.
+            </p>
+          </Section>
+        </div>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/SubprocessorsPage.test.jsx
+++ b/ui/src/components/SubprocessorsPage.test.jsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import SubprocessorsPage from "./SubprocessorsPage.jsx";
+
+function renderInRouter() {
+  return render(
+    <MemoryRouter>
+      <SubprocessorsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("SubprocessorsPage", () => {
+  it("renders heading and last-updated date", async () => {
+    await act(async () => renderInRouter());
+    expect(screen.getByRole("heading", { name: "Subprocessors" })).toBeTruthy();
+    expect(screen.getByText(/Last updated: April 2026/)).toBeTruthy();
+  });
+
+  it("lists each current subprocessor in the table", async () => {
+    const { container } = await act(async () => renderInRouter());
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+    const tableBody = within(table);
+    // AWS + two Google entries expected
+    expect(tableBody.getAllByText("Amazon Web Services")).toHaveLength(1);
+    expect(tableBody.getAllByText("Google LLC").length).toBeGreaterThanOrEqual(2);
+    expect(
+      tableBody.getByText("Google OAuth 2.0"),
+    ).toBeTruthy();
+    expect(
+      tableBody.getByText("Google Analytics 4"),
+    ).toBeTruthy();
+    expect(
+      tableBody.getByText(/DynamoDB, Lambda/),
+    ).toBeTruthy();
+    expect(tableBody.getByText("us-east-1 (United States)")).toBeTruthy();
+  });
+
+  it("renders column headers", async () => {
+    await act(async () => renderInRouter());
+    expect(screen.getByText("Subprocessor")).toBeTruthy();
+    expect(screen.getByText("Purpose")).toBeTruthy();
+    expect(screen.getByText("Data processed")).toBeTruthy();
+    expect(screen.getByText("Location")).toBeTruthy();
+  });
+
+  it("includes the change-notification commitment", async () => {
+    await act(async () => renderInRouter());
+    expect(screen.getByText(/Notification of changes/)).toBeTruthy();
+    expect(screen.getByText(/30 days' advance notice/)).toBeTruthy();
+  });
+
+  it("links back to the Privacy Policy", async () => {
+    const { container } = await act(async () => renderInRouter());
+    const main = container.querySelector("main");
+    const link = within(main).getByText("Privacy Policy");
+    expect(link.getAttribute("href")).toBe("/privacy");
+  });
+});

--- a/ui/src/components/TermsPage.jsx
+++ b/ui/src/components/TermsPage.jsx
@@ -133,8 +133,8 @@ export default function TermsPage() {
           <Section title="10. Contact">
             <p>
               Questions about these Terms? Email us at{" "}
-              <a href="mailto:hello@hive.so" className="text-brand no-underline hover:underline">
-                hello@hive.so
+              <a href="mailto:hello@warlordofmars.net" className="text-brand no-underline hover:underline">
+                hello@warlordofmars.net
               </a>
               .
             </p>

--- a/ui/src/components/UseCasesPage.jsx
+++ b/ui/src/components/UseCasesPage.jsx
@@ -10,29 +10,29 @@ const USE_CASES = [
     icon: BookOpen,
     title: "Remember project context across sessions",
     body: "Store architecture decisions, conventions, and open questions once. Every new Claude session picks up exactly where you left off — no more re-explaining the same context.",
-    snippet: `remember("auth uses JWT, tokens stored in DynamoDB with 24h TTL")
-remember("all API routes require Bearer token, except /health")`,
+    snippet: `You: "Remember that auth uses JWT — tokens in DynamoDB, 24h TTL."
+You: "Remember all API routes require a Bearer token, except /health."`,
   },
   {
     icon: Share2,
     title: "Share team knowledge with AI agents",
     body: "One Hive, many agents. Store shared conventions, runbooks, and team decisions so every team member's AI assistant draws from the same pool of knowledge.",
-    snippet: `remember("deploy via 'uv run inv deploy', never push directly to main")
-remember("on-call rotation: Mon–Wed Alice, Thu–Fri Bob")`,
+    snippet: `You: "Remember: deploy via 'uv run inv deploy', never push to main."
+You: "Remember the on-call rotation — Mon–Wed Alice, Thu–Fri Bob."`,
   },
   {
     icon: Bot,
     title: "Persistent preferences and instructions",
     body: "Store how you like to work — preferred code style, tone, output format — and every session with every MCP-compatible client respects those preferences automatically.",
-    snippet: `remember("always use TypeScript strict mode")
-remember("responses should be concise, no preamble")`,
+    snippet: `You: "Remember: always use TypeScript strict mode."
+You: "Remember: keep responses concise, no preamble."`,
   },
   {
     icon: Workflow,
     title: "Cross-tool memory for automated workflows",
     body: "Connect multiple AI tools to the same memory store. A workflow running in Cursor can leave context that a Claude Code session picks up — seamless handoffs across tools.",
-    snippet: `remember("migration v42 is pending, run after PR #108 merges")
-recall("pending migrations")`,
+    snippet: `You (in Cursor): "Remember migration v42 is pending — run after #108 merges."
+You (in Claude Code, later): "What pending migrations do I have?"`,
   },
 ];
 

--- a/ui/src/lib/consent.js
+++ b/ui/src/lib/consent.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+
+/**
+ * GA4 consent utilities. The marketing site must not load Google Analytics
+ * before the visitor has explicitly opted in (GDPR/CCPA). Both this module
+ * and the inline bootstrap in index.html gate on the `hive_ga_consent`
+ * localStorage key.
+ */
+
+export const CONSENT_KEY = "hive_ga_consent";
+export const CONSENT_RESET_EVENT = "hive:consent-reset";
+
+export function getConsent() {
+  try {
+    return globalThis.localStorage?.getItem(CONSENT_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function setConsent(value) {
+  try {
+    globalThis.localStorage?.setItem(CONSENT_KEY, value);
+  } catch {
+    /* private browsing / SSR — silently ignore */
+  }
+}
+
+export function clearConsent() {
+  try {
+    globalThis.localStorage?.removeItem(CONSENT_KEY);
+  } catch {
+    /* private browsing / SSR — silently ignore */
+  }
+}
+
+export function hasAcceptedConsent() {
+  return getConsent() === "accept";
+}
+
+export function loadGtag(measurementId) {
+  if (!measurementId) return;
+  const doc = globalThis.document;
+  if (!doc) return;
+  if (doc.querySelector("script[data-hive-ga]")) return;
+  const s = doc.createElement("script");
+  s.src = "https://www.googletagmanager.com/gtag/js?id=" + measurementId;
+  s.async = true;
+  s.dataset.hiveGa = "1";
+  doc.head.appendChild(s);
+  globalThis.dataLayer = globalThis.dataLayer || [];
+  function gtag() {
+    globalThis.dataLayer.push(arguments);
+  }
+  globalThis.gtag = gtag;
+  gtag("js", new Date());
+  gtag("config", measurementId, { send_page_view: false });
+}

--- a/ui/src/lib/consent.test.js
+++ b/ui/src/lib/consent.test.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CONSENT_KEY,
+  CONSENT_RESET_EVENT,
+  clearConsent,
+  getConsent,
+  hasAcceptedConsent,
+  loadGtag,
+  setConsent,
+} from "./consent.js";
+
+describe("consent utilities", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("getConsent returns null when unset", () => {
+    expect(getConsent()).toBeNull();
+  });
+
+  it("setConsent/getConsent round-trip", () => {
+    setConsent("accept");
+    expect(getConsent()).toBe("accept");
+  });
+
+  it("clearConsent removes the stored value", () => {
+    setConsent("reject");
+    clearConsent();
+    expect(getConsent()).toBeNull();
+  });
+
+  it("hasAcceptedConsent is true only for 'accept'", () => {
+    expect(hasAcceptedConsent()).toBe(false);
+    setConsent("reject");
+    expect(hasAcceptedConsent()).toBe(false);
+    setConsent("accept");
+    expect(hasAcceptedConsent()).toBe(true);
+  });
+
+  it("swallows localStorage errors from get", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(getConsent()).toBeNull();
+  });
+
+  it("swallows localStorage errors from set", () => {
+    vi.stubGlobal("localStorage", {
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(() => setConsent("accept")).not.toThrow();
+  });
+
+  it("swallows localStorage errors from remove", () => {
+    vi.stubGlobal("localStorage", {
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    });
+    expect(() => clearConsent()).not.toThrow();
+  });
+
+  it("CONSENT_KEY and CONSENT_RESET_EVENT are stable strings", () => {
+    expect(CONSENT_KEY).toBe("hive_ga_consent");
+    expect(CONSENT_RESET_EVENT).toBe("hive:consent-reset");
+  });
+
+  describe("loadGtag", () => {
+    beforeEach(() => {
+      document
+        .querySelectorAll("script[data-hive-ga]")
+        .forEach((s) => s.remove());
+      delete globalThis.gtag;
+      delete globalThis.dataLayer;
+    });
+
+    it("is a no-op when no measurement id is given", () => {
+      loadGtag("");
+      expect(document.querySelector("script[data-hive-ga]")).toBeNull();
+    });
+
+    it("injects the gtag script and initialises gtag()", () => {
+      loadGtag("G-TESTID");
+      const s = document.querySelector("script[data-hive-ga]");
+      expect(s).not.toBeNull();
+      expect(s.src).toContain("googletagmanager.com/gtag/js?id=G-TESTID");
+      expect(typeof globalThis.gtag).toBe("function");
+      expect(Array.isArray(globalThis.dataLayer)).toBe(true);
+    });
+
+    it("does not inject the script twice", () => {
+      loadGtag("G-TESTID");
+      loadGtag("G-TESTID");
+      expect(document.querySelectorAll("script[data-hive-ga]")).toHaveLength(1);
+    });
+
+    it("is a no-op when document is missing", () => {
+      vi.stubGlobal("document", undefined);
+      expect(() => loadGtag("G-TESTID")).not.toThrow();
+    });
+  });
+});

--- a/ui/src/lib/limits.js
+++ b/ui/src/lib/limits.js
@@ -1,0 +1,4 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+// Free tier quotas surfaced in marketing copy. Must stay in sync with
+// DEFAULT_QUOTA_MAX_MEMORIES in src/hive/quota.py.
+export const FREE_TIER_MEMORY_LIMIT = 500;


### PR DESCRIPTION
Release v0.21.0.

Closes milestone `v0.21` — all 7 issues merged to `development`. See [CHANGELOG.md](https://github.com/warlordofmars/hive/blob/release/v0.21.0/CHANGELOG.md) for the full entry.

## Scope highlights

- **MCP surface:** 4 new tools (`ping`, `list_tags`, `relate_memories`, `remember_if_absent`), size-cap on `remember`, filter/threshold params on `search_memories`, annotations + titles on every tool, attribution surfaced on list/search responses.
- **Compliance:** GDPR data export (`GET /api/account/export`), opt-in GA4 consent banner, `/subprocessors` page, CSP-RO + full security headers, domain-reference fix.
- **Observability:** new alarm coverage (Lambda throttles, DDB user-errors, auth failures), OK actions + alarm runbook, backup/restore runbook.
- **DX/CI:** `main`-branch guard, Dependabot daily+auto-merge, SEO robots+sitemap, OG+Twitter Card meta, URL-based Claude Desktop / ChatGPT setup.

## Merge strategy

**Use merge commit (`--merge`), not squash.** This preserves the squashed-commit history already on `development`. The prod pipeline on push to `main` will:
1. Create the GitHub release + `v0.21.0` tag.
2. Deploy to prod.
3. Back-merge `main` → `development`.

Do **not** run `gh release create` manually — the pipeline owns it.