### PR TITLE
feat: surface remaining quota + rate-limit on every tool response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) f
 
 _Changes accumulated on `development` since v0.21.0. Will be rolled into the next release._
 
+### Added
+
+- Every MCP tool response now carries the caller's quota and rate-limit state under a top-level `_meta.hive` block (`memory_quota.{used,limit,remaining}` + `rate_limit.{per_minute_limit,per_day_limit}`), so well-behaved agents can self-throttle before hitting a hard limit. New docs page `/docs/concepts/quotas` documents the schema. `memory_history` now returns `{versions, count}` instead of a bare list so the structured-content envelope is consistent across tools. (#453)
+
 ## v0.21.0 — 2026-04-18
 
 ### Added

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -98,6 +98,7 @@ export default defineConfig({
           { text: "How memory scoping works", link: "/concepts/memory-scoping" },
           { text: "Tags and organisation", link: "/concepts/tags" },
           { text: "Key naming conventions", link: "/concepts/key-conventions" },
+          { text: "Quotas and rate limits", link: "/concepts/quotas" },
         ],
       },
       {

--- a/docs-site/concepts/quotas.md
+++ b/docs-site/concepts/quotas.md
@@ -1,0 +1,67 @@
+# Quotas and rate limits
+
+Every Hive tool response carries the caller's current quota usage and rate-limit configuration under a top-level `_meta.hive` block. Well-behaved agents can read this to self-throttle before they hit a hard limit.
+
+## Response shape
+
+Every MCP tool call returns metadata alongside the usual result:
+
+```json
+{
+  "content": [...],
+  "structuredContent": {...},
+  "_meta": {
+    "hive": {
+      "memory_quota": {
+        "used": 42,
+        "limit": 500,
+        "remaining": 458
+      },
+      "rate_limit": {
+        "per_minute_limit": 60,
+        "per_day_limit": 10000
+      }
+    }
+  }
+}
+```
+
+The `_meta.hive` block is present on **every** Hive tool response, including error-adjacent paths like "no memories found" or vector-index-missing.
+
+## Fields
+
+### `memory_quota`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `used` | int | Number of memories currently owned by the caller's user |
+| `limit` | int | Hard cap on memories per user (default 500) |
+| `remaining` | int | `max(0, limit - used)` |
+
+When `remaining` hits zero, the next `remember` call for a new key will raise a `ToolError` with a quota-exceeded message. Updates to existing memories do not consume quota.
+
+### `rate_limit`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `per_minute_limit` | int | Maximum tool calls per minute per client (default 60) |
+| `per_day_limit` | int | Maximum tool calls per day per client (default 10000) |
+
+The rate-limit block reports the configured limits, not the caller's remaining budget. Current consumption isn't returned because it would cost extra DynamoDB reads on every response. If you hit the limit, the next call raises a `ToolError` with a `Retry after Ns` hint.
+
+## Use cases
+
+- **Self-throttling agents** — back off proactively when `memory_quota.remaining` falls below a threshold, rather than waiting for a hard error
+- **Fleet dashboards** — aggregate `used` across clients to visualise per-user usage without hitting the management API
+- **Write-planning** — an agent about to store a batch of memories can check `remaining` and pick which ones to keep if the batch would overflow
+
+## Overrides
+
+Both quota and rate limits are configurable via environment variables on the Hive server:
+
+- `HIVE_QUOTA_MAX_MEMORIES` — memory quota per user
+- `HIVE_QUOTA_EXEMPT_USERS` — comma-separated user IDs that skip the memory quota check
+- `HIVE_RATE_LIMIT_RPM` — per-minute rate limit
+- `HIVE_RATE_LIMIT_RPD` — per-day rate limit
+
+Exempt users still receive the metadata block — the `limit` and `remaining` values reflect the baseline config, not the bypass.

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -28,6 +28,7 @@ from fastmcp.exceptions import ToolError
 from fastmcp.server.auth import AccessToken as FastMCPAccessToken
 from fastmcp.server.auth import RemoteAuthProvider, TokenVerifier
 from fastmcp.server.dependencies import get_http_request
+from fastmcp.tools.tool import ToolResult
 from pydantic import AnyHttpUrl
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
@@ -37,8 +38,13 @@ from hive.auth.tokens import ISSUER, _origin_verify_secret, validate_bearer_toke
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 from hive.metrics import emit_metric
 from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult
-from hive.quota import QuotaExceeded, check_memory_quota
-from hive.rate_limiter import RateLimitExceeded, check_rate_limit
+from hive.quota import QuotaExceeded, check_memory_quota, get_memory_limit
+from hive.rate_limiter import (
+    DEFAULT_RATE_LIMIT_RPD,
+    DEFAULT_RATE_LIMIT_RPM,
+    RateLimitExceeded,
+    check_rate_limit,
+)
 from hive.storage import HiveStorage
 from hive.vector_store import VectorIndexNotFoundError, VectorStore
 
@@ -187,6 +193,47 @@ def _vector_store() -> VectorStore:
 
 
 # ---------------------------------------------------------------------------
+# Response metadata — every tool response carries quota + rate-limit state
+# under ``_meta.hive`` so well-behaved agents can self-throttle.
+# ---------------------------------------------------------------------------
+
+
+def _quota_meta(storage: HiveStorage, client_id: str) -> dict[str, Any]:
+    """Build the ``_meta.hive`` block from the caller's current quota state."""
+    client = storage.get_client(client_id)
+    owner_user_id = client.owner_user_id if client else None
+    memory_limit = get_memory_limit()
+    used = storage.count_memories(owner_user_id=owner_user_id) if owner_user_id else 0
+    return {
+        "hive": {
+            "memory_quota": {
+                "used": used,
+                "limit": memory_limit,
+                "remaining": max(0, memory_limit - used),
+            },
+            "rate_limit": {
+                "per_minute_limit": int(
+                    os.environ.get("HIVE_RATE_LIMIT_RPM", str(DEFAULT_RATE_LIMIT_RPM))
+                ),
+                "per_day_limit": int(
+                    os.environ.get("HIVE_RATE_LIMIT_RPD", str(DEFAULT_RATE_LIMIT_RPD))
+                ),
+            },
+        }
+    }
+
+
+def _tool_result(payload: Any, storage: HiveStorage, client_id: str) -> ToolResult:
+    """Wrap a tool's return value in an MCP ``ToolResult`` carrying quota +
+    rate-limit metadata in ``_meta.hive``. Strings become text content;
+    dicts become structured content so clients can still use them directly."""
+    meta = _quota_meta(storage, client_id)
+    if isinstance(payload, dict):
+        return ToolResult(structured_content=payload, meta=meta)
+    return ToolResult(content=payload, meta=meta)
+
+
+# ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
 
@@ -201,9 +248,9 @@ async def ping(ctx: Context | None = None) -> str:
     Performs no storage reads or writes. A successful call confirms both
     connectivity to the MCP server and that the caller's token is still valid.
     """
-    await _auth(ctx)
+    storage, client_id = await _auth(ctx)
     await emit_metric("ToolInvocations", operation="ping")
-    return "ok"
+    return _tool_result("ok", storage, client_id)
 
 
 @mcp.tool(
@@ -263,7 +310,7 @@ async def remember(
                     "status": "unchanged",
                 },
             )
-            return f"Memory '{key}' unchanged."
+            return _tool_result(f"Memory '{key}' unchanged.", storage, client_id)
         existing.value = value
         existing.tags = tags
         existing.expires_at = expires_at
@@ -323,7 +370,7 @@ async def remember(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="remember"
     )
-    return f"{action} memory '{key}'."
+    return _tool_result(f"{action} memory '{key}'.", storage, client_id)
 
 
 @mcp.tool(
@@ -386,7 +433,7 @@ async def remember_if_absent(
             },
         )
         await emit_metric("ToolInvocations", operation="remember_if_absent")
-        return f"Memory '{key}' already exists — not overwritten."
+        return _tool_result(f"Memory '{key}' already exists — not overwritten.", storage, client_id)
 
     client = storage.get_client(client_id)
     owner_user_id = client.owner_user_id if client else None
@@ -432,7 +479,7 @@ async def remember_if_absent(
         unit="Milliseconds",
         operation="remember_if_absent",
     )
-    return f"Stored memory '{key}'."
+    return _tool_result(f"Stored memory '{key}'.", storage, client_id)
 
 
 @mcp.tool(
@@ -484,7 +531,7 @@ async def recall(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="recall"
     )
-    return memory.value
+    return _tool_result(memory.value, storage, client_id)
 
 
 @mcp.tool(
@@ -544,7 +591,7 @@ async def forget(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="forget"
     )
-    return f"Deleted memory '{key}'."
+    return _tool_result(f"Deleted memory '{key}'.", storage, client_id)
 
 
 @mcp.tool(
@@ -590,7 +637,7 @@ async def forget_all(
         unit="Milliseconds",
         operation="forget_all",
     )
-    return f"Deleted {deleted} memories with tag '{tag}'."
+    return _tool_result(f"Deleted {deleted} memories with tag '{tag}'.", storage, client_id)
 
 
 @mcp.tool(
@@ -600,7 +647,7 @@ async def forget_all(
 async def memory_history(
     key: Annotated[str, "Key of the memory to retrieve history for"],
     ctx: Context | None = None,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     """Return the version history of a memory (previous values before each overwrite)."""
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope="memories:read")
@@ -617,7 +664,7 @@ async def memory_history(
         unit="Milliseconds",
         operation="memory_history",
     )
-    return [
+    items = [
         {
             "version_timestamp": v.version_timestamp,
             "value": v.value,
@@ -626,6 +673,7 @@ async def memory_history(
         }
         for v in versions
     ]
+    return _tool_result({"versions": items, "count": len(items)}, storage, client_id)
 
 
 @mcp.tool(
@@ -672,7 +720,9 @@ async def restore_memory(
         unit="Milliseconds",
         operation="restore_memory",
     )
-    return f"Restored memory '{key}' to version '{version_timestamp}'."
+    return _tool_result(
+        f"Restored memory '{key}' to version '{version_timestamp}'.", storage, client_id
+    )
 
 
 @mcp.tool(
@@ -732,7 +782,7 @@ async def list_memories(
     }
     if next_cursor:
         result["next_cursor"] = next_cursor
-    return result
+    return _tool_result(result, storage, client_id)
 
 
 @mcp.tool(
@@ -762,7 +812,7 @@ async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="list_tags"
     )
-    return {"tags": tags, "count": len(tags)}
+    return _tool_result({"tags": tags, "count": len(tags)}, storage, client_id)
 
 
 @mcp.tool(
@@ -795,7 +845,7 @@ async def summarize_context(
             },
         )
         await emit_metric("ToolInvocations", operation="summarize_context")
-        return f"No memories found for topic '{topic}'."
+        return _tool_result(f"No memories found for topic '{topic}'.", storage, client_id)
 
     lines = [f"## Memories tagged '{topic}'\n"]
     for m in memories:
@@ -831,7 +881,7 @@ async def summarize_context(
         unit="Milliseconds",
         operation="summarize_context",
     )
-    return "\n".join(lines)
+    return _tool_result("\n".join(lines), storage, client_id)
 
 
 @mcp.tool(
@@ -871,10 +921,10 @@ async def search_memories(
     try:
         pairs = _vector_store().search(query, client_id, top_k=search_top_k)
     except VectorIndexNotFoundError:
-        return {"items": [], "count": 0, "query": query}
+        return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
     except Exception:
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
-        return {"items": [], "count": 0, "query": query}
+        return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
 
     if threshold is not None:
         pairs = [(mid, score) for mid, score in pairs if score >= threshold]
@@ -911,13 +961,18 @@ async def search_memories(
         unit="Milliseconds",
         operation="search_memories",
     )
-    return {
-        "items": [
-            MemorySearchResult.from_memory_and_score(m, score).model_dump() for m, score in results
-        ],
-        "count": len(results),
-        "query": query,
-    }
+    return _tool_result(
+        {
+            "items": [
+                MemorySearchResult.from_memory_and_score(m, score).model_dump()
+                for m, score in results
+            ],
+            "count": len(results),
+            "query": query,
+        },
+        storage,
+        client_id,
+    )
 
 
 @mcp.tool(
@@ -947,10 +1002,10 @@ async def relate_memories(
         # Fetch top_k+1 so that dropping the source still leaves up to top_k.
         pairs = _vector_store().search(memory.value, client_id, top_k=top_k + 1)
     except VectorIndexNotFoundError:
-        return {"items": [], "count": 0, "key": key}
+        return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
     except Exception:
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
-        return {"items": [], "count": 0, "key": key}
+        return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
 
     pairs = [(mid, score) for mid, score in pairs if mid != memory.memory_id][:top_k]
     results = storage.hydrate_memory_ids(pairs)
@@ -980,13 +1035,18 @@ async def relate_memories(
         unit="Milliseconds",
         operation="relate_memories",
     )
-    return {
-        "items": [
-            MemorySearchResult.from_memory_and_score(m, score).model_dump() for m, score in results
-        ],
-        "count": len(results),
-        "key": key,
-    }
+    return _tool_result(
+        {
+            "items": [
+                MemorySearchResult.from_memory_and_score(m, score).model_dump()
+                for m, score in results
+            ],
+            "count": len(results),
+            "key": key,
+        },
+        storage,
+        client_id,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -26,6 +26,16 @@ def _make_context(token_str: str):
     return ctx
 
 
+def _text(r) -> str:
+    """Extract text payload from a ToolResult."""
+    return r.content[0].text
+
+
+def _body(r) -> dict:
+    """Extract structured content from a ToolResult."""
+    return r.structured_content
+
+
 @pytest.fixture(scope="module")
 def setup():
     """Set up DynamoDB Local table + a valid token for MCP tool calls."""
@@ -118,10 +128,10 @@ class TestMCPTools:
         jwt = setup
         ctx = _make_context(jwt)
         result = await remember(key="greeting", value="Hello, Hive!", tags=["test"], ctx=ctx)
-        assert "greeting" in result
+        assert "greeting" in _text(result)
 
         recalled = await recall(key="greeting", ctx=ctx)
-        assert recalled == "Hello, Hive!"
+        assert _text(recalled) == "Hello, Hive!"
 
     async def test_forget(self, setup):
         from fastmcp.exceptions import ToolError
@@ -132,7 +142,7 @@ class TestMCPTools:
         ctx = _make_context(jwt)
         await remember(key="temp", value="ephemeral", ctx=ctx)
         result = await forget(key="temp", ctx=ctx)
-        assert "temp" in result
+        assert "temp" in _text(result)
 
         with pytest.raises(ToolError):
             await recall(key="temp", ctx=ctx)
@@ -146,7 +156,7 @@ class TestMCPTools:
         await remember(key="list-b", value="B", tags=["listtest"], ctx=ctx)
 
         result = await list_memories(tag="listtest", ctx=ctx)
-        keys = [m["key"] for m in result["items"]]
+        keys = [m["key"] for m in _body(result)["items"]]
         assert "list-a" in keys
         assert "list-b" in keys
 
@@ -159,5 +169,6 @@ class TestMCPTools:
         await remember(key="s2", value="Summary value 2", tags=["summary"], ctx=ctx)
 
         result = await summarize_context(topic="summary", ctx=ctx)
-        assert "summary" in result.lower()
-        assert "s1" in result or "s2" in result
+        text = _text(result)
+        assert "summary" in text.lower()
+        assert "s1" in text or "s2" in text

--- a/tests/unit/test_quota.py
+++ b/tests/unit/test_quota.py
@@ -189,6 +189,9 @@ class TestMcpQuotaIntegration:
             existing_memory.tags = []
             instance = MockStorage.return_value
             instance.get_memory_by_key.return_value = existing_memory
+            # Response-meta builder reads count_memories; return a real int.
+            instance.count_memories.return_value = 0
+            instance.get_client.return_value = None
 
             from hive.server import remember
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -78,6 +78,21 @@ def _make_ctx(jwt: str) -> MagicMock:
     return ctx
 
 
+def _text(r) -> str:
+    """Extract text payload from a ToolResult (for string-returning tools)."""
+    return r.content[0].text
+
+
+def _body(r) -> dict:
+    """Extract structured content from a ToolResult (for dict-returning tools)."""
+    return r.structured_content
+
+
+def _hive_meta(r) -> dict:
+    """Extract the ``_meta.hive`` quota/rate-limit block from a ToolResult."""
+    return r.meta["hive"]
+
+
 @pytest.fixture()
 def server_env():
     """moto-backed storage + valid JWT for MCP tool tests."""
@@ -125,7 +140,11 @@ class TestPing:
         from hive.server import ping
 
         result = await ping(ctx=_make_ctx(jwt))
-        assert result == "ok"
+        assert _text(result) == "ok"
+        # Every tool response carries quota + rate-limit state under _meta.hive
+        meta = _hive_meta(result)
+        assert "memory_quota" in meta
+        assert "rate_limit" in meta
 
     async def test_missing_auth_raises_tool_error(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -169,7 +188,7 @@ class TestRemember:
         from hive.server import remember
 
         result = await remember("my-key", "my-value", ["tag1"], ctx=_make_ctx(jwt))
-        assert result == "Stored memory 'my-key'."
+        assert _text(result) == "Stored memory 'my-key'."
         assert storage.get_memory_by_key("my-key") is not None
 
     async def test_update_existing_memory(self, server_env):
@@ -178,7 +197,7 @@ class TestRemember:
 
         await remember("upd-key", "original", [], ctx=_make_ctx(jwt))
         result = await remember("upd-key", "updated", ["new-tag"], ctx=_make_ctx(jwt))
-        assert result == "Updated memory 'upd-key'."
+        assert _text(result) == "Updated memory 'upd-key'."
         m = storage.get_memory_by_key("upd-key")
         assert m is not None
         assert m.value == "updated"
@@ -189,7 +208,7 @@ class TestRemember:
 
         await remember("same-key", "same-value", ["t"], ctx=_make_ctx(jwt))
         result = await remember("same-key", "same-value", ["t"], ctx=_make_ctx(jwt))
-        assert result == "Memory 'same-key' unchanged."
+        assert _text(result) == "Memory 'same-key' unchanged."
 
     async def test_missing_auth_raises_tool_error(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -213,7 +232,7 @@ class TestRemember:
         ctx = MagicMock()
         ctx.request_context.meta = meta
         result = await remember("pydantic-meta-key", "v", [], ctx=ctx)
-        assert result == "Stored memory 'pydantic-meta-key'."
+        assert _text(result) == "Stored memory 'pydantic-meta-key'."
 
     async def test_oversized_value_raises_tool_error(self, server_env):
         from unittest.mock import patch
@@ -238,7 +257,7 @@ class TestRemember:
         storage, _, jwt = server_env
         value = "x" * DEFAULT_MAX_VALUE_BYTES
         result = await remember("at-limit-key", value, [], ctx=_make_ctx(jwt))
-        assert result == "Stored memory 'at-limit-key'."
+        assert _text(result) == "Stored memory 'at-limit-key'."
 
     async def test_value_over_limit_raises_tool_error(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -276,14 +295,14 @@ class TestRemember:
                 await remember("custom-limit-key", "x" * 6, [], ctx=_make_ctx(jwt))
             # within the override limit is fine
             result = await remember("within-key", "x" * 5, [], ctx=_make_ctx(jwt))
-            assert result == "Stored memory 'within-key'."
+            assert _text(result) == "Stored memory 'within-key'."
 
     async def test_remember_with_ttl_sets_expires_at(self, server_env):
         storage, client_id, jwt = server_env
         from hive.server import remember
 
         result = await remember("ttl-key", "ttl-val", [], ttl_seconds=3600, ctx=_make_ctx(jwt))
-        assert result == "Stored memory 'ttl-key'."
+        assert _text(result) == "Stored memory 'ttl-key'."
         m = storage.get_memory_by_key("ttl-key")
         assert m is not None
         assert m.expires_at is not None
@@ -306,7 +325,7 @@ class TestRemember:
         assert m1 is not None
         # Second call with same value but no ttl should NOT be idempotent
         result = await remember("idem-ttl", "v", [], ttl_seconds=None, ctx=_make_ctx(jwt))
-        assert result == "Updated memory 'idem-ttl'."
+        assert _text(result) == "Updated memory 'idem-ttl'."
         m2 = storage.get_memory_by_key("idem-ttl")
         assert m2 is not None
         assert m2.expires_at is None
@@ -323,7 +342,7 @@ class TestRememberIfAbsent:
         from hive.server import remember_if_absent
 
         result = await remember_if_absent("ifa-new", "v", ["t"], ctx=_make_ctx(jwt))
-        assert result == "Stored memory 'ifa-new'."
+        assert _text(result) == "Stored memory 'ifa-new'."
         m = storage.get_memory_by_key("ifa-new")
         assert m is not None
         assert m.value == "v"
@@ -334,7 +353,7 @@ class TestRememberIfAbsent:
 
         await remember("ifa-dupe", "original", ["old"], ctx=_make_ctx(jwt))
         result = await remember_if_absent("ifa-dupe", "new-value", ["new"], ctx=_make_ctx(jwt))
-        assert result == "Memory 'ifa-dupe' already exists — not overwritten."
+        assert _text(result) == "Memory 'ifa-dupe' already exists — not overwritten."
         m = storage.get_memory_by_key("ifa-dupe")
         assert m.value == "original"
         assert set(m.tags) == {"old"}
@@ -404,7 +423,7 @@ class TestRememberIfAbsent:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await remember_if_absent("ifa-vs-fail", "v", ctx=_make_ctx(jwt))
 
-        assert result == "Stored memory 'ifa-vs-fail'."
+        assert _text(result) == "Stored memory 'ifa-vs-fail'."
 
     async def test_requires_write_scope(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -429,7 +448,7 @@ class TestRecall:
 
         await remember("rec-key", "the-value", [], ctx=_make_ctx(jwt))
         result = await recall("rec-key", ctx=_make_ctx(jwt))
-        assert result == "the-value"
+        assert _text(result) == "the-value"
 
     async def test_recall_nonexistent_raises(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -472,7 +491,7 @@ class TestForget:
 
         await remember("del-key", "v", [], ctx=_make_ctx(jwt))
         result = await forget("del-key", ctx=_make_ctx(jwt))
-        assert result == "Deleted memory 'del-key'."
+        assert _text(result) == "Deleted memory 'del-key'."
         assert storage.get_memory_by_key("del-key") is None
 
     async def test_forget_nonexistent_raises(self, server_env):
@@ -498,15 +517,16 @@ class TestListMemories:
         await remember("lst-a", "v1", ["alpha"], ctx=_make_ctx(jwt))
         await remember("lst-b", "v2", ["beta"], ctx=_make_ctx(jwt))
         result = await list_memories("alpha", ctx=_make_ctx(jwt))
-        assert "items" in result and "has_more" in result
-        keys = [m["key"] for m in result["items"]]
+        body = _body(result)
+        assert "items" in body and "has_more" in body
+        keys = [m["key"] for m in body["items"]]
         assert "lst-a" in keys
         assert "lst-b" not in keys
         # Agent attribution is surfaced on every item.
-        assert result["items"][0]["owner_client_id"] == client_id
+        assert body["items"][0]["owner_client_id"] == client_id
         # Usage metrics are surfaced too; fresh memories have count=0, no access.
-        assert result["items"][0]["recall_count"] == 0
-        assert result["items"][0]["last_accessed_at"] is None
+        assert body["items"][0]["recall_count"] == 0
+        assert body["items"][0]["last_accessed_at"] is None
 
     async def test_list_memories_surfaces_recall_metrics_after_recall(self, server_env):
         _, _, jwt = server_env
@@ -516,7 +536,7 @@ class TestListMemories:
         await recall("bumped", ctx=_make_ctx(jwt))
 
         result = await list_memories("alpha", ctx=_make_ctx(jwt))
-        item = next(x for x in result["items"] if x["key"] == "bumped")
+        item = next(x for x in _body(result)["items"] if x["key"] == "bumped")
         assert item["recall_count"] == 1
         assert item["last_accessed_at"] is not None
 
@@ -525,8 +545,9 @@ class TestListMemories:
         from hive.server import list_memories
 
         result = await list_memories("nonexistent-tag", ctx=_make_ctx(jwt))
-        assert result["items"] == []
-        assert result["has_more"] is False
+        body = _body(result)
+        assert body["items"] == []
+        assert body["has_more"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -545,14 +566,14 @@ class TestListTags:
         await remember("c", "3", [], ctx=ctx)
 
         result = await list_tags(ctx=ctx)
-        assert result == {"tags": ["alpha", "mango", "zebra"], "count": 3}
+        assert _body(result) == {"tags": ["alpha", "mango", "zebra"], "count": 3}
 
     async def test_empty_when_no_memories(self, server_env):
         _, _, jwt = server_env
         from hive.server import list_tags
 
         result = await list_tags(ctx=_make_ctx(jwt))
-        assert result == {"tags": [], "count": 0}
+        assert _body(result) == {"tags": [], "count": 0}
 
     async def test_scoped_to_caller_client(self, server_env):
         storage, client_id, jwt = server_env
@@ -566,7 +587,7 @@ class TestListTags:
         )
 
         result = await list_tags(ctx=_make_ctx(jwt))
-        assert result["tags"] == ["owned"]
+        assert _body(result)["tags"] == ["owned"]
 
     async def test_requires_read_scope(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -592,15 +613,16 @@ class TestSummarizeContext:
         await remember("sum-a", "detail about foo", ["foo"], ctx=_make_ctx(jwt))
         await remember("sum-b", "more about foo", ["foo"], ctx=_make_ctx(jwt))
         result = await summarize_context("foo", ctx=_make_ctx(jwt))
-        assert "foo" in result
-        assert "sum-a" in result or "detail about foo" in result
+        text = _text(result)
+        assert "foo" in text
+        assert "sum-a" in text or "detail about foo" in text
 
     async def test_summarize_no_memories(self, server_env):
         _, _, jwt = server_env
         from hive.server import summarize_context
 
         result = await summarize_context("nonexistent-topic", ctx=_make_ctx(jwt))
-        assert "No memories found" in result
+        assert "No memories found" in _text(result)
 
 
 # ---------------------------------------------------------------------------
@@ -663,7 +685,7 @@ class TestAuthHttpPath:
 
         with patch("hive.server.get_http_request", return_value=mock_request):
             result = await remember("http-path-key", "value", [], ctx=ctx)
-        assert "http-path-key" in result
+        assert "http-path-key" in _text(result)
 
 
 # ---------------------------------------------------------------------------
@@ -708,8 +730,9 @@ class TestListMemoriesPagination:
             await remember(f"pg-key-{i}", f"val-{i}", ["pagtest"], ctx=ctx)
 
         result = await list_memories("pagtest", limit=1, ctx=ctx)
-        assert result["has_more"] is True
-        assert "next_cursor" in result
+        body = _body(result)
+        assert body["has_more"] is True
+        assert "next_cursor" in body
 
 
 # ---------------------------------------------------------------------------
@@ -869,9 +892,10 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("searchable content", top_k=5, ctx=ctx)
 
-        assert result["count"] == 1
-        assert result["query"] == "searchable content"
-        item = result["items"][0]
+        body = _body(result)
+        assert body["count"] == 1
+        assert body["query"] == "searchable content"
+        item = body["items"][0]
         assert item["key"] == "search-key"
         assert item["score"] == 0.88
         assert item["owner_client_id"] == client_id
@@ -889,7 +913,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("anything", ctx=_make_ctx(jwt))
 
-        assert result == {"items": [], "count": 0, "query": "anything"}
+        assert _body(result) == {"items": [], "count": 0, "query": "anything"}
 
     async def test_caps_top_k_at_50(self, server_env):
         from unittest.mock import patch
@@ -931,8 +955,9 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("anything", min_score=0.5, ctx=ctx)
 
-        assert result["count"] == 1
-        assert [item["key"] for item in result["items"]] == ["hi-key"]
+        body = _body(result)
+        assert body["count"] == 1
+        assert [item["key"] for item in body["items"]] == ["hi-key"]
 
     async def test_min_score_none_returns_all(self, server_env):
         from unittest.mock import patch
@@ -950,7 +975,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", ctx=ctx)
 
-        assert result["count"] == 2
+        assert _body(result)["count"] == 2
 
     async def test_min_score_all_below_threshold_returns_empty(self, server_env):
         from unittest.mock import patch
@@ -966,7 +991,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", min_score=0.9, ctx=ctx)
 
-        assert result == {"items": [], "count": 0, "query": "q"}
+        assert _body(result) == {"items": [], "count": 0, "query": "q"}
 
     async def test_filter_tags_requires_all_tags(self, server_env):
         from unittest.mock import patch
@@ -988,9 +1013,10 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", filter_tags=["x", "y"], ctx=ctx)
 
+        body = _body(result)
         # Only "a" has both x and y
-        assert [item["key"] for item in result["items"]] == ["a"]
-        assert result["count"] == 1
+        assert [item["key"] for item in body["items"]] == ["a"]
+        assert body["count"] == 1
 
     async def test_filter_tags_none_returns_all(self, server_env):
         from unittest.mock import patch
@@ -1006,7 +1032,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", ctx=ctx)
 
-        assert result["count"] == 1
+        assert _body(result)["count"] == 1
 
     async def test_filter_tags_requests_wider_candidate_pool(self, server_env):
         from unittest.mock import patch
@@ -1040,8 +1066,9 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", top_k=2, filter_tags=["x"], ctx=ctx)
 
-        assert result["count"] == 2
-        assert [item["key"] for item in result["items"]] == ["k0", "k1"]
+        body = _body(result)
+        assert body["count"] == 2
+        assert [item["key"] for item in body["items"]] == ["k0", "k1"]
 
     async def test_min_score_clamped_to_unit_interval(self, server_env):
         from unittest.mock import patch
@@ -1058,14 +1085,14 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", min_score=5.0, ctx=ctx)
 
-        assert result["count"] == 1
+        assert _body(result)["count"] == 1
 
         # min_score < 0.0 gets clamped to 0.0; everything passes
         mock_vs2 = _make_mock_vector_store([(m.memory_id, 0.0)])
         with patch("hive.server._vector_store", return_value=mock_vs2):
             result = await search_memories("q", min_score=-1.0, ctx=ctx)
 
-        assert result["count"] == 1
+        assert _body(result)["count"] == 1
 
     async def test_remember_dual_writes_to_vector_store(self, server_env):
         """remember() calls upsert_memory on the VectorStore for new memories."""
@@ -1124,7 +1151,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await remember("vec-fail-new", "v", [], ctx=_make_ctx(jwt))
 
-        assert "Stored" in result
+        assert "Stored" in _text(result)
 
     async def test_remember_vector_upsert_failure_on_update_is_non_fatal(self, server_env):
         """VectorStore errors during remember() update are logged but do not raise."""
@@ -1142,7 +1169,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await remember("vec-fail-upd", "updated", [], ctx=_make_ctx(jwt))
 
-        assert "Updated" in result
+        assert "Updated" in _text(result)
 
     async def test_forget_vector_delete_failure_is_non_fatal(self, server_env):
         """VectorStore errors during forget() are logged but do not raise."""
@@ -1158,7 +1185,7 @@ class TestSearchMemories:
             await remember("vec-fail-forget", "v", [], ctx=_make_ctx(jwt))
             result = await forget("vec-fail-forget", ctx=_make_ctx(jwt))
 
-        assert "Deleted" in result
+        assert "Deleted" in _text(result)
 
     async def test_search_vector_failure_returns_empty(self, server_env):
         """Unexpected VectorStore errors during search_memories() return empty results."""
@@ -1173,7 +1200,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("anything", ctx=_make_ctx(jwt))
 
-        assert result == {"items": [], "count": 0, "query": "anything"}
+        assert _body(result) == {"items": [], "count": 0, "query": "anything"}
 
 
 # ---------------------------------------------------------------------------
@@ -1203,10 +1230,11 @@ class TestRelateMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await relate_memories("source", top_k=2, ctx=ctx)
 
-        keys = [item["key"] for item in result["items"]]
+        body = _body(result)
+        keys = [item["key"] for item in body["items"]]
         assert keys == ["a", "b"]
-        assert result["count"] == 2
-        assert result["key"] == "source"
+        assert body["count"] == 2
+        assert body["key"] == "source"
 
     async def test_uses_source_value_as_query(self, server_env):
         from unittest.mock import patch
@@ -1249,7 +1277,7 @@ class TestRelateMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await relate_memories("src", ctx=ctx)
 
-        assert result == {"items": [], "count": 0, "key": "src"}
+        assert _body(result) == {"items": [], "count": 0, "key": "src"}
 
     async def test_returns_empty_on_vector_error(self, server_env):
         from unittest.mock import MagicMock, patch
@@ -1265,7 +1293,7 @@ class TestRelateMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await relate_memories("src", ctx=ctx)
 
-        assert result == {"items": [], "count": 0, "key": "src"}
+        assert _body(result) == {"items": [], "count": 0, "key": "src"}
 
     async def test_top_k_clamped(self, server_env):
         from unittest.mock import patch
@@ -1308,7 +1336,7 @@ class TestForgetAll:
         await remember("fa-b", "v2", ["purge"], ctx=_make_ctx(jwt))
         await remember("fa-c", "v3", ["keep"], ctx=_make_ctx(jwt))
         result = await forget_all("purge", ctx=_make_ctx(jwt))
-        assert "2" in result
+        assert "2" in _text(result)
         assert storage.get_memory_by_key("fa-a") is None
         assert storage.get_memory_by_key("fa-b") is None
         assert storage.get_memory_by_key("fa-c") is not None
@@ -1318,7 +1346,7 @@ class TestForgetAll:
         from hive.server import forget_all
 
         result = await forget_all("no-such-tag", ctx=_make_ctx(jwt))
-        assert "0" in result
+        assert "0" in _text(result)
 
     async def test_forget_all_requires_write_scope(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -1344,8 +1372,10 @@ class TestMemoryHistory:
         await remember("hist-k", "v1", [], ctx=_make_ctx(jwt))
         await remember("hist-k", "v2", [], ctx=_make_ctx(jwt))
         result = await memory_history("hist-k", ctx=_make_ctx(jwt))
-        assert len(result) == 1
-        assert result[0]["value"] == "v1"
+        body = _body(result)
+        assert body["count"] == 1
+        assert len(body["versions"]) == 1
+        assert body["versions"][0]["value"] == "v1"
 
     async def test_memory_history_empty_for_new_memory(self, server_env):
         storage, client_id, jwt = server_env
@@ -1353,7 +1383,7 @@ class TestMemoryHistory:
 
         await remember("new-hist", "v1", [], ctx=_make_ctx(jwt))
         result = await memory_history("new-hist", ctx=_make_ctx(jwt))
-        assert result == []
+        assert _body(result) == {"versions": [], "count": 0}
 
     async def test_memory_history_raises_for_missing_key(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -1388,9 +1418,9 @@ class TestRestoreMemory:
         await remember("rst-k", "v1", [], ctx=_make_ctx(jwt))
         await remember("rst-k", "v2", [], ctx=_make_ctx(jwt))
         versions = await memory_history("rst-k", ctx=_make_ctx(jwt))
-        vts = versions[0]["version_timestamp"]
+        vts = _body(versions)["versions"][0]["version_timestamp"]
         result = await restore_memory("rst-k", vts, ctx=_make_ctx(jwt))
-        assert "rst-k" in result
+        assert "rst-k" in _text(result)
         m = storage.get_memory_by_key("rst-k")
         assert m is not None
         assert m.value == "v1"


### PR DESCRIPTION
Closes #453

## Summary

Every MCP tool response now carries the caller's current quota usage and rate-limit configuration under a top-level `_meta.hive` block, so well-behaved agents can self-throttle before hitting a hard limit.

```json
{
  "_meta": {
    "hive": {
      "memory_quota": { "used": 42, "limit": 500, "remaining": 458 },
      "rate_limit":  { "per_minute_limit": 60, "per_day_limit": 10000 }
    }
  }
}
```

## Approach

- New `_quota_meta()` + `_tool_result()` helpers in `server.py` wrap every tool return in a FastMCP `ToolResult` with `_meta.hive` set. Strings become text content; dicts become `structured_content` so existing clients still use them directly.
- `memory_history` now returns `{"versions": [...], "count": N}` instead of a bare list — FastMCP's structured-content envelope requires a dict, and this also brings the tool in line with `list_memories` / `list_tags` / `search_memories`.
- Unit + integration test assertions updated to read through `result.content[0].text` / `result.structured_content`; added `_text`, `_body`, `_hive_meta` helpers at the top of each test file.
- New docs page `/docs/concepts/quotas` documenting the `_meta.hive` schema, when to use it, and the configurable env vars.
- `CHANGELOG.md` `[Unreleased]` entry.

Chose the "wrap every tool return" approach (rather than a FastMCP middleware) because FastMCP doesn't have a response-middleware hook today, and an explicit wrapper keeps the metadata-generation branch adjacent to the tool logic that owns it.

## Test plan

- [x] `uv run inv pre-push` — unit + frontend + lint + typecheck
- [ ] CI green on this PR
- [ ] `development` pipeline green post-merge (e2e suite runs against the dev deploy)