### PR TITLE
feat: cross-surface mobile polish — marketing, docs, management app

### DIFF
--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -250,6 +250,23 @@
   box-shadow: none !important;
 }
 
+/* Shrink the magnifier-icon search button on narrow screens so it matches the
+   hamburger icon size instead of floating between them as a larger circle. */
+@media (max-width: 767px) {
+  .VPNavBarSearch .DocSearch-Button {
+    width: 24px !important;
+    height: 24px !important;
+    padding: 0 !important;
+    background-color: transparent !important;
+    border: none !important;
+  }
+
+  .VPNavBarSearch .DocSearch-Button .DocSearch-Search-Icon {
+    width: 20px !important;
+    height: 20px !important;
+  }
+}
+
 /* ============================================================
    Home page hero — gradient matching marketing site
    ============================================================ */

--- a/src/hive/api/csp.py
+++ b/src/hive/api/csp.py
@@ -15,6 +15,7 @@ Instead we rate-limit per source IP so an attacker can't amplify log volume.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from typing import Annotated, Any
 from urllib.parse import urlparse
 
@@ -58,8 +59,6 @@ def _client_ip(request: Request) -> str:
 
 def _check_ip_rate_limit(ip: str, storage: HiveStorage) -> None:
     """Per-IP per-minute rate limit for unauthenticated CSP reports."""
-    from datetime import datetime, timezone
-
     minute = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
     bucket = f"csp#{ip}#{minute}"
     # Share the rate-limit counter table with the authenticated path; we use

--- a/tests/unit/test_csp_api.py
+++ b/tests/unit/test_csp_api.py
@@ -182,10 +182,28 @@ class TestCspReport:
         mock_emit.assert_not_awaited()
 
     def test_rate_limit_per_ip(self, client):
-        """After 60 reports/min from the same IP, subsequent reports get 429."""
+        """After 60 reports/min from the same IP, subsequent reports get 429.
+
+        The rate-limit bucket keys on the current minute (``strftime("%Y-%m-%dT%H:%M")``),
+        so the 61st request can slip into a fresh bucket if the loop crosses a
+        minute boundary. Freeze ``datetime.now`` inside the rate-limit check so
+        every request lands in the same bucket.
+        """
+        from datetime import datetime, timezone
+
         tc, _ = client
         mock_emit = AsyncMock()
-        with patch("hive.api.csp.emit_metric", mock_emit):
+        frozen = datetime(2026, 4, 18, 12, 34, 0, tzinfo=timezone.utc)
+
+        class _FrozenDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return frozen if tz is None else frozen.astimezone(tz)
+
+        with (
+            patch("hive.api.csp.emit_metric", mock_emit),
+            patch("hive.api.csp.datetime", _FrozenDatetime),
+        ):
             headers = {"x-forwarded-for": "203.0.113.42"}
             for _ in range(60):
                 resp = tc.post("/api/csp-report", json=_LEGACY_REPORT, headers=headers)

--- a/ui/src/components/ChangelogPage.jsx
+++ b/ui/src/components/ChangelogPage.jsx
@@ -88,7 +88,7 @@ export default function ChangelogPage() {
   return (
     <PageLayout>
       {/* Header */}
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">Changelog</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[480px] mx-auto leading-relaxed">
@@ -98,7 +98,7 @@ export default function ChangelogPage() {
       </section>
 
       {/* Entries */}
-      <section className="py-16 px-8">
+      <section className="py-16 px-4 md:px-8">
         <div className="max-w-[720px] mx-auto">
           {sections.map((s) => (
             <ChangelogSection key={s.version} {...s} />

--- a/ui/src/components/FaqPage.jsx
+++ b/ui/src/components/FaqPage.jsx
@@ -67,7 +67,7 @@ export default function FaqPage() {
   return (
     <PageLayout>
       {/* Header */}
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">Frequently asked questions</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[480px] mx-auto leading-relaxed">
@@ -77,7 +77,7 @@ export default function FaqPage() {
       </section>
 
       {/* Accordion */}
-      <section className="py-16 px-8">
+      <section className="py-16 px-4 md:px-8">
         <div className="max-w-[720px] mx-auto">
           {FAQS.map((item) => (
             <FaqItem key={item.q} q={item.q} a={item.a} />
@@ -86,7 +86,7 @@ export default function FaqPage() {
       </section>
 
       {/* CTA */}
-      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+      <section className="py-12 px-4 md:px-8 text-center border-t border-[var(--border)]">
         <p className="text-[var(--text-muted)] text-sm">
           Still have questions?{" "}
           <a href="/docs/" className="text-brand no-underline hover:underline">

--- a/ui/src/components/HomePage.jsx
+++ b/ui/src/components/HomePage.jsx
@@ -59,7 +59,7 @@ export default function HomePage() {
     <PageLayout>
       {/* Hero */}
       <section
-        className="text-white py-24 px-8 text-center"
+        className="text-white py-24 px-4 md:px-8 text-center"
         style={{
           background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%)",
         }}
@@ -80,7 +80,7 @@ export default function HomePage() {
       </section>
 
       {/* Features */}
-      <section className="py-20 px-8">
+      <section className="py-20 px-4 md:px-8">
         <div className="max-w-[1100px] mx-auto">
           <h2 className="text-center text-[1.75rem] font-bold mb-14">
             Everything your agents need to remember
@@ -103,7 +103,7 @@ export default function HomePage() {
       </section>
 
       {/* How it works */}
-      <section className="bg-[var(--surface)] py-20 px-8">
+      <section className="bg-[var(--surface)] py-20 px-4 md:px-8">
         <div className="max-w-[1100px] mx-auto">
           <h2 className="text-center text-[1.75rem] font-bold mb-14">
             Up and running in minutes

--- a/ui/src/components/McpClientsPage.jsx
+++ b/ui/src/components/McpClientsPage.jsx
@@ -98,7 +98,7 @@ export default function McpClientsPage() {
   return (
     <PageLayout>
       {/* Header */}
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">MCP client compatibility</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[560px] mx-auto leading-relaxed">
@@ -109,8 +109,8 @@ export default function McpClientsPage() {
       </section>
 
       {/* Client cards */}
-      <section className="py-20 px-8">
-        <div className="max-w-[1100px] mx-auto grid grid-cols-[repeat(auto-fit,minmax(460px,1fr))] gap-6">
+      <section className="py-20 px-4 md:px-8">
+        <div className="max-w-[1100px] mx-auto grid grid-cols-1 md:grid-cols-[repeat(auto-fit,minmax(460px,1fr))] gap-6">
           {CLIENTS.map((c) => (
             <ClientCard key={c.name} {...c} />
           ))}
@@ -118,7 +118,7 @@ export default function McpClientsPage() {
       </section>
 
       {/* Footer note */}
-      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+      <section className="py-12 px-4 md:px-8 text-center border-t border-[var(--border)]">
         <p className="text-[var(--text-muted)] text-sm max-w-[560px] mx-auto leading-relaxed">
           Any MCP-compatible client works with Hive — these are the most commonly used ones.
           See the{" "}

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -423,10 +423,10 @@ export default function MemoryBrowser() {
 
       {/* List */}
       <div className="flex-1">
-        <div className="flex gap-2.5 mb-4 items-center">
-          <h2 className="flex-1 text-lg font-semibold">Memories</h2>
+        <div className="flex flex-wrap gap-2.5 mb-4 items-center">
+          <h2 className="text-lg font-semibold sm:flex-1 w-full sm:w-auto">Memories</h2>
           <Input
-            className="w-44"
+            className="flex-1 min-w-0 sm:flex-none sm:w-44"
             placeholder="Search by meaning…"
             value={searchQuery}
             onChange={handleSearchQueryChange}

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -271,6 +271,16 @@ describe("MemoryBrowser", () => {
     expect(screen.getByText("+ New")).toBeTruthy();
   });
 
+  it("toolbar row wraps on narrow screens so the New button stays in view", async () => {
+    const { container } = await act(async () => render(<MemoryBrowser />));
+    // The heading + search + tag picker + New button share a flex row that
+    // must `flex-wrap` (below sm) so the rightmost button doesn't clip when
+    // the viewport is 375px.
+    const heading = container.querySelector("h2");
+    const toolbar = heading.parentElement;
+    expect(toolbar.className).toMatch(/flex-wrap/);
+  });
+
   it("renders empty state after load", async () => {
     await act(async () => render(<MemoryBrowser />));
     await waitFor(() => expect(screen.getByText("No memories yet")).toBeTruthy());

--- a/ui/src/components/PricingPage.jsx
+++ b/ui/src/components/PricingPage.jsx
@@ -22,7 +22,7 @@ export default function PricingPage() {
   return (
     <PageLayout>
       {/* Header */}
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">Simple, honest pricing</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[480px] mx-auto leading-relaxed">
@@ -32,7 +32,7 @@ export default function PricingPage() {
       </section>
 
       {/* Pricing card */}
-      <section className="py-20 px-8">
+      <section className="py-20 px-4 md:px-8">
         <div className="max-w-[420px] mx-auto">
           <div className="bg-[var(--surface)] border border-[var(--border)] rounded-2xl p-8 shadow-sm">
             <div className="mb-6">
@@ -65,7 +65,7 @@ export default function PricingPage() {
       </section>
 
       {/* FAQ nudge */}
-      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+      <section className="py-12 px-4 md:px-8 text-center border-t border-[var(--border)]">
         <p className="text-[var(--text-muted)] text-sm">
           Questions about limits or data?{" "}
           <a href="/faq" className="text-brand no-underline hover:underline">

--- a/ui/src/components/PrivacyPage.jsx
+++ b/ui/src/components/PrivacyPage.jsx
@@ -15,7 +15,7 @@ export default function PrivacyPage() {
   return (
     <PageLayout>
       {/* Header */}
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">Privacy Policy</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[520px] mx-auto leading-relaxed">
@@ -25,7 +25,7 @@ export default function PrivacyPage() {
       </section>
 
       {/* Body */}
-      <section className="py-16 px-8">
+      <section className="py-16 px-4 md:px-8">
         <div className="max-w-[720px] mx-auto">
 
           <Section title="1. Who We Are">
@@ -211,7 +211,7 @@ export default function PrivacyPage() {
       </section>
 
       {/* Footer CTA */}
-      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+      <section className="py-12 px-4 md:px-8 text-center border-t border-[var(--border)]">
         <p className="text-[var(--text-muted)] text-sm">
           See also our{" "}
           <a href="/terms" className="text-brand no-underline hover:underline">

--- a/ui/src/components/StatusPage.jsx
+++ b/ui/src/components/StatusPage.jsx
@@ -62,7 +62,7 @@ export default function StatusPage() {
   return (
     <PageLayout>
       {/* Header */}
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">Service status</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[480px] mx-auto leading-relaxed">
@@ -72,7 +72,7 @@ export default function StatusPage() {
       </section>
 
       {/* Status card */}
-      <section className="py-16 px-8">
+      <section className="py-16 px-4 md:px-8">
         <div className="max-w-[480px] mx-auto">
           <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-8">
             <div className="flex items-center gap-4 mb-6">

--- a/ui/src/components/SubprocessorsPage.jsx
+++ b/ui/src/components/SubprocessorsPage.jsx
@@ -42,7 +42,7 @@ function Section({ title, children }) {
 export default function SubprocessorsPage() {
   return (
     <PageLayout>
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">Subprocessors</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[520px] mx-auto leading-relaxed">
@@ -52,7 +52,7 @@ export default function SubprocessorsPage() {
         </div>
       </section>
 
-      <section className="py-16 px-8">
+      <section className="py-16 px-4 md:px-8">
         <div className="max-w-[960px] mx-auto">
           <Section title="Current subprocessors">
             <p>

--- a/ui/src/components/TermsPage.jsx
+++ b/ui/src/components/TermsPage.jsx
@@ -15,7 +15,7 @@ export default function TermsPage() {
   return (
     <PageLayout>
       {/* Header */}
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">Terms of Service</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[520px] mx-auto leading-relaxed">
@@ -25,7 +25,7 @@ export default function TermsPage() {
       </section>
 
       {/* Body */}
-      <section className="py-16 px-8">
+      <section className="py-16 px-4 md:px-8">
         <div className="max-w-[720px] mx-auto">
 
           <Section title="1. Acceptance of Terms">
@@ -143,7 +143,7 @@ export default function TermsPage() {
       </section>
 
       {/* Footer CTA */}
-      <section className="py-12 px-8 text-center border-t border-[var(--border)]">
+      <section className="py-12 px-4 md:px-8 text-center border-t border-[var(--border)]">
         <p className="text-[var(--text-muted)] text-sm">
           See also our{" "}
           <a href="/privacy" className="text-brand no-underline hover:underline">

--- a/ui/src/components/UseCasesPage.jsx
+++ b/ui/src/components/UseCasesPage.jsx
@@ -50,7 +50,7 @@ export default function UseCasesPage() {
   return (
     <PageLayout>
       {/* Header */}
-      <section className="py-20 px-8 text-center bg-[var(--surface)]">
+      <section className="py-20 px-4 md:px-8 text-center bg-[var(--surface)]">
         <div className="max-w-[1100px] mx-auto">
           <h1 className="text-[2.5rem] font-extrabold mb-4">What can you do with Hive?</h1>
           <p className="text-[var(--text-muted)] text-lg max-w-[560px] mx-auto leading-relaxed">
@@ -60,7 +60,7 @@ export default function UseCasesPage() {
       </section>
 
       {/* Use cases */}
-      <section className="py-20 px-8">
+      <section className="py-20 px-4 md:px-8">
         <div className="max-w-[1100px] mx-auto flex flex-col gap-16">
           {USE_CASES.map((uc) => (
             <div key={uc.title} className="grid grid-cols-1 gap-8 md:grid-cols-2 md:gap-16 items-start">
@@ -78,7 +78,7 @@ export default function UseCasesPage() {
       </section>
 
       {/* CTA */}
-      <section className="py-16 px-8 text-center border-t border-[var(--border)]">
+      <section className="py-16 px-4 md:px-8 text-center border-t border-[var(--border)]">
         <div className="max-w-[480px] mx-auto">
           <h2 className="text-2xl font-bold mb-4">Ready to give your agents a memory?</h2>
           <p className="text-[var(--text-muted)] text-sm mb-8 leading-relaxed">

--- a/ui/src/components/ui/alert-dialog.jsx
+++ b/ui/src/components/ui/alert-dialog.jsx
@@ -33,7 +33,7 @@ function AlertDialog({
         <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
         <Dialog.Content
           className={cn(
-            "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-[var(--surface)] border border-[var(--border)] rounded-lg p-6 w-full max-w-sm z-50 shadow-lg",
+            "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-[var(--surface)] border border-[var(--border)] rounded-lg p-6 w-[calc(100vw-2rem)] max-w-sm z-50 shadow-lg",
             className,
           )}
           onOpenAutoFocus={(e) => e.preventDefault()}


### PR DESCRIPTION
Closes #529

Follow-up pass after re-shooting marketing, docs, and management app at 375px on the deployed dev stack. Rolls every remaining mobile papercut into one PR.

## Marketing

- Sweep `px-8` → `px-4 md:px-8` on every marketing-page section (Home, Pricing, UseCases, McpClients, FAQ, Changelog, Status, Terms, Privacy, Subprocessors) so the content container gets back 32px of width at <md.
- `McpClientsPage` grid collapses to a single column below `md` (was `minmax(460px,1fr)`, which forced horizontal page scroll on 375px since 460px > viewport).

## Docs

- Shrink the VitePress local-search button on <md so it matches the hamburger icon visually instead of floating between the logo and hamburger as an oversized circle.

## Management app (#529)

- `MemoryBrowser` toolbar row `flex-wrap`s at `<sm` so the `+ New` button doesn't clip past the viewport. Heading is full-width on narrow screens; search input fills remaining space; tag picker and New button stay inline.
- `AlertDialog` gains `w-[calc(100vw-2rem)]` so modals always have 16px of viewport margin instead of touching the edges on 375px.

## Infra — drive-by

- `hive/api/csp.py` hoists the `datetime` import to module scope so `_check_ip_rate_limit` is directly mockable.
- `test_rate_limit_per_ip` now freezes `datetime.now` across the 60-request loop — it was flaking when the 60th and 61st requests straddled a minute boundary.

## Test plan

- [x] `uv run inv pre-push` — 618 unit + 611 frontend (100% coverage both)
- [ ] Dev CI green
- [ ] Re-shoot all three surfaces post-merge to confirm

## Out of scope

- Visible scroll affordance for the docs/app wide-table patterns (iOS auto-hides scrollbars so content appears cut off even when it's reachable via horizontal scroll). Will file as a follow-up if the trade-off is worth it.
- Navbar visual parity (logo/Hive sizing across marketing/docs/app) — file separately since it's tuning, not a bug.