### PR TITLE
chore(ci): add release-milestone-watcher workflow

### DIFF
--- a/.github/workflows/release-milestone-watcher.yml
+++ b/.github/workflows/release-milestone-watcher.yml
@@ -1,0 +1,70 @@
+name: Release milestone watcher
+
+# Watches for any vX.Y milestone that has drained to zero open non-epic
+# issues and files a "Release: cut vX.Y" tracking issue so the operator
+# (or the autonomous agent) picks it up. Pairs with the in-session stop
+# condition in CLAUDE.md §Autonomous issue workflow §9 (#483).
+
+on:
+  issues:
+    types: [closed, milestoned, demilestoned]
+  pull_request:
+    types: [closed]
+  schedule:
+    # Daily belt-and-braces catch for milestone-reassignments that emptied
+    # a milestone without a close event (which wouldn't trigger `issues`).
+    - cron: '0 9 * * *'
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  check-drained-milestones:
+    name: check-drained-milestones
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if any vX.Y milestone is drained
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          MILESTONES=$(gh api "repos/$REPO/milestones?state=open" \
+            --jq '.[] | select(.title | test("^v[0-9]+\\.[0-9]+$")) | .title')
+
+          if [ -z "$MILESTONES" ]; then
+            echo "No open vX.Y milestones — nothing to check."
+            exit 0
+          fi
+
+          while IFS= read -r m; do
+            [ -z "$m" ] && continue
+
+            OPEN=$(gh issue list --milestone "$m" --state open \
+              --json labels \
+              --jq '[.[] | select(.labels | map(.name) | contains(["epic"]) | not)] | length')
+
+            if [ "$OPEN" -ne 0 ]; then
+              echo "Milestone $m still has $OPEN open non-epic issues — skipping."
+              continue
+            fi
+
+            EXISTING=$(gh issue list --search "Release: cut $m in:title is:open" \
+              --json number --jq 'length')
+
+            if [ "$EXISTING" -ne 0 ]; then
+              echo "Milestone $m is drained but \"Release: cut $m\" issue already exists."
+              continue
+            fi
+
+            echo "Milestone $m is drained — filing release tracking issue."
+            gh issue create \
+              --title "Release: cut $m" \
+              --body "Milestone \`$m\` has drained to zero open non-epic issues. Time to cut the release per CLAUDE.md §Releasing to production. Filed automatically by release-milestone-watcher." \
+              --label "chore" \
+              --label "status:ready" \
+              --label "priority:p1" \
+              --label "size:s"
+          done <<< "$MILESTONES"


### PR DESCRIPTION
Closes #484

## Summary

New `release-milestone-watcher.yml` workflow watches for any `vX.Y` milestone that has drained to zero open non-epic issues and files a **"Release: cut vX.Y"** tracking issue so the operator (or the autonomous agent) picks it up.

Pairs with the in-session stop condition added in #483 — together they cover both the agent-running and agent-idle cases.

## Approach

Triggered on:

- `issues` closed / milestoned / demilestoned
- `pull_request` closed (covers Dependabot merges that close the last milestone issue)
- Daily cron at 09:00 UTC (belt-and-braces catch for milestone-reassignments that emptied a milestone without a close event)

For each open milestone matching `^vX.Y$`, counts open non-epic issues. If zero **and** no existing `Release: cut vX.Y` issue is open, files a new one labelled `chore` + `status:ready` + `priority:p1` + `size:s`.

Issue body references the release flow from `CLAUDE.md §Releasing to production`.

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + unit + frontend
- [x] YAML parses with `yaml.safe_load`
- [ ] CI green on this PR
- [ ] First firing will be observable when v0.22 drains