### PR TITLE
fix(ci): release-milestone-watcher fails because gh can't find a repo

### DIFF
--- a/.github/workflows/release-milestone-watcher.yml
+++ b/.github/workflows/release-milestone-watcher.yml
@@ -27,11 +27,16 @@ jobs:
       - name: Check if any vX.Y milestone is drained
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+          # gh reads GH_REPO to scope repo-aware commands (gh issue list,
+          # gh issue create). Without it, gh tries to detect the repo via
+          # git, but this workflow doesn't run actions/checkout — so those
+          # commands fail with `fatal: not a git repository`. Setting
+          # GH_REPO avoids the checkout without needing git context.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          MILESTONES=$(gh api "repos/$REPO/milestones?state=open" \
+          MILESTONES=$(gh api "repos/$GH_REPO/milestones?state=open" \
             --jq '.[] | select(.title | test("^v[0-9]+\\.[0-9]+$")) | .title')
 
           if [ -z "$MILESTONES" ]; then


### PR DESCRIPTION
Closes #484 follow-up.

## Root cause

The release-milestone-watcher workflow has been failing on every run since it shipped. The error:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Process completed with exit code 1.
```

`gh issue list` and `gh issue create` are repo-aware commands — they default to inferring the target repo from the current directory's git remote. Since this workflow doesn't run `actions/checkout` (intentionally, since it doesn't need any repo contents), `gh` can't find a `.git` and bails.

## Fix

Rename the `REPO` env var to `GH_REPO`. `gh` reads `GH_REPO` as its canonical repo override — no git context needed. Inline comment explains why this is preferred over adding `actions/checkout` just to satisfy gh.

## Why not actions/checkout

- The workflow only needs the GitHub API, not repo contents
- `actions/checkout` adds ~5-10s and downloads the whole repo every run
- Would also require pinning the action to a SHA per CLAUDE.md

`GH_REPO` is the documented, minimal fix.

## Test plan

- [x] `gh` commands in the workflow will pick up `GH_REPO` automatically (it's the standard env var)
- [ ] Next issue-close event after merge should trigger the workflow cleanly
- [ ] Manually trigger via `gh workflow run "Release milestone watcher"` post-merge to confirm

https://claude.ai/code/session_01CHZukppdQyVuVfG3cJb2xV