### PR TITLE
feat: emit MCP progress notifications from long-running tools

### DIFF
--- a/docs-site/tools/overview.md
+++ b/docs-site/tools/overview.md
@@ -33,3 +33,14 @@ You typically don't need to tell your agent which tool to use — just give natu
 - *"List everything tagged..."* → `list_memories`
 - *"Forget the..."* → `forget`
 - *"Give me a summary of..."* → `summarize_context`
+
+## Progress notifications
+
+Tools whose expected duration exceeds ~2 seconds emit MCP [`notifications/progress`](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress) events at each major stage of work. Supporting clients (Claude Desktop, Claude Code) render these as a progress indicator or streaming status line.
+
+Currently emitted by:
+
+- `search_memories` — reports at 3 stages (vector search → hydrate → rank)
+- `summarize_context` — reports at 2 stages (retrieve → synthesise)
+
+Clients that don't support progress notifications ignore them — the tool still returns its normal final result. Emission is best-effort: if the transport rejects a notification, the tool continues without raising.

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -233,6 +233,24 @@ def _tool_result(payload: Any, storage: HiveStorage, client_id: str) -> ToolResu
     return ToolResult(content=payload, meta=meta)
 
 
+async def _report_progress(
+    ctx: Context | None, progress: float, total: float | None, message: str
+) -> None:
+    """Emit an MCP ``notifications/progress`` event if the client supports it.
+
+    Any exception from the transport (client doesn't support progress, the
+    ctx is stale, etc.) is swallowed — progress is advisory, never fatal.
+    Policy: tools whose expected duration exceeds ~2s call this at sensible
+    milestones so clients can render a progress indicator.
+    """
+    if ctx is None:
+        return
+    try:
+        await ctx.report_progress(progress=progress, total=total, message=message)
+    except Exception:
+        logger.debug("progress notification dropped", exc_info=True)
+
+
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
@@ -832,7 +850,11 @@ async def summarize_context(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
 
+    await _report_progress(ctx, 0, 2, f"Retrieving memories for '{topic}'...")
     memories, _ = storage.list_memories_by_tag(topic, limit=500)
+    await _report_progress(
+        ctx, 1, 2, f"Retrieved {len(memories)} memories; synthesising summary..."
+    )
 
     if not memories:
         logger.info(
@@ -918,6 +940,7 @@ async def search_memories(
     # so we have headroom to still return up to top_k matches after filtering.
     search_top_k = 50 if required_tags else top_k
 
+    await _report_progress(ctx, 0, 3, f"Running vector search for '{query}'...")
     try:
         pairs = _vector_store().search(query, client_id, top_k=search_top_k)
     except VectorIndexNotFoundError:
@@ -929,12 +952,16 @@ async def search_memories(
     if threshold is not None:
         pairs = [(mid, score) for mid, score in pairs if score >= threshold]
 
+    await _report_progress(
+        ctx, 1, 3, f"Vector search returned {len(pairs)} candidates; hydrating..."
+    )
     results = storage.hydrate_memory_ids(pairs)
 
     if required_tags:
         results = [(m, s) for m, s in results if required_tags.issubset(m.tags)]
 
     results = results[:top_k]
+    await _report_progress(ctx, 2, 3, f"Ranked {len(results)} result(s); returning.")
 
     storage.log_event(
         ActivityEvent(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -71,10 +71,24 @@ def _create_table(table_name: str = "hive-unit-server") -> None:
     )
 
 
-def _make_ctx(jwt: str) -> MagicMock:
-    """Build a minimal mock Context that passes token via meta."""
+def _make_ctx(jwt: str, *, progress_sink: list | None = None) -> MagicMock:
+    """Build a minimal mock Context that passes token via meta.
+
+    If ``progress_sink`` is provided, each ``report_progress`` call is
+    appended to it so tests can assert on the emitted notifications.
+    """
+    from unittest.mock import AsyncMock
+
     ctx = MagicMock()
     ctx.request_context.meta = {"Authorization": f"Bearer {jwt}"}
+    if progress_sink is not None:
+
+        async def _capture(**kwargs):
+            progress_sink.append(kwargs)
+
+        ctx.report_progress = AsyncMock(side_effect=_capture)
+    else:
+        ctx.report_progress = AsyncMock()
     return ctx
 
 
@@ -1494,6 +1508,74 @@ class TestMcpToolAnnotations:
         assert tool.annotations.destructiveHint is destructive
         # Every Hive tool is closed-world (our DynamoDB only).
         assert tool.annotations.openWorldHint is False
+
+
+class TestProgressNotifications:
+    """Long-running tools emit MCP ``notifications/progress`` events so
+    clients can render a progress indicator. Clients that don't support
+    them must still get a usable result — emission is best-effort."""
+
+    async def test_summarize_context_emits_progress(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import remember, summarize_context
+
+        sink: list = []
+        ctx = _make_ctx(jwt, progress_sink=sink)
+        await remember("p-a", "about foo", ["prog"], ctx=_make_ctx(jwt))
+        await remember("p-b", "more about foo", ["prog"], ctx=_make_ctx(jwt))
+
+        await summarize_context("prog", ctx=ctx)
+
+        assert len(sink) >= 2
+        progresses = [c["progress"] for c in sink]
+        totals = {c["total"] for c in sink}
+        assert progresses[0] == 0
+        assert progresses[-1] == 1
+        assert totals == {2}
+
+    async def test_search_memories_emits_progress(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        await remember("ps-a", "searchable content", ["t"], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("ps-a")
+
+        sink: list = []
+        ctx = _make_ctx(jwt, progress_sink=sink)
+        from unittest.mock import MagicMock as _MM
+
+        mock_vs = _MM()
+        mock_vs.search.return_value = [(m.memory_id, 0.9)]
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await search_memories("searchable", ctx=ctx)
+
+        # 3 stages: before vector search, after hydrate, after ranking
+        assert len(sink) == 3
+        assert [c["progress"] for c in sink] == [0, 1, 2]
+        assert {c["total"] for c in sink} == {3}
+
+    async def test_progress_emission_is_non_fatal(self, server_env):
+        """If ctx.report_progress raises (client doesn't support it), the
+        tool still returns successfully — progress is advisory only."""
+        from unittest.mock import AsyncMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        ctx.report_progress = AsyncMock(side_effect=RuntimeError("client refused"))
+        await remember("np-a", "v", ["np"], ctx=_make_ctx(jwt))
+
+        result = await summarize_context("np", ctx=ctx)
+        assert _text(result)  # still returned a usable summary
+
+    async def test_report_progress_noop_when_ctx_is_none(self):
+        """Direct call with ctx=None must not raise."""
+        from hive.server import _report_progress
+
+        await _report_progress(None, 0, 2, "no-ctx")
 
 
 class TestHiveTokenVerifier:


### PR DESCRIPTION
Closes #449

## Summary

New `_report_progress()` helper in `server.py` wraps FastMCP's `ctx.report_progress()` so MCP tools can emit `notifications/progress` events at major stages of work. Supporting clients (Claude Desktop, Claude Code) render these as a status line; clients that don't simply ignore them.

Wired into the two existing tools whose duration scales with memory count:

- **`search_memories`** — 3 stages (vector search → hydrate → rank)
- **`summarize_context`** — 2 stages (retrieve → synthesise)

## Approach

- Emission is **best-effort**: if the transport rejects a notification (client doesn't support it, connection is stale), the tool logs and continues — progress is advisory, never fatal.
- `ctx=None` is a no-op, so existing direct-invocation callers (integration tests, scripts) don't need to change.
- Establishes the pattern for future bulk tools (#396 `bulk_remember`, #427 bulk import/export), which the issue notes are the primary beneficiaries.
- `docs-site/tools/overview.md` gets a "Progress notifications" section documenting the policy (tools > 2s duration emit progress) and which tools currently emit.

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + unit + frontend (545 + 604 passing)
- [x] New `TestProgressNotifications` class covering both emitting tools, best-effort semantics, and the `ctx=None` path
- [ ] CI green on this PR
- [ ] `development` pipeline green post-merge