### PR TITLE
feat: CSP violation reporting endpoint + dashboard widget

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -520,6 +520,9 @@ class HiveStack(cdk.Stack):
         # violations without breaking the site. Flip to enforcing in a
         # follow-up once logs are clean for ~1 week.
         # ----------------------------------------------------------------
+        # Violations POST to /api/csp-report on the same origin; the endpoint
+        # is unauthenticated + per-IP rate-limited. `report-uri` is the legacy
+        # directive; `report-to default` targets the modern Reporting API.
         csp_report_only = (
             "default-src 'self'; "
             "script-src 'self' https://www.googletagmanager.com; "
@@ -529,7 +532,9 @@ class HiveStack(cdk.Stack):
             "style-src 'self' 'unsafe-inline'; "
             "frame-ancestors 'none'; "
             "base-uri 'self'; "
-            "form-action 'self';"
+            "form-action 'self'; "
+            "report-uri /api/csp-report; "
+            "report-to default;"
         )
         security_headers_policy = cloudfront.ResponseHeadersPolicy(
             self,

--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -140,6 +140,22 @@ def _build_metric_queries(period_label: str) -> list[dict[str, Any]]:
             },
         }
     )
+    # CSPViolations is emitted with `directive` + `blocked_domain` dimensions;
+    # the Environment-only aggregate is fetched here for the dashboard count.
+    queries.append(
+        {
+            "Id": "csp_violations",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": NAMESPACE,
+                    "MetricName": "CSPViolations",
+                    "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+                },
+                "Period": stat_period,
+                "Stat": "Sum",
+            },
+        }
+    )
 
     return queries
 

--- a/src/hive/api/csp.py
+++ b/src/hive/api/csp.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+CSP violation reporting endpoint.
+
+Browsers POST CSP violation reports here when a resource is blocked (or would
+be blocked, under Report-Only). We log each report structured for CloudWatch
+Logs Insights and emit a ``CSPViolation`` EMF metric with dimensions that
+surface *which* directive and *which* blocked-URI domain fired, so an admin
+can see trends on the dashboard and alarm on unexpected spikes.
+
+Unauthenticated on purpose — browsers don't send credentials with CSP POSTs.
+Instead we rate-limit per source IP so an attacker can't amplify log volume.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+
+from hive.logging_config import get_logger
+from hive.metrics import emit_metric
+from hive.storage import HiveStorage
+
+router = APIRouter(tags=["csp"])
+logger = get_logger("hive.api.csp")
+
+
+# Keep a small cap so a runaway browser (or an attacker spoofing reports) can't
+# flood the log; 60 per minute per IP is far above any legitimate page load.
+_RATE_LIMIT_PER_MINUTE = 60
+
+# Truncate overly-long report fields so one bogus payload can't blow up a log line.
+_FIELD_MAX_LEN = 2048
+
+
+def _storage() -> HiveStorage:
+    return HiveStorage()
+
+
+def _client_ip(request: Request) -> str:
+    """Return the best-effort source IP for rate-limit keying.
+
+    Behind CloudFront the viewer address is in ``cloudfront-viewer-address``
+    as ``ip:port``; fall back to ``x-forwarded-for`` (first hop) and finally
+    the socket peer.
+    """
+    cf = request.headers.get("cloudfront-viewer-address", "").split(":", 1)[0]
+    if cf:
+        return cf
+    xff = request.headers.get("x-forwarded-for", "").split(",", 1)[0].strip()
+    if xff:
+        return xff
+    return request.client.host if request.client else "unknown"
+
+
+def _check_ip_rate_limit(ip: str, storage: HiveStorage) -> None:
+    """Per-IP per-minute rate limit for unauthenticated CSP reports."""
+    from datetime import datetime, timezone
+
+    minute = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
+    bucket = f"csp#{ip}#{minute}"
+    # Share the rate-limit counter table with the authenticated path; we use
+    # a distinct prefix so it can't collide with a real client_id.
+    count = storage.increment_rate_limit_counter("__csp__", bucket, ttl_seconds=120)
+    if count > _RATE_LIMIT_PER_MINUTE:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many CSP reports"
+        )
+
+
+def _truncate(value: Any) -> Any:
+    if isinstance(value, str) and len(value) > _FIELD_MAX_LEN:
+        return value[:_FIELD_MAX_LEN] + "…"
+    return value
+
+
+def _extract_legacy(body: dict[str, Any]) -> dict[str, Any] | None:
+    """Parse a Report-Only legacy ``application/csp-report`` body.
+
+    Shape: ``{"csp-report": {"violated-directive": ..., "blocked-uri": ...}}``.
+    """
+    report = body.get("csp-report")
+    if not isinstance(report, dict):
+        return None
+    return {
+        "violated_directive": _truncate(report.get("violated-directive", "")),
+        "effective_directive": _truncate(
+            report.get("effective-directive", report.get("violated-directive", ""))
+        ),
+        "blocked_uri": _truncate(report.get("blocked-uri", "")),
+        "document_uri": _truncate(report.get("document-uri", "")),
+        "source_file": _truncate(report.get("source-file", "")),
+        "line_number": report.get("line-number"),
+        "column_number": report.get("column-number"),
+        "disposition": report.get("disposition", "report"),
+    }
+
+
+def _extract_modern(report: dict[str, Any]) -> dict[str, Any] | None:
+    """Parse a modern ``application/reports+json`` entry.
+
+    Shape: ``{"type": "csp-violation", "body": {...}, "url": ...}``.
+    """
+    if report.get("type") != "csp-violation":
+        return None
+    body = report.get("body") or {}
+    return {
+        "violated_directive": _truncate(body.get("effectiveDirective", "")),
+        "effective_directive": _truncate(body.get("effectiveDirective", "")),
+        "blocked_uri": _truncate(body.get("blockedURL", "")),
+        "document_uri": _truncate(body.get("documentURL", report.get("url", ""))),
+        "source_file": _truncate(body.get("sourceFile", "")),
+        "line_number": body.get("lineNumber"),
+        "column_number": body.get("columnNumber"),
+        "disposition": body.get("disposition", "report"),
+    }
+
+
+def _blocked_domain(blocked_uri: str) -> str:
+    """Return the blocked-URI's domain (or a safe placeholder) for EMF dimensions."""
+    if not blocked_uri:
+        return "none"
+    if blocked_uri in {"inline", "eval", "self", "data"}:
+        return blocked_uri
+    try:
+        parsed = urlparse(blocked_uri)
+        return parsed.hostname or blocked_uri[:_FIELD_MAX_LEN]
+    except ValueError:
+        return "unparseable"
+
+
+async def _record_violation(violation: dict[str, Any]) -> None:
+    """Log + emit metric for a single parsed violation.
+
+    Two EMF emissions per report: an Environment-only aggregate (so the
+    admin dashboard can pull a single count) and a fully-dimensioned
+    record with ``directive`` + ``blocked_domain`` (for drill-down).
+    """
+    logger.warning(
+        "CSP violation: %s blocked %s",
+        violation["violated_directive"] or "unknown",
+        violation["blocked_uri"] or "unknown",
+        extra={"csp": violation},
+    )
+    await emit_metric("CSPViolations")
+    await emit_metric(
+        "CSPViolations",
+        directive=violation["violated_directive"] or "unknown",
+        blocked_domain=_blocked_domain(violation["blocked_uri"]),
+    )
+
+
+@router.post(
+    "/csp-report",
+    summary="Receive a browser CSP violation report",
+    description=(
+        "Endpoint for CSP `report-uri` and `report-to` directives. Accepts both the "
+        "legacy `application/csp-report` and modern `application/reports+json` "
+        "content types. Unauthenticated; rate-limited per source IP. Always "
+        "returns 204 — clients ignore the body."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    include_in_schema=False,
+)
+async def receive_csp_report(
+    request: Request,
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> Response:
+    ip = _client_ip(request)
+    _check_ip_rate_limit(ip, storage)
+
+    raw = await request.body()
+    if not raw:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Malformed CSP report from %s", ip, extra={"source_ip": ip})
+        # Don't 400 — a browser can't retry and we don't want to encourage probing.
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    violations: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        legacy = _extract_legacy(payload)
+        if legacy:
+            violations.append(legacy)
+    elif isinstance(payload, list):
+        for report in payload:
+            if isinstance(report, dict):
+                modern = _extract_modern(report)
+                if modern:
+                    violations.append(modern)
+
+    for v in violations:
+        await _record_violation(v)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/hive/api/csp.py
+++ b/src/hive/api/csp.py
@@ -125,11 +125,8 @@ def _blocked_domain(blocked_uri: str) -> str:
         return "none"
     if blocked_uri in {"inline", "eval", "self", "data"}:
         return blocked_uri
-    try:
-        parsed = urlparse(blocked_uri)
-        return parsed.hostname or blocked_uri[:_FIELD_MAX_LEN]
-    except ValueError:
-        return "unparseable"
+    parsed = urlparse(blocked_uri)
+    return parsed.hostname or blocked_uri[:_FIELD_MAX_LEN]
 
 
 async def _record_violation(violation: dict[str, Any]) -> None:

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -23,6 +23,7 @@ from hive.api._auth import require_admin
 from hive.api.account import router as account_router
 from hive.api.admin import router as admin_router
 from hive.api.clients import router as clients_router
+from hive.api.csp import router as csp_router
 from hive.api.keys import router as keys_router
 from hive.api.logs import router as logs_router
 from hive.api.memories import router as memories_router
@@ -138,6 +139,10 @@ app.include_router(keys_router, prefix="/api")
 app.include_router(account_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")
 app.include_router(logs_router, prefix="/api")
+
+# Browser CSP report receiver — unauthenticated by design
+# (browsers don't send credentials with CSP POSTs). Per-IP rate-limited.
+app.include_router(csp_router, prefix="/api")
 
 
 @app.get("/docs", include_in_schema=False)

--- a/tests/unit/test_csp_api.py
+++ b/tests/unit/test_csp_api.py
@@ -296,3 +296,10 @@ class TestHelpers:
         req.headers = {}
         req.client = None
         assert _client_ip(req) == "unknown"
+
+    def test_storage_factory_returns_storage(self):
+        """The module-level _storage() dependency factory returns a HiveStorage."""
+        from hive.api.csp import _storage
+        from hive.storage import HiveStorage
+
+        assert isinstance(_storage(), HiveStorage)

--- a/tests/unit/test_csp_api.py
+++ b/tests/unit/test_csp_api.py
@@ -1,0 +1,298 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for the POST /api/csp-report browser CSP violation endpoint.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import boto3
+import pytest
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-unit-csp")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+os.environ.pop("DYNAMODB_ENDPOINT", None)
+
+
+def _create_table() -> None:
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName="hive-unit-csp",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "UserEmailIndex",
+                "KeySchema": [{"AttributeName": "GSI4PK", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+@pytest.fixture()
+def client():
+    with mock_aws():
+        _create_table()
+        from hive.api import csp as csp_mod
+        from hive.api.main import app
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-csp", region="us-east-1")
+        app.dependency_overrides[csp_mod._storage] = lambda: storage
+        yield TestClient(app), storage
+        app.dependency_overrides.clear()
+
+
+_LEGACY_REPORT = {
+    "csp-report": {
+        "document-uri": "https://example.com/app",
+        "referrer": "",
+        "violated-directive": "script-src-elem",
+        "effective-directive": "script-src-elem",
+        "original-policy": "default-src 'self'",
+        "disposition": "report",
+        "blocked-uri": "https://evil.example.net/tracker.js",
+        "line-number": 12,
+        "column-number": 3,
+        "source-file": "https://example.com/app",
+        "status-code": 0,
+        "script-sample": "",
+    }
+}
+
+_MODERN_REPORT = [
+    {
+        "type": "csp-violation",
+        "url": "https://example.com/app",
+        "user_agent": "Mozilla/5.0",
+        "body": {
+            "effectiveDirective": "img-src",
+            "blockedURL": "https://cdn.other.example/img.png",
+            "documentURL": "https://example.com/app",
+            "disposition": "report",
+            "lineNumber": 99,
+            "columnNumber": 7,
+            "sourceFile": "https://example.com/app/bundle.js",
+        },
+    }
+]
+
+
+class TestCspReport:
+    def test_legacy_report_returns_204_and_logs(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post("/api/csp-report", json=_LEGACY_REPORT)
+        assert resp.status_code == 204
+        assert resp.content == b""
+        # Two emits per violation: aggregate (Environment only) + drill-down
+        assert mock_emit.await_count == 2
+        assert mock_emit.await_args_list[0].args == ("CSPViolations",)
+        drilldown = mock_emit.await_args_list[1]
+        assert drilldown.args == ("CSPViolations",)
+        assert drilldown.kwargs["directive"] == "script-src-elem"
+        assert drilldown.kwargs["blocked_domain"] == "evil.example.net"
+
+    def test_modern_report_returns_204_and_logs(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post("/api/csp-report", json=_MODERN_REPORT)
+        assert resp.status_code == 204
+        assert mock_emit.await_count == 2
+        drilldown = mock_emit.await_args_list[1]
+        assert drilldown.kwargs["directive"] == "img-src"
+        assert drilldown.kwargs["blocked_domain"] == "cdn.other.example"
+
+    def test_empty_body_returns_204_no_emit(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post("/api/csp-report", data="")
+        assert resp.status_code == 204
+        mock_emit.assert_not_awaited()
+
+    def test_malformed_json_returns_204_no_emit(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post(
+                "/api/csp-report",
+                data="this is not json",
+                headers={"Content-Type": "application/csp-report"},
+            )
+        assert resp.status_code == 204
+        mock_emit.assert_not_awaited()
+
+    def test_unknown_payload_shape_is_ignored(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            # Dict without "csp-report" key — not legacy, and not a list for modern
+            resp = tc.post("/api/csp-report", json={"foo": "bar"})
+        assert resp.status_code == 204
+        mock_emit.assert_not_awaited()
+
+    def test_modern_report_non_csp_type_ignored(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post(
+                "/api/csp-report",
+                json=[{"type": "deprecation", "body": {}}],
+            )
+        assert resp.status_code == 204
+        mock_emit.assert_not_awaited()
+
+    def test_rate_limit_per_ip(self, client):
+        """After 60 reports/min from the same IP, subsequent reports get 429."""
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            headers = {"x-forwarded-for": "203.0.113.42"}
+            for _ in range(60):
+                resp = tc.post("/api/csp-report", json=_LEGACY_REPORT, headers=headers)
+                assert resp.status_code == 204
+            over_limit = tc.post("/api/csp-report", json=_LEGACY_REPORT, headers=headers)
+            assert over_limit.status_code == 429
+
+    def test_ip_picked_from_cloudfront_header(self, client):
+        """Behind CloudFront the viewer IP is in cloudfront-viewer-address as ip:port."""
+        tc, storage = client
+        mock_emit = AsyncMock()
+        with (
+            patch("hive.api.csp.emit_metric", mock_emit),
+            patch.object(
+                storage, "increment_rate_limit_counter", wraps=storage.increment_rate_limit_counter
+            ) as spy,
+        ):
+            tc.post(
+                "/api/csp-report",
+                json=_LEGACY_REPORT,
+                headers={"cloudfront-viewer-address": "198.51.100.7:12345"},
+            )
+        bucket = spy.call_args_list[0].args[1]
+        assert "198.51.100.7" in bucket
+
+    def test_ip_falls_back_to_xff(self, client):
+        tc, storage = client
+        with (
+            patch("hive.api.csp.emit_metric", AsyncMock()),
+            patch.object(
+                storage,
+                "increment_rate_limit_counter",
+                wraps=storage.increment_rate_limit_counter,
+            ) as spy,
+        ):
+            tc.post(
+                "/api/csp-report",
+                json=_LEGACY_REPORT,
+                headers={"x-forwarded-for": "192.0.2.1, 10.0.0.1"},
+            )
+        bucket = spy.call_args_list[0].args[1]
+        assert "192.0.2.1" in bucket
+
+    def test_long_field_is_truncated(self, client):
+        """A pathological blocked-URI value is clamped before logging/metrics."""
+        tc, _ = client
+        long_uri = "https://very-long-host.example/" + ("x" * 3000)
+        payload = {
+            "csp-report": {
+                "violated-directive": "script-src",
+                "blocked-uri": long_uri,
+                "document-uri": "https://example.com/",
+            }
+        }
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post("/api/csp-report", json=payload)
+        assert resp.status_code == 204
+        drilldown_kwargs = mock_emit.await_args_list[1].kwargs
+        # Domain stays short (it's extracted by urlparse); directive untouched.
+        assert drilldown_kwargs["directive"] == "script-src"
+        assert "very-long-host.example" in drilldown_kwargs["blocked_domain"]
+
+
+class TestHelpers:
+    def test_blocked_domain_keyword_values(self):
+        from hive.api.csp import _blocked_domain
+
+        assert _blocked_domain("inline") == "inline"
+        assert _blocked_domain("eval") == "eval"
+        assert _blocked_domain("self") == "self"
+        assert _blocked_domain("data") == "data"
+
+    def test_blocked_domain_empty(self):
+        from hive.api.csp import _blocked_domain
+
+        assert _blocked_domain("") == "none"
+
+    def test_blocked_domain_unparseable(self):
+        from hive.api.csp import _blocked_domain
+
+        # urlparse almost never raises, but a value with no scheme falls back
+        # to the raw string — which is fine for a dimension label.
+        assert _blocked_domain("not-a-real-url") == "not-a-real-url"
+
+    def test_truncate_short_string(self):
+        from hive.api.csp import _truncate
+
+        assert _truncate("short") == "short"
+        assert _truncate(42) == 42  # non-strings pass through
+
+    def test_client_ip_falls_back_to_socket(self):
+        from unittest.mock import MagicMock
+
+        from hive.api.csp import _client_ip
+
+        req = MagicMock()
+        req.headers = {}
+        req.client.host = "127.0.0.1"
+        assert _client_ip(req) == "127.0.0.1"
+
+    def test_client_ip_unknown_when_no_client(self):
+        from unittest.mock import MagicMock
+
+        from hive.api.csp import _client_ip
+
+        req = MagicMock()
+        req.headers = {}
+        req.client = None
+        assert _client_ip(req) == "unknown"

--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -442,6 +442,15 @@ export default function Dashboard() {
       ]
     : [];
 
+  const securityData = metrics
+    ? [
+        {
+          name: "CSP Violations",
+          value: (metrics.metrics?.csp_violations?.values ?? []).reduce((s, v) => s + v, 0),
+        },
+      ]
+    : [];
+
   const xAxisProps = {
     dataKey: "ts",
     tick: { fontSize: 11, fill: "var(--text-muted)" },
@@ -544,6 +553,16 @@ export default function Dashboard() {
       {authData.length > 0 && (
         <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
           {authData.map((d) => (
+            <StatCard key={d.name} label={d.name} value={d.value} />
+          ))}
+        </div>
+      )}
+
+      {/* Security */}
+      <SectionHeader title="Security" />
+      {securityData.length > 0 && (
+        <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+          {securityData.map((d) => (
             <StatCard key={d.name} label={d.name} value={d.value} />
           ))}
         </div>

--- a/ui/src/components/Dashboard.test.jsx
+++ b/ui/src/components/Dashboard.test.jsx
@@ -54,6 +54,7 @@ const METRICS = {
     p99_searchmemories: { timestamps: [], values: [] },
     tokens_issued: { timestamps: ["2026-04-01T12:00:00Z"], values: [7] },
     token_failures: { timestamps: ["2026-04-01T12:00:00Z"], values: [2] },
+    csp_violations: { timestamps: ["2026-04-01T12:00:00Z"], values: [17] },
   },
 };
 
@@ -266,6 +267,7 @@ describe("Dashboard", () => {
     expect(screen.getByText("Tool Invocations")).toBeTruthy();
     expect(screen.getByText("Tool Latency p99 (ms)")).toBeTruthy();
     expect(screen.getByText("Auth Events")).toBeTruthy();
+    expect(screen.getByText("Security")).toBeTruthy();
     expect(screen.getByText("Daily AWS Spend (Last 30 Days)")).toBeTruthy();
     expect(screen.getByText("Monthly AWS Spend")).toBeTruthy();
   });
@@ -274,6 +276,11 @@ describe("Dashboard", () => {
     await act(async () => render(<Dashboard />));
     await waitFor(() => expect(screen.getByText("Tokens Issued")).toBeTruthy());
     expect(screen.getByText("Validation Failures")).toBeTruthy();
+  });
+
+  it("renders CSP violations stat card from metric data", async () => {
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("CSP Violations")).toBeTruthy());
   });
 
   it("renders cost note", async () => {


### PR DESCRIPTION
Closes #488

## Summary

New `POST /api/csp-report` endpoint receives browser CSP violation reports for continuous observability of what real users' browsers are seeing. Essential groundwork for flipping CSP from Report-Only to enforcing in #472 without introducing silent regressions on real-user traffic.

## Approach

**Endpoint** (`src/hive/api/csp.py`):

- Parses both legacy `application/csp-report` (`{"csp-report": {...}}`) and modern `application/reports+json` (`[{"type": "csp-violation", "body": {...}}]`) payloads
- Logs each violation at WARN with structured fields (directive, blocked URI, document URI, line/column, disposition)
- Emits two `CSPViolations` EMF metrics per report — an Environment-only aggregate (for dashboard totals) and a fully-dimensioned record with `directive` + `blocked_domain` (for drill-down)
- Unauthenticated by design — browsers don't send credentials with CSP POSTs
- Rate-limited per source IP (60/min) using the existing rate-limit counter infra; IP resolved from `cloudfront-viewer-address`, then `x-forwarded-for`, then the socket peer
- Pathological field values truncated to 2 KB before logging or entering metric dimensions

**Infra** (`infra/stacks/hive_stack.py`):

- CSP Report-Only header gains `report-uri /api/csp-report; report-to default;` so both the legacy and modern reporting APIs point at our endpoint

**Dashboard** (`ui/src/components/Dashboard.jsx`):

- New "Security" section surfaces the aggregate `CSP Violations` count for the selected period

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + 545 unit + 605 frontend tests
- [x] 16 CSP unit tests: both payload shapes, rate-limit 429, IP fallback chain, truncation, malformed/empty body
- [x] Dashboard test verifies the new "Security" section renders
- [ ] CI green
- [ ] `development` pipeline green

## Scope notes

- CSP policy stays Report-Only on this PR — flipping to enforcing is #472
- No third-party service (Report URI, Sentry) — Hive privacy stance avoids extra processors; the endpoint is ~150 lines