### PR TITLE
feat(ui): unify navbar + hamburger across marketing, docs, app

### DIFF
--- a/docs-site/.vitepress/theme/index.js
+++ b/docs-site/.vitepress/theme/index.js
@@ -11,6 +11,10 @@ export default {
   //
   // VitePress .content-body flex order:
   //   [nav-bar-content-before] Search Menu Appearance Social [nav-bar-content-after]
+  //
+  // Sign in sits in the navbar at every breakpoint so it parallels the
+  // management app's layout (follow-up to #543). The mobile drawer holds
+  // nav links only.
   Layout() {
     return h(DefaultTheme.Layout, null, {
       "nav-bar-content-after": () =>
@@ -24,9 +28,9 @@ export default {
             { href: "/docs/getting-started/what-is-hive", class: "docs-nav-link docs-nav-link--active" },
             "Docs",
           ),
-          h("a", { href: "/app", class: "docs-signin-btn" }, "Sign in"),
+          h("a", { href: "/app", class: "docs-signin-btn docs-signin-btn--always" }, "Sign in"),
         ]),
-      // Mobile expanded menu
+      // Mobile expanded menu — nav links only (Sign in is always in navbar)
       "nav-screen-content-after": () =>
         h("div", { class: "docs-screen-group" }, [
           h("a", { href: "/use-cases", class: "docs-screen-nav-link" }, "Use cases"),
@@ -38,7 +42,6 @@ export default {
             { href: "/docs/getting-started/what-is-hive", class: "docs-screen-nav-link" },
             "Docs",
           ),
-          h("a", { href: "/app", class: "docs-signin-screen-btn" }, "Sign in"),
         ]),
     });
   },

--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -121,11 +121,12 @@
   background-color: transparent !important;
 }
 
-/* Desktop navbar group: Docs link + Sign in button rendered via
-   nav-bar-content-after so they appear at the far right, in order, matching
-   the marketing site layout. Hidden below the VitePress nav-screen breakpoint
-   (768px) — mobile users get the same links via `nav-screen-content-after`
-   inside the hamburger menu (#528). */
+/* Desktop navbar group: nav links + Sign in button rendered via
+   nav-bar-content-after so they appear at the far right of the navbar.
+   The whole group is hidden below 768px so the hamburger takes over — but
+   the Sign in button inside it keeps its own always-visible variant
+   (.docs-signin-btn--always) so it renders next to the hamburger on mobile,
+   matching the management app. */
 .docs-nav-group {
   display: none;
   align-items: center;
@@ -136,6 +137,24 @@
 @media (min-width: 768px) {
   .docs-nav-group {
     display: flex;
+  }
+}
+
+/* Always-visible Sign in: break out of the parent .docs-nav-group hide on
+   mobile so it sits next to the hamburger + appearance toggle. */
+@media (max-width: 767px) {
+  .docs-nav-group {
+    display: flex;
+  }
+
+  .docs-nav-group > .docs-nav-link {
+    display: none;
+  }
+
+  .docs-signin-btn--always {
+    display: inline-flex;
+    padding: 4px 10px;
+    font-size: 13px;
   }
 }
 
@@ -213,8 +232,15 @@
   border-color: rgba(255, 255, 255, 0.5);
 }
 
-/* Hide the dark/light mode appearance toggle */
+/* Show the VitePress appearance (dark/light) toggle in the navbar at every
+   breakpoint so the docs site matches the management app layout (always-
+   visible theme toggle next to Sign in + hamburger). Hide the drawer's
+   "Appearance" row since it's redundant with the navbar. */
 .VPNavBarAppearance {
+  display: flex !important;
+}
+
+.VPNavScreenAppearance {
   display: none !important;
 }
 

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -1,9 +1,10 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Menu, X } from "lucide-react";
+import { Menu, Moon, Sun, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ConsentBanner from "@/components/ConsentBanner";
+import { useTheme } from "@/hooks/useTheme";
 import { CONSENT_RESET_EVENT, clearConsent } from "@/lib/consent";
 
 const NAV_LINK_BASE = "text-sm no-underline hover:text-white transition-colors";
@@ -25,6 +26,7 @@ function handleReopenConsent(e) {
 export default function PageLayout({ children }) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const { theme, toggle } = useTheme();
   const [menuOpen, setMenuOpen] = useState(false);
 
   // Close the mobile menu whenever the route changes so a link click doesn't
@@ -43,9 +45,11 @@ export default function PageLayout({ children }) {
 
   return (
     <div className="font-[system-ui,sans-serif] text-[var(--text)] flex flex-col min-h-screen">
-      {/* Nav */}
+      {/* Nav — mirrors the management app's navbar (#543 follow-up):
+          logo · spacer · Sign in · theme toggle · hamburger (mobile only).
+          Desktop adds the inline nav links before Sign in. */}
       <header className="bg-navy text-white">
-        <div className="max-w-[1100px] mx-auto px-4 md:px-8 h-14 flex items-center justify-between">
+        <div className="max-w-[1100px] mx-auto px-4 md:px-8 h-14 flex items-center gap-3">
           <button
             className="flex items-center gap-2 cursor-pointer bg-transparent border-none p-0 text-inherit"
             onClick={() => navigate("/")}
@@ -54,36 +58,62 @@ export default function PageLayout({ children }) {
             <span className="font-bold text-xl tracking-[1px]">Hive</span>
           </button>
 
-          {/* Desktop nav (>=768px) */}
-          <div className="hidden md:flex items-center gap-6">
+          {/* Desktop inline nav links — hidden below md */}
+          <nav className="hidden md:flex items-center gap-6 flex-1 ml-4">
             {NAV_LINKS.map(({ href, label }) => (
               <a
                 key={href}
                 href={href}
                 className={`text-white/75 ${NAV_LINK_BASE}`}
-                style={label === "Docs" ? { borderBottom: "2px solid transparent", paddingBottom: 2 } : navLinkStyle(href)}
+                style={
+                  label === "Docs"
+                    ? { borderBottom: "2px solid transparent", paddingBottom: 2 }
+                    : navLinkStyle(href)
+                }
               >
                 {label}
               </a>
             ))}
-            <Button variant="nav" size="sm" className="marketing-signin-btn" onClick={() => navigate("/app")}>
-              Sign in
-            </Button>
-          </div>
+          </nav>
 
-          {/* Mobile hamburger (<768px) */}
-          <button
-            type="button"
-            className="md:hidden inline-flex items-center justify-center w-11 h-11 text-white/85 bg-transparent cursor-pointer"
+          {/* Spacer keeps right-side controls right-aligned on mobile */}
+          <div className="flex-1 md:hidden" />
+
+          {/* Always-visible right-side controls: Sign in + theme toggle */}
+          <Button
+            variant="nav"
+            size="sm"
+            className="marketing-signin-btn"
+            onClick={() => navigate("/app")}
+          >
+            Sign in
+          </Button>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={toggle}
+            aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
+          </Button>
+
+          {/* Hamburger — mobile only; drawer holds nav links only */}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="md:hidden text-white hover:bg-white/10"
+            onClick={() => setMenuOpen((v) => !v)}
             aria-label={menuOpen ? "Close menu" : "Open menu"}
             aria-expanded={menuOpen}
-            onClick={() => setMenuOpen((v) => !v)}
           >
-            {menuOpen ? <X size={24} /> : <Menu size={24} />}
-          </button>
+            {menuOpen ? <X size={20} /> : <Menu size={20} />}
+          </Button>
         </div>
 
-        {/* Mobile drawer (<768px) */}
+        {/* Mobile drawer (<768px): nav links only. Sign in and theme toggle
+            live in the navbar on every breakpoint for visual parity with the
+            management app. */}
         {menuOpen && (
           <div className="md:hidden bg-navy border-t border-white/10">
             <nav className="px-4 py-4 flex flex-col gap-1">
@@ -100,14 +130,6 @@ export default function PageLayout({ children }) {
                   </a>
                 );
               })}
-              <Button
-                variant="nav"
-                size="sm"
-                className="marketing-signin-btn mt-2 min-h-11"
-                onClick={() => navigate("/app")}
-              >
-                Sign in
-              </Button>
             </nav>
           </div>
         )}

--- a/ui/src/components/PageLayout.test.jsx
+++ b/ui/src/components/PageLayout.test.jsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import PageLayout from "./PageLayout.jsx";
 
@@ -8,6 +8,20 @@ const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, useNavigate: () => mockNavigate };
+});
+
+beforeEach(() => {
+  // useTheme reads prefers-color-scheme on first render; jsdom doesn't
+  // implement matchMedia so we stub a minimal response.
+  vi.stubGlobal("matchMedia", (q) => ({
+    matches: false,
+    media: q,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
 });
 
 function renderInRouter(ui, path = "/") {
@@ -145,42 +159,48 @@ describe("PageLayout", () => {
     await act(async () => renderInRouter(<PageLayout><span /></PageLayout>));
     const btn = screen.getByLabelText("Open menu");
     await act(async () => fireEvent.click(btn));
-    // After opening, the button's aria-label flips to "Close menu".
     const closeBtn = screen.getByLabelText("Close menu");
     expect(closeBtn.getAttribute("aria-expanded")).toBe("true");
-    // The drawer itself renders a <nav>; assert it's in the DOM now.
-    const nav = closeBtn.closest("header").querySelector("nav");
-    expect(nav).toBeTruthy();
-    // Toggle closed again.
+    // Drawer renders its own <nav> inside a div with md:hidden wrapper.
+    const drawer = closeBtn.closest("header").querySelector(".md\\:hidden nav");
+    expect(drawer).toBeTruthy();
     await act(async () => fireEvent.click(closeBtn));
     expect(screen.getByLabelText("Open menu").getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("mobile drawer lists every nav link + a Sign in button", async () => {
+  it("mobile drawer lists every nav link; Sign in + theme toggle live in the navbar", async () => {
     await act(async () => renderInRouter(<PageLayout><span /></PageLayout>));
     await act(async () => fireEvent.click(screen.getByLabelText("Open menu")));
-    const { container } = { container: document };
-    const drawer = container.querySelector("header nav");
+    const drawer = document.querySelector("header .md\\:hidden nav");
     expect(drawer).toBeTruthy();
     for (const label of ["Use cases", "Clients", "Pricing", "FAQ", "Docs"]) {
       expect(within(drawer).getByText(label)).toBeTruthy();
     }
-    expect(within(drawer).getByRole("button", { name: "Sign in" })).toBeTruthy();
+    // Sign in lives in the navbar (visible at every breakpoint), not in the drawer.
+    expect(within(drawer).queryByRole("button", { name: "Sign in" })).toBeNull();
   });
 
-  it("mobile drawer Sign in navigates to /app", async () => {
+  it("navbar Sign in navigates to /app at every breakpoint", async () => {
     await act(async () => renderInRouter(<PageLayout><span /></PageLayout>));
-    await act(async () => fireEvent.click(screen.getByLabelText("Open menu")));
-    const drawer = document.querySelector("header nav");
-    const signIn = within(drawer).getByRole("button", { name: "Sign in" });
-    await act(async () => fireEvent.click(signIn));
+    // Sign in is rendered in the navbar row itself (not the drawer).
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: "Sign in" })));
     expect(mockNavigate).toHaveBeenCalledWith("/app");
+  });
+
+  it("navbar theme toggle flips the theme and updates its aria-label", async () => {
+    localStorage.removeItem("hive_theme");
+    await act(async () => renderInRouter(<PageLayout><span /></PageLayout>));
+    const btn = screen.getByLabelText(/Switch to (dark|light) mode/);
+    const before = btn.getAttribute("aria-label");
+    await act(async () => fireEvent.click(btn));
+    const after = screen.getByLabelText(/Switch to (dark|light) mode/).getAttribute("aria-label");
+    expect(after).not.toBe(before);
   });
 
   it("mobile drawer marks the current page with an orange left border", async () => {
     await act(async () => renderInRouter(<PageLayout><span /></PageLayout>, "/faq"));
     await act(async () => fireEvent.click(screen.getByLabelText("Open menu")));
-    const drawer = document.querySelector("header nav");
+    const drawer = document.querySelector("header .md\\:hidden nav");
     const faqLink = within(drawer).getByText("FAQ");
     expect(faqLink.style.borderLeftColor).toBe("rgb(232, 160, 32)");
     const pricingLink = within(drawer).getByText("Pricing");

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -4,3 +4,20 @@ import "@testing-library/jest-dom";
 // jsdom does not implement scrollIntoView; stub it so components that call it
 // do not throw and coverage branches are reachable.
 globalThis.HTMLElement.prototype.scrollIntoView = function () {};
+
+// useTheme reads `matchMedia("(prefers-color-scheme: dark)")` on first render.
+// jsdom doesn't ship matchMedia, so stub a default-light response. Individual
+// tests that need a different value (e.g. the useTheme suite) can override
+// with `vi.stubGlobal("matchMedia", ...)`.
+if (typeof globalThis.matchMedia === "undefined") {
+  globalThis.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}


### PR DESCRIPTION
Follow-up to #527 / #528 / #529 / #543 design feedback: all three surfaces (marketing, docs, management app) should share the same navbar shape — always-visible Sign in/out + theme toggle, with the hamburger drawer holding only nav links.

## Marketing (`PageLayout.jsx`)

- Sign in moves from the drawer into the navbar row alongside a new theme toggle, visible at every breakpoint.
- New Sun/Moon theme toggle (via the existing `useTheme` hook) — matches the app's button exactly.
- Mobile drawer is now nav links only.
- Desktop inline nav links sit between the logo and the right-side controls; no desktop behaviour change.

## Docs (`.vitepress/theme`)

- Sign in button lives in the navbar at every breakpoint (was desktop-only; mobile users saw it only after opening the drawer).
- VitePress Appearance toggle is un-hidden in the navbar and hidden in the drawer.
- `nav-screen-content-after` no longer renders Sign in; drawer is nav links only.

## Tests

- `setupTests.js` stubs `matchMedia` globally so every test that renders `PageLayout` (via the marketing-page suites) gets a safe default for the `useTheme` `prefers-color-scheme` read.
- `PageLayout.test.jsx`: drawer selector updated; 3 new tests cover navbar Sign in → `/app` navigation, theme-toggle aria-label flip on click, and the drawer containing no Sign in button.

## Test plan

- [x] `uv run inv pre-push` — 618 unit + 612 frontend (100% coverage both)
- [ ] CI green
- [ ] Post-merge re-shoots confirm visual parity across marketing, docs, and app

## Notes

- Marketing's dark/light toggle exercises the same CSS vars the app uses (`--bg`, `--surface`, `--text`, etc.). Some marketing pages still use hardcoded `bg-navy`/gradient colours for hero sections — those stay dark navy either way. If any content areas look off in light mode post-merge, a cleanup pass will be filed as a separate issue.
- No linked issue — this closes user-driven design polish, not a tracked feature.