### PR TITLE
chore(ci): automate changelog generation with Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,63 @@
+# Configuration for release-drafter: aggregates merged PR titles into a
+# draft release so we never have to hand-maintain CHANGELOG `[Unreleased]`.
+# Categories map to the label taxonomy in CLAUDE.md §Backlog labels.
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Features"
+    labels:
+      - "enhancement"
+      - "feature"
+  - title: "Fixes"
+    labels:
+      - "bug"
+      - "fix"
+  - title: "Security"
+    labels:
+      - "security"
+  - title: "Docs"
+    labels:
+      - "docs"
+  - title: "Infrastructure & CI"
+    labels:
+      - "infra"
+      - "ci"
+  - title: "Chores"
+    labels:
+      - "chore"
+
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+  minor:
+    labels:
+      - "enhancement"
+      - "feature"
+  patch:
+    labels:
+      - "bug"
+      - "fix"
+      - "docs"
+      - "chore"
+      - "infra"
+      - "ci"
+      - "security"
+  default: patch
+
+# Any PR that doesn't match a category above still appears here so
+# nothing is silently dropped.
+exclude-labels:
+  - "skip-changelog"
+
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -44,10 +44,15 @@ jobs:
           echo "$LABELS" | grep -qE '(^|,)status:' || MISSING+=("status:*")
           echo "$LABELS" | grep -qE '(^|,)priority:' || MISSING+=("priority:p0|p1|p2|p3")
           echo "$LABELS" | grep -qE '(^|,)size:' || MISSING+=("size:xs|s|m|l|xl")
+          # Release Drafter (#420) groups PRs by category label, so every
+          # issue linked from a PR must carry one of these category labels
+          # so the auto-drafted release notes land in the right section.
+          echo "$LABELS" | grep -qE '(^|,)(enhancement|bug|docs|chore|infra|ci|security|breaking)(,|$)' \
+            || MISSING+=("category (enhancement|bug|docs|chore|infra|ci|security|breaking)")
 
           if [ ${#MISSING[@]} -gt 0 ]; then
             echo "::error::Issue #$ISSUE_NUM is missing required labels: ${MISSING[*]}"
-            echo "Add status, priority, and size labels to the issue before merging this PR."
+            echo "Add status, priority, size, and a category label to the issue before merging this PR."
             exit 1
           fi
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release drafter
+
+# Keeps a draft GitHub release current as PRs merge into development.
+# The draft is consumed when cutting a release branch so CHANGELOG `[Unreleased]`
+# no longer has to be hand-maintained. See CLAUDE.md §Releasing to production.
+
+on:
+  push:
+    branches: [development]
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [development]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,9 +7,6 @@ name: Release drafter
 on:
   push:
     branches: [development]
-  pull_request:
-    types: [opened, reopened, synchronize]
-    branches: [development]
 
 permissions:
   contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,8 +353,11 @@ gh pr merge --auto --merge
    ```
 
 2. **Update `CHANGELOG.md`** — move items from `[Unreleased]` to a new
-   versioned section, e.g. `## [X.Y.Z] - 2026-04-11`.
-   Commit the change:
+   versioned section, e.g. `## [X.Y.Z] - 2026-04-11`. The **draft release
+   auto-maintained by Release Drafter** (see
+   https://github.com/warlordofmars/hive/releases) is the source of
+   truth — copy its body into the new section rather than re-deriving
+   from PR history. Commit the change:
 
    ```bash
    git add CHANGELOG.md


### PR DESCRIPTION
Closes #420

## Summary

Automates CHANGELOG upkeep via Release Drafter. On every merge to `development`, a draft GitHub release is updated with the new PR's title under the category derived from its label (Features / Fixes / Security / Docs / Infrastructure & CI / Chores). When cutting a release branch, the operator copies the draft's body into `CHANGELOG.md` — no more hand-maintaining `[Unreleased]` and no more merge conflicts between concurrent PRs.

Note: this issue is in the `Backlog` milestone, not `v0.22`.

## Approach

**`.github/release-drafter.yml`** — category mapping + version resolver aligned with the existing label taxonomy from CLAUDE.md. Categories map to the same labels the existing `label-check` workflow already requires on linked issues.

**`.github/workflows/release-drafter.yml`** — runs on push to `development` (updates the draft) and on PR open/sync (pre-merge preview). Pinned to `release-drafter/release-drafter@5de93583…` (v7.2.0) per CLAUDE.md's action-pinning rule.

**`.github/workflows/label-check.yml`** — extended to require one of the category labels (`enhancement` / `bug` / `docs` / `chore` / `infra` / `ci` / `security` / `breaking`) on the linked issue, so nothing slips through uncategorised and the draft release has the correct section.

**`CLAUDE.md`** §Releasing to production — clarifies that the auto-maintained draft release is the source of truth for `CHANGELOG.md`; the release-cutter copies its body rather than re-deriving from PR history.

## Out of scope (follow-ups)

- Fully automated `CHANGELOG.md` population on release-branch creation (script that reads the draft and rewrites the file). This PR still relies on a manual copy — safer for a first iteration since it lets the human edit the body before committing.
- Semantic-release / fully automated version bumps — the issue explicitly calls this out as out of scope.

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + unit + frontend
- [x] All three YAML files parse with `yaml.safe_load`
- [ ] CI green
- [ ] First post-merge run on `development` should create/update the draft (observable on the Releases page)