### PR TITLE
feat: hybrid retrieval in search_memories (semantic + keyword + recency)

### DIFF
--- a/src/hive/hybrid_search.py
+++ b/src/hive/hybrid_search.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Hybrid retrieval scoring for `search_memories` (#481).
+
+Combines three independent signals into a single blended score:
+
+- **semantic** — cosine similarity from the S3 Vectors index (already
+  in the 0-1 range from the vector store).
+- **keyword** — cheap term-frequency match over the query tokens
+  against the memory value. Gives short/exact-match queries (e.g.
+  "wifi password") a meaningful score even when they fall outside
+  the embedding neighbourhood.
+- **recency** — exponential decay against ``last_accessed_at``
+  (falling back to ``updated_at`` when the memory has never been
+  recalled). Half-life defaults to 30 days.
+
+Deliberately uses a simple TF heuristic rather than BM25 to avoid
+adding a tokeniser dependency — memory values are short, so the
+heuristic is good enough. Tokenisation is case-insensitive, no
+stemming.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import datetime, timezone
+
+from hive.models import Memory
+
+DEFAULT_W_SEMANTIC = 0.6
+DEFAULT_W_KEYWORD = 0.3
+DEFAULT_W_RECENCY = 0.1
+DEFAULT_RECENCY_HALF_LIFE_DAYS = 30.0
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase + word-chars-only tokeniser. No stemming."""
+    if not text:
+        return []
+    return _TOKEN_RE.findall(text.lower())
+
+
+def keyword_score(query_tokens: list[str], value: str) -> float:
+    """Return a 0-1 keyword score for ``value`` against ``query_tokens``.
+
+    Score = fraction of query tokens that appear at least once in the
+    tokenised value. Simple, bounded, and monotonic in recall — a value
+    that matches every query token scores 1.0, none scores 0.0.
+    """
+    if not query_tokens:
+        return 0.0
+    value_tokens = set(tokenize(value))
+    if not value_tokens:
+        return 0.0
+    hits = sum(1 for t in query_tokens if t in value_tokens)
+    return hits / len(query_tokens)
+
+
+def recency_score(
+    memory: Memory,
+    *,
+    now: datetime | None = None,
+    half_life_days: float = DEFAULT_RECENCY_HALF_LIFE_DAYS,
+) -> float:
+    """Return a 0-1 recency score using a true half-life decay.
+
+    Formula: ``2 ** (-age_days / half_life_days)``. A memory exactly
+    one half-life old scores 0.5; two half-lives → 0.25; etc. Uses
+    ``last_accessed_at`` when set (recall touched the memory), otherwise
+    ``updated_at``.
+    """
+    now = now or datetime.now(timezone.utc)
+    ref = memory.last_accessed_at or memory.updated_at
+    age_seconds = max(0.0, (now - ref).total_seconds())
+    age_days = age_seconds / 86400.0
+    return math.pow(2.0, -age_days / half_life_days)
+
+
+def blend_score(
+    *,
+    semantic: float,
+    keyword: float,
+    recency: float,
+    w_semantic: float = DEFAULT_W_SEMANTIC,
+    w_keyword: float = DEFAULT_W_KEYWORD,
+    w_recency: float = DEFAULT_W_RECENCY,
+) -> float:
+    """Weighted sum, with weights renormalised to sum to 1.0.
+
+    Renormalising lets callers pass any relative weighting (e.g. all
+    zeros except `w_keyword=1.0`) without having to do the arithmetic
+    themselves. If all weights are zero we fall back to the defaults
+    rather than returning an all-zero score.
+    """
+    total = w_semantic + w_keyword + w_recency
+    if total <= 0:
+        w_semantic, w_keyword, w_recency = (
+            DEFAULT_W_SEMANTIC,
+            DEFAULT_W_KEYWORD,
+            DEFAULT_W_RECENCY,
+        )
+        total = 1.0
+    ws = w_semantic / total
+    wk = w_keyword / total
+    wr = w_recency / total
+    return ws * semantic + wk * keyword + wr * recency

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -803,21 +803,37 @@ class ApiKeyCreateResponse(ApiKeyResponse):
 
 
 class MemorySearchResult(BaseModel):
-    """A memory returned by semantic search, with a relevance score."""
+    """A memory returned by search, with its blended relevance score.
+
+    ``score`` is the final blended value on [0, 1]. The per-signal sub-scores
+    (``semantic_score`` / ``keyword_score`` / ``recency_score``) are included
+    for debugging and agent-side re-ranking when hybrid mode is on (#481).
+    """
 
     memory_id: str
     key: str
     value: str
     tags: list[str]
     owner_client_id: str | None
-    score: float  # cosine similarity (0.0–1.0); higher = more relevant
+    score: float  # blended score (0.0–1.0); higher = more relevant
+    semantic_score: float = 0.0
+    keyword_score: float = 0.0
+    recency_score: float = 0.0
     created_at: datetime
     updated_at: datetime
     recall_count: int = 0
     last_accessed_at: datetime | None = None
 
     @classmethod
-    def from_memory_and_score(cls, m: Memory, score: float) -> MemorySearchResult:
+    def from_memory_and_score(
+        cls,
+        m: Memory,
+        score: float,
+        *,
+        semantic_score: float = 0.0,
+        keyword_score: float = 0.0,
+        recency_score: float = 0.0,
+    ) -> MemorySearchResult:
         return cls(
             memory_id=m.memory_id,
             key=m.key,
@@ -825,6 +841,9 @@ class MemorySearchResult(BaseModel):
             tags=m.tags,
             owner_client_id=m.owner_client_id,
             score=score,
+            semantic_score=semantic_score,
+            keyword_score=keyword_score,
+            recency_score=recency_score,
             created_at=m.created_at,
             updated_at=m.updated_at,
             recall_count=m.recall_count,

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -36,6 +36,15 @@ from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse as StarletteJSONResponse
 
 from hive.auth.tokens import ISSUER, _origin_verify_secret, validate_bearer_token
+from hive.hybrid_search import (
+    DEFAULT_W_KEYWORD,
+    DEFAULT_W_RECENCY,
+    DEFAULT_W_SEMANTIC,
+    blend_score,
+    keyword_score,
+    recency_score,
+    tokenize,
+)
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 from hive.metrics import emit_metric
 from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult
@@ -992,7 +1001,7 @@ async def search_memories(
     top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 10,
     min_score: Annotated[
         float | None,
-        "Minimum similarity score (0.0–1.0). Results below this threshold are "
+        "Minimum blended score (0.0–1.0). Results below this threshold are "
         "excluded. None disables filtering.",
     ] = None,
     filter_tags: Annotated[
@@ -1000,12 +1009,24 @@ async def search_memories(
         "Optional list of tags. Only memories carrying ALL of the given tags "
         "are returned. None disables filtering.",
     ] = None,
+    w_semantic: Annotated[
+        float, "Weight for semantic/vector similarity (default 0.6)"
+    ] = DEFAULT_W_SEMANTIC,
+    w_keyword: Annotated[
+        float, "Weight for keyword (term-frequency) match (default 0.3)"
+    ] = DEFAULT_W_KEYWORD,
+    w_recency: Annotated[
+        float, "Weight for recency decay against last_accessed_at/updated_at (default 0.1)"
+    ] = DEFAULT_W_RECENCY,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
-    """Search memories by semantic similarity to a natural language query.
+    """Search memories using hybrid retrieval: semantic + keyword + recency.
 
-    Returns memories ranked by relevance.  ``score`` ranges from 0.0 to 1.0
-    where higher means more semantically similar to the query.
+    Final score is a weighted sum of (a) cosine similarity from the vector
+    store, (b) a term-frequency keyword match, and (c) an exponential
+    recency decay. Weights are re-normalised to sum to 1.0; pass any
+    relative weighting. Per-signal sub-scores are returned on each item
+    for debugging.
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
@@ -1013,9 +1034,10 @@ async def search_memories(
     threshold = max(0.0, min(1.0, min_score)) if min_score is not None else None
     required_tags = set(filter_tags) if filter_tags else None
 
-    # When post-filtering by tags, request the full cap from the vector store
-    # so we have headroom to still return up to top_k matches after filtering.
-    search_top_k = 50 if required_tags else top_k
+    # Always request a wider candidate pool than top_k so keyword + recency
+    # blending has headroom to re-rank, and (if tag filtering is on) so the
+    # post-filter still leaves up to top_k survivors.
+    search_top_k = 50 if required_tags else min(max(top_k * 3, 10), 50)
 
     await _report_progress(ctx, 0, 3, f"Running vector search for '{query}'...")
     try:
@@ -1026,33 +1048,53 @@ async def search_memories(
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
         return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
 
-    if threshold is not None:
-        pairs = [(mid, score) for mid, score in pairs if score >= threshold]
-
     await _report_progress(
         ctx, 1, 3, f"Vector search returned {len(pairs)} candidates; hydrating..."
     )
-    results = storage.hydrate_memory_ids(pairs)
+    hydrated = storage.hydrate_memory_ids(pairs)
+
+    # Score each hydrated memory. sem_map lets us pair each Memory with its
+    # original cosine similarity; absent memories (hydrate dropped expired
+    # ones) are simply skipped.
+    query_tokens = tokenize(query)
+    now = datetime.now(timezone.utc)
+    scored: list[tuple[Memory, float, float, float, float]] = []
+    for m, sem in hydrated:
+        kw = keyword_score(query_tokens, m.value)
+        rec = recency_score(m, now=now)
+        blended = blend_score(
+            semantic=sem,
+            keyword=kw,
+            recency=rec,
+            w_semantic=w_semantic,
+            w_keyword=w_keyword,
+            w_recency=w_recency,
+        )
+        scored.append((m, blended, sem, kw, rec))
+
+    if threshold is not None:
+        scored = [row for row in scored if row[1] >= threshold]
 
     if required_tags:
-        results = [(m, s) for m, s in results if required_tags.issubset(m.tags)]
+        scored = [row for row in scored if required_tags.issubset(row[0].tags)]
 
-    results = results[:top_k]
-    await _report_progress(ctx, 2, 3, f"Ranked {len(results)} result(s); returning.")
+    scored.sort(key=lambda row: row[1], reverse=True)
+    scored = scored[:top_k]
+    await _report_progress(ctx, 2, 3, f"Ranked {len(scored)} result(s); returning.")
 
     _log(
         storage,
         ActivityEvent(
             event_type=EventType.memory_searched,
             client_id=client_id,
-            metadata={"query": query, "result_count": len(results)},
+            metadata={"query": query, "result_count": len(scored)},
         ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
         "Searched memories for '%s', %d result(s)",
         query,
-        len(results),
+        len(scored),
         extra={
             "tool": "search_memories",
             "duration_ms": duration_ms,
@@ -1069,10 +1111,16 @@ async def search_memories(
     return _tool_result(
         {
             "items": [
-                MemorySearchResult.from_memory_and_score(m, score).model_dump()
-                for m, score in results
+                MemorySearchResult.from_memory_and_score(
+                    m,
+                    blended,
+                    semantic_score=sem,
+                    keyword_score=kw,
+                    recency_score=rec,
+                ).model_dump()
+                for m, blended, sem, kw, rec in scored
             ],
-            "count": len(results),
+            "count": len(scored),
             "query": query,
         },
         storage,

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for the hybrid search scoring helpers (#481)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hive.hybrid_search import (
+    DEFAULT_W_KEYWORD,
+    DEFAULT_W_RECENCY,
+    DEFAULT_W_SEMANTIC,
+    blend_score,
+    keyword_score,
+    recency_score,
+    tokenize,
+)
+from hive.models import Memory
+
+
+class TestTokenize:
+    def test_lowercases_and_splits_on_non_word(self):
+        assert tokenize("Hello, World! 2026") == ["hello", "world", "2026"]
+
+    def test_empty_string_returns_empty_list(self):
+        assert tokenize("") == []
+
+    def test_unicode_word_chars(self):
+        # \w is Unicode-aware under the re.UNICODE flag.
+        assert tokenize("café Résumé") == ["café", "résumé"]
+
+
+class TestKeywordScore:
+    def test_returns_fraction_of_tokens_matched(self):
+        assert keyword_score(["wifi", "password"], "the wifi password is 1234") == 1.0
+        assert keyword_score(["wifi", "password"], "the wifi is up") == 0.5
+        assert keyword_score(["wifi", "password"], "nothing to see") == 0.0
+
+    def test_empty_query_returns_zero(self):
+        assert keyword_score([], "any value") == 0.0
+
+    def test_empty_value_returns_zero(self):
+        assert keyword_score(["wifi"], "") == 0.0
+
+    def test_value_tokenisation_is_case_insensitive(self):
+        # The scorer assumes query tokens are already lowercased via tokenize();
+        # this test verifies it still matches when the value has mixed case.
+        assert keyword_score(tokenize("WIFI"), "WIFI works") == 1.0
+        assert keyword_score(tokenize("WiFi"), "the WIFI password") == 1.0
+
+
+class TestRecencyScore:
+    def _mem(self, *, updated_at=None, last_accessed_at=None) -> Memory:
+        return Memory(
+            key="k",
+            value="v",
+            owner_client_id="c1",
+            updated_at=updated_at or datetime.now(timezone.utc),
+            last_accessed_at=last_accessed_at,
+        )
+
+    def test_fresh_memory_scores_near_one(self):
+        now = datetime.now(timezone.utc)
+        m = self._mem(updated_at=now)
+        assert recency_score(m, now=now) == 1.0
+
+    def test_half_life_produces_half_score(self):
+        now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        m = self._mem(updated_at=now - timedelta(days=30))
+        assert abs(recency_score(m, now=now, half_life_days=30) - 0.5) < 1e-6
+
+    def test_uses_last_accessed_at_when_set(self):
+        now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        # updated_at is old but last_accessed_at is fresh — recency should be high.
+        m = self._mem(
+            updated_at=now - timedelta(days=365),
+            last_accessed_at=now,
+        )
+        assert recency_score(m, now=now) == 1.0
+
+    def test_future_timestamps_clamped_to_now(self):
+        now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        m = self._mem(updated_at=now + timedelta(days=10))
+        # Future ref shouldn't blow up; age is clamped to 0 → score 1.0.
+        assert recency_score(m, now=now) == 1.0
+
+
+class TestBlendScore:
+    def test_weighted_sum(self):
+        # With defaults: 0.6 * 1 + 0.3 * 0 + 0.1 * 0 = 0.6
+        assert blend_score(semantic=1.0, keyword=0.0, recency=0.0) == pytest.approx(0.6)
+
+    def test_renormalises_uneven_weights(self):
+        # Weights 2:2:0 should behave like 0.5 / 0.5 / 0
+        score = blend_score(
+            semantic=1.0,
+            keyword=0.0,
+            recency=0.0,
+            w_semantic=2.0,
+            w_keyword=2.0,
+            w_recency=0.0,
+        )
+        assert score == pytest.approx(0.5)
+
+    def test_all_zero_weights_falls_back_to_defaults(self):
+        # Shouldn't produce NaN or zero when caller passes all-zero weights.
+        score = blend_score(
+            semantic=1.0,
+            keyword=0.5,
+            recency=0.25,
+            w_semantic=0,
+            w_keyword=0,
+            w_recency=0,
+        )
+        expected = DEFAULT_W_SEMANTIC * 1.0 + DEFAULT_W_KEYWORD * 0.5 + DEFAULT_W_RECENCY * 0.25
+        assert score == pytest.approx(expected)
+
+    def test_all_ones_produces_one(self):
+        assert blend_score(semantic=1.0, keyword=1.0, recency=1.0) == pytest.approx(1.0)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -911,7 +911,12 @@ class TestSearchMemories:
         assert body["query"] == "searchable content"
         item = body["items"][0]
         assert item["key"] == "search-key"
-        assert item["score"] == 0.88
+        # Hybrid re-ranking exposes the original semantic score alongside the
+        # blended score — both "searchable" and "content" tokens match so the
+        # blended score exceeds the raw 0.88.
+        assert item["semantic_score"] == 0.88
+        assert item["keyword_score"] == 1.0
+        assert item["score"] >= 0.88
         assert item["owner_client_id"] == client_id
 
     async def test_returns_empty_when_no_index(self, server_env):
@@ -1091,17 +1096,19 @@ class TestSearchMemories:
 
         storage, _, jwt = server_env
         ctx = _make_ctx(jwt)
-        await remember("key", "v", ["t"], ctx=ctx)
+        # Disable recency weighting so floating-point decay against
+        # updated_at doesn't push blended below 1.0 and mask the clamp test.
+        await remember("key", "q", ["t"], ctx=ctx)
         m = storage.get_memory_by_key("key")
         mock_vs = _make_mock_vector_store([(m.memory_id, 1.0)])
 
-        # min_score > 1.0 gets clamped to 1.0; a perfect score still matches
+        # min_score > 1.0 gets clamped to 1.0; with w_recency=0 blended = 1.0.
         with patch("hive.server._vector_store", return_value=mock_vs):
-            result = await search_memories("q", min_score=5.0, ctx=ctx)
+            result = await search_memories("q", min_score=5.0, w_recency=0, ctx=ctx)
 
         assert _body(result)["count"] == 1
 
-        # min_score < 0.0 gets clamped to 0.0; everything passes
+        # min_score < 0.0 gets clamped to 0.0; everything passes.
         mock_vs2 = _make_mock_vector_store([(m.memory_id, 0.0)])
         with patch("hive.server._vector_store", return_value=mock_vs2):
             result = await search_memories("q", min_score=-1.0, ctx=ctx)


### PR DESCRIPTION
Closes #481

## Summary

`search_memories` now re-ranks the vector-store candidates by a weighted blend of three signals so short / exact-match queries ("wifi password") and recently-touched memories score properly instead of relying on cosine similarity alone:

```
final_score = w_semantic * cosine
            + w_keyword  * (fraction of query tokens matched)
            + w_recency  * (2^(-age_days / half_life_days))
```

Closes the known gap vs Mem0 (hybrid retrieval) and makes `last_accessed_at` (#394) earn its keep in ranking.

## Approach

**New `src/hive/hybrid_search.py`:**

- `tokenize(text)` — lowercase, word-chars-only. No stemming. Unicode-aware.
- `keyword_score(query_tokens, value)` — fraction of query tokens present in the tokenised value. Cheap term-frequency heuristic — no BM25 dependency. Good enough for short memory values per the issue design note.
- `recency_score(memory, half_life_days=30)` — `2 ** (-age_days / half_life)`. True half-life decay. Uses `last_accessed_at` when set, else `updated_at`.
- `blend_score(...)` — weighted sum with weights re-normalised to sum to 1.0. All-zero weights fall back to defaults rather than returning zero.

**`search_memories` changes:**

- 3 new optional params: `w_semantic` (0.6), `w_keyword` (0.3), `w_recency` (0.1). Callers can pass any relative weighting; weights are renormalised.
- Candidate pool widened to `3 × top_k` (capped at 50) so the re-ranking has headroom to surprise the vector-first ordering.
- `min_score` threshold now applies to the **blended** score (was: raw semantic) — matches the user-facing `score` field.
- `MemorySearchResult` carries per-signal sub-scores (`semantic_score`, `keyword_score`, `recency_score`) alongside the blended `score` for debugging + agent-side re-ranking.

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + 602 unit + 605 frontend (100% coverage)
- [x] New `test_hybrid_search.py` covering tokenise edge cases, keyword fractions, recency half-life behaviour, and blend renormalisation
- [x] Existing search tests updated to assert on `semantic_score` + `keyword_score` alongside blended `score`
- [ ] CI green
- [ ] `development` pipeline green

## Scope notes

- BM25 library deliberately not added — the design-decision note on the issue says the TF heuristic is good enough for short memory values.
- `min_score` threshold semantics change is a narrow behaviour change (now blended rather than raw cosine). Default weights keep the ordering "close enough" to the old behaviour for non-threshold queries.