### PR TITLE
feat(marketing): mobile UX — hamburger nav + code-block overflow safety

### DIFF
--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -1,11 +1,20 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ConsentBanner from "@/components/ConsentBanner";
 import { CONSENT_RESET_EVENT, clearConsent } from "@/lib/consent";
 
 const NAV_LINK_BASE = "text-sm no-underline hover:text-white transition-colors";
+
+const NAV_LINKS = [
+  { href: "/use-cases", label: "Use cases" },
+  { href: "/clients", label: "Clients" },
+  { href: "/pricing", label: "Pricing" },
+  { href: "/faq", label: "FAQ" },
+  { href: "/docs/", label: "Docs" },
+];
 
 function handleReopenConsent(e) {
   e.preventDefault();
@@ -16,6 +25,13 @@ function handleReopenConsent(e) {
 export default function PageLayout({ children }) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Close the mobile menu whenever the route changes so a link click doesn't
+  // leave the drawer open over the new page.
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
 
   function navLinkStyle(href) {
     const active = pathname === href;
@@ -29,7 +45,7 @@ export default function PageLayout({ children }) {
     <div className="font-[system-ui,sans-serif] text-[var(--text)] flex flex-col min-h-screen">
       {/* Nav */}
       <header className="bg-navy text-white">
-        <div className="max-w-[1100px] mx-auto px-8 h-14 flex items-center justify-between">
+        <div className="max-w-[1100px] mx-auto px-4 md:px-8 h-14 flex items-center justify-between">
           <button
             className="flex items-center gap-2 cursor-pointer bg-transparent border-none p-0 text-inherit"
             onClick={() => navigate("/")}
@@ -37,17 +53,64 @@ export default function PageLayout({ children }) {
             <img src="/logo.svg" alt="Hive" className="h-7 w-auto" />
             <span className="font-bold text-xl tracking-[1px]">Hive</span>
           </button>
-          <div className="flex items-center gap-6">
-            <a href="/use-cases" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/use-cases")}>Use cases</a>
-            <a href="/clients" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/clients")}>Clients</a>
-            <a href="/pricing" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/pricing")}>Pricing</a>
-            <a href="/faq" className={`text-white/75 ${NAV_LINK_BASE}`} style={navLinkStyle("/faq")}>FAQ</a>
-            <a href="/docs/" className={`text-white/75 ${NAV_LINK_BASE}`} style={{ borderBottom: "2px solid transparent", paddingBottom: 2 }}>Docs</a>
+
+          {/* Desktop nav (>=768px) */}
+          <div className="hidden md:flex items-center gap-6">
+            {NAV_LINKS.map(({ href, label }) => (
+              <a
+                key={href}
+                href={href}
+                className={`text-white/75 ${NAV_LINK_BASE}`}
+                style={label === "Docs" ? { borderBottom: "2px solid transparent", paddingBottom: 2 } : navLinkStyle(href)}
+              >
+                {label}
+              </a>
+            ))}
             <Button variant="nav" size="sm" className="marketing-signin-btn" onClick={() => navigate("/app")}>
               Sign in
             </Button>
           </div>
+
+          {/* Mobile hamburger (<768px) */}
+          <button
+            type="button"
+            className="md:hidden inline-flex items-center justify-center w-11 h-11 text-white/85 bg-transparent cursor-pointer"
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen((v) => !v)}
+          >
+            {menuOpen ? <X size={24} /> : <Menu size={24} />}
+          </button>
         </div>
+
+        {/* Mobile drawer (<768px) */}
+        {menuOpen && (
+          <div className="md:hidden bg-navy border-t border-white/10">
+            <nav className="px-4 py-4 flex flex-col gap-1">
+              {NAV_LINKS.map(({ href, label }) => {
+                const active = pathname === href;
+                return (
+                  <a
+                    key={href}
+                    href={href}
+                    className="block px-3 py-3 text-white/85 text-base no-underline hover:text-white hover:bg-white/5 rounded"
+                    style={{ borderLeft: active ? "2px solid #e8a020" : "2px solid transparent" }}
+                  >
+                    {label}
+                  </a>
+                );
+              })}
+              <Button
+                variant="nav"
+                size="sm"
+                className="marketing-signin-btn mt-2 min-h-11"
+                onClick={() => navigate("/app")}
+              >
+                Sign in
+              </Button>
+            </nav>
+          </div>
+        )}
       </header>
 
       {/* Page content */}
@@ -57,7 +120,7 @@ export default function PageLayout({ children }) {
 
       {/* Footer */}
       <footer className="border-t border-[var(--border)]">
-        <div className="max-w-[1100px] mx-auto px-8 py-8">
+        <div className="max-w-[1100px] mx-auto px-4 md:px-8 py-8">
           <div className="flex flex-col gap-6 sm:flex-row sm:justify-between sm:items-start">
             <div className="flex items-center gap-2">
               <img src="/logo.svg" alt="Hive" className="h-5 w-auto opacity-60" />

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -134,6 +134,40 @@ describe("PageLayout", () => {
     expect(within(footer).getByText("Cookie preferences")).toBeTruthy();
   });
 
+  it("renders a mobile hamburger button with correct aria-label", async () => {
+    await act(async () => renderInRouter(<PageLayout><span /></PageLayout>));
+    const btn = screen.getByLabelText("Open menu");
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("hamburger toggles the mobile drawer and flips its aria label", async () => {
+    await act(async () => renderInRouter(<PageLayout><span /></PageLayout>));
+    const btn = screen.getByLabelText("Open menu");
+    await act(async () => fireEvent.click(btn));
+    // After opening, the button's aria-label flips to "Close menu".
+    const closeBtn = screen.getByLabelText("Close menu");
+    expect(closeBtn.getAttribute("aria-expanded")).toBe("true");
+    // The drawer itself renders a <nav>; assert it's in the DOM now.
+    const nav = closeBtn.closest("header").querySelector("nav");
+    expect(nav).toBeTruthy();
+    // Toggle closed again.
+    await act(async () => fireEvent.click(closeBtn));
+    expect(screen.getByLabelText("Open menu").getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("mobile drawer lists every nav link + a Sign in button", async () => {
+    await act(async () => renderInRouter(<PageLayout><span /></PageLayout>));
+    await act(async () => fireEvent.click(screen.getByLabelText("Open menu")));
+    const { container } = { container: document };
+    const drawer = container.querySelector("header nav");
+    expect(drawer).toBeTruthy();
+    for (const label of ["Use cases", "Clients", "Pricing", "FAQ", "Docs"]) {
+      expect(within(drawer).getByText(label)).toBeTruthy();
+    }
+    expect(within(drawer).getByRole("button", { name: "Sign in" })).toBeTruthy();
+  });
+
   it("Cookie preferences click clears stored consent and re-shows the banner", async () => {
     localStorage.setItem("hive_ga_consent", "reject");
     const { container } = await act(async () =>

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -168,6 +168,25 @@ describe("PageLayout", () => {
     expect(within(drawer).getByRole("button", { name: "Sign in" })).toBeTruthy();
   });
 
+  it("mobile drawer Sign in navigates to /app", async () => {
+    await act(async () => renderInRouter(<PageLayout><span /></PageLayout>));
+    await act(async () => fireEvent.click(screen.getByLabelText("Open menu")));
+    const drawer = document.querySelector("header nav");
+    const signIn = within(drawer).getByRole("button", { name: "Sign in" });
+    await act(async () => fireEvent.click(signIn));
+    expect(mockNavigate).toHaveBeenCalledWith("/app");
+  });
+
+  it("mobile drawer marks the current page with an orange left border", async () => {
+    await act(async () => renderInRouter(<PageLayout><span /></PageLayout>, "/faq"));
+    await act(async () => fireEvent.click(screen.getByLabelText("Open menu")));
+    const drawer = document.querySelector("header nav");
+    const faqLink = within(drawer).getByText("FAQ");
+    expect(faqLink.style.borderLeftColor).toBe("rgb(232, 160, 32)");
+    const pricingLink = within(drawer).getByText("Pricing");
+    expect(pricingLink.style.borderLeftColor).toBe("transparent");
+  });
+
   it("Cookie preferences click clears stored consent and re-shows the banner", async () => {
     localStorage.setItem("hive_ga_consent", "reject");
     const { container } = await act(async () =>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -58,4 +58,12 @@ body {
   button {
     border: none;
   }
+
+  /* Marketing + management pages drop verbatim commands and JSON into
+     `<pre>` blocks. `white-space: pre` otherwise forces the parent card
+     to grow to content width, which breaks the 375px viewport (#527).
+     Clamp `<pre>` to its parent so long lines scroll inside the block. */
+  pre {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
Closes #527

## Summary

Mobile UX pass for the marketing site. Screenshots at 375px showed two concrete breakages:

1. **`PageLayout` nav overflowed the viewport.** Logo + 5 nav links + Sign in button lived in a single flex row that couldn't fit below ~640px. The row wrapped chaotically ("Use cases" stacked on top of the logo) and let the whole page scroll horizontally.
2. **Code blocks inside rounded cards overflowed the card's right edge** on McpClients and UseCases. `<pre>` has `white-space: pre`, so with no `max-width` it grew to fit content and pushed the card + viewport wide.

## Approach

- `PageLayout.jsx` gains a hamburger toggle below 768px. Desktop row unchanged; mobile gets a `lucide-react` `Menu`/`X` button with `aria-label` + `aria-expanded`. Drawer holds every nav link plus the Sign in button, closes automatically on route change. Touch target is 44×44 (`min-h-11` / `w-11 h-11`).
- Global `pre { max-width: 100% }` in `ui/src/index.css` clamps every `<pre>` to its parent so the existing `overflow-x-auto` actually fires (instead of the pre stretching the parent to content width). Covers the McpClients JSON blocks, UseCases sample prompts, and the management SetupPanel commands as a side-benefit.
- Outer container padding steps down to `px-4` at `<md` so content isn't squeezed to ~16px right-margin.

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + 18 PageLayout tests (3 new) + all other frontend tests
- [ ] CI green on this PR
- [ ] Post-merge: re-shoot at 375px — Home, Pricing, UseCases, McpClients — to confirm no horizontal overflow and the hamburger works

## Out of scope

- Management app mobile UX (#529)
- Docs site mobile UX (#528 — already merged)