### PR TITLE
feat: redact_memory tool — tombstone values while preserving audit trail

### DIFF
--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -61,6 +61,7 @@ class Memory(BaseModel):
     expires_at: datetime | None = None  # optional TTL; None means never expires
     recall_count: int = 0  # incremented on every successful recall
     last_accessed_at: datetime | None = None  # set on every successful recall
+    redacted_at: datetime | None = None  # when redact_memory tombstoned the value (#400)
 
     # ------------------------------------------------------------------
     # DynamoDB serialisation
@@ -90,6 +91,8 @@ class Memory(BaseModel):
             item["ttl"] = int(self.expires_at.timestamp())
         if self.last_accessed_at is not None:
             item["last_accessed_at"] = self.last_accessed_at.isoformat()
+        if self.redacted_at is not None:
+            item["redacted_at"] = self.redacted_at.isoformat()
         return item
 
     def to_dynamo_tag_items(self) -> list[dict[str, Any]]:
@@ -118,6 +121,9 @@ class Memory(BaseModel):
         last_accessed_at = None
         if la := item.get("last_accessed_at"):
             last_accessed_at = datetime.fromisoformat(la)
+        redacted_at = None
+        if ra := item.get("redacted_at"):
+            redacted_at = datetime.fromisoformat(ra)
         return cls(
             memory_id=item["memory_id"],
             key=item["key"],
@@ -130,11 +136,17 @@ class Memory(BaseModel):
             expires_at=expires_at,
             recall_count=int(item.get("recall_count", 0) or 0),
             last_accessed_at=last_accessed_at,
+            redacted_at=redacted_at,
         )
 
     @property
     def is_expired(self) -> bool:
         return self.expires_at is not None and _now_utc() >= self.expires_at
+
+    @property
+    def is_redacted(self) -> bool:
+        """True when ``redact_memory`` has tombstoned this memory (#400)."""
+        return self.redacted_at is not None
 
     @property
     def version(self) -> str:
@@ -447,6 +459,7 @@ class EventType(str, Enum):
     memory_created = "memory_created"
     memory_updated = "memory_updated"
     memory_deleted = "memory_deleted"
+    memory_redacted = "memory_redacted"
     memory_recalled = "memory_recalled"
     memory_listed = "memory_listed"
     memory_searched = "memory_searched"

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -652,6 +652,23 @@ async def recall(
         await emit_metric("ToolErrors", operation="recall")
         raise ToolError(f"No memory found for key '{key}'.")
 
+    # A redacted memory tombstone surfaces a safe sentinel — the fact that
+    # the memory once existed is itself the signal (#400).
+    if memory.is_redacted:
+        sentinel = (
+            f"Memory '{key}' was redacted on {memory.redacted_at.isoformat()}. Value removed."
+        )
+        _log(
+            storage,
+            ActivityEvent(
+                event_type=EventType.memory_recalled,
+                client_id=client_id,
+                metadata={"key": key, "redacted": True},
+            ),
+        )
+        await emit_metric("ToolInvocations", operation="recall")
+        return _tool_result(sentinel, storage, client_id, memory=memory)
+
     _log(
         storage,
         ActivityEvent(
@@ -785,6 +802,95 @@ async def forget_all(
     return _tool_result(f"Deleted {deleted} memories with tag '{tag}'.", storage, client_id)
 
 
+_REDACTION_SENTINEL = "__redacted__"
+
+
+@mcp.tool(
+    title="Redact memory",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def redact_memory(
+    key: Annotated[str, "Key of the memory to redact"],
+    reason: Annotated[
+        str | None,
+        "Optional reason written to the audit trail (PII, secret leak, etc.)",
+    ] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Tombstone a memory: replace its value with a sentinel and record
+    ``redacted_at``, preserving the audit trail (#400).
+
+    Use this when the value contains content that must be removed (PII,
+    secret accidentally captured, etc.) but the fact that the memory
+    existed is itself meaningful. For full deletion, use ``forget``.
+    """
+    t0 = time.monotonic()
+    storage, client_id = await _auth(ctx, required_scope="memories:write")
+
+    existing = storage.get_memory_by_key(key)
+    if existing is None:
+        await emit_metric("ToolErrors", operation="redact_memory")
+        raise ToolError(f"No memory found for key '{key}'.")
+    if existing.is_redacted:
+        return _tool_result(f"Memory '{key}' is already redacted.", storage, client_id)
+
+    # Record the pre-redaction value in the audit log BEFORE we overwrite
+    # it — the tombstone path is the only thing that preserves what was
+    # there when a reviewer needs to understand a redaction after-the-fact.
+    storage.log_audit_event(
+        ActivityEvent(
+            event_type=EventType.memory_redacted,
+            client_id=client_id,
+            metadata={
+                "key": key,
+                "memory_id": existing.memory_id,
+                "reason": reason,
+                "previous_value": existing.value,
+                "previous_tags": existing.tags,
+            },
+        )
+    )
+
+    existing.value = _REDACTION_SENTINEL
+    existing.redacted_at = datetime.now(timezone.utc)
+    existing.updated_at = existing.redacted_at
+    storage.put_memory(existing)
+    try:
+        _vector_store().delete_memory(existing.memory_id, client_id)
+    except Exception:
+        logger.warning("Vector delete on redaction failed (non-fatal)", exc_info=True)
+
+    # The user-visible activity log gets a sanitised entry so the Activity Log
+    # UI surfaces the redaction without leaking the pre-redaction value.
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_redacted,
+            client_id=client_id,
+            metadata={"key": key, "reason": reason},
+        )
+    )
+
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "Redacted memory '%s'",
+        key,
+        extra={"tool": "redact_memory", "duration_ms": duration_ms, "status": "success"},
+    )
+    await emit_metric("ToolInvocations", operation="redact_memory")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="redact_memory",
+    )
+    return _tool_result(f"Redacted memory '{key}'.", storage, client_id)
+
+
 @mcp.tool(
     title="Memory history",
     annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
@@ -879,6 +985,10 @@ async def list_memories(
     tag: Annotated[str, "Tag to filter memories by"],
     limit: Annotated[int, "Maximum number of memories to return (1–500)"] = 100,
     cursor: Annotated[str | None, "Pagination cursor from a previous call"] = None,
+    include_redacted: Annotated[
+        bool,
+        "Include tombstoned (redacted) memories in the result. False by default.",
+    ] = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """List memories that have a specific tag, with optional pagination."""
@@ -887,6 +997,8 @@ async def list_memories(
 
     limit = max(1, min(limit, 500))
     memories, next_cursor = storage.list_memories_by_tag(tag, limit=limit, cursor=cursor)
+    if not include_redacted:
+        memories = [m for m in memories if not m.is_redacted]
     _log(
         storage,
         ActivityEvent(
@@ -1066,6 +1178,10 @@ async def search_memories(
     w_recency: Annotated[
         float, "Weight for recency decay against last_accessed_at/updated_at (default 0.1)"
     ] = DEFAULT_W_RECENCY,
+    include_redacted: Annotated[
+        bool,
+        "Include tombstoned (redacted) memories in the result. False by default.",
+    ] = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Search memories using hybrid retrieval: semantic + keyword + recency.
@@ -1119,6 +1235,9 @@ async def search_memories(
             w_recency=w_recency,
         )
         scored.append((m, blended, sem, kw, rec))
+
+    if not include_redacted:
+        scored = [row for row in scored if not row[0].is_redacted]
 
     if threshold is not None:
         scored = [row for row in scored if row[1] >= threshold]

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -654,7 +654,7 @@ async def recall(
 
     # A redacted memory tombstone surfaces a safe sentinel — the fact that
     # the memory once existed is itself the signal (#400).
-    if memory.is_redacted:
+    if memory.redacted_at is not None:
         sentinel = (
             f"Memory '{key}' was redacted on {memory.redacted_at.isoformat()}. Value removed."
         )

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1561,6 +1561,7 @@ class TestMcpToolAnnotations:
             ("recall", "Recall", True, None),
             ("forget", "Forget", False, True),
             ("forget_all", "Forget all (by tag)", False, True),
+            ("redact_memory", "Redact memory", False, True),
             ("memory_history", "Memory history", True, None),
             ("restore_memory", "Restore memory", False, False),
             ("list_memories", "List memories", True, None),
@@ -1680,6 +1681,167 @@ class TestRememberOptimisticLocking:
             pytest.raises(ToolError, match="Conflict"),
         ):
             await remember("lock-r2", "v2", [], version=m.version, ctx=_make_ctx(jwt))
+
+
+class TestRedactMemory:
+    """`redact_memory` tombstones a memory's value while preserving the record (#400)."""
+
+    async def test_redacts_existing_memory(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import redact_memory, remember
+
+        await remember("secret", "the wifi password is 1234", ["pii"], ctx=_make_ctx(jwt))
+        result = await redact_memory("secret", reason="pii leak", ctx=_make_ctx(jwt))
+        assert _text(result) == "Redacted memory 'secret'."
+
+        stored = storage.get_memory_by_key("secret")
+        assert stored.is_redacted is True
+        assert stored.value == "__redacted__"
+        assert stored.redacted_at is not None
+
+    async def test_recall_returns_sentinel_on_redacted(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import recall, redact_memory, remember
+
+        await remember("s", "raw secret", [], ctx=_make_ctx(jwt))
+        await redact_memory("s", reason="gdpr", ctx=_make_ctx(jwt))
+
+        result = await recall("s", ctx=_make_ctx(jwt))
+        text = _text(result)
+        assert "redacted" in text.lower()
+        assert "raw secret" not in text
+
+    async def test_list_memories_skips_redacted_by_default(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_memories, redact_memory, remember
+
+        ctx = _make_ctx(jwt)
+        await remember("visible", "keep me", ["r"], ctx=ctx)
+        await remember("hidden", "redact me", ["r"], ctx=ctx)
+        await redact_memory("hidden", ctx=ctx)
+
+        result = await list_memories("r", ctx=ctx)
+        keys = [i["key"] for i in _body(result)["items"]]
+        assert "visible" in keys
+        assert "hidden" not in keys
+
+    async def test_list_memories_include_redacted_surfaces_them(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_memories, redact_memory, remember
+
+        ctx = _make_ctx(jwt)
+        await remember("visible", "keep me", ["r2"], ctx=ctx)
+        await remember("hidden", "redact me", ["r2"], ctx=ctx)
+        await redact_memory("hidden", ctx=ctx)
+
+        result = await list_memories("r2", include_redacted=True, ctx=ctx)
+        keys = [i["key"] for i in _body(result)["items"]]
+        assert "visible" in keys
+        assert "hidden" in keys
+
+    async def test_search_memories_skips_redacted_by_default(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import redact_memory, remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "content about policy", ["t"], ctx=ctx)
+        await remember("b", "content about privacy", ["t"], ctx=ctx)
+        await redact_memory("b", ctx=ctx)
+
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        mock_vs = _make_mock_vector_store([(a.memory_id, 0.9), (b.memory_id, 0.8)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("content", ctx=ctx)
+
+        keys = [i["key"] for i in _body(result)["items"]]
+        assert "a" in keys
+        assert "b" not in keys
+
+    async def test_search_memories_include_redacted_surfaces_them(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import redact_memory, remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "content", ["t"], ctx=ctx)
+        await remember("b", "content", ["t"], ctx=ctx)
+        await redact_memory("b", ctx=ctx)
+
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        mock_vs = _make_mock_vector_store([(a.memory_id, 0.9), (b.memory_id, 0.8)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("content", include_redacted=True, ctx=ctx)
+
+        keys = [i["key"] for i in _body(result)["items"]]
+        assert "a" in keys
+        assert "b" in keys
+
+    async def test_missing_key_raises(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import redact_memory
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="No memory found"):
+            await redact_memory("no-such-key", ctx=_make_ctx(jwt))
+
+    async def test_double_redaction_is_idempotent(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import redact_memory, remember
+
+        await remember("dbl", "v", [], ctx=_make_ctx(jwt))
+        await redact_memory("dbl", ctx=_make_ctx(jwt))
+        result = await redact_memory("dbl", ctx=_make_ctx(jwt))
+        assert "already redacted" in _text(result)
+
+    async def test_audit_log_preserves_pre_redaction_value(self, server_env):
+        storage, _, jwt = server_env
+        from hive.models import EventType
+        from hive.server import redact_memory, remember
+
+        await remember("audit-r", "sensitive original value", [], ctx=_make_ctx(jwt))
+        await redact_memory("audit-r", reason="accidental leak", ctx=_make_ctx(jwt))
+
+        from datetime import datetime, timezone
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        events = storage.get_audit_events_for_dates([today], event_type="memory_redacted")
+        assert len(events) >= 1
+        redaction = events[0]
+        assert redaction.metadata["previous_value"] == "sensitive original value"
+        assert redaction.metadata["reason"] == "accidental leak"
+        assert redaction.event_type == EventType.memory_redacted
+
+    async def test_vector_delete_failure_is_non_fatal(self, server_env):
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import redact_memory, remember
+
+        _, _, jwt = server_env
+        await remember("vd", "v", [], ctx=_make_ctx(jwt))
+
+        mock_vs = MagicMock()
+        mock_vs.delete_memory.side_effect = RuntimeError("bucket down")
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await redact_memory("vd", ctx=_make_ctx(jwt))
+        assert "Redacted" in _text(result)
+
+    async def test_requires_write_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import redact_memory
+
+        storage, _, _ = server_env
+        read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await redact_memory("any", ctx=_make_ctx(read_only_jwt))
 
 
 class TestProgressNotifications:


### PR DESCRIPTION
Closes #400

(Last `status:ready` issue in v0.22 — milestone will drain on merge.)

## Summary

New `redact_memory(key, reason=None)` MCP tool handles PII / secret leak cleanup without destroying the audit trail. Complements `forget` (hard delete) rather than replacing it.

## Approach

Soft-tombstone semantics (design decided on #400):

- **`Memory.redacted_at`** is set; value is replaced with the sentinel `__redacted__`. The record itself survives so the fact-that-something-existed stays auditable.
- **`Memory.is_redacted`** is a convenience property.
- **`recall(key)`** on a redacted memory returns `"Memory '<key>' was redacted on <ts>. Value removed."` instead of the pre-redaction value.
- **`list_memories`** and **`search_memories`** skip redacted items by default; both gain an `include_redacted: bool = False` param for admin flows.
- Every redaction writes an audit-log entry (via the #395 wiring) with the pre-redaction value, tags, `memory_id`, and the caller's `reason` so a reviewer can understand what was removed and why. The user-visible activity log gets a sanitised entry without the pre-redaction value.
- The vector-store entry is deleted as part of the tombstone so semantic search never surfaces the pre-redaction embedding.
- Double-redaction is idempotent.

## Test plan

- [x] `uv run inv pre-push` — 618 unit + 605 frontend, 100% coverage
- [x] Covers: tombstone shape, recall-returns-sentinel, list/search default-skip + `include_redacted`, audit trail preserves pre-redaction value, vector-delete failure non-fatal, double-redaction idempotent, missing-key ToolError, requires write scope
- [ ] CI green
- [ ] `development` pipeline green

## Scope notes

- Management UI panel for browsing redacted memories + "Show redacted" toggle is a follow-up (#400 lists it under Management UI but it's UI-only work).
- Close of this PR drains v0.22 — the milestone watcher (#484) should open a "Release: cut v0.22" tracking issue shortly after.