### PR TITLE
release: v0.22.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,63 @@
+# Configuration for release-drafter: aggregates merged PR titles into a
+# draft release so we never have to hand-maintain CHANGELOG `[Unreleased]`.
+# Categories map to the label taxonomy in CLAUDE.md §Backlog labels.
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Features"
+    labels:
+      - "enhancement"
+      - "feature"
+  - title: "Fixes"
+    labels:
+      - "bug"
+      - "fix"
+  - title: "Security"
+    labels:
+      - "security"
+  - title: "Docs"
+    labels:
+      - "docs"
+  - title: "Infrastructure & CI"
+    labels:
+      - "infra"
+      - "ci"
+  - title: "Chores"
+    labels:
+      - "chore"
+
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+  minor:
+    labels:
+      - "enhancement"
+      - "feature"
+  patch:
+    labels:
+      - "bug"
+      - "fix"
+      - "docs"
+      - "chore"
+      - "infra"
+      - "ci"
+      - "security"
+  default: patch
+
+# Any PR that doesn't match a category above still appears here so
+# nothing is silently dropped.
+exclude-labels:
+  - "skip-changelog"
+
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -44,10 +44,15 @@ jobs:
           echo "$LABELS" | grep -qE '(^|,)status:' || MISSING+=("status:*")
           echo "$LABELS" | grep -qE '(^|,)priority:' || MISSING+=("priority:p0|p1|p2|p3")
           echo "$LABELS" | grep -qE '(^|,)size:' || MISSING+=("size:xs|s|m|l|xl")
+          # Release Drafter (#420) groups PRs by category label, so every
+          # issue linked from a PR must carry one of these category labels
+          # so the auto-drafted release notes land in the right section.
+          echo "$LABELS" | grep -qE '(^|,)(enhancement|bug|docs|chore|infra|ci|security|breaking)(,|$)' \
+            || MISSING+=("category (enhancement|bug|docs|chore|infra|ci|security|breaking)")
 
           if [ ${#MISSING[@]} -gt 0 ]; then
             echo "::error::Issue #$ISSUE_NUM is missing required labels: ${MISSING[*]}"
-            echo "Add status, priority, and size labels to the issue before merging this PR."
+            echo "Add status, priority, size, and a category label to the issue before merging this PR."
             exit 1
           fi
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release drafter
+
+# Keeps a draft GitHub release current as PRs merge into development.
+# The draft is consumed when cutting a release branch so CHANGELOG `[Unreleased]`
+# no longer has to be hand-maintained. See CLAUDE.md §Releasing to production.
+
+on:
+  push:
+    branches: [development]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-milestone-watcher.yml
+++ b/.github/workflows/release-milestone-watcher.yml
@@ -1,0 +1,70 @@
+name: Release milestone watcher
+
+# Watches for any vX.Y milestone that has drained to zero open non-epic
+# issues and files a "Release: cut vX.Y" tracking issue so the operator
+# (or the autonomous agent) picks it up. Pairs with the in-session stop
+# condition in CLAUDE.md §Autonomous issue workflow §9 (#483).
+
+on:
+  issues:
+    types: [closed, milestoned, demilestoned]
+  pull_request:
+    types: [closed]
+  schedule:
+    # Daily belt-and-braces catch for milestone-reassignments that emptied
+    # a milestone without a close event (which wouldn't trigger `issues`).
+    - cron: '0 9 * * *'
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  check-drained-milestones:
+    name: check-drained-milestones
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if any vX.Y milestone is drained
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          MILESTONES=$(gh api "repos/$REPO/milestones?state=open" \
+            --jq '.[] | select(.title | test("^v[0-9]+\\.[0-9]+$")) | .title')
+
+          if [ -z "$MILESTONES" ]; then
+            echo "No open vX.Y milestones — nothing to check."
+            exit 0
+          fi
+
+          while IFS= read -r m; do
+            [ -z "$m" ] && continue
+
+            OPEN=$(gh issue list --milestone "$m" --state open \
+              --json labels \
+              --jq '[.[] | select(.labels | map(.name) | contains(["epic"]) | not)] | length')
+
+            if [ "$OPEN" -ne 0 ]; then
+              echo "Milestone $m still has $OPEN open non-epic issues — skipping."
+              continue
+            fi
+
+            EXISTING=$(gh issue list --search "Release: cut $m in:title is:open" \
+              --json number --jq 'length')
+
+            if [ "$EXISTING" -ne 0 ]; then
+              echo "Milestone $m is drained but \"Release: cut $m\" issue already exists."
+              continue
+            fi
+
+            echo "Milestone $m is drained — filing release tracking issue."
+            gh issue create \
+              --title "Release: cut $m" \
+              --body "Milestone \`$m\` has drained to zero open non-epic issues. Time to cut the release per CLAUDE.md §Releasing to production. Filed automatically by release-milestone-watcher." \
+              --label "chore" \
+              --label "status:ready" \
+              --label "priority:p1" \
+              --label "size:s"
+          done <<< "$MILESTONES"

--- a/.github/workflows/release-milestone-watcher.yml
+++ b/.github/workflows/release-milestone-watcher.yml
@@ -27,11 +27,16 @@ jobs:
       - name: Check if any vX.Y milestone is drained
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+          # gh reads GH_REPO to scope repo-aware commands (gh issue list,
+          # gh issue create). Without it, gh tries to detect the repo via
+          # git, but this workflow doesn't run actions/checkout — so those
+          # commands fail with `fatal: not a git repository`. Setting
+          # GH_REPO avoids the checkout without needing git context.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          MILESTONES=$(gh api "repos/$REPO/milestones?state=open" \
+          MILESTONES=$(gh api "repos/$GH_REPO/milestones?state=open" \
             --jq '.[] | select(.title | test("^v[0-9]+\\.[0-9]+$")) | .title')
 
           if [ -z "$MILESTONES" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) f
 
 _Changes accumulated on `development` since v0.21.0. Will be rolled into the next release._
 
+### Added
+
+- Every MCP tool response now carries the caller's quota and rate-limit state under a top-level `_meta.hive` block (`memory_quota.{used,limit,remaining}` + `rate_limit.{per_minute_limit,per_day_limit}`), so well-behaved agents can self-throttle before hitting a hard limit. New docs page `/docs/concepts/quotas` documents the schema. `memory_history` now returns `{versions, count}` instead of a bare list so the structured-content envelope is consistent across tools. (#453)
+
 ## v0.21.0 — 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,38 @@ See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) f
 
 ## [Unreleased]
 
-_Changes accumulated on `development` since v0.21.0. Will be rolled into the next release._
+_Changes accumulated on `development` since v0.22.0. Will be rolled into the next release._
+
+## v0.22.0 — 2026-04-18
 
 ### Added
 
-- Every MCP tool response now carries the caller's quota and rate-limit state under a top-level `_meta.hive` block (`memory_quota.{used,limit,remaining}` + `rate_limit.{per_minute_limit,per_day_limit}`), so well-behaved agents can self-throttle before hitting a hard limit. New docs page `/docs/concepts/quotas` documents the schema. `memory_history` now returns `{versions, count}` instead of a bare list so the structured-content envelope is consistent across tools. (#453)
+#### MCP surface
+
+- Every MCP tool response carries the caller's quota and rate-limit state under a top-level `_meta.hive` block (`memory_quota.{used,limit,remaining}` + `rate_limit.{per_minute_limit,per_day_limit}`) so well-behaved agents can self-throttle before hitting a hard limit. New docs page `/docs/concepts/quotas` documents the schema. `memory_history` now returns `{versions, count}` instead of a bare list for a consistent structured-content envelope. (#453)
+- Long-running tools (`search_memories`, `summarize_context`) emit MCP `notifications/progress` events at major stages; supporting clients render progress indicators. Best-effort — falls through on clients that don't support it. (#449)
+- `remember(key, value, …, version=)` accepts an optimistic-lock token from a prior `recall`/`list_memories` response; concurrent-write conflicts raise a `ToolError` with the current state JSON-encoded so agents can compare-and-retry. (#391)
+- `search_memories` now hybrid-retrieves: weighted blend of semantic similarity, term-frequency keyword match, and half-life recency decay against `last_accessed_at`/`updated_at`. Three optional `w_semantic/w_keyword/w_recency` params re-normalise to 1.0. Per-signal sub-scores exposed for debugging + agent-side re-ranking. (#481)
+- `summarize_context` synthesises memories via MCP Sampling — the client's own model produces the briefing, with a deterministic concat fallback for clients that don't support sampling. (#448)
+- New `redact_memory(key, reason=None)` tool tombstones a value while preserving the record: sets `Memory.redacted_at`, replaces value with `__redacted__`, writes the pre-redaction value to the audit log. `recall` on a redacted memory returns a sentinel; `list_memories` + `search_memories` skip redacted items by default (opt-in via `include_redacted`). (#400)
+- `Memory.recall_count` + `last_accessed_at` — bumped atomically on every successful `recall`; surfaced on list/search results for ranking, dashboards, and memory-decay scoring. (#394)
+
+#### Compliance & observability
+
+- `log_audit_event` is now called from every memory-touching tool, producing an immutable `AUDIT#` trail separate from the user-visible activity log. Audit items carry a DynamoDB TTL (`HIVE_AUDIT_RETENTION_DAYS`, default 365) and a new `GET /api/admin/audit-log` endpoint exposes them with `client_id` / `event_type` / date-range filters. (#395)
+- `POST /api/csp-report` receives browser CSP violation reports (both legacy `application/csp-report` and modern `application/reports+json`), logs them structured to CloudWatch, and emits a `CSPViolations` EMF metric (aggregate + per-directive drill-down). Unauthenticated by design; per-IP rate-limited. Admin dashboard gets a "Security" section showing the count. (#488)
+
+#### Dev experience & CI
+
+- Release Drafter keeps a draft GitHub release current as PRs merge into `development`, grouped by category label — no more hand-maintained `[Unreleased]`. Label-check workflow now requires a category label on every linked issue. (#420)
+- `release-milestone-watcher` workflow opens a "Release: cut vX.Y" tracking issue when any `vX.Y` milestone drains to zero open non-epic issues. Pairs with the in-session stop condition. (#484, #512)
+
+### Meta
+
+- CLAUDE.md: design-review workflow + product-decision section. (#506)
+- CLAUDE.md: milestone preference added to the issue selection algorithm. (#514)
+
+## v0.21.0 — 2026-04-18
 
 ## v0.21.0 — 2026-04-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,9 @@ hive/
 - Token items: `PK=TOKEN#{jti}`, `SK=META` (TTL enabled)
 - Activity log items: `PK=LOG#{date}#{hour}`, `SK={timestamp}#{event_id}`
   (hour-sharded to avoid hot partitions)
+- Audit log items: `PK=AUDIT#{date}#{hour}`, `SK={timestamp}#{event_id}`
+  (immutable compliance trail, TTL via `HIVE_AUDIT_RETENTION_DAYS`,
+  default 365 days; survives user-initiated activity-log purges)
 - User items: `PK=USER#{user_id}`, `SK=META`
 - Mgmt state items: `PK=MGMT_STATE#{state}`, `SK=META`
   (TTL enabled, used for OAuth state parameter)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,8 +353,11 @@ gh pr merge --auto --merge
    ```
 
 2. **Update `CHANGELOG.md`** — move items from `[Unreleased]` to a new
-   versioned section, e.g. `## [X.Y.Z] - 2026-04-11`.
-   Commit the change:
+   versioned section, e.g. `## [X.Y.Z] - 2026-04-11`. The **draft release
+   auto-maintained by Release Drafter** (see
+   https://github.com/warlordofmars/hive/releases) is the source of
+   truth — copy its body into the new section rather than re-deriving
+   from PR history. Commit the change:
 
    ```bash
    git add CHANGELOG.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -620,19 +620,39 @@ Pick the next issue using this deterministic queue:
 2. **Sort** by priority descending: `p0` > `p1` > `p2` > `p3`.
    Missing priority label → treat as `p3`.
 
-3. **Break priority ties** by size ascending (smallest first):
+3. **Break priority ties by milestone preference**: within the same
+   priority, prefer the current release milestone first (the lowest
+   open `vX.Y`), then a themed hardening bucket (`MVP-hardening` or
+   similar), then `Backlog`, then unmilestoned. This keeps the agent
+   focused on the active release commitment without ignoring
+   higher-priority work elsewhere — a `priority:p1` in `Backlog`
+   still out-ranks a `priority:p2` in the current release.
+
+4. **Break remaining ties** by size ascending (smallest first):
    `xs` > `s` > `m` > `l` > `xl`. Missing size label → treat as `m`.
 
-4. **Break remaining ties** by issue number ascending (oldest first).
+5. **Break final ties** by issue number ascending (oldest first).
 
-Saved GitHub query for the top of the queue:
+Saved GitHub queries (run in order — exhaust the first before moving to
+the next):
 
 ```
-is:issue is:open no:assignee label:status:ready -label:epic
+# Current release — drain this first at each priority level
+is:issue is:open no:assignee label:status:ready -label:epic milestone:"v0.22"
+
+# Hardening bucket — drain after current release
+is:issue is:open no:assignee label:status:ready -label:epic milestone:"MVP-hardening"
+
+# Backlog — drain last
+is:issue is:open no:assignee label:status:ready -label:epic milestone:"Backlog"
 ```
 
-Sort the result by label priority manually (GitHub search doesn't sort by
-label precedence).
+Substitute the actual current release milestone name (e.g. `v0.22`,
+`v0.23`) when running these.
+
+Sort each result set by label priority manually (GitHub search doesn't
+sort by label precedence), then by size ascending, then by issue
+number ascending.
 
 **Never pick** issues labelled `status:design-needed` or `status:needs-info`.
 If you believe one of those issues is actually ready, state the case in a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,32 @@ first).
   (e.g. `uses: actions/checkout@<sha> # v4`); use
   `gh api repos/{owner}/{repo}/git/ref/tags/{tag}` to resolve SHAs
 
+## Product decisions
+
+Durable architectural choices that constrain future designs. Don't
+re-derive these during design review — cite them.
+
+- **Workspaces are the tenancy root** (#482) — any multi-tenancy feature
+  consumes the workspace model. Don't invent a second tenancy axis
+  (per-user, per-client-group, etc.) without explicit design review.
+- **Billing deferred** — ship features free. Do not design tier
+  abstractions, per-seat accounting, or billing gates until billing is
+  an active constraint. Keep the concept out of data models for as long
+  as possible.
+- **Client-side LLM preferred** — features needing an LLM (extraction,
+  classification, synthesis) use MCP Sampling (#448). Don't add
+  Bedrock / OpenAI dependencies when the MCP client can provide the model.
+- **Shared-infra features ship full scope** — when two capabilities share
+  ~80% of the infrastructure (e.g. text-large + binary memory in #451,
+  webhook + SSE + MCP notification in #392), ship them together in one
+  release. Splitting a shared-infra pair doubles release cost for
+  marginal benefit.
+- **Agents swap tokens to switch context** — don't design tool APIs that
+  take a `workspace_id` / `namespace` param on every call. Scope comes
+  from the token claim (`workspace_id`, `conversation_id` where
+  applicable); agents register a new DCR client per context and swap
+  tokens to switch.
+
 ## UI conventions
 
 - **CSS variables only** — never hardcode colours; use `var(--text-muted)`,
@@ -447,6 +473,103 @@ This is enforced automatically if you install the git hook:
 `uv run inv install-hooks`
 
 If infra files changed, also run: `uv run inv synth`
+
+---
+
+## Design-review workflow
+
+Governs how to process `status:design-needed` issues. Distinct from the
+autonomous issue workflow below — design review is **interactive**
+(requires user decisions), not unattended.
+
+### Pre-flight triage
+
+Before starting a design review, apply scope triage:
+
+1. **Redundant?** If another open issue or recently-landed feature
+   already covers the same use case with a broader surface, close as
+   redundant (see §Closing as redundant) rather than reviewing.
+2. **`priority:p3` + `size:xl`?** Park — keep the `status:design-needed`
+   label, skip the review. These rarely pay off soon and design effort
+   decays.
+3. **Everything else** — proceed to the 3-phase review.
+
+### Phase 1 — decisions comment
+
+Post a structured comment on the issue with this skeleton:
+
+```markdown
+## Design decisions
+
+### Resolved
+
+1. **<question>** — <answer> — <one-line rationale>
+2. ...
+
+### Derived decisions
+
+- <consequence that follows from the resolved answers>
+- ...
+
+### Breakdown (only if size:xl)
+
+This issue is `size:xl` and will be delivered via the sub-issues linked
+below. This issue stays open as the epic tracker.
+```
+
+Every open design question from the issue body must be addressed —
+either **resolved** (a decision is made and recorded) or **flagged**
+(marked as needing user input, which pauses the review).
+
+### Phase 2 — label flip
+
+Apply the correct status label based on the outcome:
+
+| Outcome | Label |
+|---|---|
+| Fully specified, no external blockers | `status:ready` |
+| Depends on another open issue in this repo | `status:blocked` (body must include `Blocked by #N`) |
+| Waiting on off-platform info (billing, account, external service) | `status:needs-info` |
+
+For `size:xl` issues that have been design-approved, also add the `epic`
+label so the autonomous loop never picks up the tracker itself.
+
+### Phase 3 — sub-issue breakdown (only if size:xl)
+
+For epics:
+
+1. Create one sub-issue per deliverable unit (typically 5–8 sub-issues)
+2. Each sub-issue body starts with `Part of #<epic>` and lists any
+   `Blocked by #N` cross-sub-issue dependencies
+3. Link each sub-issue to the epic via `mcp__github__sub_issue_write`
+   (GitHub's first-class sub-issue API), not just via the text reference
+4. Sub-issues get normal labels: `status:ready` or `status:blocked`,
+   plus priority / size / area. Never `epic`.
+
+### Closing as redundant
+
+When closing an issue rather than design-reviewing it:
+
+- **`state_reason: not_planned`** — for redundant issues (a broader
+  feature subsumes the narrower one). Post an explanatory comment
+  referencing the broader issue and explaining why the narrower one no
+  longer adds capability.
+- **`state_reason: duplicate`** + `duplicate_of: <#N>` — for true
+  duplicates (same underlying mechanism, different framing).
+
+Never close an issue as redundant without an explanatory comment — the
+audit trail matters.
+
+### Asking for user input
+
+Use the `AskUserQuestion` tool for binding decisions. Rules:
+
+- Only include options when you genuinely don't know the right call
+- Lead with the recommended option labelled `(Recommended)`
+- Describe the trade-off in each option's `description` field, not the
+  question body
+- Batch 2–4 logically related questions in one call — don't ask one at
+  a time when they're all on the table
 
 ---
 
@@ -795,12 +918,14 @@ queue trustworthy.
 
 ### Status (one, required)
 
-- `status:ready` — fully scoped, queue-eligible
-- `status:blocked` — depends on another issue; body must name the blocker
-  with `Blocked by #N`. Not queue-eligible
-- `status:design-needed` — needs a decision before implementation. Not
-  queue-eligible
-- `status:needs-info` — waiting on reporter/user. Not queue-eligible
+- `status:ready` — fully scoped, no blockers, queue-eligible
+- `status:blocked` — depends on another **open issue in this repo**;
+  body must name the blocker with `Blocked by #N`. Not queue-eligible.
+- `status:needs-info` — waiting on **off-platform info** (billing,
+  account state, external service verification, legal review). Distinct
+  from `blocked` — the resolution isn't in this repo. Not queue-eligible.
+- `status:design-needed` — not yet reviewed; needs a design pass per
+  §Design-review workflow. Not queue-eligible.
 
 ### Priority (one, required)
 

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -98,6 +98,7 @@ export default defineConfig({
           { text: "How memory scoping works", link: "/concepts/memory-scoping" },
           { text: "Tags and organisation", link: "/concepts/tags" },
           { text: "Key naming conventions", link: "/concepts/key-conventions" },
+          { text: "Quotas and rate limits", link: "/concepts/quotas" },
         ],
       },
       {

--- a/docs-site/concepts/quotas.md
+++ b/docs-site/concepts/quotas.md
@@ -1,0 +1,67 @@
+# Quotas and rate limits
+
+Every Hive tool response carries the caller's current quota usage and rate-limit configuration under a top-level `_meta.hive` block. Well-behaved agents can read this to self-throttle before they hit a hard limit.
+
+## Response shape
+
+Every MCP tool call returns metadata alongside the usual result:
+
+```json
+{
+  "content": [...],
+  "structuredContent": {...},
+  "_meta": {
+    "hive": {
+      "memory_quota": {
+        "used": 42,
+        "limit": 500,
+        "remaining": 458
+      },
+      "rate_limit": {
+        "per_minute_limit": 60,
+        "per_day_limit": 10000
+      }
+    }
+  }
+}
+```
+
+The `_meta.hive` block is present on **every** Hive tool response, including error-adjacent paths like "no memories found" or vector-index-missing.
+
+## Fields
+
+### `memory_quota`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `used` | int | Number of memories currently owned by the caller's user |
+| `limit` | int | Hard cap on memories per user (default 500) |
+| `remaining` | int | `max(0, limit - used)` |
+
+When `remaining` hits zero, the next `remember` call for a new key will raise a `ToolError` with a quota-exceeded message. Updates to existing memories do not consume quota.
+
+### `rate_limit`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `per_minute_limit` | int | Maximum tool calls per minute per client (default 60) |
+| `per_day_limit` | int | Maximum tool calls per day per client (default 10000) |
+
+The rate-limit block reports the configured limits, not the caller's remaining budget. Current consumption isn't returned because it would cost extra DynamoDB reads on every response. If you hit the limit, the next call raises a `ToolError` with a `Retry after Ns` hint.
+
+## Use cases
+
+- **Self-throttling agents** — back off proactively when `memory_quota.remaining` falls below a threshold, rather than waiting for a hard error
+- **Fleet dashboards** — aggregate `used` across clients to visualise per-user usage without hitting the management API
+- **Write-planning** — an agent about to store a batch of memories can check `remaining` and pick which ones to keep if the batch would overflow
+
+## Overrides
+
+Both quota and rate limits are configurable via environment variables on the Hive server:
+
+- `HIVE_QUOTA_MAX_MEMORIES` — memory quota per user
+- `HIVE_QUOTA_EXEMPT_USERS` — comma-separated user IDs that skip the memory quota check
+- `HIVE_RATE_LIMIT_RPM` — per-minute rate limit
+- `HIVE_RATE_LIMIT_RPD` — per-day rate limit
+
+Exempt users still receive the metadata block — the `limit` and `remaining` values reflect the baseline config, not the bypass.

--- a/docs-site/tools/overview.md
+++ b/docs-site/tools/overview.md
@@ -33,3 +33,14 @@ You typically don't need to tell your agent which tool to use — just give natu
 - *"List everything tagged..."* → `list_memories`
 - *"Forget the..."* → `forget`
 - *"Give me a summary of..."* → `summarize_context`
+
+## Progress notifications
+
+Tools whose expected duration exceeds ~2 seconds emit MCP [`notifications/progress`](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress) events at each major stage of work. Supporting clients (Claude Desktop, Claude Code) render these as a progress indicator or streaming status line.
+
+Currently emitted by:
+
+- `search_memories` — reports at 3 stages (vector search → hydrate → rank)
+- `summarize_context` — reports at 2 stages (retrieve → synthesise)
+
+Clients that don't support progress notifications ignore them — the tool still returns its normal final result. Emission is best-effort: if the transport rejects a notification, the tool continues without raising.

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -520,6 +520,9 @@ class HiveStack(cdk.Stack):
         # violations without breaking the site. Flip to enforcing in a
         # follow-up once logs are clean for ~1 week.
         # ----------------------------------------------------------------
+        # Violations POST to /api/csp-report on the same origin; the endpoint
+        # is unauthenticated + per-IP rate-limited. `report-uri` is the legacy
+        # directive; `report-to default` targets the modern Reporting API.
         csp_report_only = (
             "default-src 'self'; "
             "script-src 'self' https://www.googletagmanager.com; "
@@ -529,7 +532,9 @@ class HiveStack(cdk.Stack):
             "style-src 'self' 'unsafe-inline'; "
             "frame-ancestors 'none'; "
             "base-uri 'self'; "
-            "form-action 'self';"
+            "form-action 'self'; "
+            "report-uri /api/csp-report; "
+            "report-to default;"
         )
         security_headers_policy = cloudfront.ResponseHeadersPolicy(
             self,

--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -346,3 +346,67 @@ async def get_alarms(
     Admin-only. Results cached for 5 min.
     """
     return _get_alarm_data()
+
+
+def _storage() -> Any:
+    from hive.storage import HiveStorage
+
+    return HiveStorage()
+
+
+_AUDIT_LIMIT_DEFAULT = 100
+_AUDIT_LIMIT_MAX = 500
+
+
+@router.get(
+    "/audit-log",
+    summary="Query the compliance audit log",
+    description=(
+        "Immutable audit trail of every memory read/write/delete (#395). "
+        "Admin-only. Use ``days`` to widen the window (capped at 90). "
+        "Optional ``client_id`` / ``event_type`` filters narrow the result."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Admin role required"},
+    },
+)
+async def get_audit_log(
+    _claims: Annotated[dict[str, Any], Depends(require_admin)],
+    storage: Annotated[Any, Depends(_storage)],
+    days: Annotated[int, Query(ge=1, le=90, description="Days of history to return")] = 7,
+    limit: Annotated[
+        int, Query(ge=1, le=_AUDIT_LIMIT_MAX, description="Max events to return")
+    ] = _AUDIT_LIMIT_DEFAULT,
+    client_id: Annotated[str | None, Query(description="Filter by client_id")] = None,
+    event_type: Annotated[str | None, Query(description="Filter by event_type")] = None,
+) -> dict[str, Any]:
+    import datetime as _dt
+
+    today = _dt.date.today()
+    dates = [
+        (today - _dt.timedelta(days=i)).isoformat()
+        for i in range(days)  # NOSONAR — days bounded by FastAPI Query(ge=1, le=90)
+    ]
+    events = storage.get_audit_events_for_dates(
+        dates,
+        client_id=client_id,
+        event_type=event_type,
+        limit=limit + 1,
+    )
+    has_more = len(events) > limit
+    events = events[:limit]
+    return {
+        "items": [
+            {
+                "event_id": e.event_id,
+                "event_type": e.event_type.value,
+                "client_id": e.client_id,
+                "timestamp": e.timestamp.isoformat(),
+                "metadata": e.metadata,
+            }
+            for e in events
+        ],
+        "count": len(events),
+        "has_more": has_more,
+    }

--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -140,6 +140,22 @@ def _build_metric_queries(period_label: str) -> list[dict[str, Any]]:
             },
         }
     )
+    # CSPViolations is emitted with `directive` + `blocked_domain` dimensions;
+    # the Environment-only aggregate is fetched here for the dashboard count.
+    queries.append(
+        {
+            "Id": "csp_violations",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": NAMESPACE,
+                    "MetricName": "CSPViolations",
+                    "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+                },
+                "Period": stat_period,
+                "Stat": "Sum",
+            },
+        }
+    )
 
     return queries
 

--- a/src/hive/api/csp.py
+++ b/src/hive/api/csp.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+CSP violation reporting endpoint.
+
+Browsers POST CSP violation reports here when a resource is blocked (or would
+be blocked, under Report-Only). We log each report structured for CloudWatch
+Logs Insights and emit a ``CSPViolation`` EMF metric with dimensions that
+surface *which* directive and *which* blocked-URI domain fired, so an admin
+can see trends on the dashboard and alarm on unexpected spikes.
+
+Unauthenticated on purpose — browsers don't send credentials with CSP POSTs.
+Instead we rate-limit per source IP so an attacker can't amplify log volume.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+
+from hive.logging_config import get_logger
+from hive.metrics import emit_metric
+from hive.storage import HiveStorage
+
+router = APIRouter(tags=["csp"])
+logger = get_logger("hive.api.csp")
+
+
+# Keep a small cap so a runaway browser (or an attacker spoofing reports) can't
+# flood the log; 60 per minute per IP is far above any legitimate page load.
+_RATE_LIMIT_PER_MINUTE = 60
+
+# Truncate overly-long report fields so one bogus payload can't blow up a log line.
+_FIELD_MAX_LEN = 2048
+
+
+def _storage() -> HiveStorage:
+    return HiveStorage()
+
+
+def _client_ip(request: Request) -> str:
+    """Return the best-effort source IP for rate-limit keying.
+
+    Behind CloudFront the viewer address is in ``cloudfront-viewer-address``
+    as ``ip:port``; fall back to ``x-forwarded-for`` (first hop) and finally
+    the socket peer.
+    """
+    cf = request.headers.get("cloudfront-viewer-address", "").split(":", 1)[0]
+    if cf:
+        return cf
+    xff = request.headers.get("x-forwarded-for", "").split(",", 1)[0].strip()
+    if xff:
+        return xff
+    return request.client.host if request.client else "unknown"
+
+
+def _check_ip_rate_limit(ip: str, storage: HiveStorage) -> None:
+    """Per-IP per-minute rate limit for unauthenticated CSP reports."""
+    from datetime import datetime, timezone
+
+    minute = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
+    bucket = f"csp#{ip}#{minute}"
+    # Share the rate-limit counter table with the authenticated path; we use
+    # a distinct prefix so it can't collide with a real client_id.
+    count = storage.increment_rate_limit_counter("__csp__", bucket, ttl_seconds=120)
+    if count > _RATE_LIMIT_PER_MINUTE:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many CSP reports"
+        )
+
+
+def _truncate(value: Any) -> Any:
+    if isinstance(value, str) and len(value) > _FIELD_MAX_LEN:
+        return value[:_FIELD_MAX_LEN] + "…"
+    return value
+
+
+def _extract_legacy(body: dict[str, Any]) -> dict[str, Any] | None:
+    """Parse a Report-Only legacy ``application/csp-report`` body.
+
+    Shape: ``{"csp-report": {"violated-directive": ..., "blocked-uri": ...}}``.
+    """
+    report = body.get("csp-report")
+    if not isinstance(report, dict):
+        return None
+    return {
+        "violated_directive": _truncate(report.get("violated-directive", "")),
+        "effective_directive": _truncate(
+            report.get("effective-directive", report.get("violated-directive", ""))
+        ),
+        "blocked_uri": _truncate(report.get("blocked-uri", "")),
+        "document_uri": _truncate(report.get("document-uri", "")),
+        "source_file": _truncate(report.get("source-file", "")),
+        "line_number": report.get("line-number"),
+        "column_number": report.get("column-number"),
+        "disposition": report.get("disposition", "report"),
+    }
+
+
+def _extract_modern(report: dict[str, Any]) -> dict[str, Any] | None:
+    """Parse a modern ``application/reports+json`` entry.
+
+    Shape: ``{"type": "csp-violation", "body": {...}, "url": ...}``.
+    """
+    if report.get("type") != "csp-violation":
+        return None
+    body = report.get("body") or {}
+    return {
+        "violated_directive": _truncate(body.get("effectiveDirective", "")),
+        "effective_directive": _truncate(body.get("effectiveDirective", "")),
+        "blocked_uri": _truncate(body.get("blockedURL", "")),
+        "document_uri": _truncate(body.get("documentURL", report.get("url", ""))),
+        "source_file": _truncate(body.get("sourceFile", "")),
+        "line_number": body.get("lineNumber"),
+        "column_number": body.get("columnNumber"),
+        "disposition": body.get("disposition", "report"),
+    }
+
+
+def _blocked_domain(blocked_uri: str) -> str:
+    """Return the blocked-URI's domain (or a safe placeholder) for EMF dimensions."""
+    if not blocked_uri:
+        return "none"
+    if blocked_uri in {"inline", "eval", "self", "data"}:
+        return blocked_uri
+    parsed = urlparse(blocked_uri)
+    return parsed.hostname or blocked_uri[:_FIELD_MAX_LEN]
+
+
+async def _record_violation(violation: dict[str, Any]) -> None:
+    """Log + emit metric for a single parsed violation.
+
+    Two EMF emissions per report: an Environment-only aggregate (so the
+    admin dashboard can pull a single count) and a fully-dimensioned
+    record with ``directive`` + ``blocked_domain`` (for drill-down).
+    """
+    logger.warning(
+        "CSP violation: %s blocked %s",
+        violation["violated_directive"] or "unknown",
+        violation["blocked_uri"] or "unknown",
+        extra={"csp": violation},
+    )
+    await emit_metric("CSPViolations")
+    await emit_metric(
+        "CSPViolations",
+        directive=violation["violated_directive"] or "unknown",
+        blocked_domain=_blocked_domain(violation["blocked_uri"]),
+    )
+
+
+@router.post(
+    "/csp-report",
+    summary="Receive a browser CSP violation report",
+    description=(
+        "Endpoint for CSP `report-uri` and `report-to` directives. Accepts both the "
+        "legacy `application/csp-report` and modern `application/reports+json` "
+        "content types. Unauthenticated; rate-limited per source IP. Always "
+        "returns 204 — clients ignore the body."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    include_in_schema=False,
+)
+async def receive_csp_report(
+    request: Request,
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> Response:
+    ip = _client_ip(request)
+    _check_ip_rate_limit(ip, storage)
+
+    raw = await request.body()
+    if not raw:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Malformed CSP report from %s", ip, extra={"source_ip": ip})
+        # Don't 400 — a browser can't retry and we don't want to encourage probing.
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    violations: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        legacy = _extract_legacy(payload)
+        if legacy:
+            violations.append(legacy)
+    elif isinstance(payload, list):
+        for report in payload:
+            if isinstance(report, dict):
+                modern = _extract_modern(report)
+                if modern:
+                    violations.append(modern)
+
+    for v in violations:
+        await _record_violation(v)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -23,6 +23,7 @@ from hive.api._auth import require_admin
 from hive.api.account import router as account_router
 from hive.api.admin import router as admin_router
 from hive.api.clients import router as clients_router
+from hive.api.csp import router as csp_router
 from hive.api.keys import router as keys_router
 from hive.api.logs import router as logs_router
 from hive.api.memories import router as memories_router
@@ -138,6 +139,10 @@ app.include_router(keys_router, prefix="/api")
 app.include_router(account_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")
 app.include_router(logs_router, prefix="/api")
+
+# Browser CSP report receiver — unauthenticated by design
+# (browsers don't send credentials with CSP POSTs). Per-IP rate-limited.
+app.include_router(csp_router, prefix="/api")
 
 
 @app.get("/docs", include_in_schema=False)

--- a/src/hive/hybrid_search.py
+++ b/src/hive/hybrid_search.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Hybrid retrieval scoring for `search_memories` (#481).
+
+Combines three independent signals into a single blended score:
+
+- **semantic** — cosine similarity from the S3 Vectors index (already
+  in the 0-1 range from the vector store).
+- **keyword** — cheap term-frequency match over the query tokens
+  against the memory value. Gives short/exact-match queries (e.g.
+  "wifi password") a meaningful score even when they fall outside
+  the embedding neighbourhood.
+- **recency** — exponential decay against ``last_accessed_at``
+  (falling back to ``updated_at`` when the memory has never been
+  recalled). Half-life defaults to 30 days.
+
+Deliberately uses a simple TF heuristic rather than BM25 to avoid
+adding a tokeniser dependency — memory values are short, so the
+heuristic is good enough. Tokenisation is case-insensitive, no
+stemming.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import datetime, timezone
+
+from hive.models import Memory
+
+DEFAULT_W_SEMANTIC = 0.6
+DEFAULT_W_KEYWORD = 0.3
+DEFAULT_W_RECENCY = 0.1
+DEFAULT_RECENCY_HALF_LIFE_DAYS = 30.0
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase + word-chars-only tokeniser. No stemming."""
+    if not text:
+        return []
+    return _TOKEN_RE.findall(text.lower())
+
+
+def keyword_score(query_tokens: list[str], value: str) -> float:
+    """Return a 0-1 keyword score for ``value`` against ``query_tokens``.
+
+    Score = fraction of query tokens that appear at least once in the
+    tokenised value. Simple, bounded, and monotonic in recall — a value
+    that matches every query token scores 1.0, none scores 0.0.
+    """
+    if not query_tokens:
+        return 0.0
+    value_tokens = set(tokenize(value))
+    if not value_tokens:
+        return 0.0
+    hits = sum(1 for t in query_tokens if t in value_tokens)
+    return hits / len(query_tokens)
+
+
+def recency_score(
+    memory: Memory,
+    *,
+    now: datetime | None = None,
+    half_life_days: float = DEFAULT_RECENCY_HALF_LIFE_DAYS,
+) -> float:
+    """Return a 0-1 recency score using a true half-life decay.
+
+    Formula: ``2 ** (-age_days / half_life_days)``. A memory exactly
+    one half-life old scores 0.5; two half-lives → 0.25; etc. Uses
+    ``last_accessed_at`` when set (recall touched the memory), otherwise
+    ``updated_at``.
+    """
+    now = now or datetime.now(timezone.utc)
+    ref = memory.last_accessed_at or memory.updated_at
+    age_seconds = max(0.0, (now - ref).total_seconds())
+    age_days = age_seconds / 86400.0
+    return math.pow(2.0, -age_days / half_life_days)
+
+
+def blend_score(
+    *,
+    semantic: float,
+    keyword: float,
+    recency: float,
+    w_semantic: float = DEFAULT_W_SEMANTIC,
+    w_keyword: float = DEFAULT_W_KEYWORD,
+    w_recency: float = DEFAULT_W_RECENCY,
+) -> float:
+    """Weighted sum, with weights renormalised to sum to 1.0.
+
+    Renormalising lets callers pass any relative weighting (e.g. all
+    zeros except `w_keyword=1.0`) without having to do the arithmetic
+    themselves. If all weights are zero we fall back to the defaults
+    rather than returning an all-zero score.
+    """
+    total = w_semantic + w_keyword + w_recency
+    if total <= 0:
+        w_semantic, w_keyword, w_recency = (
+            DEFAULT_W_SEMANTIC,
+            DEFAULT_W_KEYWORD,
+            DEFAULT_W_RECENCY,
+        )
+        total = 1.0
+    ws = w_semantic / total
+    wk = w_keyword / total
+    wr = w_recency / total
+    return ws * semantic + wk * keyword + wr * recency

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -803,21 +803,37 @@ class ApiKeyCreateResponse(ApiKeyResponse):
 
 
 class MemorySearchResult(BaseModel):
-    """A memory returned by semantic search, with a relevance score."""
+    """A memory returned by search, with its blended relevance score.
+
+    ``score`` is the final blended value on [0, 1]. The per-signal sub-scores
+    (``semantic_score`` / ``keyword_score`` / ``recency_score``) are included
+    for debugging and agent-side re-ranking when hybrid mode is on (#481).
+    """
 
     memory_id: str
     key: str
     value: str
     tags: list[str]
     owner_client_id: str | None
-    score: float  # cosine similarity (0.0–1.0); higher = more relevant
+    score: float  # blended score (0.0–1.0); higher = more relevant
+    semantic_score: float = 0.0
+    keyword_score: float = 0.0
+    recency_score: float = 0.0
     created_at: datetime
     updated_at: datetime
     recall_count: int = 0
     last_accessed_at: datetime | None = None
 
     @classmethod
-    def from_memory_and_score(cls, m: Memory, score: float) -> MemorySearchResult:
+    def from_memory_and_score(
+        cls,
+        m: Memory,
+        score: float,
+        *,
+        semantic_score: float = 0.0,
+        keyword_score: float = 0.0,
+        recency_score: float = 0.0,
+    ) -> MemorySearchResult:
         return cls(
             memory_id=m.memory_id,
             key=m.key,
@@ -825,6 +841,9 @@ class MemorySearchResult(BaseModel):
             tags=m.tags,
             owner_client_id=m.owner_client_id,
             score=score,
+            semantic_score=semantic_score,
+            keyword_score=keyword_score,
+            recency_score=recency_score,
             created_at=m.created_at,
             updated_at=m.updated_at,
             recall_count=m.recall_count,

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -61,6 +61,7 @@ class Memory(BaseModel):
     expires_at: datetime | None = None  # optional TTL; None means never expires
     recall_count: int = 0  # incremented on every successful recall
     last_accessed_at: datetime | None = None  # set on every successful recall
+    redacted_at: datetime | None = None  # when redact_memory tombstoned the value (#400)
 
     # ------------------------------------------------------------------
     # DynamoDB serialisation
@@ -90,6 +91,8 @@ class Memory(BaseModel):
             item["ttl"] = int(self.expires_at.timestamp())
         if self.last_accessed_at is not None:
             item["last_accessed_at"] = self.last_accessed_at.isoformat()
+        if self.redacted_at is not None:
+            item["redacted_at"] = self.redacted_at.isoformat()
         return item
 
     def to_dynamo_tag_items(self) -> list[dict[str, Any]]:
@@ -118,6 +121,9 @@ class Memory(BaseModel):
         last_accessed_at = None
         if la := item.get("last_accessed_at"):
             last_accessed_at = datetime.fromisoformat(la)
+        redacted_at = None
+        if ra := item.get("redacted_at"):
+            redacted_at = datetime.fromisoformat(ra)
         return cls(
             memory_id=item["memory_id"],
             key=item["key"],
@@ -130,11 +136,17 @@ class Memory(BaseModel):
             expires_at=expires_at,
             recall_count=int(item.get("recall_count", 0) or 0),
             last_accessed_at=last_accessed_at,
+            redacted_at=redacted_at,
         )
 
     @property
     def is_expired(self) -> bool:
         return self.expires_at is not None and _now_utc() >= self.expires_at
+
+    @property
+    def is_redacted(self) -> bool:
+        """True when ``redact_memory`` has tombstoned this memory (#400)."""
+        return self.redacted_at is not None
 
     @property
     def version(self) -> str:
@@ -447,6 +459,7 @@ class EventType(str, Enum):
     memory_created = "memory_created"
     memory_updated = "memory_updated"
     memory_deleted = "memory_deleted"
+    memory_redacted = "memory_redacted"
     memory_recalled = "memory_recalled"
     memory_listed = "memory_listed"
     memory_searched = "memory_searched"

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -136,6 +136,16 @@ class Memory(BaseModel):
     def is_expired(self) -> bool:
         return self.expires_at is not None and _now_utc() >= self.expires_at
 
+    @property
+    def version(self) -> str:
+        """Opaque version token for optimistic locking (#391).
+
+        Derived from ``updated_at`` so every write produces a fresh value.
+        Agents pass this back to ``remember(key, ..., version=...)`` to
+        detect concurrent-write conflicts.
+        """
+        return self.updated_at.isoformat()
+
 
 # ---------------------------------------------------------------------------
 # OAuth Client (RFC 7591 Dynamic Client Registration)

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -59,6 +59,8 @@ class Memory(BaseModel):
     owner_client_id: str  # which OAuth client owns this memory
     owner_user_id: str | None = None  # which user owns this memory (None for pre-migration items)
     expires_at: datetime | None = None  # optional TTL; None means never expires
+    recall_count: int = 0  # incremented on every successful recall
+    last_accessed_at: datetime | None = None  # set on every successful recall
 
     # ------------------------------------------------------------------
     # DynamoDB serialisation
@@ -76,6 +78,7 @@ class Memory(BaseModel):
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
             "owner_client_id": self.owner_client_id,
+            "recall_count": self.recall_count,
             # GSI: look up by key across all memories
             "GSI1PK": f"KEY#{self.key}",
             "GSI1SK": self.memory_id,
@@ -85,6 +88,8 @@ class Memory(BaseModel):
         if self.expires_at is not None:
             item["expires_at"] = self.expires_at.isoformat()
             item["ttl"] = int(self.expires_at.timestamp())
+        if self.last_accessed_at is not None:
+            item["last_accessed_at"] = self.last_accessed_at.isoformat()
         return item
 
     def to_dynamo_tag_items(self) -> list[dict[str, Any]]:
@@ -110,6 +115,9 @@ class Memory(BaseModel):
         expires_at = None
         if ea := item.get("expires_at"):
             expires_at = datetime.fromisoformat(ea)
+        last_accessed_at = None
+        if la := item.get("last_accessed_at"):
+            last_accessed_at = datetime.fromisoformat(la)
         return cls(
             memory_id=item["memory_id"],
             key=item["key"],
@@ -120,6 +128,8 @@ class Memory(BaseModel):
             owner_client_id=item["owner_client_id"],
             owner_user_id=item.get("owner_user_id"),
             expires_at=expires_at,
+            recall_count=int(item.get("recall_count", 0) or 0),
+            last_accessed_at=last_accessed_at,
         )
 
     @property
@@ -555,6 +565,8 @@ class MemoryResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     expires_at: datetime | None = None
+    recall_count: int = 0
+    last_accessed_at: datetime | None = None
 
     @classmethod
     def from_memory(cls, m: Memory) -> MemoryResponse:
@@ -566,6 +578,8 @@ class MemoryResponse(BaseModel):
             created_at=m.created_at,
             updated_at=m.updated_at,
             expires_at=m.expires_at,
+            recall_count=m.recall_count,
+            last_accessed_at=m.last_accessed_at,
         )
 
 
@@ -789,6 +803,8 @@ class MemorySearchResult(BaseModel):
     score: float  # cosine similarity (0.0–1.0); higher = more relevant
     created_at: datetime
     updated_at: datetime
+    recall_count: int = 0
+    last_accessed_at: datetime | None = None
 
     @classmethod
     def from_memory_and_score(cls, m: Memory, score: float) -> MemorySearchResult:
@@ -801,4 +817,6 @@ class MemorySearchResult(BaseModel):
             score=score,
             created_at=m.created_at,
             updated_at=m.updated_at,
+            recall_count=m.recall_count,
+            last_accessed_at=m.last_accessed_at,
         )

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -233,6 +233,24 @@ def _tool_result(payload: Any, storage: HiveStorage, client_id: str) -> ToolResu
     return ToolResult(content=payload, meta=meta)
 
 
+async def _report_progress(
+    ctx: Context | None, progress: float, total: float | None, message: str
+) -> None:
+    """Emit an MCP ``notifications/progress`` event if the client supports it.
+
+    Any exception from the transport (client doesn't support progress, the
+    ctx is stale, etc.) is swallowed — progress is advisory, never fatal.
+    Policy: tools whose expected duration exceeds ~2s call this at sensible
+    milestones so clients can render a progress indicator.
+    """
+    if ctx is None:
+        return
+    try:
+        await ctx.report_progress(progress=progress, total=total, message=message)
+    except Exception:
+        logger.debug("progress notification dropped", exc_info=True)
+
+
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
@@ -832,7 +850,11 @@ async def summarize_context(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
 
+    await _report_progress(ctx, 0, 2, f"Retrieving memories for '{topic}'...")
     memories, _ = storage.list_memories_by_tag(topic, limit=500)
+    await _report_progress(
+        ctx, 1, 2, f"Retrieved {len(memories)} memories; synthesising summary..."
+    )
 
     if not memories:
         logger.info(
@@ -918,6 +940,7 @@ async def search_memories(
     # so we have headroom to still return up to top_k matches after filtering.
     search_top_k = 50 if required_tags else top_k
 
+    await _report_progress(ctx, 0, 3, f"Running vector search for '{query}'...")
     try:
         pairs = _vector_store().search(query, client_id, top_k=search_top_k)
     except VectorIndexNotFoundError:
@@ -929,12 +952,16 @@ async def search_memories(
     if threshold is not None:
         pairs = [(mid, score) for mid, score in pairs if score >= threshold]
 
+    await _report_progress(
+        ctx, 1, 3, f"Vector search returned {len(pairs)} candidates; hydrating..."
+    )
     results = storage.hydrate_memory_ids(pairs)
 
     if required_tags:
         results = [(m, s) for m, s in results if required_tags.issubset(m.tags)]
 
     results = results[:top_k]
+    await _report_progress(ctx, 2, 3, f"Ranked {len(results)} result(s); returning.")
 
     storage.log_event(
         ActivityEvent(

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -293,6 +293,51 @@ def _tool_result(
     return ToolResult(content=payload, meta=meta)
 
 
+_SUMMARY_MAX_TOKENS = 512
+_SUMMARY_SYSTEM_PROMPT = (
+    "You synthesise a set of memories into a concise briefing for the agent "
+    "that will use them. Return only the synthesis — no preamble, no "
+    "disclaimers. Preserve specific names, numbers, and decisions verbatim; "
+    "paraphrase the rest. Target 2-5 short paragraphs."
+)
+
+
+async def _sampled_summary(
+    ctx: Context | None,
+    topic: str,
+    memories: list[Memory],
+    fallback: str,
+) -> str:
+    """Synthesise a set of memories via MCP Sampling (#448).
+
+    Sends a ``sampling/createMessage`` request back to the client and uses
+    its model to produce the summary. If the client doesn't support
+    sampling, the transport rejects it, or ctx is unavailable (e.g. direct
+    invocation in tests), returns ``fallback`` — the deterministic
+    concatenated listing — so the tool never fails just because an agent
+    can't sample.
+    """
+    if ctx is None:
+        return fallback
+
+    body = "\n\n".join(f"- **{m.key}**: {m.value}" for m in memories)
+    prompt = (
+        f"The following memories are tagged '{topic}'. Synthesise them into a briefing.\n\n{body}"
+    )
+    try:
+        result = await ctx.sample(
+            prompt,
+            system_prompt=_SUMMARY_SYSTEM_PROMPT,
+            max_tokens=_SUMMARY_MAX_TOKENS,
+        )
+    except Exception:
+        logger.info("MCP sampling unavailable; falling back to concat summary", exc_info=True)
+        return fallback
+
+    text = getattr(result, "text", None) or fallback
+    return text.strip() or fallback
+
+
 async def _report_progress(
     ctx: Context | None, progress: float, total: float | None, message: str
 ) -> None:
@@ -958,10 +1003,13 @@ async def summarize_context(
     for m in memories:
         lines.append(f"**{m.key}**: {m.value}")
 
-    lines.append(
-        f"\n---\n*Summary: {len(memories)} memory/memories found for topic '{topic}'. "
-        "Review the entries above for relevant context.*"
-    )
+    lines.append(f"\n---\n*{len(memories)} memory/memories found for topic '{topic}'.*")
+    concat_summary = "\n".join(lines)
+
+    # Try MCP Sampling first (#448). If the client supports it, we get a real
+    # LLM synthesis without any server-side Bedrock cost; otherwise the
+    # sampler raises and we fall back to the concatenated listing above.
+    summary = await _sampled_summary(ctx, topic, memories, concat_summary)
 
     _log(
         storage,
@@ -989,7 +1037,7 @@ async def summarize_context(
         unit="Milliseconds",
         operation="summarize_context",
     )
-    return _tool_result("\n".join(lines), storage, client_id)
+    return _tool_result(summary, storage, client_id)
 
 
 @mcp.tool(

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -193,6 +193,19 @@ def _vector_store() -> VectorStore:
     return VectorStore()
 
 
+def _log(storage: HiveStorage, event: ActivityEvent) -> None:
+    """Record the event in both the user-visible activity log and the
+    immutable compliance audit log (#395).
+
+    Memory reads/writes/deletes surface in the Activity Log UI via the
+    LOG# partition; the AUDIT# partition carries the same events but
+    with a distinct retention (``HIVE_AUDIT_RETENTION_DAYS``, default
+    365 days) and survives an activity-log purge.
+    """
+    storage.log_event(event)
+    storage.log_audit_event(event)
+
+
 # ---------------------------------------------------------------------------
 # Response metadata — every tool response carries quota + rate-limit state
 # under ``_meta.hive`` so well-behaved agents can self-throttle.
@@ -421,12 +434,13 @@ async def remember(
         except Exception:
             logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=event_type,
             client_id=client_id,
             metadata={"key": key, "tags": tags},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -528,12 +542,13 @@ async def remember_if_absent(
     except Exception:
         logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_created,
             client_id=client_id,
             metadata={"key": key, "tags": tags},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -583,12 +598,13 @@ async def recall(
         await emit_metric("ToolErrors", operation="recall")
         raise ToolError(f"No memory found for key '{key}'.")
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_recalled,
             client_id=client_id,
             metadata={"key": key},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -643,12 +659,13 @@ async def forget(
         _vector_store().delete_memory(existing.memory_id, client_id)
     except Exception:
         logger.warning("Vector delete failed (non-fatal)", exc_info=True)
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_deleted,
             client_id=client_id,
             metadata={"key": key},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -685,12 +702,13 @@ async def forget_all(
     storage, client_id = await _auth(ctx, required_scope="memories:write")
 
     deleted = storage.delete_memories_by_tag(tag)
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_deleted,
             client_id=client_id,
             metadata={"tag": tag, "count": deleted},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -778,12 +796,13 @@ async def restore_memory(
     memory.tags = version.tags
     memory.updated_at = datetime.now(timezone.utc)
     storage.put_memory(memory)
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_updated,
             client_id=client_id,
             metadata={"key": key, "version_timestamp": version_timestamp},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     await emit_metric("ToolInvocations", operation="restore_memory")
@@ -814,12 +833,13 @@ async def list_memories(
 
     limit = max(1, min(limit, 500))
     memories, next_cursor = storage.list_memories_by_tag(tag, limit=limit, cursor=cursor)
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_listed,
             client_id=client_id,
             metadata={"tag": tag, "count": len(memories)},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -934,12 +954,13 @@ async def summarize_context(
         "Review the entries above for relevant context.*"
     )
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.context_summarized,
             client_id=client_id,
             metadata={"topic": topic, "memory_count": len(memories)},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -1019,12 +1040,13 @@ async def search_memories(
     results = results[:top_k]
     await _report_progress(ctx, 2, 3, f"Ranked {len(results)} result(s); returning.")
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_searched,
             client_id=client_id,
             metadata={"query": query, "result_count": len(results)},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
@@ -1093,12 +1115,13 @@ async def relate_memories(
     pairs = [(mid, score) for mid, score in pairs if mid != memory.memory_id][:top_k]
     results = storage.hydrate_memory_ids(pairs)
 
-    storage.log_event(
+    _log(
+        storage,
         ActivityEvent(
             event_type=EventType.memory_searched,
             client_id=client_id,
             metadata={"key": key, "result_count": len(results), "related_to": memory.memory_id},
-        )
+        ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -28,6 +28,7 @@ from fastmcp.exceptions import ToolError
 from fastmcp.server.auth import AccessToken as FastMCPAccessToken
 from fastmcp.server.auth import RemoteAuthProvider, TokenVerifier
 from fastmcp.server.dependencies import get_http_request
+from fastmcp.tools.tool import ToolResult
 from pydantic import AnyHttpUrl
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
@@ -37,8 +38,13 @@ from hive.auth.tokens import ISSUER, _origin_verify_secret, validate_bearer_toke
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 from hive.metrics import emit_metric
 from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult
-from hive.quota import QuotaExceeded, check_memory_quota
-from hive.rate_limiter import RateLimitExceeded, check_rate_limit
+from hive.quota import QuotaExceeded, check_memory_quota, get_memory_limit
+from hive.rate_limiter import (
+    DEFAULT_RATE_LIMIT_RPD,
+    DEFAULT_RATE_LIMIT_RPM,
+    RateLimitExceeded,
+    check_rate_limit,
+)
 from hive.storage import HiveStorage
 from hive.vector_store import VectorIndexNotFoundError, VectorStore
 
@@ -187,6 +193,47 @@ def _vector_store() -> VectorStore:
 
 
 # ---------------------------------------------------------------------------
+# Response metadata — every tool response carries quota + rate-limit state
+# under ``_meta.hive`` so well-behaved agents can self-throttle.
+# ---------------------------------------------------------------------------
+
+
+def _quota_meta(storage: HiveStorage, client_id: str) -> dict[str, Any]:
+    """Build the ``_meta.hive`` block from the caller's current quota state."""
+    client = storage.get_client(client_id)
+    owner_user_id = client.owner_user_id if client else None
+    memory_limit = get_memory_limit()
+    used = storage.count_memories(owner_user_id=owner_user_id) if owner_user_id else 0
+    return {
+        "hive": {
+            "memory_quota": {
+                "used": used,
+                "limit": memory_limit,
+                "remaining": max(0, memory_limit - used),
+            },
+            "rate_limit": {
+                "per_minute_limit": int(
+                    os.environ.get("HIVE_RATE_LIMIT_RPM", str(DEFAULT_RATE_LIMIT_RPM))
+                ),
+                "per_day_limit": int(
+                    os.environ.get("HIVE_RATE_LIMIT_RPD", str(DEFAULT_RATE_LIMIT_RPD))
+                ),
+            },
+        }
+    }
+
+
+def _tool_result(payload: Any, storage: HiveStorage, client_id: str) -> ToolResult:
+    """Wrap a tool's return value in an MCP ``ToolResult`` carrying quota +
+    rate-limit metadata in ``_meta.hive``. Strings become text content;
+    dicts become structured content so clients can still use them directly."""
+    meta = _quota_meta(storage, client_id)
+    if isinstance(payload, dict):
+        return ToolResult(structured_content=payload, meta=meta)
+    return ToolResult(content=payload, meta=meta)
+
+
+# ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
 
@@ -201,9 +248,9 @@ async def ping(ctx: Context | None = None) -> str:
     Performs no storage reads or writes. A successful call confirms both
     connectivity to the MCP server and that the caller's token is still valid.
     """
-    await _auth(ctx)
+    storage, client_id = await _auth(ctx)
     await emit_metric("ToolInvocations", operation="ping")
-    return "ok"
+    return _tool_result("ok", storage, client_id)
 
 
 @mcp.tool(
@@ -263,7 +310,7 @@ async def remember(
                     "status": "unchanged",
                 },
             )
-            return f"Memory '{key}' unchanged."
+            return _tool_result(f"Memory '{key}' unchanged.", storage, client_id)
         existing.value = value
         existing.tags = tags
         existing.expires_at = expires_at
@@ -323,7 +370,7 @@ async def remember(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="remember"
     )
-    return f"{action} memory '{key}'."
+    return _tool_result(f"{action} memory '{key}'.", storage, client_id)
 
 
 @mcp.tool(
@@ -386,7 +433,7 @@ async def remember_if_absent(
             },
         )
         await emit_metric("ToolInvocations", operation="remember_if_absent")
-        return f"Memory '{key}' already exists — not overwritten."
+        return _tool_result(f"Memory '{key}' already exists — not overwritten.", storage, client_id)
 
     client = storage.get_client(client_id)
     owner_user_id = client.owner_user_id if client else None
@@ -432,7 +479,7 @@ async def remember_if_absent(
         unit="Milliseconds",
         operation="remember_if_absent",
     )
-    return f"Stored memory '{key}'."
+    return _tool_result(f"Stored memory '{key}'.", storage, client_id)
 
 
 @mcp.tool(
@@ -484,7 +531,7 @@ async def recall(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="recall"
     )
-    return memory.value
+    return _tool_result(memory.value, storage, client_id)
 
 
 @mcp.tool(
@@ -544,7 +591,7 @@ async def forget(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="forget"
     )
-    return f"Deleted memory '{key}'."
+    return _tool_result(f"Deleted memory '{key}'.", storage, client_id)
 
 
 @mcp.tool(
@@ -590,7 +637,7 @@ async def forget_all(
         unit="Milliseconds",
         operation="forget_all",
     )
-    return f"Deleted {deleted} memories with tag '{tag}'."
+    return _tool_result(f"Deleted {deleted} memories with tag '{tag}'.", storage, client_id)
 
 
 @mcp.tool(
@@ -600,7 +647,7 @@ async def forget_all(
 async def memory_history(
     key: Annotated[str, "Key of the memory to retrieve history for"],
     ctx: Context | None = None,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any]:
     """Return the version history of a memory (previous values before each overwrite)."""
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope="memories:read")
@@ -617,7 +664,7 @@ async def memory_history(
         unit="Milliseconds",
         operation="memory_history",
     )
-    return [
+    items = [
         {
             "version_timestamp": v.version_timestamp,
             "value": v.value,
@@ -626,6 +673,7 @@ async def memory_history(
         }
         for v in versions
     ]
+    return _tool_result({"versions": items, "count": len(items)}, storage, client_id)
 
 
 @mcp.tool(
@@ -672,7 +720,9 @@ async def restore_memory(
         unit="Milliseconds",
         operation="restore_memory",
     )
-    return f"Restored memory '{key}' to version '{version_timestamp}'."
+    return _tool_result(
+        f"Restored memory '{key}' to version '{version_timestamp}'.", storage, client_id
+    )
 
 
 @mcp.tool(
@@ -732,7 +782,7 @@ async def list_memories(
     }
     if next_cursor:
         result["next_cursor"] = next_cursor
-    return result
+    return _tool_result(result, storage, client_id)
 
 
 @mcp.tool(
@@ -762,7 +812,7 @@ async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="list_tags"
     )
-    return {"tags": tags, "count": len(tags)}
+    return _tool_result({"tags": tags, "count": len(tags)}, storage, client_id)
 
 
 @mcp.tool(
@@ -795,7 +845,7 @@ async def summarize_context(
             },
         )
         await emit_metric("ToolInvocations", operation="summarize_context")
-        return f"No memories found for topic '{topic}'."
+        return _tool_result(f"No memories found for topic '{topic}'.", storage, client_id)
 
     lines = [f"## Memories tagged '{topic}'\n"]
     for m in memories:
@@ -831,7 +881,7 @@ async def summarize_context(
         unit="Milliseconds",
         operation="summarize_context",
     )
-    return "\n".join(lines)
+    return _tool_result("\n".join(lines), storage, client_id)
 
 
 @mcp.tool(
@@ -871,10 +921,10 @@ async def search_memories(
     try:
         pairs = _vector_store().search(query, client_id, top_k=search_top_k)
     except VectorIndexNotFoundError:
-        return {"items": [], "count": 0, "query": query}
+        return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
     except Exception:
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
-        return {"items": [], "count": 0, "query": query}
+        return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
 
     if threshold is not None:
         pairs = [(mid, score) for mid, score in pairs if score >= threshold]
@@ -911,13 +961,18 @@ async def search_memories(
         unit="Milliseconds",
         operation="search_memories",
     )
-    return {
-        "items": [
-            MemorySearchResult.from_memory_and_score(m, score).model_dump() for m, score in results
-        ],
-        "count": len(results),
-        "query": query,
-    }
+    return _tool_result(
+        {
+            "items": [
+                MemorySearchResult.from_memory_and_score(m, score).model_dump()
+                for m, score in results
+            ],
+            "count": len(results),
+            "query": query,
+        },
+        storage,
+        client_id,
+    )
 
 
 @mcp.tool(
@@ -947,10 +1002,10 @@ async def relate_memories(
         # Fetch top_k+1 so that dropping the source still leaves up to top_k.
         pairs = _vector_store().search(memory.value, client_id, top_k=top_k + 1)
     except VectorIndexNotFoundError:
-        return {"items": [], "count": 0, "key": key}
+        return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
     except Exception:
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
-        return {"items": [], "count": 0, "key": key}
+        return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
 
     pairs = [(mid, score) for mid, score in pairs if mid != memory.memory_id][:top_k]
     results = storage.hydrate_memory_ids(pairs)
@@ -980,13 +1035,18 @@ async def relate_memories(
         unit="Milliseconds",
         operation="relate_memories",
     )
-    return {
-        "items": [
-            MemorySearchResult.from_memory_and_score(m, score).model_dump() for m, score in results
-        ],
-        "count": len(results),
-        "key": key,
-    }
+    return _tool_result(
+        {
+            "items": [
+                MemorySearchResult.from_memory_and_score(m, score).model_dump()
+                for m, score in results
+            ],
+            "count": len(results),
+            "key": key,
+        },
+        storage,
+        client_id,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -652,6 +652,23 @@ async def recall(
         await emit_metric("ToolErrors", operation="recall")
         raise ToolError(f"No memory found for key '{key}'.")
 
+    # A redacted memory tombstone surfaces a safe sentinel — the fact that
+    # the memory once existed is itself the signal (#400).
+    if memory.redacted_at is not None:
+        sentinel = (
+            f"Memory '{key}' was redacted on {memory.redacted_at.isoformat()}. Value removed."
+        )
+        _log(
+            storage,
+            ActivityEvent(
+                event_type=EventType.memory_recalled,
+                client_id=client_id,
+                metadata={"key": key, "redacted": True},
+            ),
+        )
+        await emit_metric("ToolInvocations", operation="recall")
+        return _tool_result(sentinel, storage, client_id, memory=memory)
+
     _log(
         storage,
         ActivityEvent(
@@ -785,6 +802,95 @@ async def forget_all(
     return _tool_result(f"Deleted {deleted} memories with tag '{tag}'.", storage, client_id)
 
 
+_REDACTION_SENTINEL = "__redacted__"
+
+
+@mcp.tool(
+    title="Redact memory",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def redact_memory(
+    key: Annotated[str, "Key of the memory to redact"],
+    reason: Annotated[
+        str | None,
+        "Optional reason written to the audit trail (PII, secret leak, etc.)",
+    ] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Tombstone a memory: replace its value with a sentinel and record
+    ``redacted_at``, preserving the audit trail (#400).
+
+    Use this when the value contains content that must be removed (PII,
+    secret accidentally captured, etc.) but the fact that the memory
+    existed is itself meaningful. For full deletion, use ``forget``.
+    """
+    t0 = time.monotonic()
+    storage, client_id = await _auth(ctx, required_scope="memories:write")
+
+    existing = storage.get_memory_by_key(key)
+    if existing is None:
+        await emit_metric("ToolErrors", operation="redact_memory")
+        raise ToolError(f"No memory found for key '{key}'.")
+    if existing.is_redacted:
+        return _tool_result(f"Memory '{key}' is already redacted.", storage, client_id)
+
+    # Record the pre-redaction value in the audit log BEFORE we overwrite
+    # it — the tombstone path is the only thing that preserves what was
+    # there when a reviewer needs to understand a redaction after-the-fact.
+    storage.log_audit_event(
+        ActivityEvent(
+            event_type=EventType.memory_redacted,
+            client_id=client_id,
+            metadata={
+                "key": key,
+                "memory_id": existing.memory_id,
+                "reason": reason,
+                "previous_value": existing.value,
+                "previous_tags": existing.tags,
+            },
+        )
+    )
+
+    existing.value = _REDACTION_SENTINEL
+    existing.redacted_at = datetime.now(timezone.utc)
+    existing.updated_at = existing.redacted_at
+    storage.put_memory(existing)
+    try:
+        _vector_store().delete_memory(existing.memory_id, client_id)
+    except Exception:
+        logger.warning("Vector delete on redaction failed (non-fatal)", exc_info=True)
+
+    # The user-visible activity log gets a sanitised entry so the Activity Log
+    # UI surfaces the redaction without leaking the pre-redaction value.
+    storage.log_event(
+        ActivityEvent(
+            event_type=EventType.memory_redacted,
+            client_id=client_id,
+            metadata={"key": key, "reason": reason},
+        )
+    )
+
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "Redacted memory '%s'",
+        key,
+        extra={"tool": "redact_memory", "duration_ms": duration_ms, "status": "success"},
+    )
+    await emit_metric("ToolInvocations", operation="redact_memory")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="redact_memory",
+    )
+    return _tool_result(f"Redacted memory '{key}'.", storage, client_id)
+
+
 @mcp.tool(
     title="Memory history",
     annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
@@ -879,6 +985,10 @@ async def list_memories(
     tag: Annotated[str, "Tag to filter memories by"],
     limit: Annotated[int, "Maximum number of memories to return (1–500)"] = 100,
     cursor: Annotated[str | None, "Pagination cursor from a previous call"] = None,
+    include_redacted: Annotated[
+        bool,
+        "Include tombstoned (redacted) memories in the result. False by default.",
+    ] = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """List memories that have a specific tag, with optional pagination."""
@@ -887,6 +997,8 @@ async def list_memories(
 
     limit = max(1, min(limit, 500))
     memories, next_cursor = storage.list_memories_by_tag(tag, limit=limit, cursor=cursor)
+    if not include_redacted:
+        memories = [m for m in memories if not m.is_redacted]
     _log(
         storage,
         ActivityEvent(
@@ -1066,6 +1178,10 @@ async def search_memories(
     w_recency: Annotated[
         float, "Weight for recency decay against last_accessed_at/updated_at (default 0.1)"
     ] = DEFAULT_W_RECENCY,
+    include_redacted: Annotated[
+        bool,
+        "Include tombstoned (redacted) memories in the result. False by default.",
+    ] = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Search memories using hybrid retrieval: semantic + keyword + recency.
@@ -1119,6 +1235,9 @@ async def search_memories(
             w_recency=w_recency,
         )
         scored.append((m, blended, sem, kw, rec))
+
+    if not include_redacted:
+        scored = [row for row in scored if not row[0].is_redacted]
 
     if threshold is not None:
         scored = [row for row in scored if row[1] >= threshold]

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -36,6 +36,15 @@ from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse as StarletteJSONResponse
 
 from hive.auth.tokens import ISSUER, _origin_verify_secret, validate_bearer_token
+from hive.hybrid_search import (
+    DEFAULT_W_KEYWORD,
+    DEFAULT_W_RECENCY,
+    DEFAULT_W_SEMANTIC,
+    blend_score,
+    keyword_score,
+    recency_score,
+    tokenize,
+)
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 from hive.metrics import emit_metric
 from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult
@@ -992,7 +1001,7 @@ async def search_memories(
     top_k: Annotated[int, "Maximum number of results to return (1–50)"] = 10,
     min_score: Annotated[
         float | None,
-        "Minimum similarity score (0.0–1.0). Results below this threshold are "
+        "Minimum blended score (0.0–1.0). Results below this threshold are "
         "excluded. None disables filtering.",
     ] = None,
     filter_tags: Annotated[
@@ -1000,12 +1009,24 @@ async def search_memories(
         "Optional list of tags. Only memories carrying ALL of the given tags "
         "are returned. None disables filtering.",
     ] = None,
+    w_semantic: Annotated[
+        float, "Weight for semantic/vector similarity (default 0.6)"
+    ] = DEFAULT_W_SEMANTIC,
+    w_keyword: Annotated[
+        float, "Weight for keyword (term-frequency) match (default 0.3)"
+    ] = DEFAULT_W_KEYWORD,
+    w_recency: Annotated[
+        float, "Weight for recency decay against last_accessed_at/updated_at (default 0.1)"
+    ] = DEFAULT_W_RECENCY,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
-    """Search memories by semantic similarity to a natural language query.
+    """Search memories using hybrid retrieval: semantic + keyword + recency.
 
-    Returns memories ranked by relevance.  ``score`` ranges from 0.0 to 1.0
-    where higher means more semantically similar to the query.
+    Final score is a weighted sum of (a) cosine similarity from the vector
+    store, (b) a term-frequency keyword match, and (c) an exponential
+    recency decay. Weights are re-normalised to sum to 1.0; pass any
+    relative weighting. Per-signal sub-scores are returned on each item
+    for debugging.
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
@@ -1013,9 +1034,10 @@ async def search_memories(
     threshold = max(0.0, min(1.0, min_score)) if min_score is not None else None
     required_tags = set(filter_tags) if filter_tags else None
 
-    # When post-filtering by tags, request the full cap from the vector store
-    # so we have headroom to still return up to top_k matches after filtering.
-    search_top_k = 50 if required_tags else top_k
+    # Always request a wider candidate pool than top_k so keyword + recency
+    # blending has headroom to re-rank, and (if tag filtering is on) so the
+    # post-filter still leaves up to top_k survivors.
+    search_top_k = 50 if required_tags else min(max(top_k * 3, 10), 50)
 
     await _report_progress(ctx, 0, 3, f"Running vector search for '{query}'...")
     try:
@@ -1026,33 +1048,53 @@ async def search_memories(
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
         return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
 
-    if threshold is not None:
-        pairs = [(mid, score) for mid, score in pairs if score >= threshold]
-
     await _report_progress(
         ctx, 1, 3, f"Vector search returned {len(pairs)} candidates; hydrating..."
     )
-    results = storage.hydrate_memory_ids(pairs)
+    hydrated = storage.hydrate_memory_ids(pairs)
+
+    # Score each hydrated memory. sem_map lets us pair each Memory with its
+    # original cosine similarity; absent memories (hydrate dropped expired
+    # ones) are simply skipped.
+    query_tokens = tokenize(query)
+    now = datetime.now(timezone.utc)
+    scored: list[tuple[Memory, float, float, float, float]] = []
+    for m, sem in hydrated:
+        kw = keyword_score(query_tokens, m.value)
+        rec = recency_score(m, now=now)
+        blended = blend_score(
+            semantic=sem,
+            keyword=kw,
+            recency=rec,
+            w_semantic=w_semantic,
+            w_keyword=w_keyword,
+            w_recency=w_recency,
+        )
+        scored.append((m, blended, sem, kw, rec))
+
+    if threshold is not None:
+        scored = [row for row in scored if row[1] >= threshold]
 
     if required_tags:
-        results = [(m, s) for m, s in results if required_tags.issubset(m.tags)]
+        scored = [row for row in scored if required_tags.issubset(row[0].tags)]
 
-    results = results[:top_k]
-    await _report_progress(ctx, 2, 3, f"Ranked {len(results)} result(s); returning.")
+    scored.sort(key=lambda row: row[1], reverse=True)
+    scored = scored[:top_k]
+    await _report_progress(ctx, 2, 3, f"Ranked {len(scored)} result(s); returning.")
 
     _log(
         storage,
         ActivityEvent(
             event_type=EventType.memory_searched,
             client_id=client_id,
-            metadata={"query": query, "result_count": len(results)},
+            metadata={"query": query, "result_count": len(scored)},
         ),
     )
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
         "Searched memories for '%s', %d result(s)",
         query,
-        len(results),
+        len(scored),
         extra={
             "tool": "search_memories",
             "duration_ms": duration_ms,
@@ -1069,10 +1111,16 @@ async def search_memories(
     return _tool_result(
         {
             "items": [
-                MemorySearchResult.from_memory_and_score(m, score).model_dump()
-                for m, score in results
+                MemorySearchResult.from_memory_and_score(
+                    m,
+                    blended,
+                    semantic_score=sem,
+                    keyword_score=kw,
+                    recency_score=rec,
+                ).model_dump()
+                for m, blended, sem, kw, rec in scored
             ],
-            "count": len(results),
+            "count": len(scored),
             "query": query,
         },
         storage,

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -18,6 +18,7 @@ Tools:
 from __future__ import annotations
 
 import importlib.metadata
+import json
 import os
 import time
 from datetime import datetime, timedelta, timezone
@@ -45,7 +46,7 @@ from hive.rate_limiter import (
     RateLimitExceeded,
     check_rate_limit,
 )
-from hive.storage import HiveStorage
+from hive.storage import HiveStorage, VersionConflict
 from hive.vector_store import VectorIndexNotFoundError, VectorStore
 
 configure_logging("mcp")
@@ -223,11 +224,48 @@ def _quota_meta(storage: HiveStorage, client_id: str) -> dict[str, Any]:
     }
 
 
-def _tool_result(payload: Any, storage: HiveStorage, client_id: str) -> ToolResult:
+def _conflict_message(
+    key: str,
+    attempted_version: str | None,
+    current_value: str | None,
+    current_version: str | None,
+) -> str:
+    """Serialise an optimistic-lock conflict into a ToolError message (#391).
+
+    ToolError currently has no structured-data slot, so agents parse the
+    JSON block appended to the text message to decide how to reconcile.
+    """
+    payload = {
+        "conflict": True,
+        "key": key,
+        "attempted_version": attempted_version,
+        "current_version": current_version,
+        "current_value": current_value,
+    }
+    return (
+        f"Conflict: memory {key!r} was updated since version "
+        f"{attempted_version!r}. " + json.dumps(payload)
+    )
+
+
+def _tool_result(
+    payload: Any,
+    storage: HiveStorage,
+    client_id: str,
+    *,
+    memory: Memory | None = None,
+) -> ToolResult:
     """Wrap a tool's return value in an MCP ``ToolResult`` carrying quota +
     rate-limit metadata in ``_meta.hive``. Strings become text content;
-    dicts become structured content so clients can still use them directly."""
+    dicts become structured content so clients can still use them directly.
+
+    When the tool operated on a specific memory, pass it via ``memory=`` so
+    its optimistic-lock version is surfaced as ``_meta.hive.memory.version``
+    — the agent can thread that back into a subsequent ``remember`` call.
+    """
     meta = _quota_meta(storage, client_id)
+    if memory is not None:
+        meta["hive"]["memory"] = {"key": memory.key, "version": memory.version}
     if isinstance(payload, dict):
         return ToolResult(structured_content=payload, meta=meta)
     return ToolResult(content=payload, meta=meta)
@@ -291,6 +329,12 @@ async def remember(
     ttl_seconds: Annotated[
         int | None, "Seconds until the memory expires. None = never expires."
     ] = None,
+    version: Annotated[
+        str | None,
+        "Optimistic-lock token from a prior recall/list_memories response. "
+        "If provided, the write is rejected with a conflict error when the "
+        "stored memory's version has moved on since the caller read it.",
+    ] = None,
     ctx: Context | None = None,
 ) -> str:
     """Store or update a memory with optional tags and optional TTL."""
@@ -314,6 +358,10 @@ async def remember(
     existing = storage.get_memory_by_key(key)
 
     if existing:
+        # Optimistic lock: reject early if the caller's version is already stale.
+        if version is not None and existing.version != version:
+            await emit_metric("ToolErrors", operation="remember")
+            raise ToolError(_conflict_message(key, version, existing.value, existing.version))
         # Idempotent: skip write and log if nothing changed
         if (
             existing.value == value
@@ -334,7 +382,14 @@ async def remember(
         existing.expires_at = expires_at
         existing.updated_at = datetime.now(timezone.utc)
         try:
-            storage.put_memory(existing)
+            storage.put_memory(existing, expected_version=version)
+        except VersionConflict as exc:
+            await emit_metric("ToolErrors", operation="remember")
+            raise ToolError(
+                _conflict_message(
+                    key, exc.attempted_version, exc.current_value, exc.current_version
+                )
+            ) from exc
         except ValueError as exc:
             await emit_metric("ToolErrors", operation="remember")
             raise ToolError(str(exc)) from exc
@@ -549,7 +604,7 @@ async def recall(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="recall"
     )
-    return _tool_result(memory.value, storage, client_id)
+    return _tool_result(memory.value, storage, client_id, memory=memory)
 
 
 @mcp.tool(
@@ -792,6 +847,7 @@ async def list_memories(
                 "last_accessed_at": (
                     m.last_accessed_at.isoformat() if m.last_accessed_at else None
                 ),
+                "version": m.version,
             }
             for m in memories
         ],

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -447,7 +447,9 @@ async def recall(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
 
-    memory = storage.get_memory_by_key(key)
+    # record_recall atomically bumps recall_count + last_accessed_at and
+    # returns the updated Memory (None if missing/expired).
+    memory = storage.record_recall(key)
     if memory is None:
         logger.warning(
             "Memory not found for key '%s'",
@@ -718,6 +720,10 @@ async def list_memories(
                 "value": m.value,
                 "tags": m.tags,
                 "owner_client_id": m.owner_client_id,
+                "recall_count": m.recall_count,
+                "last_accessed_at": (
+                    m.last_accessed_at.isoformat() if m.last_accessed_at else None
+                ),
             }
             for m in memories
         ],

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 from typing import Any
 
 import boto3
-from boto3.dynamodb.conditions import Key
+from boto3.dynamodb.conditions import Attr, Key
 from botocore.exceptions import ClientError
 
 from hive.models import (
@@ -56,6 +56,26 @@ REFRESH_TOKEN_TTL_SECONDS = 86400 * 30  # 30 days
 AUTH_CODE_TTL_SECONDS = 300  # 5 minutes
 PENDING_AUTH_TTL_SECONDS = 600  # 10 minutes (enough for Google login flow)
 MGMT_PENDING_STATE_TTL_SECONDS = 600  # 10 minutes (enough for Google login flow)
+
+
+class VersionConflict(Exception):
+    """Raised by put_memory when an optimistic-lock version check fails (#391).
+
+    Carries the state the caller needs to compare-and-retry without an
+    extra round-trip: the attempted version, the actual current value,
+    and the actual current version.
+    """
+
+    def __init__(
+        self,
+        attempted_version: str,
+        current_value: str | None,
+        current_version: str | None,
+    ) -> None:
+        self.attempted_version = attempted_version
+        self.current_value = current_value
+        self.current_version = current_version
+        super().__init__(f"Memory was updated since version {attempted_version!r}")
 
 
 def _now() -> datetime:
@@ -93,27 +113,68 @@ class HiveStorage:
     # Memory CRUD
     # ------------------------------------------------------------------
 
-    def put_memory(self, memory: Memory) -> None:
+    def put_memory(self, memory: Memory, *, expected_version: str | None = None) -> None:
         """Write (create or replace) a memory and all its tag items.
 
         When replacing an existing memory, the previous state is snapshotted
         as a VERSION item so it can be retrieved via list_memory_versions.
+
+        If ``expected_version`` is provided, the META item is written with a
+        conditional expression requiring the stored ``updated_at`` to match
+        — supporting optimistic locking (#391). Raises ``VersionConflict``
+        if the stored version has moved on since the caller read it.
         """
-        # First delete old tag items if the memory already exists
         existing_raw = self._get_memory_meta(memory.memory_id)
+        if expected_version is not None:
+            if existing_raw is None:
+                raise VersionConflict(
+                    attempted_version=expected_version,
+                    current_value=None,
+                    current_version=None,
+                )
+            current = Memory.from_dynamo(existing_raw)
+            if current.version != expected_version:
+                raise VersionConflict(
+                    attempted_version=expected_version,
+                    current_value=current.value,
+                    current_version=current.version,
+                )
+
         if existing_raw:
             old = Memory.from_dynamo(existing_raw)
             self._delete_tag_items(old)
             self.save_memory_version(old)
 
+        meta_item = memory.to_dynamo_meta()
         try:
-            with self.table.batch_writer() as batch:
-                batch.put_item(Item=memory.to_dynamo_meta())
-                for tag_item in memory.to_dynamo_tag_items():
-                    batch.put_item(Item=tag_item)
+            if expected_version is not None:
+                # Conditional put on the META item to close the TOCTOU window
+                # between the read above and the write below. Tag items get
+                # rewritten unconditionally — they carry no value state and
+                # are rebuilt from the memory's tag list on every put.
+                self.table.put_item(
+                    Item=meta_item,
+                    ConditionExpression=Attr("updated_at").eq(expected_version),
+                )
+                with self.table.batch_writer() as batch:
+                    for tag_item in memory.to_dynamo_tag_items():
+                        batch.put_item(Item=tag_item)
+            else:
+                with self.table.batch_writer() as batch:
+                    batch.put_item(Item=meta_item)
+                    for tag_item in memory.to_dynamo_tag_items():
+                        batch.put_item(Item=tag_item)
         except ClientError as exc:
             code = exc.response["Error"]["Code"]
             msg = exc.response["Error"]["Message"]
+            if code == "ConditionalCheckFailedException":
+                latest = self._get_memory_meta(memory.memory_id)
+                latest_mem = Memory.from_dynamo(latest) if latest else None
+                raise VersionConflict(
+                    attempted_version=expected_version or "",
+                    current_value=latest_mem.value if latest_mem else None,
+                    current_version=latest_mem.version if latest_mem else None,
+                ) from exc
             if code == "ValidationException" and "size" in msg.lower():
                 raise ValueError(
                     "Memory value is too large to store (DynamoDB 400 KB item limit exceeded)."

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -143,6 +143,37 @@ class HiveStorage:
         memory_id = items[0]["memory_id"]
         return self.get_memory_by_id(memory_id)
 
+    def record_recall(self, key: str) -> Memory | None:
+        """Atomically increment ``recall_count`` and refresh ``last_accessed_at``
+        on the memory with the given key, returning the updated Memory.
+
+        Returns ``None`` if the key doesn't exist or the memory is expired.
+        Does the work in a single DynamoDB ``update_item`` (with ``ALL_NEW``
+        return values) so we don't pay two round-trips per recall.
+        """
+        resp = self.table.query(
+            IndexName="KeyIndex",
+            KeyConditionExpression=Key("GSI1PK").eq(f"KEY#{key}"),
+            Limit=1,
+        )
+        items = resp.get("Items", [])
+        if not items:
+            return None
+        memory_id = items[0]["memory_id"]
+        now_iso = _now().isoformat()
+        updated = self.table.update_item(
+            Key={"PK": f"MEMORY#{memory_id}", "SK": "META"},
+            UpdateExpression=("SET last_accessed_at = :now ADD recall_count :one"),
+            ExpressionAttributeValues={":now": now_iso, ":one": Decimal("1")},
+            ReturnValues="ALL_NEW",
+        )
+        # ALL_NEW always populates Attributes once the KeyIndex lookup above
+        # has confirmed the item exists, so there's no "None" path to guard.
+        memory = Memory.from_dynamo(updated["Attributes"])
+        if memory.is_expired:
+            return None
+        return memory
+
     def delete_memory(self, memory_id: str) -> bool:
         """Delete a memory and all its tag items. Returns True if found."""
         existing = self._get_memory_meta(memory_id)

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -903,13 +903,52 @@ class HiveStorage:
         """Write an audit event to the immutable audit log (AUDIT# PK prefix).
 
         Audit events use a separate PK prefix from activity log events (LOG#)
-        and are never deleted, even when a user's activity log is purged.
+        so they survive a user-requested activity-log purge. A DynamoDB TTL
+        provides a hard retention horizon (``HIVE_AUDIT_RETENTION_DAYS``,
+        default 365) so items age out automatically and we stay compliant
+        with data-minimisation expectations.
         """
         item = event.to_dynamo()
-        # Override the PK prefix so audit events are stored separately
         date_hour_str = event.timestamp.strftime("%Y-%m-%d#%H")
         item["PK"] = f"AUDIT#{date_hour_str}"
+        retention_days = int(os.environ.get("HIVE_AUDIT_RETENTION_DAYS", "365"))
+        item["ttl"] = int(event.timestamp.timestamp()) + retention_days * 86400
         self.table.put_item(Item=item)
+
+    def get_audit_events_for_dates(
+        self,
+        dates: list[str],
+        *,
+        client_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 100,
+    ) -> list[ActivityEvent]:
+        """Fetch audit events across multiple dates, newest-first, capped at limit.
+
+        Optional post-query filters on ``client_id`` and ``event_type`` keep
+        the admin audit-log endpoint simple; the partition scan itself reads
+        every hour-shard in parallel.
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        def _query(pk: str) -> list[ActivityEvent]:
+            resp = self.table.query(KeyConditionExpression=Key("PK").eq(pk))
+            return [ActivityEvent.from_dynamo(i) for i in resp.get("Items", [])]
+
+        pks = [f"AUDIT#{d}#{hour:02d}" for d in dates for hour in range(24)]
+        events: list[ActivityEvent] = []
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = {executor.submit(_query, pk): pk for pk in pks}
+            for future in as_completed(futures):
+                events.extend(future.result())
+
+        if client_id is not None:
+            events = [e for e in events if e.client_id == client_id]
+        if event_type is not None:
+            events = [e for e in events if e.event_type.value == event_type]
+
+        events.sort(key=lambda e: e.timestamp, reverse=True)
+        return events[:limit]
 
     # ------------------------------------------------------------------
     # Account deletion

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -26,6 +26,16 @@ def _make_context(token_str: str):
     return ctx
 
 
+def _text(r) -> str:
+    """Extract text payload from a ToolResult."""
+    return r.content[0].text
+
+
+def _body(r) -> dict:
+    """Extract structured content from a ToolResult."""
+    return r.structured_content
+
+
 @pytest.fixture(scope="module")
 def setup():
     """Set up DynamoDB Local table + a valid token for MCP tool calls."""
@@ -118,10 +128,10 @@ class TestMCPTools:
         jwt = setup
         ctx = _make_context(jwt)
         result = await remember(key="greeting", value="Hello, Hive!", tags=["test"], ctx=ctx)
-        assert "greeting" in result
+        assert "greeting" in _text(result)
 
         recalled = await recall(key="greeting", ctx=ctx)
-        assert recalled == "Hello, Hive!"
+        assert _text(recalled) == "Hello, Hive!"
 
     async def test_forget(self, setup):
         from fastmcp.exceptions import ToolError
@@ -132,7 +142,7 @@ class TestMCPTools:
         ctx = _make_context(jwt)
         await remember(key="temp", value="ephemeral", ctx=ctx)
         result = await forget(key="temp", ctx=ctx)
-        assert "temp" in result
+        assert "temp" in _text(result)
 
         with pytest.raises(ToolError):
             await recall(key="temp", ctx=ctx)
@@ -146,7 +156,7 @@ class TestMCPTools:
         await remember(key="list-b", value="B", tags=["listtest"], ctx=ctx)
 
         result = await list_memories(tag="listtest", ctx=ctx)
-        keys = [m["key"] for m in result["items"]]
+        keys = [m["key"] for m in _body(result)["items"]]
         assert "list-a" in keys
         assert "list-b" in keys
 
@@ -159,5 +169,6 @@ class TestMCPTools:
         await remember(key="s2", value="Summary value 2", tags=["summary"], ctx=ctx)
 
         result = await summarize_context(topic="summary", ctx=ctx)
-        assert "summary" in result.lower()
-        assert "s1" in result or "s2" in result
+        text = _text(result)
+        assert "summary" in text.lower()
+        assert "s1" in text or "s2" in text

--- a/tests/unit/test_admin_api.py
+++ b/tests/unit/test_admin_api.py
@@ -447,3 +447,101 @@ class TestAdminAlarms:
                 resp = admin_tc.get("/api/admin/alarms")
 
             assert resp.json()["alarms"][0]["state"] == state
+
+
+class TestAdminAuditLog:
+    """GET /api/admin/audit-log — admin-only compliance audit trail (#395)."""
+
+    @pytest.fixture()
+    def audit_storage(self):
+        from hive.api import admin as admin_mod
+        from hive.api.main import app
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-admin", region="us-east-1")
+        app.dependency_overrides[admin_mod._storage] = lambda: storage
+        yield storage
+        app.dependency_overrides.pop(admin_mod._storage, None)
+
+    def test_returns_events_newest_first(self, admin_tc, audit_storage):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import ActivityEvent, EventType
+
+        base = datetime.now(timezone.utc).replace(microsecond=0)
+        for i, etype in enumerate(
+            [EventType.memory_created, EventType.memory_recalled, EventType.memory_deleted]
+        ):
+            audit_storage.log_audit_event(
+                ActivityEvent(
+                    event_type=etype,
+                    client_id="c1",
+                    metadata={"i": i},
+                    timestamp=base - timedelta(seconds=i),
+                )
+            )
+
+        resp = admin_tc.get("/api/admin/audit-log?days=1&limit=10")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 3
+        # Newest-first ordering
+        assert body["items"][0]["event_type"] == "memory_created"
+        assert body["items"][-1]["event_type"] == "memory_deleted"
+
+    def test_filter_by_client_id(self, admin_tc, audit_storage):
+        from hive.models import ActivityEvent, EventType
+
+        for cid in ["c1", "c2", "c1"]:
+            audit_storage.log_audit_event(
+                ActivityEvent(event_type=EventType.memory_created, client_id=cid)
+            )
+
+        resp = admin_tc.get("/api/admin/audit-log?days=1&client_id=c1")
+        items = resp.json()["items"]
+        assert {it["client_id"] for it in items} == {"c1"}
+
+    def test_filter_by_event_type(self, admin_tc, audit_storage):
+        from hive.models import ActivityEvent, EventType
+
+        audit_storage.log_audit_event(
+            ActivityEvent(event_type=EventType.memory_created, client_id="c")
+        )
+        audit_storage.log_audit_event(
+            ActivityEvent(event_type=EventType.memory_deleted, client_id="c")
+        )
+
+        resp = admin_tc.get("/api/admin/audit-log?days=1&event_type=memory_deleted")
+        items = resp.json()["items"]
+        assert {it["event_type"] for it in items} == {"memory_deleted"}
+
+    def test_has_more_flag(self, admin_tc, audit_storage):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import ActivityEvent, EventType
+
+        base = datetime.now(timezone.utc)
+        for i in range(5):
+            audit_storage.log_audit_event(
+                ActivityEvent(
+                    event_type=EventType.memory_created,
+                    client_id="c",
+                    timestamp=base - timedelta(seconds=i),
+                )
+            )
+
+        resp = admin_tc.get("/api/admin/audit-log?days=1&limit=3")
+        body = resp.json()
+        assert body["count"] == 3
+        assert body["has_more"] is True
+
+    def test_non_admin_forbidden(self, user_tc):
+        resp = user_tc.get("/api/admin/audit-log?days=1")
+        assert resp.status_code == 403
+
+    def test_storage_factory_returns_storage(self):
+        """_storage() dep factory returns a HiveStorage so the endpoint can run in prod."""
+        from hive.api.admin import _storage
+        from hive.storage import HiveStorage
+
+        assert isinstance(_storage(), HiveStorage)

--- a/tests/unit/test_csp_api.py
+++ b/tests/unit/test_csp_api.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for the POST /api/csp-report browser CSP violation endpoint.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import boto3
+import pytest
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-unit-csp")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+os.environ.pop("DYNAMODB_ENDPOINT", None)
+
+
+def _create_table() -> None:
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName="hive-unit-csp",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "UserEmailIndex",
+                "KeySchema": [{"AttributeName": "GSI4PK", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+@pytest.fixture()
+def client():
+    with mock_aws():
+        _create_table()
+        from hive.api import csp as csp_mod
+        from hive.api.main import app
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name="hive-unit-csp", region="us-east-1")
+        app.dependency_overrides[csp_mod._storage] = lambda: storage
+        yield TestClient(app), storage
+        app.dependency_overrides.clear()
+
+
+_LEGACY_REPORT = {
+    "csp-report": {
+        "document-uri": "https://example.com/app",
+        "referrer": "",
+        "violated-directive": "script-src-elem",
+        "effective-directive": "script-src-elem",
+        "original-policy": "default-src 'self'",
+        "disposition": "report",
+        "blocked-uri": "https://evil.example.net/tracker.js",
+        "line-number": 12,
+        "column-number": 3,
+        "source-file": "https://example.com/app",
+        "status-code": 0,
+        "script-sample": "",
+    }
+}
+
+_MODERN_REPORT = [
+    {
+        "type": "csp-violation",
+        "url": "https://example.com/app",
+        "user_agent": "Mozilla/5.0",
+        "body": {
+            "effectiveDirective": "img-src",
+            "blockedURL": "https://cdn.other.example/img.png",
+            "documentURL": "https://example.com/app",
+            "disposition": "report",
+            "lineNumber": 99,
+            "columnNumber": 7,
+            "sourceFile": "https://example.com/app/bundle.js",
+        },
+    }
+]
+
+
+class TestCspReport:
+    def test_legacy_report_returns_204_and_logs(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post("/api/csp-report", json=_LEGACY_REPORT)
+        assert resp.status_code == 204
+        assert resp.content == b""
+        # Two emits per violation: aggregate (Environment only) + drill-down
+        assert mock_emit.await_count == 2
+        assert mock_emit.await_args_list[0].args == ("CSPViolations",)
+        drilldown = mock_emit.await_args_list[1]
+        assert drilldown.args == ("CSPViolations",)
+        assert drilldown.kwargs["directive"] == "script-src-elem"
+        assert drilldown.kwargs["blocked_domain"] == "evil.example.net"
+
+    def test_modern_report_returns_204_and_logs(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post("/api/csp-report", json=_MODERN_REPORT)
+        assert resp.status_code == 204
+        assert mock_emit.await_count == 2
+        drilldown = mock_emit.await_args_list[1]
+        assert drilldown.kwargs["directive"] == "img-src"
+        assert drilldown.kwargs["blocked_domain"] == "cdn.other.example"
+
+    def test_empty_body_returns_204_no_emit(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post("/api/csp-report", data="")
+        assert resp.status_code == 204
+        mock_emit.assert_not_awaited()
+
+    def test_malformed_json_returns_204_no_emit(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post(
+                "/api/csp-report",
+                data="this is not json",
+                headers={"Content-Type": "application/csp-report"},
+            )
+        assert resp.status_code == 204
+        mock_emit.assert_not_awaited()
+
+    def test_unknown_payload_shape_is_ignored(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            # Dict without "csp-report" key — not legacy, and not a list for modern
+            resp = tc.post("/api/csp-report", json={"foo": "bar"})
+        assert resp.status_code == 204
+        mock_emit.assert_not_awaited()
+
+    def test_modern_report_non_csp_type_ignored(self, client):
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post(
+                "/api/csp-report",
+                json=[{"type": "deprecation", "body": {}}],
+            )
+        assert resp.status_code == 204
+        mock_emit.assert_not_awaited()
+
+    def test_rate_limit_per_ip(self, client):
+        """After 60 reports/min from the same IP, subsequent reports get 429."""
+        tc, _ = client
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            headers = {"x-forwarded-for": "203.0.113.42"}
+            for _ in range(60):
+                resp = tc.post("/api/csp-report", json=_LEGACY_REPORT, headers=headers)
+                assert resp.status_code == 204
+            over_limit = tc.post("/api/csp-report", json=_LEGACY_REPORT, headers=headers)
+            assert over_limit.status_code == 429
+
+    def test_ip_picked_from_cloudfront_header(self, client):
+        """Behind CloudFront the viewer IP is in cloudfront-viewer-address as ip:port."""
+        tc, storage = client
+        mock_emit = AsyncMock()
+        with (
+            patch("hive.api.csp.emit_metric", mock_emit),
+            patch.object(
+                storage, "increment_rate_limit_counter", wraps=storage.increment_rate_limit_counter
+            ) as spy,
+        ):
+            tc.post(
+                "/api/csp-report",
+                json=_LEGACY_REPORT,
+                headers={"cloudfront-viewer-address": "198.51.100.7:12345"},
+            )
+        bucket = spy.call_args_list[0].args[1]
+        assert "198.51.100.7" in bucket
+
+    def test_ip_falls_back_to_xff(self, client):
+        tc, storage = client
+        with (
+            patch("hive.api.csp.emit_metric", AsyncMock()),
+            patch.object(
+                storage,
+                "increment_rate_limit_counter",
+                wraps=storage.increment_rate_limit_counter,
+            ) as spy,
+        ):
+            tc.post(
+                "/api/csp-report",
+                json=_LEGACY_REPORT,
+                headers={"x-forwarded-for": "192.0.2.1, 10.0.0.1"},
+            )
+        bucket = spy.call_args_list[0].args[1]
+        assert "192.0.2.1" in bucket
+
+    def test_long_field_is_truncated(self, client):
+        """A pathological blocked-URI value is clamped before logging/metrics."""
+        tc, _ = client
+        long_uri = "https://very-long-host.example/" + ("x" * 3000)
+        payload = {
+            "csp-report": {
+                "violated-directive": "script-src",
+                "blocked-uri": long_uri,
+                "document-uri": "https://example.com/",
+            }
+        }
+        mock_emit = AsyncMock()
+        with patch("hive.api.csp.emit_metric", mock_emit):
+            resp = tc.post("/api/csp-report", json=payload)
+        assert resp.status_code == 204
+        drilldown_kwargs = mock_emit.await_args_list[1].kwargs
+        # Domain stays short (it's extracted by urlparse); directive untouched.
+        assert drilldown_kwargs["directive"] == "script-src"
+        assert "very-long-host.example" in drilldown_kwargs["blocked_domain"]
+
+
+class TestHelpers:
+    def test_blocked_domain_keyword_values(self):
+        from hive.api.csp import _blocked_domain
+
+        assert _blocked_domain("inline") == "inline"
+        assert _blocked_domain("eval") == "eval"
+        assert _blocked_domain("self") == "self"
+        assert _blocked_domain("data") == "data"
+
+    def test_blocked_domain_empty(self):
+        from hive.api.csp import _blocked_domain
+
+        assert _blocked_domain("") == "none"
+
+    def test_blocked_domain_unparseable(self):
+        from hive.api.csp import _blocked_domain
+
+        # urlparse almost never raises, but a value with no scheme falls back
+        # to the raw string — which is fine for a dimension label.
+        assert _blocked_domain("not-a-real-url") == "not-a-real-url"
+
+    def test_truncate_short_string(self):
+        from hive.api.csp import _truncate
+
+        assert _truncate("short") == "short"
+        assert _truncate(42) == 42  # non-strings pass through
+
+    def test_client_ip_falls_back_to_socket(self):
+        from unittest.mock import MagicMock
+
+        from hive.api.csp import _client_ip
+
+        req = MagicMock()
+        req.headers = {}
+        req.client.host = "127.0.0.1"
+        assert _client_ip(req) == "127.0.0.1"
+
+    def test_client_ip_unknown_when_no_client(self):
+        from unittest.mock import MagicMock
+
+        from hive.api.csp import _client_ip
+
+        req = MagicMock()
+        req.headers = {}
+        req.client = None
+        assert _client_ip(req) == "unknown"
+
+    def test_storage_factory_returns_storage(self):
+        """The module-level _storage() dependency factory returns a HiveStorage."""
+        from hive.api.csp import _storage
+        from hive.storage import HiveStorage
+
+        assert isinstance(_storage(), HiveStorage)

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for the hybrid search scoring helpers (#481)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hive.hybrid_search import (
+    DEFAULT_W_KEYWORD,
+    DEFAULT_W_RECENCY,
+    DEFAULT_W_SEMANTIC,
+    blend_score,
+    keyword_score,
+    recency_score,
+    tokenize,
+)
+from hive.models import Memory
+
+
+class TestTokenize:
+    def test_lowercases_and_splits_on_non_word(self):
+        assert tokenize("Hello, World! 2026") == ["hello", "world", "2026"]
+
+    def test_empty_string_returns_empty_list(self):
+        assert tokenize("") == []
+
+    def test_unicode_word_chars(self):
+        # \w is Unicode-aware under the re.UNICODE flag.
+        assert tokenize("café Résumé") == ["café", "résumé"]
+
+
+class TestKeywordScore:
+    def test_returns_fraction_of_tokens_matched(self):
+        assert keyword_score(["wifi", "password"], "the wifi password is 1234") == 1.0
+        assert keyword_score(["wifi", "password"], "the wifi is up") == 0.5
+        assert keyword_score(["wifi", "password"], "nothing to see") == 0.0
+
+    def test_empty_query_returns_zero(self):
+        assert keyword_score([], "any value") == 0.0
+
+    def test_empty_value_returns_zero(self):
+        assert keyword_score(["wifi"], "") == 0.0
+
+    def test_value_tokenisation_is_case_insensitive(self):
+        # The scorer assumes query tokens are already lowercased via tokenize();
+        # this test verifies it still matches when the value has mixed case.
+        assert keyword_score(tokenize("WIFI"), "WIFI works") == 1.0
+        assert keyword_score(tokenize("WiFi"), "the WIFI password") == 1.0
+
+
+class TestRecencyScore:
+    def _mem(self, *, updated_at=None, last_accessed_at=None) -> Memory:
+        return Memory(
+            key="k",
+            value="v",
+            owner_client_id="c1",
+            updated_at=updated_at or datetime.now(timezone.utc),
+            last_accessed_at=last_accessed_at,
+        )
+
+    def test_fresh_memory_scores_near_one(self):
+        now = datetime.now(timezone.utc)
+        m = self._mem(updated_at=now)
+        assert recency_score(m, now=now) == 1.0
+
+    def test_half_life_produces_half_score(self):
+        now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        m = self._mem(updated_at=now - timedelta(days=30))
+        assert abs(recency_score(m, now=now, half_life_days=30) - 0.5) < 1e-6
+
+    def test_uses_last_accessed_at_when_set(self):
+        now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        # updated_at is old but last_accessed_at is fresh — recency should be high.
+        m = self._mem(
+            updated_at=now - timedelta(days=365),
+            last_accessed_at=now,
+        )
+        assert recency_score(m, now=now) == 1.0
+
+    def test_future_timestamps_clamped_to_now(self):
+        now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        m = self._mem(updated_at=now + timedelta(days=10))
+        # Future ref shouldn't blow up; age is clamped to 0 → score 1.0.
+        assert recency_score(m, now=now) == 1.0
+
+
+class TestBlendScore:
+    def test_weighted_sum(self):
+        # With defaults: 0.6 * 1 + 0.3 * 0 + 0.1 * 0 = 0.6
+        assert blend_score(semantic=1.0, keyword=0.0, recency=0.0) == pytest.approx(0.6)
+
+    def test_renormalises_uneven_weights(self):
+        # Weights 2:2:0 should behave like 0.5 / 0.5 / 0
+        score = blend_score(
+            semantic=1.0,
+            keyword=0.0,
+            recency=0.0,
+            w_semantic=2.0,
+            w_keyword=2.0,
+            w_recency=0.0,
+        )
+        assert score == pytest.approx(0.5)
+
+    def test_all_zero_weights_falls_back_to_defaults(self):
+        # Shouldn't produce NaN or zero when caller passes all-zero weights.
+        score = blend_score(
+            semantic=1.0,
+            keyword=0.5,
+            recency=0.25,
+            w_semantic=0,
+            w_keyword=0,
+            w_recency=0,
+        )
+        expected = DEFAULT_W_SEMANTIC * 1.0 + DEFAULT_W_KEYWORD * 0.5 + DEFAULT_W_RECENCY * 0.25
+        assert score == pytest.approx(expected)
+
+    def test_all_ones_produces_one(self):
+        assert blend_score(semantic=1.0, keyword=1.0, recency=1.0) == pytest.approx(1.0)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -53,6 +53,40 @@ class TestMemory:
         m = Memory(key="k", value="v", owner_client_id="c1")
         assert m.to_dynamo_tag_items() == []
 
+    def test_default_recall_fields(self):
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        assert m.recall_count == 0
+        assert m.last_accessed_at is None
+
+    def test_recall_fields_persist_and_roundtrip(self):
+        from datetime import datetime, timezone
+
+        accessed = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+        m = Memory(
+            key="k",
+            value="v",
+            owner_client_id="c1",
+            recall_count=7,
+            last_accessed_at=accessed,
+        )
+        item = m.to_dynamo_meta()
+        assert item["recall_count"] == 7
+        assert item["last_accessed_at"] == accessed.isoformat()
+        m2 = Memory.from_dynamo(item)
+        assert m2.recall_count == 7
+        assert m2.last_accessed_at == accessed
+
+    def test_from_dynamo_tolerates_missing_recall_fields(self):
+        # Items written before this field existed won't have recall_count or
+        # last_accessed_at; Memory.from_dynamo must default them cleanly.
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        item = m.to_dynamo_meta()
+        item.pop("recall_count", None)
+        item.pop("last_accessed_at", None)
+        m2 = Memory.from_dynamo(item)
+        assert m2.recall_count == 0
+        assert m2.last_accessed_at is None
+
 
 class TestOAuthClient:
     def test_defaults(self):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -87,6 +87,15 @@ class TestMemory:
         assert m2.recall_count == 0
         assert m2.last_accessed_at is None
 
+    def test_version_reflects_updated_at(self):
+        """Memory.version is the updated_at isoformat — advances on every write."""
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        assert m.version == m.updated_at.isoformat()
+        old = m.version
+        m.updated_at = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        assert m.version != old
+        assert m.version == m.updated_at.isoformat()
+
 
 class TestOAuthClient:
     def test_defaults(self):

--- a/tests/unit/test_quota.py
+++ b/tests/unit/test_quota.py
@@ -189,6 +189,9 @@ class TestMcpQuotaIntegration:
             existing_memory.tags = []
             instance = MockStorage.return_value
             instance.get_memory_by_key.return_value = existing_memory
+            # Response-meta builder reads count_memories; return a real int.
+            instance.count_memories.return_value = 0
+            instance.get_client.return_value = None
 
             from hive.server import remember
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -440,6 +440,25 @@ class TestRecall:
         with pytest.raises(ToolError, match="No memory found"):
             await recall("no-such-key", ctx=_make_ctx(jwt))
 
+    async def test_recall_bumps_recall_count_and_last_accessed_at(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import recall, remember
+
+        await remember("rec-counter", "v", [], ctx=_make_ctx(jwt))
+        before = storage.get_memory_by_key("rec-counter")
+        assert before.recall_count == 0
+        assert before.last_accessed_at is None
+
+        await recall("rec-counter", ctx=_make_ctx(jwt))
+        after_first = storage.get_memory_by_key("rec-counter")
+        assert after_first.recall_count == 1
+        assert after_first.last_accessed_at is not None
+
+        await recall("rec-counter", ctx=_make_ctx(jwt))
+        after_second = storage.get_memory_by_key("rec-counter")
+        assert after_second.recall_count == 2
+        assert after_second.last_accessed_at >= after_first.last_accessed_at
+
 
 # ---------------------------------------------------------------------------
 # forget
@@ -485,6 +504,21 @@ class TestListMemories:
         assert "lst-b" not in keys
         # Agent attribution is surfaced on every item.
         assert result["items"][0]["owner_client_id"] == client_id
+        # Usage metrics are surfaced too; fresh memories have count=0, no access.
+        assert result["items"][0]["recall_count"] == 0
+        assert result["items"][0]["last_accessed_at"] is None
+
+    async def test_list_memories_surfaces_recall_metrics_after_recall(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_memories, recall, remember
+
+        await remember("bumped", "v", ["alpha"], ctx=_make_ctx(jwt))
+        await recall("bumped", ctx=_make_ctx(jwt))
+
+        result = await list_memories("alpha", ctx=_make_ctx(jwt))
+        item = next(x for x in result["items"] if x["key"] == "bumped")
+        assert item["recall_count"] == 1
+        assert item["last_accessed_at"] is not None
 
     async def test_list_empty_tag_returns_empty(self, server_env):
         _, _, jwt = server_env

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -78,6 +78,21 @@ def _make_ctx(jwt: str) -> MagicMock:
     return ctx
 
 
+def _text(r) -> str:
+    """Extract text payload from a ToolResult (for string-returning tools)."""
+    return r.content[0].text
+
+
+def _body(r) -> dict:
+    """Extract structured content from a ToolResult (for dict-returning tools)."""
+    return r.structured_content
+
+
+def _hive_meta(r) -> dict:
+    """Extract the ``_meta.hive`` quota/rate-limit block from a ToolResult."""
+    return r.meta["hive"]
+
+
 @pytest.fixture()
 def server_env():
     """moto-backed storage + valid JWT for MCP tool tests."""
@@ -125,7 +140,11 @@ class TestPing:
         from hive.server import ping
 
         result = await ping(ctx=_make_ctx(jwt))
-        assert result == "ok"
+        assert _text(result) == "ok"
+        # Every tool response carries quota + rate-limit state under _meta.hive
+        meta = _hive_meta(result)
+        assert "memory_quota" in meta
+        assert "rate_limit" in meta
 
     async def test_missing_auth_raises_tool_error(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -169,7 +188,7 @@ class TestRemember:
         from hive.server import remember
 
         result = await remember("my-key", "my-value", ["tag1"], ctx=_make_ctx(jwt))
-        assert result == "Stored memory 'my-key'."
+        assert _text(result) == "Stored memory 'my-key'."
         assert storage.get_memory_by_key("my-key") is not None
 
     async def test_update_existing_memory(self, server_env):
@@ -178,7 +197,7 @@ class TestRemember:
 
         await remember("upd-key", "original", [], ctx=_make_ctx(jwt))
         result = await remember("upd-key", "updated", ["new-tag"], ctx=_make_ctx(jwt))
-        assert result == "Updated memory 'upd-key'."
+        assert _text(result) == "Updated memory 'upd-key'."
         m = storage.get_memory_by_key("upd-key")
         assert m is not None
         assert m.value == "updated"
@@ -189,7 +208,7 @@ class TestRemember:
 
         await remember("same-key", "same-value", ["t"], ctx=_make_ctx(jwt))
         result = await remember("same-key", "same-value", ["t"], ctx=_make_ctx(jwt))
-        assert result == "Memory 'same-key' unchanged."
+        assert _text(result) == "Memory 'same-key' unchanged."
 
     async def test_missing_auth_raises_tool_error(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -213,7 +232,7 @@ class TestRemember:
         ctx = MagicMock()
         ctx.request_context.meta = meta
         result = await remember("pydantic-meta-key", "v", [], ctx=ctx)
-        assert result == "Stored memory 'pydantic-meta-key'."
+        assert _text(result) == "Stored memory 'pydantic-meta-key'."
 
     async def test_oversized_value_raises_tool_error(self, server_env):
         from unittest.mock import patch
@@ -238,7 +257,7 @@ class TestRemember:
         storage, _, jwt = server_env
         value = "x" * DEFAULT_MAX_VALUE_BYTES
         result = await remember("at-limit-key", value, [], ctx=_make_ctx(jwt))
-        assert result == "Stored memory 'at-limit-key'."
+        assert _text(result) == "Stored memory 'at-limit-key'."
 
     async def test_value_over_limit_raises_tool_error(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -276,14 +295,14 @@ class TestRemember:
                 await remember("custom-limit-key", "x" * 6, [], ctx=_make_ctx(jwt))
             # within the override limit is fine
             result = await remember("within-key", "x" * 5, [], ctx=_make_ctx(jwt))
-            assert result == "Stored memory 'within-key'."
+            assert _text(result) == "Stored memory 'within-key'."
 
     async def test_remember_with_ttl_sets_expires_at(self, server_env):
         storage, client_id, jwt = server_env
         from hive.server import remember
 
         result = await remember("ttl-key", "ttl-val", [], ttl_seconds=3600, ctx=_make_ctx(jwt))
-        assert result == "Stored memory 'ttl-key'."
+        assert _text(result) == "Stored memory 'ttl-key'."
         m = storage.get_memory_by_key("ttl-key")
         assert m is not None
         assert m.expires_at is not None
@@ -306,7 +325,7 @@ class TestRemember:
         assert m1 is not None
         # Second call with same value but no ttl should NOT be idempotent
         result = await remember("idem-ttl", "v", [], ttl_seconds=None, ctx=_make_ctx(jwt))
-        assert result == "Updated memory 'idem-ttl'."
+        assert _text(result) == "Updated memory 'idem-ttl'."
         m2 = storage.get_memory_by_key("idem-ttl")
         assert m2 is not None
         assert m2.expires_at is None
@@ -323,7 +342,7 @@ class TestRememberIfAbsent:
         from hive.server import remember_if_absent
 
         result = await remember_if_absent("ifa-new", "v", ["t"], ctx=_make_ctx(jwt))
-        assert result == "Stored memory 'ifa-new'."
+        assert _text(result) == "Stored memory 'ifa-new'."
         m = storage.get_memory_by_key("ifa-new")
         assert m is not None
         assert m.value == "v"
@@ -334,7 +353,7 @@ class TestRememberIfAbsent:
 
         await remember("ifa-dupe", "original", ["old"], ctx=_make_ctx(jwt))
         result = await remember_if_absent("ifa-dupe", "new-value", ["new"], ctx=_make_ctx(jwt))
-        assert result == "Memory 'ifa-dupe' already exists — not overwritten."
+        assert _text(result) == "Memory 'ifa-dupe' already exists — not overwritten."
         m = storage.get_memory_by_key("ifa-dupe")
         assert m.value == "original"
         assert set(m.tags) == {"old"}
@@ -404,7 +423,7 @@ class TestRememberIfAbsent:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await remember_if_absent("ifa-vs-fail", "v", ctx=_make_ctx(jwt))
 
-        assert result == "Stored memory 'ifa-vs-fail'."
+        assert _text(result) == "Stored memory 'ifa-vs-fail'."
 
     async def test_requires_write_scope(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -429,7 +448,7 @@ class TestRecall:
 
         await remember("rec-key", "the-value", [], ctx=_make_ctx(jwt))
         result = await recall("rec-key", ctx=_make_ctx(jwt))
-        assert result == "the-value"
+        assert _text(result) == "the-value"
 
     async def test_recall_nonexistent_raises(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -472,7 +491,7 @@ class TestForget:
 
         await remember("del-key", "v", [], ctx=_make_ctx(jwt))
         result = await forget("del-key", ctx=_make_ctx(jwt))
-        assert result == "Deleted memory 'del-key'."
+        assert _text(result) == "Deleted memory 'del-key'."
         assert storage.get_memory_by_key("del-key") is None
 
     async def test_forget_nonexistent_raises(self, server_env):
@@ -498,15 +517,16 @@ class TestListMemories:
         await remember("lst-a", "v1", ["alpha"], ctx=_make_ctx(jwt))
         await remember("lst-b", "v2", ["beta"], ctx=_make_ctx(jwt))
         result = await list_memories("alpha", ctx=_make_ctx(jwt))
-        assert "items" in result and "has_more" in result
-        keys = [m["key"] for m in result["items"]]
+        body = _body(result)
+        assert "items" in body and "has_more" in body
+        keys = [m["key"] for m in body["items"]]
         assert "lst-a" in keys
         assert "lst-b" not in keys
         # Agent attribution is surfaced on every item.
-        assert result["items"][0]["owner_client_id"] == client_id
+        assert body["items"][0]["owner_client_id"] == client_id
         # Usage metrics are surfaced too; fresh memories have count=0, no access.
-        assert result["items"][0]["recall_count"] == 0
-        assert result["items"][0]["last_accessed_at"] is None
+        assert body["items"][0]["recall_count"] == 0
+        assert body["items"][0]["last_accessed_at"] is None
 
     async def test_list_memories_surfaces_recall_metrics_after_recall(self, server_env):
         _, _, jwt = server_env
@@ -516,7 +536,7 @@ class TestListMemories:
         await recall("bumped", ctx=_make_ctx(jwt))
 
         result = await list_memories("alpha", ctx=_make_ctx(jwt))
-        item = next(x for x in result["items"] if x["key"] == "bumped")
+        item = next(x for x in _body(result)["items"] if x["key"] == "bumped")
         assert item["recall_count"] == 1
         assert item["last_accessed_at"] is not None
 
@@ -525,8 +545,9 @@ class TestListMemories:
         from hive.server import list_memories
 
         result = await list_memories("nonexistent-tag", ctx=_make_ctx(jwt))
-        assert result["items"] == []
-        assert result["has_more"] is False
+        body = _body(result)
+        assert body["items"] == []
+        assert body["has_more"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -545,14 +566,14 @@ class TestListTags:
         await remember("c", "3", [], ctx=ctx)
 
         result = await list_tags(ctx=ctx)
-        assert result == {"tags": ["alpha", "mango", "zebra"], "count": 3}
+        assert _body(result) == {"tags": ["alpha", "mango", "zebra"], "count": 3}
 
     async def test_empty_when_no_memories(self, server_env):
         _, _, jwt = server_env
         from hive.server import list_tags
 
         result = await list_tags(ctx=_make_ctx(jwt))
-        assert result == {"tags": [], "count": 0}
+        assert _body(result) == {"tags": [], "count": 0}
 
     async def test_scoped_to_caller_client(self, server_env):
         storage, client_id, jwt = server_env
@@ -566,7 +587,7 @@ class TestListTags:
         )
 
         result = await list_tags(ctx=_make_ctx(jwt))
-        assert result["tags"] == ["owned"]
+        assert _body(result)["tags"] == ["owned"]
 
     async def test_requires_read_scope(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -592,15 +613,16 @@ class TestSummarizeContext:
         await remember("sum-a", "detail about foo", ["foo"], ctx=_make_ctx(jwt))
         await remember("sum-b", "more about foo", ["foo"], ctx=_make_ctx(jwt))
         result = await summarize_context("foo", ctx=_make_ctx(jwt))
-        assert "foo" in result
-        assert "sum-a" in result or "detail about foo" in result
+        text = _text(result)
+        assert "foo" in text
+        assert "sum-a" in text or "detail about foo" in text
 
     async def test_summarize_no_memories(self, server_env):
         _, _, jwt = server_env
         from hive.server import summarize_context
 
         result = await summarize_context("nonexistent-topic", ctx=_make_ctx(jwt))
-        assert "No memories found" in result
+        assert "No memories found" in _text(result)
 
 
 # ---------------------------------------------------------------------------
@@ -663,7 +685,7 @@ class TestAuthHttpPath:
 
         with patch("hive.server.get_http_request", return_value=mock_request):
             result = await remember("http-path-key", "value", [], ctx=ctx)
-        assert "http-path-key" in result
+        assert "http-path-key" in _text(result)
 
 
 # ---------------------------------------------------------------------------
@@ -708,8 +730,9 @@ class TestListMemoriesPagination:
             await remember(f"pg-key-{i}", f"val-{i}", ["pagtest"], ctx=ctx)
 
         result = await list_memories("pagtest", limit=1, ctx=ctx)
-        assert result["has_more"] is True
-        assert "next_cursor" in result
+        body = _body(result)
+        assert body["has_more"] is True
+        assert "next_cursor" in body
 
 
 # ---------------------------------------------------------------------------
@@ -869,9 +892,10 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("searchable content", top_k=5, ctx=ctx)
 
-        assert result["count"] == 1
-        assert result["query"] == "searchable content"
-        item = result["items"][0]
+        body = _body(result)
+        assert body["count"] == 1
+        assert body["query"] == "searchable content"
+        item = body["items"][0]
         assert item["key"] == "search-key"
         assert item["score"] == 0.88
         assert item["owner_client_id"] == client_id
@@ -889,7 +913,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("anything", ctx=_make_ctx(jwt))
 
-        assert result == {"items": [], "count": 0, "query": "anything"}
+        assert _body(result) == {"items": [], "count": 0, "query": "anything"}
 
     async def test_caps_top_k_at_50(self, server_env):
         from unittest.mock import patch
@@ -931,8 +955,9 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("anything", min_score=0.5, ctx=ctx)
 
-        assert result["count"] == 1
-        assert [item["key"] for item in result["items"]] == ["hi-key"]
+        body = _body(result)
+        assert body["count"] == 1
+        assert [item["key"] for item in body["items"]] == ["hi-key"]
 
     async def test_min_score_none_returns_all(self, server_env):
         from unittest.mock import patch
@@ -950,7 +975,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", ctx=ctx)
 
-        assert result["count"] == 2
+        assert _body(result)["count"] == 2
 
     async def test_min_score_all_below_threshold_returns_empty(self, server_env):
         from unittest.mock import patch
@@ -966,7 +991,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", min_score=0.9, ctx=ctx)
 
-        assert result == {"items": [], "count": 0, "query": "q"}
+        assert _body(result) == {"items": [], "count": 0, "query": "q"}
 
     async def test_filter_tags_requires_all_tags(self, server_env):
         from unittest.mock import patch
@@ -988,9 +1013,10 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", filter_tags=["x", "y"], ctx=ctx)
 
+        body = _body(result)
         # Only "a" has both x and y
-        assert [item["key"] for item in result["items"]] == ["a"]
-        assert result["count"] == 1
+        assert [item["key"] for item in body["items"]] == ["a"]
+        assert body["count"] == 1
 
     async def test_filter_tags_none_returns_all(self, server_env):
         from unittest.mock import patch
@@ -1006,7 +1032,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", ctx=ctx)
 
-        assert result["count"] == 1
+        assert _body(result)["count"] == 1
 
     async def test_filter_tags_requests_wider_candidate_pool(self, server_env):
         from unittest.mock import patch
@@ -1040,8 +1066,9 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", top_k=2, filter_tags=["x"], ctx=ctx)
 
-        assert result["count"] == 2
-        assert [item["key"] for item in result["items"]] == ["k0", "k1"]
+        body = _body(result)
+        assert body["count"] == 2
+        assert [item["key"] for item in body["items"]] == ["k0", "k1"]
 
     async def test_min_score_clamped_to_unit_interval(self, server_env):
         from unittest.mock import patch
@@ -1058,14 +1085,14 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("q", min_score=5.0, ctx=ctx)
 
-        assert result["count"] == 1
+        assert _body(result)["count"] == 1
 
         # min_score < 0.0 gets clamped to 0.0; everything passes
         mock_vs2 = _make_mock_vector_store([(m.memory_id, 0.0)])
         with patch("hive.server._vector_store", return_value=mock_vs2):
             result = await search_memories("q", min_score=-1.0, ctx=ctx)
 
-        assert result["count"] == 1
+        assert _body(result)["count"] == 1
 
     async def test_remember_dual_writes_to_vector_store(self, server_env):
         """remember() calls upsert_memory on the VectorStore for new memories."""
@@ -1124,7 +1151,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await remember("vec-fail-new", "v", [], ctx=_make_ctx(jwt))
 
-        assert "Stored" in result
+        assert "Stored" in _text(result)
 
     async def test_remember_vector_upsert_failure_on_update_is_non_fatal(self, server_env):
         """VectorStore errors during remember() update are logged but do not raise."""
@@ -1142,7 +1169,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await remember("vec-fail-upd", "updated", [], ctx=_make_ctx(jwt))
 
-        assert "Updated" in result
+        assert "Updated" in _text(result)
 
     async def test_forget_vector_delete_failure_is_non_fatal(self, server_env):
         """VectorStore errors during forget() are logged but do not raise."""
@@ -1158,7 +1185,7 @@ class TestSearchMemories:
             await remember("vec-fail-forget", "v", [], ctx=_make_ctx(jwt))
             result = await forget("vec-fail-forget", ctx=_make_ctx(jwt))
 
-        assert "Deleted" in result
+        assert "Deleted" in _text(result)
 
     async def test_search_vector_failure_returns_empty(self, server_env):
         """Unexpected VectorStore errors during search_memories() return empty results."""
@@ -1173,7 +1200,7 @@ class TestSearchMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await search_memories("anything", ctx=_make_ctx(jwt))
 
-        assert result == {"items": [], "count": 0, "query": "anything"}
+        assert _body(result) == {"items": [], "count": 0, "query": "anything"}
 
 
 # ---------------------------------------------------------------------------
@@ -1203,10 +1230,11 @@ class TestRelateMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await relate_memories("source", top_k=2, ctx=ctx)
 
-        keys = [item["key"] for item in result["items"]]
+        body = _body(result)
+        keys = [item["key"] for item in body["items"]]
         assert keys == ["a", "b"]
-        assert result["count"] == 2
-        assert result["key"] == "source"
+        assert body["count"] == 2
+        assert body["key"] == "source"
 
     async def test_uses_source_value_as_query(self, server_env):
         from unittest.mock import patch
@@ -1249,7 +1277,7 @@ class TestRelateMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await relate_memories("src", ctx=ctx)
 
-        assert result == {"items": [], "count": 0, "key": "src"}
+        assert _body(result) == {"items": [], "count": 0, "key": "src"}
 
     async def test_returns_empty_on_vector_error(self, server_env):
         from unittest.mock import MagicMock, patch
@@ -1265,7 +1293,7 @@ class TestRelateMemories:
         with patch("hive.server._vector_store", return_value=mock_vs):
             result = await relate_memories("src", ctx=ctx)
 
-        assert result == {"items": [], "count": 0, "key": "src"}
+        assert _body(result) == {"items": [], "count": 0, "key": "src"}
 
     async def test_top_k_clamped(self, server_env):
         from unittest.mock import patch
@@ -1308,7 +1336,7 @@ class TestForgetAll:
         await remember("fa-b", "v2", ["purge"], ctx=_make_ctx(jwt))
         await remember("fa-c", "v3", ["keep"], ctx=_make_ctx(jwt))
         result = await forget_all("purge", ctx=_make_ctx(jwt))
-        assert "2" in result
+        assert "2" in _text(result)
         assert storage.get_memory_by_key("fa-a") is None
         assert storage.get_memory_by_key("fa-b") is None
         assert storage.get_memory_by_key("fa-c") is not None
@@ -1318,7 +1346,7 @@ class TestForgetAll:
         from hive.server import forget_all
 
         result = await forget_all("no-such-tag", ctx=_make_ctx(jwt))
-        assert "0" in result
+        assert "0" in _text(result)
 
     async def test_forget_all_requires_write_scope(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -1344,8 +1372,10 @@ class TestMemoryHistory:
         await remember("hist-k", "v1", [], ctx=_make_ctx(jwt))
         await remember("hist-k", "v2", [], ctx=_make_ctx(jwt))
         result = await memory_history("hist-k", ctx=_make_ctx(jwt))
-        assert len(result) == 1
-        assert result[0]["value"] == "v1"
+        body = _body(result)
+        assert body["count"] == 1
+        assert len(body["versions"]) == 1
+        assert body["versions"][0]["value"] == "v1"
 
     async def test_memory_history_empty_for_new_memory(self, server_env):
         storage, client_id, jwt = server_env
@@ -1353,7 +1383,7 @@ class TestMemoryHistory:
 
         await remember("new-hist", "v1", [], ctx=_make_ctx(jwt))
         result = await memory_history("new-hist", ctx=_make_ctx(jwt))
-        assert result == []
+        assert _body(result) == {"versions": [], "count": 0}
 
     async def test_memory_history_raises_for_missing_key(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -1388,9 +1418,9 @@ class TestRestoreMemory:
         await remember("rst-k", "v1", [], ctx=_make_ctx(jwt))
         await remember("rst-k", "v2", [], ctx=_make_ctx(jwt))
         versions = await memory_history("rst-k", ctx=_make_ctx(jwt))
-        vts = versions[0]["version_timestamp"]
+        vts = _body(versions)["versions"][0]["version_timestamp"]
         result = await restore_memory("rst-k", vts, ctx=_make_ctx(jwt))
-        assert "rst-k" in result
+        assert "rst-k" in _text(result)
         m = storage.get_memory_by_key("rst-k")
         assert m is not None
         assert m.value == "v1"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -638,6 +638,71 @@ class TestSummarizeContext:
         result = await summarize_context("nonexistent-topic", ctx=_make_ctx(jwt))
         assert "No memories found" in _text(result)
 
+    async def test_summarize_uses_mcp_sampling_when_available(self, server_env):
+        """When ctx.sample returns a result, the synthesised text replaces
+        the concat fallback."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("s-a", "policy X says Y", ["sampled"], ctx=_make_ctx(jwt))
+
+        ctx = _make_ctx(jwt)
+        sampled = MagicMock()
+        sampled.text = "SYNTHESISED BRIEFING OUTPUT"
+        ctx.sample = AsyncMock(return_value=sampled)
+
+        result = await summarize_context("sampled", ctx=ctx)
+        assert _text(result) == "SYNTHESISED BRIEFING OUTPUT"
+        # Client was asked with a system prompt + the memories inline.
+        ctx.sample.assert_awaited_once()
+        args, kwargs = ctx.sample.call_args
+        assert "policy X says Y" in args[0]
+        assert "system_prompt" in kwargs
+
+    async def test_summarize_falls_back_when_sampling_raises(self, server_env):
+        """If the client rejects sampling (or transport errors), the concat
+        listing is returned — the tool never fails because sampling isn't
+        supported."""
+        from unittest.mock import AsyncMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("f-a", "raw detail one", ["fallback"], ctx=_make_ctx(jwt))
+
+        ctx = _make_ctx(jwt)
+        ctx.sample = AsyncMock(side_effect=RuntimeError("sampling not supported"))
+
+        result = await summarize_context("fallback", ctx=ctx)
+        text = _text(result)
+        assert "raw detail one" in text  # concat fallback contains the verbatim values
+
+    async def test_sampled_summary_empty_text_falls_back(self, server_env):
+        """An empty/whitespace-only sampling response falls back to concat."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("e-a", "verbatim detail", ["empty"], ctx=_make_ctx(jwt))
+
+        ctx = _make_ctx(jwt)
+        sampled = MagicMock()
+        sampled.text = "   "
+        ctx.sample = AsyncMock(return_value=sampled)
+
+        result = await summarize_context("empty", ctx=ctx)
+        assert "verbatim detail" in _text(result)
+
+    async def test_sampled_summary_handles_ctx_none(self):
+        """Direct call to the helper with ctx=None returns the fallback verbatim."""
+        from hive.server import _sampled_summary
+
+        out = await _sampled_summary(None, "t", [], "FALLBACK_TEXT")
+        assert out == "FALLBACK_TEXT"
+
 
 # ---------------------------------------------------------------------------
 # _app_version() branches — covers server.py:39 and 42-43

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -911,7 +911,12 @@ class TestSearchMemories:
         assert body["query"] == "searchable content"
         item = body["items"][0]
         assert item["key"] == "search-key"
-        assert item["score"] == 0.88
+        # Hybrid re-ranking exposes the original semantic score alongside the
+        # blended score — both "searchable" and "content" tokens match so the
+        # blended score exceeds the raw 0.88.
+        assert item["semantic_score"] == 0.88
+        assert item["keyword_score"] == 1.0
+        assert item["score"] >= 0.88
         assert item["owner_client_id"] == client_id
 
     async def test_returns_empty_when_no_index(self, server_env):
@@ -1091,17 +1096,19 @@ class TestSearchMemories:
 
         storage, _, jwt = server_env
         ctx = _make_ctx(jwt)
-        await remember("key", "v", ["t"], ctx=ctx)
+        # Disable recency weighting so floating-point decay against
+        # updated_at doesn't push blended below 1.0 and mask the clamp test.
+        await remember("key", "q", ["t"], ctx=ctx)
         m = storage.get_memory_by_key("key")
         mock_vs = _make_mock_vector_store([(m.memory_id, 1.0)])
 
-        # min_score > 1.0 gets clamped to 1.0; a perfect score still matches
+        # min_score > 1.0 gets clamped to 1.0; with w_recency=0 blended = 1.0.
         with patch("hive.server._vector_store", return_value=mock_vs):
-            result = await search_memories("q", min_score=5.0, ctx=ctx)
+            result = await search_memories("q", min_score=5.0, w_recency=0, ctx=ctx)
 
         assert _body(result)["count"] == 1
 
-        # min_score < 0.0 gets clamped to 0.0; everything passes
+        # min_score < 0.0 gets clamped to 0.0; everything passes.
         mock_vs2 = _make_mock_vector_store([(m.memory_id, 0.0)])
         with patch("hive.server._vector_store", return_value=mock_vs2):
             result = await search_memories("q", min_score=-1.0, ctx=ctx)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1510,6 +1510,106 @@ class TestMcpToolAnnotations:
         assert tool.annotations.openWorldHint is False
 
 
+class TestRememberOptimisticLocking:
+    """`remember(key, value, version=...)` rejects stale writes with a
+    ToolError carrying the current state so the agent can reconcile."""
+
+    async def test_version_match_updates_successfully(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import recall, remember
+
+        await remember("lock-k", "v1", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("lock-k")
+        result = await remember("lock-k", "v2", [], version=m.version, ctx=_make_ctx(jwt))
+        assert _text(result) == "Updated memory 'lock-k'."
+        assert (await recall("lock-k", ctx=_make_ctx(jwt))).content[0].text == "v2"
+
+    async def test_stale_version_raises_conflict(self, server_env):
+        import json as _json
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        storage, _, jwt = server_env
+        await remember("lock-s", "v1", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("lock-s")
+        # A concurrent writer advances the version out from under us.
+        await remember("lock-s", "concurrent", [], ctx=_make_ctx(jwt))
+
+        with pytest.raises(ToolError) as exc_info:
+            await remember("lock-s", "mine", [], version=m.version, ctx=_make_ctx(jwt))
+
+        msg = str(exc_info.value)
+        assert "Conflict" in msg
+        # Tail of the message is a JSON payload with the conflict state.
+        payload = _json.loads(msg[msg.index("{") :])
+        assert payload["conflict"] is True
+        assert payload["attempted_version"] == m.version
+        assert payload["current_value"] == "concurrent"
+        assert payload["current_version"] != m.version
+
+    async def test_no_version_preserves_backwards_compat(self, server_env):
+        """Unconditional upsert still works when version param is omitted."""
+        storage, _, jwt = server_env
+        from hive.server import remember
+
+        await remember("lock-b", "v1", [], ctx=_make_ctx(jwt))
+        result = await remember("lock-b", "v2", [], ctx=_make_ctx(jwt))
+        assert _text(result) == "Updated memory 'lock-b'."
+        assert storage.get_memory_by_key("lock-b").value == "v2"
+
+    async def test_version_surfaces_in_recall_meta(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import recall, remember
+
+        await remember("lock-r", "v1", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("lock-r")
+        result = await recall("lock-r", ctx=_make_ctx(jwt))
+        meta = _hive_meta(result)
+        assert meta["memory"]["key"] == "lock-r"
+        assert meta["memory"]["version"] == m.version
+
+    async def test_version_surfaces_in_list_memories_items(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_memories, remember
+
+        await remember("lock-l", "v1", ["locktag"], ctx=_make_ctx(jwt))
+        result = await list_memories("locktag", ctx=_make_ctx(jwt))
+        item = next(it for it in _body(result)["items"] if it["key"] == "lock-l")
+        assert "version" in item
+        assert item["version"]
+
+    async def test_conflict_raced_put_surfaces_as_tool_error(self, server_env):
+        """Covers the path where storage raises VersionConflict during the
+        put (e.g. the narrow race between the pre-check read and the
+        conditional write) — remember surfaces it as a ToolError."""
+        from unittest.mock import patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+        from hive.storage import VersionConflict
+
+        storage, _, jwt = server_env
+        await remember("lock-r2", "v1", [], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("lock-r2")
+
+        with (
+            patch.object(
+                storage.__class__,
+                "put_memory",
+                side_effect=VersionConflict(
+                    attempted_version=m.version,
+                    current_value="raced-in",
+                    current_version="newer",
+                ),
+            ),
+            pytest.raises(ToolError, match="Conflict"),
+        ):
+            await remember("lock-r2", "v2", [], version=m.version, ctx=_make_ctx(jwt))
+
+
 class TestProgressNotifications:
     """Long-running tools emit MCP ``notifications/progress`` events so
     clients can render a progress indicator. Clients that don't support

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -71,10 +71,24 @@ def _create_table(table_name: str = "hive-unit-server") -> None:
     )
 
 
-def _make_ctx(jwt: str) -> MagicMock:
-    """Build a minimal mock Context that passes token via meta."""
+def _make_ctx(jwt: str, *, progress_sink: list | None = None) -> MagicMock:
+    """Build a minimal mock Context that passes token via meta.
+
+    If ``progress_sink`` is provided, each ``report_progress`` call is
+    appended to it so tests can assert on the emitted notifications.
+    """
+    from unittest.mock import AsyncMock
+
     ctx = MagicMock()
     ctx.request_context.meta = {"Authorization": f"Bearer {jwt}"}
+    if progress_sink is not None:
+
+        async def _capture(**kwargs):
+            progress_sink.append(kwargs)
+
+        ctx.report_progress = AsyncMock(side_effect=_capture)
+    else:
+        ctx.report_progress = AsyncMock()
     return ctx
 
 
@@ -1494,6 +1508,74 @@ class TestMcpToolAnnotations:
         assert tool.annotations.destructiveHint is destructive
         # Every Hive tool is closed-world (our DynamoDB only).
         assert tool.annotations.openWorldHint is False
+
+
+class TestProgressNotifications:
+    """Long-running tools emit MCP ``notifications/progress`` events so
+    clients can render a progress indicator. Clients that don't support
+    them must still get a usable result — emission is best-effort."""
+
+    async def test_summarize_context_emits_progress(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import remember, summarize_context
+
+        sink: list = []
+        ctx = _make_ctx(jwt, progress_sink=sink)
+        await remember("p-a", "about foo", ["prog"], ctx=_make_ctx(jwt))
+        await remember("p-b", "more about foo", ["prog"], ctx=_make_ctx(jwt))
+
+        await summarize_context("prog", ctx=ctx)
+
+        assert len(sink) >= 2
+        progresses = [c["progress"] for c in sink]
+        totals = {c["total"] for c in sink}
+        assert progresses[0] == 0
+        assert progresses[-1] == 1
+        assert totals == {2}
+
+    async def test_search_memories_emits_progress(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = server_env
+        await remember("ps-a", "searchable content", ["t"], ctx=_make_ctx(jwt))
+        m = storage.get_memory_by_key("ps-a")
+
+        sink: list = []
+        ctx = _make_ctx(jwt, progress_sink=sink)
+        from unittest.mock import MagicMock as _MM
+
+        mock_vs = _MM()
+        mock_vs.search.return_value = [(m.memory_id, 0.9)]
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await search_memories("searchable", ctx=ctx)
+
+        # 3 stages: before vector search, after hydrate, after ranking
+        assert len(sink) == 3
+        assert [c["progress"] for c in sink] == [0, 1, 2]
+        assert {c["total"] for c in sink} == {3}
+
+    async def test_progress_emission_is_non_fatal(self, server_env):
+        """If ctx.report_progress raises (client doesn't support it), the
+        tool still returns successfully — progress is advisory only."""
+        from unittest.mock import AsyncMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        ctx.report_progress = AsyncMock(side_effect=RuntimeError("client refused"))
+        await remember("np-a", "v", ["np"], ctx=_make_ctx(jwt))
+
+        result = await summarize_context("np", ctx=ctx)
+        assert _text(result)  # still returned a usable summary
+
+    async def test_report_progress_noop_when_ctx_is_none(self):
+        """Direct call with ctx=None must not raise."""
+        from hive.server import _report_progress
+
+        await _report_progress(None, 0, 2, "no-ctx")
 
 
 class TestHiveTokenVerifier:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1561,6 +1561,7 @@ class TestMcpToolAnnotations:
             ("recall", "Recall", True, None),
             ("forget", "Forget", False, True),
             ("forget_all", "Forget all (by tag)", False, True),
+            ("redact_memory", "Redact memory", False, True),
             ("memory_history", "Memory history", True, None),
             ("restore_memory", "Restore memory", False, False),
             ("list_memories", "List memories", True, None),
@@ -1680,6 +1681,167 @@ class TestRememberOptimisticLocking:
             pytest.raises(ToolError, match="Conflict"),
         ):
             await remember("lock-r2", "v2", [], version=m.version, ctx=_make_ctx(jwt))
+
+
+class TestRedactMemory:
+    """`redact_memory` tombstones a memory's value while preserving the record (#400)."""
+
+    async def test_redacts_existing_memory(self, server_env):
+        storage, _, jwt = server_env
+        from hive.server import redact_memory, remember
+
+        await remember("secret", "the wifi password is 1234", ["pii"], ctx=_make_ctx(jwt))
+        result = await redact_memory("secret", reason="pii leak", ctx=_make_ctx(jwt))
+        assert _text(result) == "Redacted memory 'secret'."
+
+        stored = storage.get_memory_by_key("secret")
+        assert stored.is_redacted is True
+        assert stored.value == "__redacted__"
+        assert stored.redacted_at is not None
+
+    async def test_recall_returns_sentinel_on_redacted(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import recall, redact_memory, remember
+
+        await remember("s", "raw secret", [], ctx=_make_ctx(jwt))
+        await redact_memory("s", reason="gdpr", ctx=_make_ctx(jwt))
+
+        result = await recall("s", ctx=_make_ctx(jwt))
+        text = _text(result)
+        assert "redacted" in text.lower()
+        assert "raw secret" not in text
+
+    async def test_list_memories_skips_redacted_by_default(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_memories, redact_memory, remember
+
+        ctx = _make_ctx(jwt)
+        await remember("visible", "keep me", ["r"], ctx=ctx)
+        await remember("hidden", "redact me", ["r"], ctx=ctx)
+        await redact_memory("hidden", ctx=ctx)
+
+        result = await list_memories("r", ctx=ctx)
+        keys = [i["key"] for i in _body(result)["items"]]
+        assert "visible" in keys
+        assert "hidden" not in keys
+
+    async def test_list_memories_include_redacted_surfaces_them(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import list_memories, redact_memory, remember
+
+        ctx = _make_ctx(jwt)
+        await remember("visible", "keep me", ["r2"], ctx=ctx)
+        await remember("hidden", "redact me", ["r2"], ctx=ctx)
+        await redact_memory("hidden", ctx=ctx)
+
+        result = await list_memories("r2", include_redacted=True, ctx=ctx)
+        keys = [i["key"] for i in _body(result)["items"]]
+        assert "visible" in keys
+        assert "hidden" in keys
+
+    async def test_search_memories_skips_redacted_by_default(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import redact_memory, remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "content about policy", ["t"], ctx=ctx)
+        await remember("b", "content about privacy", ["t"], ctx=ctx)
+        await redact_memory("b", ctx=ctx)
+
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        mock_vs = _make_mock_vector_store([(a.memory_id, 0.9), (b.memory_id, 0.8)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("content", ctx=ctx)
+
+        keys = [i["key"] for i in _body(result)["items"]]
+        assert "a" in keys
+        assert "b" not in keys
+
+    async def test_search_memories_include_redacted_surfaces_them(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import redact_memory, remember, search_memories
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "content", ["t"], ctx=ctx)
+        await remember("b", "content", ["t"], ctx=ctx)
+        await redact_memory("b", ctx=ctx)
+
+        a = storage.get_memory_by_key("a")
+        b = storage.get_memory_by_key("b")
+        mock_vs = _make_mock_vector_store([(a.memory_id, 0.9), (b.memory_id, 0.8)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("content", include_redacted=True, ctx=ctx)
+
+        keys = [i["key"] for i in _body(result)["items"]]
+        assert "a" in keys
+        assert "b" in keys
+
+    async def test_missing_key_raises(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import redact_memory
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="No memory found"):
+            await redact_memory("no-such-key", ctx=_make_ctx(jwt))
+
+    async def test_double_redaction_is_idempotent(self, server_env):
+        _, _, jwt = server_env
+        from hive.server import redact_memory, remember
+
+        await remember("dbl", "v", [], ctx=_make_ctx(jwt))
+        await redact_memory("dbl", ctx=_make_ctx(jwt))
+        result = await redact_memory("dbl", ctx=_make_ctx(jwt))
+        assert "already redacted" in _text(result)
+
+    async def test_audit_log_preserves_pre_redaction_value(self, server_env):
+        storage, _, jwt = server_env
+        from hive.models import EventType
+        from hive.server import redact_memory, remember
+
+        await remember("audit-r", "sensitive original value", [], ctx=_make_ctx(jwt))
+        await redact_memory("audit-r", reason="accidental leak", ctx=_make_ctx(jwt))
+
+        from datetime import datetime, timezone
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        events = storage.get_audit_events_for_dates([today], event_type="memory_redacted")
+        assert len(events) >= 1
+        redaction = events[0]
+        assert redaction.metadata["previous_value"] == "sensitive original value"
+        assert redaction.metadata["reason"] == "accidental leak"
+        assert redaction.event_type == EventType.memory_redacted
+
+    async def test_vector_delete_failure_is_non_fatal(self, server_env):
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import redact_memory, remember
+
+        _, _, jwt = server_env
+        await remember("vd", "v", [], ctx=_make_ctx(jwt))
+
+        mock_vs = MagicMock()
+        mock_vs.delete_memory.side_effect = RuntimeError("bucket down")
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await redact_memory("vd", ctx=_make_ctx(jwt))
+        assert "Redacted" in _text(result)
+
+    async def test_requires_write_scope(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import redact_memory
+
+        storage, _, _ = server_env
+        read_only_jwt = _make_limited_scope_jwt(storage, "memories:read")
+        with pytest.raises(ToolError, match="Insufficient scope"):
+            await redact_memory("any", ctx=_make_ctx(read_only_jwt))
 
 
 class TestProgressNotifications:

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -561,6 +561,92 @@ class TestActivityLog:
         assert len(events) == 1
         assert events[0].event_id == event.event_id
 
+
+class TestAuditLog:
+    def test_log_audit_event_sets_ttl_from_retention_env(self, storage):
+        from datetime import datetime, timezone
+
+        event = ActivityEvent(
+            event_type=EventType.memory_created,
+            client_id="c1",
+            metadata={"key": "k1"},
+            timestamp=datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("HIVE_AUDIT_RETENTION_DAYS", "30")
+            storage.log_audit_event(event)
+
+        # Re-read the raw item to verify TTL was written.
+        date_hour_str = event.timestamp.strftime("%Y-%m-%d#%H")
+        resp = storage.table.get_item(
+            Key={
+                "PK": f"AUDIT#{date_hour_str}",
+                "SK": f"{event.timestamp.isoformat()}#{event.event_id}",
+            }
+        )
+        item = resp["Item"]
+        assert "ttl" in item
+        assert int(item["ttl"]) == int(event.timestamp.timestamp()) + 30 * 86400
+
+    def test_audit_events_separate_from_activity_events(self, storage):
+        """Writing to the audit log must not leak into the activity log."""
+        event = ActivityEvent(
+            event_type=EventType.memory_created,
+            client_id="c1",
+            metadata={},
+        )
+        storage.log_audit_event(event)
+        # No activity log entry should exist
+        assert storage.get_events_for_date(event.timestamp.strftime("%Y-%m-%d")) == []
+
+    def test_get_audit_events_filters_by_client_id_and_event_type(self, storage):
+        from datetime import datetime, timezone
+
+        ts = datetime.now(timezone.utc)
+        events = [
+            ActivityEvent(event_type=EventType.memory_created, client_id="c1", timestamp=ts),
+            ActivityEvent(event_type=EventType.memory_deleted, client_id="c1", timestamp=ts),
+            ActivityEvent(event_type=EventType.memory_created, client_id="c2", timestamp=ts),
+        ]
+        for e in events:
+            storage.log_audit_event(e)
+
+        dates = [ts.strftime("%Y-%m-%d")]
+
+        all_events = storage.get_audit_events_for_dates(dates)
+        assert len(all_events) == 3
+
+        c1_only = storage.get_audit_events_for_dates(dates, client_id="c1")
+        assert {e.client_id for e in c1_only} == {"c1"}
+
+        created_only = storage.get_audit_events_for_dates(dates, event_type="memory_created")
+        assert {e.event_type.value for e in created_only} == {"memory_created"}
+
+        combined = storage.get_audit_events_for_dates(
+            dates, client_id="c1", event_type="memory_created"
+        )
+        assert len(combined) == 1
+        assert combined[0].client_id == "c1"
+        assert combined[0].event_type == EventType.memory_created
+
+    def test_get_audit_events_limit_and_sort(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        base = datetime.now(timezone.utc).replace(microsecond=0)
+        for i in range(5):
+            e = ActivityEvent(
+                event_type=EventType.memory_created,
+                client_id="c",
+                timestamp=base - timedelta(seconds=i),
+            )
+            storage.log_audit_event(e)
+
+        dates = [base.strftime("%Y-%m-%d")]
+        events = storage.get_audit_events_for_dates(dates, limit=3)
+        assert len(events) == 3
+        # Newest-first
+        assert events[0].timestamp > events[1].timestamp > events[2].timestamp
+
     def test_hour_sharded_pk(self, storage):
         """Events must be written to LOG#{date}#{hour} partitions."""
         event = ActivityEvent(

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -259,6 +259,35 @@ class TestMemoryStorage:
         result = storage.get_memory_by_key("expired-key2")
         assert result is None
 
+    def test_record_recall_increments_count_and_sets_timestamp(self, storage):
+        m = Memory(key="recall-k", value="v", owner_client_id="c1")
+        storage.put_memory(m)
+
+        first = storage.record_recall("recall-k")
+        assert first is not None
+        assert first.recall_count == 1
+        assert first.last_accessed_at is not None
+
+        second = storage.record_recall("recall-k")
+        assert second is not None
+        assert second.recall_count == 2
+        assert second.last_accessed_at is not None
+        assert second.last_accessed_at >= first.last_accessed_at
+
+    def test_record_recall_returns_none_for_missing_key(self, storage):
+        assert storage.record_recall("does-not-exist") is None
+
+    def test_record_recall_returns_none_for_expired_memory(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        past = datetime.now(timezone.utc) - timedelta(seconds=1)
+        storage.put_memory(
+            Memory(key="expired-recall", value="v", owner_client_id="c1", expires_at=past)
+        )
+        # update_item still runs, but record_recall returns None because the
+        # memory is past its TTL (matches get_memory_by_key behaviour).
+        assert storage.record_recall("expired-recall") is None
+
     def test_memory_serialise_ttl_in_dynamo(self):
         from datetime import datetime, timedelta, timezone
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -229,6 +229,91 @@ class TestMemoryStorage:
             with pytest.raises(ClientError):
                 storage.put_memory(m)
 
+    def test_put_memory_with_matching_version_succeeds(self, storage):
+        """expected_version on put_memory matches stored updated_at → write succeeds."""
+        from datetime import datetime, timezone
+
+        # Tags are set so the conditional-write branch also rewrites tag items.
+        m = Memory(key="ver-ok", value="v1", tags=["t1"], owner_client_id="c1")
+        storage.put_memory(m)
+        stored = storage.get_memory_by_id(m.memory_id)
+        assert stored is not None
+
+        stored.value = "v2"
+        stored.tags = ["t1", "t2"]
+        stored.updated_at = datetime.now(timezone.utc)  # mimics server.remember()
+        storage.put_memory(stored, expected_version=m.version)
+        result = storage.get_memory_by_id(m.memory_id)
+        assert result.value == "v2"
+        assert set(result.tags) == {"t1", "t2"}
+
+    def test_put_memory_with_stale_version_raises(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.storage import VersionConflict
+
+        m = Memory(key="ver-stale", value="v1", owner_client_id="c1")
+        storage.put_memory(m)
+
+        # Someone else writes first, moving the version forward (updated_at bumps).
+        m2 = storage.get_memory_by_id(m.memory_id)
+        m2.value = "v2"
+        m2.updated_at = datetime.now(timezone.utc) + timedelta(seconds=1)
+        storage.put_memory(m2)
+
+        # Now a write pinned to the *original* version is rejected.
+        m.value = "stale"
+        with pytest.raises(VersionConflict) as exc_info:
+            storage.put_memory(m, expected_version=m.version)
+        assert exc_info.value.current_value == "v2"
+        assert exc_info.value.current_version != m.version
+
+    def test_put_memory_with_version_but_no_existing_item_raises(self, storage):
+        """Passing expected_version on a brand-new memory is a conflict (there's
+        nothing to lock against)."""
+        from hive.storage import VersionConflict
+
+        m = Memory(key="ver-missing", value="v1", owner_client_id="c1")
+        with pytest.raises(VersionConflict) as exc_info:
+            storage.put_memory(m, expected_version="2024-01-01T00:00:00+00:00")
+        assert exc_info.value.current_value is None
+        assert exc_info.value.current_version is None
+
+    def test_put_memory_conditional_check_failure_surfaces_as_version_conflict(self, storage):
+        """If the conditional put race fires after the pre-read, we re-read
+        and surface the real current state in VersionConflict."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        from hive.storage import VersionConflict
+
+        m = Memory(key="ver-race", value="v1", owner_client_id="c1")
+        storage.put_memory(m)
+        stored = storage.get_memory_by_id(m.memory_id)
+
+        stored.value = "v2"
+        stored.updated_at = datetime.now(timezone.utc)
+
+        # Only the conditional META put should fail; version-snapshot writes
+        # (SK=VERSION#…) must still succeed so execution reaches the conditional.
+        real_put = storage.table.put_item
+        error_response = {
+            "Error": {"Code": "ConditionalCheckFailedException", "Message": "mismatch"}
+        }
+
+        def selective(**kwargs):
+            if "ConditionExpression" in kwargs:
+                raise ClientError(error_response, "PutItem")
+            return real_put(**kwargs)
+
+        with (
+            patch.object(storage.table, "put_item", side_effect=selective),
+            pytest.raises(VersionConflict),
+        ):
+            storage.put_memory(stored, expected_version=m.version)
+
     def test_put_and_get_memory_with_ttl(self, storage):
         from datetime import datetime, timedelta, timezone
 

--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -442,6 +442,15 @@ export default function Dashboard() {
       ]
     : [];
 
+  const securityData = metrics
+    ? [
+        {
+          name: "CSP Violations",
+          value: (metrics.metrics?.csp_violations?.values ?? []).reduce((s, v) => s + v, 0),
+        },
+      ]
+    : [];
+
   const xAxisProps = {
     dataKey: "ts",
     tick: { fontSize: 11, fill: "var(--text-muted)" },
@@ -544,6 +553,16 @@ export default function Dashboard() {
       {authData.length > 0 && (
         <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
           {authData.map((d) => (
+            <StatCard key={d.name} label={d.name} value={d.value} />
+          ))}
+        </div>
+      )}
+
+      {/* Security */}
+      <SectionHeader title="Security" />
+      {securityData.length > 0 && (
+        <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+          {securityData.map((d) => (
             <StatCard key={d.name} label={d.name} value={d.value} />
           ))}
         </div>

--- a/ui/src/components/Dashboard.test.jsx
+++ b/ui/src/components/Dashboard.test.jsx
@@ -54,6 +54,7 @@ const METRICS = {
     p99_searchmemories: { timestamps: [], values: [] },
     tokens_issued: { timestamps: ["2026-04-01T12:00:00Z"], values: [7] },
     token_failures: { timestamps: ["2026-04-01T12:00:00Z"], values: [2] },
+    csp_violations: { timestamps: ["2026-04-01T12:00:00Z"], values: [17] },
   },
 };
 
@@ -266,6 +267,7 @@ describe("Dashboard", () => {
     expect(screen.getByText("Tool Invocations")).toBeTruthy();
     expect(screen.getByText("Tool Latency p99 (ms)")).toBeTruthy();
     expect(screen.getByText("Auth Events")).toBeTruthy();
+    expect(screen.getByText("Security")).toBeTruthy();
     expect(screen.getByText("Daily AWS Spend (Last 30 Days)")).toBeTruthy();
     expect(screen.getByText("Monthly AWS Spend")).toBeTruthy();
   });
@@ -274,6 +276,11 @@ describe("Dashboard", () => {
     await act(async () => render(<Dashboard />));
     await waitFor(() => expect(screen.getByText("Tokens Issued")).toBeTruthy());
     expect(screen.getByText("Validation Failures")).toBeTruthy();
+  });
+
+  it("renders CSP violations stat card from metric data", async () => {
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("CSP Violations")).toBeTruthy());
   });
 
   it("renders cost note", async () => {


### PR DESCRIPTION
Release v0.22.0. See CHANGELOG for full details.

## Highlights

**MCP surface:**
- `_meta.hive` quota + rate-limit on every response (#453)
- Progress notifications on long-running tools (#449)
- Optimistic locking on `remember(version=)` (#391)
- Hybrid retrieval in `search_memories` — semantic + keyword + recency (#481)
- `summarize_context` via MCP Sampling (#448)
- `redact_memory` tombstone tool (#400)
- `recall_count` + `last_accessed_at` on memories (#394)

**Compliance & observability:**
- Audit-log wiring on every memory operation + admin endpoint (#395)
- CSP violation reporting endpoint + dashboard widget (#488)

**Dev experience & CI:**
- Release Drafter automation (#420)
- Release milestone watcher (#484, #512)

Merge strategy: **merge commit** (not squash) so squashed feature commits preserve their history on `main`.