### PR TITLE
feat: synthesize summarize_context via MCP Sampling

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -293,6 +293,51 @@ def _tool_result(
     return ToolResult(content=payload, meta=meta)
 
 
+_SUMMARY_MAX_TOKENS = 512
+_SUMMARY_SYSTEM_PROMPT = (
+    "You synthesise a set of memories into a concise briefing for the agent "
+    "that will use them. Return only the synthesis — no preamble, no "
+    "disclaimers. Preserve specific names, numbers, and decisions verbatim; "
+    "paraphrase the rest. Target 2-5 short paragraphs."
+)
+
+
+async def _sampled_summary(
+    ctx: Context | None,
+    topic: str,
+    memories: list[Memory],
+    fallback: str,
+) -> str:
+    """Synthesise a set of memories via MCP Sampling (#448).
+
+    Sends a ``sampling/createMessage`` request back to the client and uses
+    its model to produce the summary. If the client doesn't support
+    sampling, the transport rejects it, or ctx is unavailable (e.g. direct
+    invocation in tests), returns ``fallback`` — the deterministic
+    concatenated listing — so the tool never fails just because an agent
+    can't sample.
+    """
+    if ctx is None:
+        return fallback
+
+    body = "\n\n".join(f"- **{m.key}**: {m.value}" for m in memories)
+    prompt = (
+        f"The following memories are tagged '{topic}'. Synthesise them into a briefing.\n\n{body}"
+    )
+    try:
+        result = await ctx.sample(
+            prompt,
+            system_prompt=_SUMMARY_SYSTEM_PROMPT,
+            max_tokens=_SUMMARY_MAX_TOKENS,
+        )
+    except Exception:
+        logger.info("MCP sampling unavailable; falling back to concat summary", exc_info=True)
+        return fallback
+
+    text = getattr(result, "text", None) or fallback
+    return text.strip() or fallback
+
+
 async def _report_progress(
     ctx: Context | None, progress: float, total: float | None, message: str
 ) -> None:
@@ -958,10 +1003,13 @@ async def summarize_context(
     for m in memories:
         lines.append(f"**{m.key}**: {m.value}")
 
-    lines.append(
-        f"\n---\n*Summary: {len(memories)} memory/memories found for topic '{topic}'. "
-        "Review the entries above for relevant context.*"
-    )
+    lines.append(f"\n---\n*{len(memories)} memory/memories found for topic '{topic}'.*")
+    concat_summary = "\n".join(lines)
+
+    # Try MCP Sampling first (#448). If the client supports it, we get a real
+    # LLM synthesis without any server-side Bedrock cost; otherwise the
+    # sampler raises and we fall back to the concatenated listing above.
+    summary = await _sampled_summary(ctx, topic, memories, concat_summary)
 
     _log(
         storage,
@@ -989,7 +1037,7 @@ async def summarize_context(
         unit="Milliseconds",
         operation="summarize_context",
     )
-    return _tool_result("\n".join(lines), storage, client_id)
+    return _tool_result(summary, storage, client_id)
 
 
 @mcp.tool(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -638,6 +638,71 @@ class TestSummarizeContext:
         result = await summarize_context("nonexistent-topic", ctx=_make_ctx(jwt))
         assert "No memories found" in _text(result)
 
+    async def test_summarize_uses_mcp_sampling_when_available(self, server_env):
+        """When ctx.sample returns a result, the synthesised text replaces
+        the concat fallback."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("s-a", "policy X says Y", ["sampled"], ctx=_make_ctx(jwt))
+
+        ctx = _make_ctx(jwt)
+        sampled = MagicMock()
+        sampled.text = "SYNTHESISED BRIEFING OUTPUT"
+        ctx.sample = AsyncMock(return_value=sampled)
+
+        result = await summarize_context("sampled", ctx=ctx)
+        assert _text(result) == "SYNTHESISED BRIEFING OUTPUT"
+        # Client was asked with a system prompt + the memories inline.
+        ctx.sample.assert_awaited_once()
+        args, kwargs = ctx.sample.call_args
+        assert "policy X says Y" in args[0]
+        assert "system_prompt" in kwargs
+
+    async def test_summarize_falls_back_when_sampling_raises(self, server_env):
+        """If the client rejects sampling (or transport errors), the concat
+        listing is returned — the tool never fails because sampling isn't
+        supported."""
+        from unittest.mock import AsyncMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("f-a", "raw detail one", ["fallback"], ctx=_make_ctx(jwt))
+
+        ctx = _make_ctx(jwt)
+        ctx.sample = AsyncMock(side_effect=RuntimeError("sampling not supported"))
+
+        result = await summarize_context("fallback", ctx=ctx)
+        text = _text(result)
+        assert "raw detail one" in text  # concat fallback contains the verbatim values
+
+    async def test_sampled_summary_empty_text_falls_back(self, server_env):
+        """An empty/whitespace-only sampling response falls back to concat."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("e-a", "verbatim detail", ["empty"], ctx=_make_ctx(jwt))
+
+        ctx = _make_ctx(jwt)
+        sampled = MagicMock()
+        sampled.text = "   "
+        ctx.sample = AsyncMock(return_value=sampled)
+
+        result = await summarize_context("empty", ctx=ctx)
+        assert "verbatim detail" in _text(result)
+
+    async def test_sampled_summary_handles_ctx_none(self):
+        """Direct call to the helper with ctx=None returns the fallback verbatim."""
+        from hive.server import _sampled_summary
+
+        out = await _sampled_summary(None, "t", [], "FALLBACK_TEXT")
+        assert out == "FALLBACK_TEXT"
+
 
 # ---------------------------------------------------------------------------
 # _app_version() branches — covers server.py:39 and 42-43


### PR DESCRIPTION
Closes #448

(Supersedes #374 which closed in favour of this approach.)

## Summary

`summarize_context` now tries an MCP `sampling/createMessage` request first so the client's own model produces a real synthesis. When the client doesn't advertise sampling capability — or the transport rejects the request — the tool falls back to the deterministic concatenated listing, so no agent ever sees a failure from a capability mismatch.

## Approach

- New `_sampled_summary(ctx, topic, memories, fallback)` helper in `server.py` wraps `ctx.sample(...)` with a tight system prompt (2-5 paragraph briefing, preserve names/numbers/decisions verbatim) and a 512-token cap.
- Any exception (client doesn't support sampling, stale ctx, network flake) returns the deterministic fallback; empty/whitespace responses also fall back.
- The existing concat listing is the fallback — integration tests and direct-invocation callers (ctx=None) see no behaviour change.

## Upside vs calling Bedrock (closed #374)

- Zero extra infra cost — the user's subscription pays for tokens
- Model quality scales with whatever the client is configured for (Opus users get Opus synthesis)
- No `bedrock:InvokeModel` IAM or region-lock-in
- One less third-party data processor to list under `/subprocessors`

## Test plan

- [x] `uv run inv pre-push` — 606 unit + 605 frontend, 100% coverage
- [x] Tests cover: sampling-success replaces fallback, sampling-raises falls back, empty text falls back, direct helper call with `ctx=None`
- [ ] CI green
- [ ] `development` pipeline green

## Scope notes

- Decision between Bedrock (#374) and Sampling (this issue) landed on Sampling; #374 has been closed.
- No `/subprocessors` page change needed — sampling happens in the user's client, no new processor.