### PR TITLE
feat: track recall_count and last_accessed_at on memory items

### DIFF
--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -59,6 +59,8 @@ class Memory(BaseModel):
     owner_client_id: str  # which OAuth client owns this memory
     owner_user_id: str | None = None  # which user owns this memory (None for pre-migration items)
     expires_at: datetime | None = None  # optional TTL; None means never expires
+    recall_count: int = 0  # incremented on every successful recall
+    last_accessed_at: datetime | None = None  # set on every successful recall
 
     # ------------------------------------------------------------------
     # DynamoDB serialisation
@@ -76,6 +78,7 @@ class Memory(BaseModel):
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
             "owner_client_id": self.owner_client_id,
+            "recall_count": self.recall_count,
             # GSI: look up by key across all memories
             "GSI1PK": f"KEY#{self.key}",
             "GSI1SK": self.memory_id,
@@ -85,6 +88,8 @@ class Memory(BaseModel):
         if self.expires_at is not None:
             item["expires_at"] = self.expires_at.isoformat()
             item["ttl"] = int(self.expires_at.timestamp())
+        if self.last_accessed_at is not None:
+            item["last_accessed_at"] = self.last_accessed_at.isoformat()
         return item
 
     def to_dynamo_tag_items(self) -> list[dict[str, Any]]:
@@ -110,6 +115,9 @@ class Memory(BaseModel):
         expires_at = None
         if ea := item.get("expires_at"):
             expires_at = datetime.fromisoformat(ea)
+        last_accessed_at = None
+        if la := item.get("last_accessed_at"):
+            last_accessed_at = datetime.fromisoformat(la)
         return cls(
             memory_id=item["memory_id"],
             key=item["key"],
@@ -120,6 +128,8 @@ class Memory(BaseModel):
             owner_client_id=item["owner_client_id"],
             owner_user_id=item.get("owner_user_id"),
             expires_at=expires_at,
+            recall_count=int(item.get("recall_count", 0) or 0),
+            last_accessed_at=last_accessed_at,
         )
 
     @property
@@ -555,6 +565,8 @@ class MemoryResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     expires_at: datetime | None = None
+    recall_count: int = 0
+    last_accessed_at: datetime | None = None
 
     @classmethod
     def from_memory(cls, m: Memory) -> MemoryResponse:
@@ -566,6 +578,8 @@ class MemoryResponse(BaseModel):
             created_at=m.created_at,
             updated_at=m.updated_at,
             expires_at=m.expires_at,
+            recall_count=m.recall_count,
+            last_accessed_at=m.last_accessed_at,
         )
 
 
@@ -789,6 +803,8 @@ class MemorySearchResult(BaseModel):
     score: float  # cosine similarity (0.0–1.0); higher = more relevant
     created_at: datetime
     updated_at: datetime
+    recall_count: int = 0
+    last_accessed_at: datetime | None = None
 
     @classmethod
     def from_memory_and_score(cls, m: Memory, score: float) -> MemorySearchResult:
@@ -801,4 +817,6 @@ class MemorySearchResult(BaseModel):
             score=score,
             created_at=m.created_at,
             updated_at=m.updated_at,
+            recall_count=m.recall_count,
+            last_accessed_at=m.last_accessed_at,
         )

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -447,7 +447,9 @@ async def recall(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
 
-    memory = storage.get_memory_by_key(key)
+    # record_recall atomically bumps recall_count + last_accessed_at and
+    # returns the updated Memory (None if missing/expired).
+    memory = storage.record_recall(key)
     if memory is None:
         logger.warning(
             "Memory not found for key '%s'",
@@ -718,6 +720,10 @@ async def list_memories(
                 "value": m.value,
                 "tags": m.tags,
                 "owner_client_id": m.owner_client_id,
+                "recall_count": m.recall_count,
+                "last_accessed_at": (
+                    m.last_accessed_at.isoformat() if m.last_accessed_at else None
+                ),
             }
             for m in memories
         ],

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -167,10 +167,9 @@ class HiveStorage:
             ExpressionAttributeValues={":now": now_iso, ":one": Decimal("1")},
             ReturnValues="ALL_NEW",
         )
-        item = updated.get("Attributes")
-        if item is None:
-            return None
-        memory = Memory.from_dynamo(item)
+        # ALL_NEW always populates Attributes once the KeyIndex lookup above
+        # has confirmed the item exists, so there's no "None" path to guard.
+        memory = Memory.from_dynamo(updated["Attributes"])
         if memory.is_expired:
             return None
         return memory

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -143,6 +143,38 @@ class HiveStorage:
         memory_id = items[0]["memory_id"]
         return self.get_memory_by_id(memory_id)
 
+    def record_recall(self, key: str) -> Memory | None:
+        """Atomically increment ``recall_count`` and refresh ``last_accessed_at``
+        on the memory with the given key, returning the updated Memory.
+
+        Returns ``None`` if the key doesn't exist or the memory is expired.
+        Does the work in a single DynamoDB ``update_item`` (with ``ALL_NEW``
+        return values) so we don't pay two round-trips per recall.
+        """
+        resp = self.table.query(
+            IndexName="KeyIndex",
+            KeyConditionExpression=Key("GSI1PK").eq(f"KEY#{key}"),
+            Limit=1,
+        )
+        items = resp.get("Items", [])
+        if not items:
+            return None
+        memory_id = items[0]["memory_id"]
+        now_iso = _now().isoformat()
+        updated = self.table.update_item(
+            Key={"PK": f"MEMORY#{memory_id}", "SK": "META"},
+            UpdateExpression=("SET last_accessed_at = :now ADD recall_count :one"),
+            ExpressionAttributeValues={":now": now_iso, ":one": Decimal("1")},
+            ReturnValues="ALL_NEW",
+        )
+        item = updated.get("Attributes")
+        if item is None:
+            return None
+        memory = Memory.from_dynamo(item)
+        if memory.is_expired:
+            return None
+        return memory
+
     def delete_memory(self, memory_id: str) -> bool:
         """Delete a memory and all its tag items. Returns True if found."""
         existing = self._get_memory_meta(memory_id)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -53,6 +53,40 @@ class TestMemory:
         m = Memory(key="k", value="v", owner_client_id="c1")
         assert m.to_dynamo_tag_items() == []
 
+    def test_default_recall_fields(self):
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        assert m.recall_count == 0
+        assert m.last_accessed_at is None
+
+    def test_recall_fields_persist_and_roundtrip(self):
+        from datetime import datetime, timezone
+
+        accessed = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+        m = Memory(
+            key="k",
+            value="v",
+            owner_client_id="c1",
+            recall_count=7,
+            last_accessed_at=accessed,
+        )
+        item = m.to_dynamo_meta()
+        assert item["recall_count"] == 7
+        assert item["last_accessed_at"] == accessed.isoformat()
+        m2 = Memory.from_dynamo(item)
+        assert m2.recall_count == 7
+        assert m2.last_accessed_at == accessed
+
+    def test_from_dynamo_tolerates_missing_recall_fields(self):
+        # Items written before this field existed won't have recall_count or
+        # last_accessed_at; Memory.from_dynamo must default them cleanly.
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        item = m.to_dynamo_meta()
+        item.pop("recall_count", None)
+        item.pop("last_accessed_at", None)
+        m2 = Memory.from_dynamo(item)
+        assert m2.recall_count == 0
+        assert m2.last_accessed_at is None
+
 
 class TestOAuthClient:
     def test_defaults(self):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -440,6 +440,25 @@ class TestRecall:
         with pytest.raises(ToolError, match="No memory found"):
             await recall("no-such-key", ctx=_make_ctx(jwt))
 
+    async def test_recall_bumps_recall_count_and_last_accessed_at(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import recall, remember
+
+        await remember("rec-counter", "v", [], ctx=_make_ctx(jwt))
+        before = storage.get_memory_by_key("rec-counter")
+        assert before.recall_count == 0
+        assert before.last_accessed_at is None
+
+        await recall("rec-counter", ctx=_make_ctx(jwt))
+        after_first = storage.get_memory_by_key("rec-counter")
+        assert after_first.recall_count == 1
+        assert after_first.last_accessed_at is not None
+
+        await recall("rec-counter", ctx=_make_ctx(jwt))
+        after_second = storage.get_memory_by_key("rec-counter")
+        assert after_second.recall_count == 2
+        assert after_second.last_accessed_at >= after_first.last_accessed_at
+
 
 # ---------------------------------------------------------------------------
 # forget
@@ -485,6 +504,21 @@ class TestListMemories:
         assert "lst-b" not in keys
         # Agent attribution is surfaced on every item.
         assert result["items"][0]["owner_client_id"] == client_id
+        # Usage metrics are surfaced too; fresh memories have count=0, no access.
+        assert result["items"][0]["recall_count"] == 0
+        assert result["items"][0]["last_accessed_at"] is None
+
+    async def test_list_memories_surfaces_recall_metrics_after_recall(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_memories, recall, remember
+
+        await remember("bumped", "v", ["alpha"], ctx=_make_ctx(jwt))
+        await recall("bumped", ctx=_make_ctx(jwt))
+
+        result = await list_memories("alpha", ctx=_make_ctx(jwt))
+        item = next(x for x in result["items"] if x["key"] == "bumped")
+        assert item["recall_count"] == 1
+        assert item["last_accessed_at"] is not None
 
     async def test_list_empty_tag_returns_empty(self, server_env):
         _, _, jwt = server_env

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -259,6 +259,35 @@ class TestMemoryStorage:
         result = storage.get_memory_by_key("expired-key2")
         assert result is None
 
+    def test_record_recall_increments_count_and_sets_timestamp(self, storage):
+        m = Memory(key="recall-k", value="v", owner_client_id="c1")
+        storage.put_memory(m)
+
+        first = storage.record_recall("recall-k")
+        assert first is not None
+        assert first.recall_count == 1
+        assert first.last_accessed_at is not None
+
+        second = storage.record_recall("recall-k")
+        assert second is not None
+        assert second.recall_count == 2
+        assert second.last_accessed_at is not None
+        assert second.last_accessed_at >= first.last_accessed_at
+
+    def test_record_recall_returns_none_for_missing_key(self, storage):
+        assert storage.record_recall("does-not-exist") is None
+
+    def test_record_recall_returns_none_for_expired_memory(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        past = datetime.now(timezone.utc) - timedelta(seconds=1)
+        storage.put_memory(
+            Memory(key="expired-recall", value="v", owner_client_id="c1", expires_at=past)
+        )
+        # update_item still runs, but record_recall returns None because the
+        # memory is past its TTL (matches get_memory_by_key behaviour).
+        assert storage.record_recall("expired-recall") is None
+
     def test_memory_serialise_ttl_in_dynamo(self):
         from datetime import datetime, timedelta, timezone
 


### PR DESCRIPTION
Closes #394

## Summary

Every Memory now tracks two usage metrics:

- `recall_count: int = 0` — incremented on every successful `recall`
- `last_accessed_at: datetime | None` — set on every successful `recall`

The fields are persisted to DynamoDB on the `META` item, `from_dynamo` tolerates older items missing them, and they flow through `MemoryResponse` (REST) and `MemorySearchResult` (MCP search) automatically. `list_memories` items also pick them up.

## Implementation

- **`Memory` model** — two new fields with safe defaults; `to_dynamo_meta` serialises both; `from_dynamo` reads them with a `recall_count=0 / last_accessed_at=None` fallback for items written pre-migration.
- **`HiveStorage.record_recall(key)`** — single `update_item` with `ADD recall_count :one` + `SET last_accessed_at = :now` and `ReturnValues=ALL_NEW`. Returns the updated `Memory` (or `None` if the key is missing / the memory is expired). Replaces the `get_memory_by_key` call in the MCP `recall` tool, so the recall path is still one round-trip.
- **Response surfaces** — `MemoryResponse`, `MemorySearchResult`, and the `list_memories` MCP response items all get the two new fields. No existing consumer needs updating — defaults make the schema additive.

## Tests

- **Model:** default values, round-trip through `to_dynamo_meta` / `from_dynamo`, and tolerance for items missing the new fields.
- **Storage:** `record_recall` bumps the counter, sets the timestamp, and the second call increments again; returns `None` for a missing key and for an expired memory.
- **Server:** `recall` tool leaves `recall_count=0, last_accessed_at=None` on a fresh memory, bumps to 1 after one call and 2 after two; `list_memories` surfaces the updated metrics after a recall.

`uv run inv pre-push` green (604 vitest + 546 pytest).

## Downstream unlocks

- UI: sort memories in the browser by most/least recently used or by recall frequency (already surfaced in the list response).
- Memory-decay scoring (#387 when it lands): can factor in staleness + frequency.
- Dead-memory identification: filter `recall_count == 0` + `last_accessed_at is null` to surface memories that have never been read.