### PR TITLE
feat(docs): mobile UX fixes — hide desktop nav group, contain wide tables

### DIFF
--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -123,12 +123,20 @@
 
 /* Desktop navbar group: Docs link + Sign in button rendered via
    nav-bar-content-after so they appear at the far right, in order, matching
-   the marketing site layout. */
+   the marketing site layout. Hidden below the VitePress nav-screen breakpoint
+   (768px) — mobile users get the same links via `nav-screen-content-after`
+   inside the hamburger menu (#528). */
 .docs-nav-group {
-  display: flex;
+  display: none;
   align-items: center;
   gap: 4px;
   margin-left: 8px;
+}
+
+@media (min-width: 768px) {
+  .docs-nav-group {
+    display: flex;
+  }
 }
 
 .docs-nav-link {

--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -297,3 +297,36 @@
   font-size: 12px !important;
   color: rgba(255, 255, 255, 0.45) !important;
 }
+
+/* ============================================================
+   Mobile safety — #528
+   Keep long code blocks and wide tables from busting the
+   375px viewport. VitePress already wraps tables in a
+   `.vp-doc .table-wrapper` with overflow-x auto and sets
+   `overflow-x: auto` on `.vp-code` wrappers, but nested
+   `<pre>` blocks and markdown-rendered tables occasionally
+   slip through — this is belt-and-braces.
+   ============================================================ */
+.vp-doc pre,
+.vp-doc .vp-code,
+.vp-doc .language- {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.vp-doc table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* On narrow screens, trim VitePress's default content padding so
+   the reading column isn't squeezed to ~40% of the viewport. */
+@media (max-width: 375px) {
+  .VPDoc .container,
+  .VPDoc.has-aside .content-container {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+}

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -494,3 +494,41 @@ class TestDocsNavbar:
         screen = page.locator(".VPNavScreen")
         screen.wait_for(state="visible", timeout=5_000)
         assert screen.is_visible(), "Mobile nav screen did not open after hamburger click"
+
+    def test_docs_page_fits_mobile_viewport(self, docs_page_mobile):
+        """Docs pages should render without horizontal overflow at 375px (#528).
+
+        VitePress plus the custom theme occasionally lets a wide code block
+        or table overflow the page — this guards against regressions.
+        """
+        page = docs_page_mobile
+        page.goto(
+            f"{UI_URL}/docs/getting-started/what-is-hive",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        doc_width, body_width = page.evaluate(
+            "() => [document.querySelector('.vp-doc').scrollWidth,"
+            " document.body.clientWidth]"
+        )
+        # Allow a small fudge for sub-pixel rounding / scrollbar — but the
+        # content must not exceed the viewport by more than a few px.
+        assert doc_width <= body_width + 4, (
+            f"Docs content scrollWidth {doc_width} exceeds body clientWidth {body_width}"
+        )
+
+    def test_mobile_sidebar_opens_on_menu(self, docs_page_mobile):
+        """The doc-pages sidebar is collapsed on mobile and opens via the menu button."""
+        page = docs_page_mobile
+        page.goto(
+            f"{UI_URL}/docs/getting-started/what-is-hive",
+            timeout=30_000,
+            wait_until="networkidle",
+        )
+        menu_btn = page.locator(".VPLocalNav button, .VPLocalNav .menu")
+        if not menu_btn.first.is_visible():
+            pytest.skip("Local nav menu not visible (layout may have changed)")
+        menu_btn.first.click()
+        sidebar = page.locator(".VPSidebar")
+        sidebar.wait_for(state="visible", timeout=5_000)
+        assert sidebar.is_visible(), "Sidebar did not open after menu click"

--- a/tests/e2e/test_docs_e2e.py
+++ b/tests/e2e/test_docs_e2e.py
@@ -508,8 +508,7 @@ class TestDocsNavbar:
             wait_until="networkidle",
         )
         doc_width, body_width = page.evaluate(
-            "() => [document.querySelector('.vp-doc').scrollWidth,"
-            " document.body.clientWidth]"
+            "() => [document.querySelector('.vp-doc').scrollWidth, document.body.clientWidth]"
         )
         # Allow a small fudge for sub-pixel rounding / scrollbar — but the
         # content must not exceed the viewport by more than a few px.


### PR DESCRIPTION
Closes #528

## Summary

Mobile UX pass for the docs site. Screenshots at 375px showed two concrete regressions:

1. **Desktop nav group overflowed the mobile viewport.** `.docs-nav-group` (Use cases / Clients / Pricing / FAQ / Docs / Sign in) was rendered at every width; the items ran off-screen and let the whole page scroll horizontally. Hidden below the VitePress 768px mobile breakpoint so the hamburger + `nav-screen-content-after` path is the only nav route on small screens.
2. **Wide tables (tool-reference parameter tables) pushed the whole page wide.** `.vp-doc table` now has `display: block; overflow-x: auto; max-width: 100%` so long rows scroll inside the block instead of stretching the viewport.

Plus belt-and-braces safety CSS for code blocks (`max-width: 100%; overflow-x: auto` on `<pre>`, `.vp-code`, `.language-`) and tighter content-container padding at ≤375px.

## Approach

- `docs-site/.vitepress/theme/style.css` — the three CSS changes above.
- `tests/e2e/test_docs_e2e.py` — two new mobile-viewport playwright tests:
  - `test_docs_page_fits_mobile_viewport` asserts `.vp-doc` `scrollWidth` stays within `body.clientWidth` on a parameter-table page (the worst-case overflow risk).
  - `test_mobile_sidebar_opens_on_menu` opens the sidebar via the local-nav menu button and asserts it becomes visible.

## Test plan

- [x] `uv run inv pre-push` — no Python changes, lint/format green
- [ ] CI green on this PR
- [ ] Visual re-check once deployed to dev — user to re-shoot the 375px screenshots post-merge to confirm the overflow is gone

## Out of scope

- Marketing site mobile UX (#527)
- Management app mobile UX (#529)