### PR TITLE
feat: wire log_audit_event into all memory-touching tools + admin endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,9 @@ hive/
 - Token items: `PK=TOKEN#{jti}`, `SK=META` (TTL enabled)
 - Activity log items: `PK=LOG#{date}#{hour}`, `SK={timestamp}#{event_id}`
   (hour-sharded to avoid hot partitions)
+- Audit log items: `PK=AUDIT#{date}#{hour}`, `SK={timestamp}#{event_id}`
+  (immutable compliance trail, TTL via `HIVE_AUDIT_RETENTION_DAYS`,
+  default 365 days; survives user-initiated activity-log purges)
 - User items: `PK=USER#{user_id}`, `SK=META`
 - Mgmt state items: `PK=MGMT_STATE#{state}`, `SK=META`
   (TTL enabled, used for OAuth state parameter)

--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -346,3 +346,67 @@ async def get_alarms(
     Admin-only. Results cached for 5 min.
     """
     return _get_alarm_data()
+
+
+def _storage() -> Any:
+    from hive.storage import HiveStorage
+
+    return HiveStorage()
+
+
+_AUDIT_LIMIT_DEFAULT = 100
+_AUDIT_LIMIT_MAX = 500
+
+
+@router.get(
+    "/audit-log",
+    summary="Query the compliance audit log",
+    description=(
+        "Immutable audit trail of every memory read/write/delete (#395). "
+        "Admin-only. Use ``days`` to widen the window (capped at 90). "
+        "Optional ``client_id`` / ``event_type`` filters narrow the result."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+    },
+)
+async def get_audit_log(
+    _claims: Annotated[dict[str, Any], Depends(require_admin)],
+    storage: Annotated[Any, Depends(_storage)],
+    days: Annotated[int, Query(ge=1, le=90, description="Days of history to return")] = 7,
+    limit: Annotated[
+        int, Query(ge=1, le=_AUDIT_LIMIT_MAX, description="Max events to return")
+    ] = _AUDIT_LIMIT_DEFAULT,
+    client_id: Annotated[str | None, Query(description="Filter by client_id")] = None,
+    event_type: Annotated[str | None, Query(description="Filter by event_type")] = None,
+) -> dict[str, Any]:
+    import datetime as _dt
+
+    today = _dt.date.today()
+    dates = [
+        (today - _dt.timedelta(days=i)).isoformat()
+        for i in range(days)  # NOSONAR — days bounded by FastAPI Query(ge=1, le=90)
+    ]
+    events = storage.get_audit_events_for_dates(
+        dates,
+        client_id=client_id,
+        event_type=event_type,
+        limit=limit + 1,
+    )
+    has_more = len(events) > limit
+    events = events[:limit]
+    return {
+        "items": [
+            {
+                "event_id": e.event_id,
+                "event_type": e.event_type.value,
+                "client_id": e.client_id,
+                "timestamp": e.timestamp.isoformat(),
+                "metadata": e.metadata,
+            }
+            for e in events
+        ],
+        "count": len(events),
+        "has_more": has_more,
+    }

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -193,6 +193,19 @@ def _vector_store() -> VectorStore:
     return VectorStore()
 
 
+def _log(storage: HiveStorage, event: ActivityEvent) -> None:
+    """Record the event in both the user-visible activity log and the
+    immutable compliance audit log (#395).
+
+    Memory reads/writes/deletes surface in the Activity Log UI via the
+    LOG# partition; the AUDIT# partition carries the same events but
+    with a distinct retention (``HIVE_AUDIT_RETENTION_DAYS``, default
+    365 days) and survives an activity-log purge.
+    """
+    storage.log_event(event)
+    storage.log_audit_event(event)
+
+
 # ---------------------------------------------------------------------------
 # Response metadata — every tool response carries quota + rate-limit state
 # under ``_meta.hive`` so well-behaved agents can self-throttle.
@@ -421,12 +434,13 @@ async def remember(
         except Exception:
             logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=event_type,
             client_id=client_id,
             metadata={"key": key, "tags": tags},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -528,12 +542,13 @@ async def remember_if_absent(
     except Exception:
         logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_created,
             client_id=client_id,
             metadata={"key": key, "tags": tags},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -583,12 +598,13 @@ async def recall(
         await emit_metric("ToolErrors", operation="recall")
         raise ToolError(f"No memory found for key '{key}'.")
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_recalled,
             client_id=client_id,
             metadata={"key": key},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -643,12 +659,13 @@ async def forget(
         _vector_store().delete_memory(existing.memory_id, client_id)
     except Exception:
         logger.warning("Vector delete failed (non-fatal)", exc_info=True)
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_deleted,
             client_id=client_id,
             metadata={"key": key},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -685,12 +702,13 @@ async def forget_all(
     storage, client_id = await _auth(ctx, required_scope="memories:write")
 
     deleted = storage.delete_memories_by_tag(tag)
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_deleted,
             client_id=client_id,
             metadata={"tag": tag, "count": deleted},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -778,12 +796,13 @@ async def restore_memory(
     memory.tags = version.tags
     memory.updated_at = datetime.now(timezone.utc)
     storage.put_memory(memory)
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_updated,
             client_id=client_id,
             metadata={"key": key, "version_timestamp": version_timestamp},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     await emit_metric("ToolInvocations", operation="restore_memory")
@@ -814,12 +833,13 @@ async def list_memories(
 
     limit = max(1, min(limit, 500))
     memories, next_cursor = storage.list_memories_by_tag(tag, limit=limit, cursor=cursor)
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_listed,
             client_id=client_id,
             metadata={"tag": tag, "count": len(memories)},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -934,12 +954,13 @@ async def summarize_context(
         "Review the entries above for relevant context.*"
     )
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.context_summarized,
             client_id=client_id,
             metadata={"topic": topic, "memory_count": len(memories)},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -1019,12 +1040,13 @@ async def search_memories(
     results = results[:top_k]
     await _report_progress(ctx, 2, 3, f"Ranked {len(results)} result(s); returning.")
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_searched,
             client_id=client_id,
             metadata={"query": query, "result_count": len(results)},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -1093,12 +1115,13 @@ async def relate_memories(
     pairs = [(mid, score) for mid, score in pairs if mid != memory.memory_id][:top_k]
     results = storage.hydrate_memory_ids(pairs)
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_searched,
             client_id=client_id,
             metadata={"key": key, "result_count": len(results), "related_to": memory.memory_id},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -903,13 +903,52 @@ class HiveStorage:
         """Write an audit event to the immutable audit log (AUDIT# PK prefix).
 
         Audit events use a separate PK prefix from activity log events (LOG#)
-        and are never deleted, even when a user's activity log is purged.
+        so they survive a user-requested activity-log purge. A DynamoDB TTL
+        provides a hard retention horizon (``HIVE_AUDIT_RETENTION_DAYS``,
+        default 365) so items age out automatically and we stay compliant
+        with data-minimisation expectations.
         """
         item = event.to_dynamo()
-        # Override the PK prefix so audit events are stored separately
         date_hour_str = event.timestamp.strftime("%Y-%m-%d#%H")
         item["PK"] = f"AUDIT#{date_hour_str}"
+        retention_days = int(os.environ.get("HIVE_AUDIT_RETENTION_DAYS", "365"))
+        item["ttl"] = int(event.timestamp.timestamp()) + retention_days * 86400
         self.table.put_item(Item=item)
+
+    def get_audit_events_for_dates(
+        self,
+        dates: list[str],
+        *,
+        client_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 100,
+    ) -> list[ActivityEvent]:
+        """Fetch audit events across multiple dates, newest-first, capped at limit.
+
+        Optional post-query filters on ``client_id`` and ``event_type`` keep
+        the admin audit-log endpoint simple; the partition scan itself reads
+        every hour-shard in parallel.
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        def _query(pk: str) -> list[ActivityEvent]:
+            resp = self.table.query(KeyConditionExpression=Key("PK").eq(pk))
+            return [ActivityEvent.from_dynamo(i) for i in resp.get("Items", [])]
+
+        pks = [f"AUDIT#{d}#{hour:02d}" for d in dates for hour in range(24)]
+        events: list[ActivityEvent] = []
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = {executor.submit(_query, pk): pk for pk in pks}
+            for future in as_completed(futures):
+                events.extend(future.result())
+
+        if client_id is not None:
+            events = [e for e in events if e.client_id == client_id]
+        if event_type is not None:
+            events = [e for e in events if e.event_type.value == event_type]
+
+        events.sort(key=lambda e: e.timestamp, reverse=True)
+        return events[:limit]
 
     # ------------------------------------------------------------------
     # Account deletion

--- a/tests/unit/test_admin_api.py
+++ b/tests/unit/test_admin_api.py
@@ -447,3 +447,101 @@ class TestAdminAlarms:
                 resp = admin_tc.get("/api/admin/alarms")
 
             assert resp.json()["alarms"][0]["state"] == state
+
+
+class TestAdminAuditLog:
+    """GET /api/admin/audit-log — admin-only compliance audit trail (#395)."""
+
+    @pytest.fixture()
+    def audit_storage(self):
+        from hive.api import admin as admin_mod
+        from hive.api.main import app
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-admin", region="us-east-1")
+        app.dependency_overrides[admin_mod._storage] = lambda: storage
+        yield storage
+        app.dependency_overrides.pop(admin_mod._storage, None)
+
+    def test_returns_events_newest_first(self, admin_tc, audit_storage):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import ActivityEvent, EventType
+
+        base = datetime.now(timezone.utc).replace(microsecond=0)
+        for i, etype in enumerate(
+            [EventType.memory_created, EventType.memory_recalled, EventType.memory_deleted]
+        ):
+            audit_storage.log_audit_event(
+                ActivityEvent(
+                    event_type=etype,
+                    client_id="c1",
+                    metadata={"i": i},
+                    timestamp=base - timedelta(seconds=i),
+                )
+            )
+
+        resp = admin_tc.get("/api/admin/audit-log?days=1&limit=10")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 3
+        # Newest-first ordering
+        assert body["items"][0]["event_type"] == "memory_created"
+        assert body["items"][-1]["event_type"] == "memory_deleted"
+
+    def test_filter_by_client_id(self, admin_tc, audit_storage):
+        from hive.models import ActivityEvent, EventType
+
+        for cid in ["c1", "c2", "c1"]:
+            audit_storage.log_audit_event(
+                ActivityEvent(event_type=EventType.memory_created, client_id=cid)
+            )
+
+        resp = admin_tc.get("/api/admin/audit-log?days=1&client_id=c1")
+        items = resp.json()["items"]
+        assert {it["client_id"] for it in items} == {"c1"}
+
+    def test_filter_by_event_type(self, admin_tc, audit_storage):
+        from hive.models import ActivityEvent, EventType
+
+        audit_storage.log_audit_event(
+            ActivityEvent(event_type=EventType.memory_created, client_id="c")
+        )
+        audit_storage.log_audit_event(
+            ActivityEvent(event_type=EventType.memory_deleted, client_id="c")
+        )
+
+        resp = admin_tc.get("/api/admin/audit-log?days=1&event_type=memory_deleted")
+        items = resp.json()["items"]
+        assert {it["event_type"] for it in items} == {"memory_deleted"}
+
+    def test_has_more_flag(self, admin_tc, audit_storage):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import ActivityEvent, EventType
+
+        base = datetime.now(timezone.utc)
+        for i in range(5):
+            audit_storage.log_audit_event(
+                ActivityEvent(
+                    event_type=EventType.memory_created,
+                    client_id="c",
+                    timestamp=base - timedelta(seconds=i),
+                )
+            )
+
+        resp = admin_tc.get("/api/admin/audit-log?days=1&limit=3")
+        body = resp.json()
+        assert body["count"] == 3
+        assert body["has_more"] is True
+
+    def test_non_admin_forbidden(self, user_tc):
+        resp = user_tc.get("/api/admin/audit-log?days=1")
+        assert resp.status_code == 403
+
+    def test_storage_factory_returns_storage(self):
+        """_storage() dep factory returns a HiveStorage so the endpoint can run in prod."""
+        from hive.api.admin import _storage
+        from hive.storage import HiveStorage
+
+        assert isinstance(_storage(), HiveStorage)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -561,6 +561,92 @@ class TestActivityLog:
         assert len(events) == 1
         assert events[0].event_id == event.event_id
 
+
+class TestAuditLog:
+    def test_log_audit_event_sets_ttl_from_retention_env(self, storage):
+        from datetime import datetime, timezone
+
+        event = ActivityEvent(
+            event_type=EventType.memory_created,
+            client_id="c1",
+            metadata={"key": "k1"},
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("HIVE_AUDIT_RETENTION_DAYS", "30")
+            storage.log_audit_event(event)
+
+        # Re-read the raw item to verify TTL was written.
+        date_hour_str = event.timestamp.strftime("%Y-%m-%d#%H")
+        resp = storage.table.get_item(
+            Key={
+                "PK": f"AUDIT#{date_hour_str}",
+                "SK": f"{event.timestamp.isoformat()}#{event.event_id}",
+            }
+        )
+        item = resp["Item"]
+        assert "ttl" in item
+        assert int(item["ttl"]) == int(event.timestamp.timestamp()) + 30 * 86400
+
+    def test_audit_events_separate_from_activity_events(self, storage):
+        """Writing to the audit log must not leak into the activity log."""
+        event = ActivityEvent(
+            event_type=EventType.memory_created,
+            client_id="c1",
+            metadata={},
+        )
+        storage.log_audit_event(event)
+        # No activity log entry should exist
+        assert storage.get_events_for_date(event.timestamp.strftime("%Y-%m-%d")) == []
+
+    def test_get_audit_events_filters_by_client_id_and_event_type(self, storage):
+        from datetime import datetime, timezone
+
+        ts = datetime.now(timezone.utc)
+        events = [
+            ActivityEvent(event_type=EventType.memory_created, client_id="c1", timestamp=ts),
+            ActivityEvent(event_type=EventType.memory_deleted, client_id="c1", timestamp=ts),
+            ActivityEvent(event_type=EventType.memory_created, client_id="c2", timestamp=ts),
+        ]
+        for e in events:
+            storage.log_audit_event(e)
+
+        dates = [ts.strftime("%Y-%m-%d")]
+
+        all_events = storage.get_audit_events_for_dates(dates)
+        assert len(all_events) == 3
+
+        c1_only = storage.get_audit_events_for_dates(dates, client_id="c1")
+        assert {e.client_id for e in c1_only} == {"c1"}
+
+        created_only = storage.get_audit_events_for_dates(dates, event_type="memory_created")
+        assert {e.event_type.value for e in created_only} == {"memory_created"}
+
+        combined = storage.get_audit_events_for_dates(
+            dates, client_id="c1", event_type="memory_created"
+        )
+        assert len(combined) == 1
+        assert combined[0].client_id == "c1"
+        assert combined[0].event_type == EventType.memory_created
+
+    def test_get_audit_events_limit_and_sort(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        base = datetime.now(timezone.utc).replace(microsecond=0)
+        for i in range(5):
+            e = ActivityEvent(
+                event_type=EventType.memory_created,
+                client_id="c",
+                timestamp=base - timedelta(seconds=i),
+            )
+            storage.log_audit_event(e)
+
+        dates = [base.strftime("%Y-%m-%d")]
+        events = storage.get_audit_events_for_dates(dates, limit=3)
+        assert len(events) == 3
+        # Newest-first
+        assert events[0].timestamp > events[1].timestamp > events[2].timestamp
+
     def test_hour_sharded_pk(self, storage):
         """Events must be written to LOG#{date}#{hour} partitions."""
         event = ActivityEvent(


### PR DESCRIPTION
Closes #395

## Summary

The `log_audit_event` helper has existed in `storage.py` since memory history shipped, but no server.py tool handler called it. This PR wires it into every memory read, write, and delete so Hive now produces an immutable compliance audit trail — separate from the user-visible activity log and surviving any user-initiated activity-log purge.

## Approach

- **`_log(storage, event)`** helper in `server.py` writes the same event to both the activity log (LOG# partition) and the compliance audit log (AUDIT# partition). Replaces the 11 direct `storage.log_event(...)` call sites.
- **`storage.log_audit_event`** gains a TTL derived from `HIVE_AUDIT_RETENTION_DAYS` (default 365) so audit items age out automatically — compliant with data-minimisation expectations while still giving a multi-month trail.
- **`storage.get_audit_events_for_dates(dates, *, client_id=None, event_type=None, limit=100)`** queries hour-sharded AUDIT# partitions in parallel with optional post-filters.
- **`GET /api/admin/audit-log?days&limit&client_id&event_type`** admin-only endpoint returns newest-first audit entries with `has_more` paging.
- **CLAUDE.md** DynamoDB layout gains the AUDIT# prefix + retention env var.

## Out of scope (follow-up)

- Admin UI panel to browse the audit log — the REST endpoint is ready; a React panel can land in a separate PR.
- Before/after snapshot on updates — `remember` update events already carry the `{key, tags}` metadata; deeper diffing would grow write volume and is better done lazily via `list_memory_versions`.

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + 587 unit + 605 frontend (100% coverage)
- [x] Covers: TTL derivation, audit-vs-activity separation, client_id + event_type filters, newest-first sort + limit, admin `/audit-log` endpoint, non-admin 403, `_storage` dep factory
- [ ] CI green
- [ ] `development` pipeline green post-merge