### PR TITLE
feat: optimistic locking on remember() to prevent concurrent-write stomping

### DIFF
--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -136,6 +136,16 @@ class Memory(BaseModel):
     def is_expired(self) -> bool:
         return self.expires_at is not None and _now_utc() >= self.expires_at
 
+    @property
+    def version(self) -> str:
+        """Opaque version token for optimistic locking (#391).
+
+        Derived from ``updated_at`` so every write produces a fresh value.
+        Agents pass this back to ``remember(key, ..., version=...)`` to
+        detect concurrent-write conflicts.
+        """
+        return self.updated_at.isoformat()
+
 
 # ---------------------------------------------------------------------------
 # OAuth Client (RFC 7591 Dynamic Client Registration)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -386,7 +386,9 @@ async def remember(
         except VersionConflict as exc:
             await emit_metric("ToolErrors", operation="remember")
             raise ToolError(
-                _conflict_message(key, exc.attempted_version, exc.current_value, exc.current_version)
+                _conflict_message(
+                    key, exc.attempted_version, exc.current_value, exc.current_version
+                )
             ) from exc
         except ValueError as exc:
             await emit_metric("ToolErrors", operation="remember")

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -18,6 +18,7 @@ Tools:
 from __future__ import annotations
 
 import importlib.metadata
+import json
 import os
 import time
 from datetime import datetime, timedelta, timezone
@@ -45,7 +46,7 @@ from hive.rate_limiter import (
     RateLimitExceeded,
     check_rate_limit,
 )
-from hive.storage import HiveStorage
+from hive.storage import HiveStorage, VersionConflict
 from hive.vector_store import VectorIndexNotFoundError, VectorStore
 
 configure_logging("mcp")
@@ -223,11 +224,48 @@ def _quota_meta(storage: HiveStorage, client_id: str) -> dict[str, Any]:
     }
 
 
-def _tool_result(payload: Any, storage: HiveStorage, client_id: str) -> ToolResult:
+def _conflict_message(
+    key: str,
+    attempted_version: str | None,
+    current_value: str | None,
+    current_version: str | None,
+) -> str:
+    """Serialise an optimistic-lock conflict into a ToolError message (#391).
+
+    ToolError currently has no structured-data slot, so agents parse the
+    JSON block appended to the text message to decide how to reconcile.
+    """
+    payload = {
+        "conflict": True,
+        "key": key,
+        "attempted_version": attempted_version,
+        "current_version": current_version,
+        "current_value": current_value,
+    }
+    return (
+        f"Conflict: memory {key!r} was updated since version "
+        f"{attempted_version!r}. " + json.dumps(payload)
+    )
+
+
+def _tool_result(
+    payload: Any,
+    storage: HiveStorage,
+    client_id: str,
+    *,
+    memory: Memory | None = None,
+) -> ToolResult:
     """Wrap a tool's return value in an MCP ``ToolResult`` carrying quota +
     rate-limit metadata in ``_meta.hive``. Strings become text content;
-    dicts become structured content so clients can still use them directly."""
+    dicts become structured content so clients can still use them directly.
+
+    When the tool operated on a specific memory, pass it via ``memory=`` so
+    its optimistic-lock version is surfaced as ``_meta.hive.memory.version``
+    — the agent can thread that back into a subsequent ``remember`` call.
+    """
     meta = _quota_meta(storage, client_id)
+    if memory is not None:
+        meta["hive"]["memory"] = {"key": memory.key, "version": memory.version}
     if isinstance(payload, dict):
         return ToolResult(structured_content=payload, meta=meta)
     return ToolResult(content=payload, meta=meta)
@@ -291,6 +329,12 @@ async def remember(
     ttl_seconds: Annotated[
         int | None, "Seconds until the memory expires. None = never expires."
     ] = None,
+    version: Annotated[
+        str | None,
+        "Optimistic-lock token from a prior recall/list_memories response. "
+        "If provided, the write is rejected with a conflict error when the "
+        "stored memory's version has moved on since the caller read it.",
+    ] = None,
     ctx: Context | None = None,
 ) -> str:
     """Store or update a memory with optional tags and optional TTL."""
@@ -314,6 +358,10 @@ async def remember(
     existing = storage.get_memory_by_key(key)
 
     if existing:
+        # Optimistic lock: reject early if the caller's version is already stale.
+        if version is not None and existing.version != version:
+            await emit_metric("ToolErrors", operation="remember")
+            raise ToolError(_conflict_message(key, version, existing.value, existing.version))
         # Idempotent: skip write and log if nothing changed
         if (
             existing.value == value
@@ -334,7 +382,12 @@ async def remember(
         existing.expires_at = expires_at
         existing.updated_at = datetime.now(timezone.utc)
         try:
-            storage.put_memory(existing)
+            storage.put_memory(existing, expected_version=version)
+        except VersionConflict as exc:
+            await emit_metric("ToolErrors", operation="remember")
+            raise ToolError(
+                _conflict_message(key, exc.attempted_version, exc.current_value, exc.current_version)
+            ) from exc
         except ValueError as exc:
             await emit_metric("ToolErrors", operation="remember")
             raise ToolError(str(exc)) from exc
@@ -549,7 +602,7 @@ async def recall(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="recall"
     )
-    return _tool_result(memory.value, storage, client_id)
+    return _tool_result(memory.value, storage, client_id, memory=memory)
 
 
 @mcp.tool(
@@ -792,6 +845,7 @@ async def list_memories(
                 "last_accessed_at": (
                     m.last_accessed_at.isoformat() if m.last_accessed_at else None
                 ),
+                "version": m.version,
             }
             for m in memories
         ],

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 from typing import Any
 
 import boto3
-from boto3.dynamodb.conditions import Key
+from boto3.dynamodb.conditions import Attr, Key
 from botocore.exceptions import ClientError
 
 from hive.models import (
@@ -56,6 +56,26 @@ REFRESH_TOKEN_TTL_SECONDS = 86400 * 30  # 30 days
 AUTH_CODE_TTL_SECONDS = 300  # 5 minutes
 PENDING_AUTH_TTL_SECONDS = 600  # 10 minutes (enough for Google login flow)
 MGMT_PENDING_STATE_TTL_SECONDS = 600  # 10 minutes (enough for Google login flow)
+
+
+class VersionConflict(Exception):
+    """Raised by put_memory when an optimistic-lock version check fails (#391).
+
+    Carries the state the caller needs to compare-and-retry without an
+    extra round-trip: the attempted version, the actual current value,
+    and the actual current version.
+    """
+
+    def __init__(
+        self,
+        attempted_version: str,
+        current_value: str | None,
+        current_version: str | None,
+    ) -> None:
+        self.attempted_version = attempted_version
+        self.current_value = current_value
+        self.current_version = current_version
+        super().__init__(f"Memory was updated since version {attempted_version!r}")
 
 
 def _now() -> datetime:
@@ -93,27 +113,68 @@ class HiveStorage:
     # Memory CRUD
     # ------------------------------------------------------------------
 
-    def put_memory(self, memory: Memory) -> None:
+    def put_memory(self, memory: Memory, *, expected_version: str | None = None) -> None:
         """Write (create or replace) a memory and all its tag items.
 
         When replacing an existing memory, the previous state is snapshotted
         as a VERSION item so it can be retrieved via list_memory_versions.
+
+        If ``expected_version`` is provided, the META item is written with a
+        conditional expression requiring the stored ``updated_at`` to match
+        — supporting optimistic locking (#391). Raises ``VersionConflict``
+        if the stored version has moved on since the caller read it.
         """
-        # First delete old tag items if the memory already exists
         existing_raw = self._get_memory_meta(memory.memory_id)
+        if expected_version is not None:
+            if existing_raw is None:
+                raise VersionConflict(
+                    attempted_version=expected_version,
+                    current_value=None,
+                    current_version=None,
+                )
+            current = Memory.from_dynamo(existing_raw)
+            if current.version != expected_version:
+                raise VersionConflict(
+                    attempted_version=expected_version,
+                    current_value=current.value,
+                    current_version=current.version,
+                )
+
         if existing_raw:
             old = Memory.from_dynamo(existing_raw)
             self._delete_tag_items(old)
             self.save_memory_version(old)
 
+        meta_item = memory.to_dynamo_meta()
         try:
-            with self.table.batch_writer() as batch:
-                batch.put_item(Item=memory.to_dynamo_meta())
-                for tag_item in memory.to_dynamo_tag_items():
-                    batch.put_item(Item=tag_item)
+            if expected_version is not None:
+                # Conditional put on the META item to close the TOCTOU window
+                # between the read above and the write below. Tag items get
+                # rewritten unconditionally — they carry no value state and
+                # are rebuilt from the memory's tag list on every put.
+                self.table.put_item(
+                    Item=meta_item,
+                    ConditionExpression=Attr("updated_at").eq(expected_version),
+                )
+                with self.table.batch_writer() as batch:
+                    for tag_item in memory.to_dynamo_tag_items():
+                        batch.put_item(Item=tag_item)
+            else:
+                with self.table.batch_writer() as batch:
+                    batch.put_item(Item=meta_item)
+                    for tag_item in memory.to_dynamo_tag_items():
+                        batch.put_item(Item=tag_item)
         except ClientError as exc:
             code = exc.response["Error"]["Code"]
             msg = exc.response["Error"]["Message"]
+            if code == "ConditionalCheckFailedException":
+                latest = self._get_memory_meta(memory.memory_id)
+                latest_mem = Memory.from_dynamo(latest) if latest else None
+                raise VersionConflict(
+                    attempted_version=expected_version or "",
+                    current_value=latest_mem.value if latest_mem else None,
+                    current_version=latest_mem.version if latest_mem else None,
+                ) from exc
             if code == "ValidationException" and "size" in msg.lower():
                 raise ValueError(
                     "Memory value is too large to store (DynamoDB 400 KB item limit exceeded)."

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -87,6 +87,15 @@ class TestMemory:
         assert m2.recall_count == 0
         assert m2.last_accessed_at is None
 
+    def test_version_reflects_updated_at(self):
+        """Memory.version is the updated_at isoformat — advances on every write."""
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        assert m.version == m.updated_at.isoformat()
+        old = m.version
+        m.updated_at = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        assert m.version != old
+        assert m.version == m.updated_at.isoformat()
+
 
 class TestOAuthClient:
     def test_defaults(self):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1543,7 +1543,7 @@ class TestRememberOptimisticLocking:
         msg = str(exc_info.value)
         assert "Conflict" in msg
         # Tail of the message is a JSON payload with the conflict state.
-        payload = _json.loads(msg[msg.index("{"):])
+        payload = _json.loads(msg[msg.index("{") :])
         assert payload["conflict"] is True
         assert payload["attempted_version"] == m.version
         assert payload["current_value"] == "concurrent"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1510,6 +1510,106 @@ class TestMcpToolAnnotations:
         assert tool.annotations.openWorldHint is False
 
 
+class TestRememberOptimisticLocking:
+    """`remember(key, value, version=...)` rejects stale writes with a
+    ToolError carrying the current state so the agent can reconcile."""
+
+    async def test_version_match_updates_successfully(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import recall, remember
+
+        await remember("lock-k", "v1", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("lock-k")
+        result = await remember("lock-k", "v2", [], version=m.version, ctx=_make_ctx(jwt))
+        assert _text(result) == "Updated memory 'lock-k'."
+        assert (await recall("lock-k", ctx=_make_ctx(jwt))).content[0].text == "v2"
+
+    async def test_stale_version_raises_conflict(self, server_env):
+        import json as _json
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        storage, _, jwt = server_env
+        await remember("lock-s", "v1", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("lock-s")
+        # A concurrent writer advances the version out from under us.
+        await remember("lock-s", "concurrent", [], ctx=_make_ctx(jwt))
+
+        with pytest.raises(ToolError) as exc_info:
+            await remember("lock-s", "mine", [], version=m.version, ctx=_make_ctx(jwt))
+
+        msg = str(exc_info.value)
+        assert "Conflict" in msg
+        # Tail of the message is a JSON payload with the conflict state.
+        payload = _json.loads(msg[msg.index("{"):])
+        assert payload["conflict"] is True
+        assert payload["attempted_version"] == m.version
+        assert payload["current_value"] == "concurrent"
+        assert payload["current_version"] != m.version
+
+    async def test_no_version_preserves_backwards_compat(self, server_env):
+        """Unconditional upsert still works when version param is omitted."""
+        storage, _, jwt = server_env
+        from hive.server import remember
+
+        await remember("lock-b", "v1", [], ctx=_make_ctx(jwt))
+        result = await remember("lock-b", "v2", [], ctx=_make_ctx(jwt))
+        assert _text(result) == "Updated memory 'lock-b'."
+        assert storage.get_memory_by_key("lock-b").value == "v2"
+
+    async def test_version_surfaces_in_recall_meta(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import recall, remember
+
+        await remember("lock-r", "v1", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("lock-r")
+        result = await recall("lock-r", ctx=_make_ctx(jwt))
+        meta = _hive_meta(result)
+        assert meta["memory"]["key"] == "lock-r"
+        assert meta["memory"]["version"] == m.version
+
+    async def test_version_surfaces_in_list_memories_items(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_memories, remember
+
+        await remember("lock-l", "v1", ["locktag"], ctx=_make_ctx(jwt))
+        result = await list_memories("locktag", ctx=_make_ctx(jwt))
+        item = next(it for it in _body(result)["items"] if it["key"] == "lock-l")
+        assert "version" in item
+        assert item["version"]
+
+    async def test_conflict_raced_put_surfaces_as_tool_error(self, server_env):
+        """Covers the path where storage raises VersionConflict during the
+        put (e.g. the narrow race between the pre-check read and the
+        conditional write) — remember surfaces it as a ToolError."""
+        from unittest.mock import patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+        from hive.storage import VersionConflict
+
+        storage, _, jwt = server_env
+        await remember("lock-r2", "v1", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("lock-r2")
+
+        with (
+            patch.object(
+                storage.__class__,
+                "put_memory",
+                side_effect=VersionConflict(
+                    attempted_version=m.version,
+                    current_value="raced-in",
+                    current_version="newer",
+                ),
+            ),
+            pytest.raises(ToolError, match="Conflict"),
+        ):
+            await remember("lock-r2", "v2", [], version=m.version, ctx=_make_ctx(jwt))
+
+
 class TestProgressNotifications:
     """Long-running tools emit MCP ``notifications/progress`` events so
     clients can render a progress indicator. Clients that don't support

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -229,6 +229,91 @@ class TestMemoryStorage:
             with pytest.raises(ClientError):
                 storage.put_memory(m)
 
+    def test_put_memory_with_matching_version_succeeds(self, storage):
+        """expected_version on put_memory matches stored updated_at → write succeeds."""
+        from datetime import datetime, timezone
+
+        # Tags are set so the conditional-write branch also rewrites tag items.
+        m = Memory(key="ver-ok", value="v1", tags=["t1"], owner_client_id="c1")
+        storage.put_memory(m)
+        stored = storage.get_memory_by_id(m.memory_id)
+        assert stored is not None
+
+        stored.value = "v2"
+        stored.tags = ["t1", "t2"]
+        stored.updated_at = datetime.now(timezone.utc)  # mimics server.remember()
+        storage.put_memory(stored, expected_version=m.version)
+        result = storage.get_memory_by_id(m.memory_id)
+        assert result.value == "v2"
+        assert set(result.tags) == {"t1", "t2"}
+
+    def test_put_memory_with_stale_version_raises(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.storage import VersionConflict
+
+        m = Memory(key="ver-stale", value="v1", owner_client_id="c1")
+        storage.put_memory(m)
+
+        # Someone else writes first, moving the version forward (updated_at bumps).
+        m2 = storage.get_memory_by_id(m.memory_id)
+        m2.value = "v2"
+        m2.updated_at = datetime.now(timezone.utc) + timedelta(seconds=1)
+        storage.put_memory(m2)
+
+        # Now a write pinned to the *original* version is rejected.
+        m.value = "stale"
+        with pytest.raises(VersionConflict) as exc_info:
+            storage.put_memory(m, expected_version=m.version)
+        assert exc_info.value.current_value == "v2"
+        assert exc_info.value.current_version != m.version
+
+    def test_put_memory_with_version_but_no_existing_item_raises(self, storage):
+        """Passing expected_version on a brand-new memory is a conflict (there's
+        nothing to lock against)."""
+        from hive.storage import VersionConflict
+
+        m = Memory(key="ver-missing", value="v1", owner_client_id="c1")
+        with pytest.raises(VersionConflict) as exc_info:
+            storage.put_memory(m, expected_version="2024-01-01T00:00:00+00:00")
+        assert exc_info.value.current_value is None
+        assert exc_info.value.current_version is None
+
+    def test_put_memory_conditional_check_failure_surfaces_as_version_conflict(self, storage):
+        """If the conditional put race fires after the pre-read, we re-read
+        and surface the real current state in VersionConflict."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        from hive.storage import VersionConflict
+
+        m = Memory(key="ver-race", value="v1", owner_client_id="c1")
+        storage.put_memory(m)
+        stored = storage.get_memory_by_id(m.memory_id)
+
+        stored.value = "v2"
+        stored.updated_at = datetime.now(timezone.utc)
+
+        # Only the conditional META put should fail; version-snapshot writes
+        # (SK=VERSION#…) must still succeed so execution reaches the conditional.
+        real_put = storage.table.put_item
+        error_response = {
+            "Error": {"Code": "ConditionalCheckFailedException", "Message": "mismatch"}
+        }
+
+        def selective(**kwargs):
+            if "ConditionExpression" in kwargs:
+                raise ClientError(error_response, "PutItem")
+            return real_put(**kwargs)
+
+        with (
+            patch.object(storage.table, "put_item", side_effect=selective),
+            pytest.raises(VersionConflict),
+        ):
+            storage.put_memory(stored, expected_version=m.version)
+
     def test_put_and_get_memory_with_ttl(self, storage):
         from datetime import datetime, timedelta, timezone
 


### PR DESCRIPTION
Closes #391

## Summary

`remember(key, value, …, version=)` now accepts an optional optimistic-lock token from a prior `recall` / `list_memories` response. When provided, the write is rejected with a `ToolError` if the stored memory's version has moved on since the caller read it — preventing the silent last-write-wins behaviour that otherwise affects multi-agent scenarios.

Backwards compatible: `remember(...)` without `version` keeps the existing unconditional upsert behaviour.

## Approach

- **`Memory.version`** — computed property = `updated_at.isoformat()`. Opaque token that advances on every write, no new schema field required.
- **`storage.put_memory(memory, expected_version=...)`** — does an in-process pre-check + a DynamoDB `ConditionExpression` on `updated_at` to close the TOCTOU window between read and write. `batch_writer` handles tag items separately since they carry no value state.
- **`VersionConflict`** exception (raised from storage, converted to `ToolError` in server) carries `attempted_version` + `current_value` + `current_version` so agents can compare-and-retry without an extra round-trip. The payload is JSON-encoded in the error message (FastMCP's `ToolError` has no structured-data slot yet).
- **`_meta.hive.memory.{key, version}`** — recall responses now include the memory's version in the `_meta.hive` block so agents get the token without changing their existing remember call sites.
- **`version`** on each `list_memories` item too.

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + 577 unit + 604 frontend tests (100% coverage)
- [x] Covers: matching version succeeds, stale version raises, brand-new key with `version=` raises, conditional-put race surfaces as `VersionConflict`, `_meta.hive.memory.version` surfaces on recall, `version` surfaces on list_memories items, server conflict → `ToolError` with JSON payload
- [ ] CI green
- [ ] `development` pipeline green post-merge