### PR TITLE
fix(docs): align mobile drawer items + top-bar order with marketing/app

### DIFF
--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -156,6 +156,26 @@
     padding: 4px 10px;
     font-size: 13px;
   }
+
+  /* Navbar parity with the management app (#544 follow-up): on mobile
+     the row should read `logo · Hive · [search] · Sign in · theme ·
+     hamburger`, matching marketing/app. Two adjustments:
+       (a) Hide the VitePress vertical divider between search and the
+           right-side controls.
+       (b) Re-order so Sign in sits before the Appearance toggle.
+     Search is kept — it's a docs-specific affordance. */
+  .VPNavBar .content-body > .divider,
+  .VPNavBar .content-body .divider-line {
+    display: none !important;
+  }
+
+  .VPNavBarAppearance {
+    order: 2 !important;
+  }
+
+  .docs-nav-group {
+    order: 1 !important;
+  }
 }
 
 .docs-nav-link {
@@ -198,38 +218,31 @@
   border-color: #fff;
 }
 
-/* Mobile nav screen group */
+/* Mobile drawer nav list — matches the management app's drawer exactly:
+   items start at the left edge with 16px inner padding, 16px text,
+   white/85 on hover rather than centered/indented. */
 .docs-screen-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin: 12px 24px 0;
+  gap: 1px;
+  margin: 0;
+  padding: 16px;
 }
 
 .docs-screen-nav-link {
-  padding: 8px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.75);
-  text-decoration: none;
-}
-
-.docs-signin-screen-btn {
   display: block;
-  padding: 8px 16px;
-  font-size: 14px;
+  padding: 12px 16px;
+  font-size: 16px;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.85);
   text-decoration: none;
-  text-align: center;
-  transition: color 0.25s, border-color 0.25s;
+  border-radius: 6px;
+  transition: color 0.15s, background-color 0.15s;
 }
 
-.docs-signin-screen-btn:hover {
+.docs-screen-nav-link:hover {
   color: #fff;
-  border-color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 /* Show the VitePress appearance (dark/light) toggle in the navbar at every


### PR DESCRIPTION
Follow-up to #544 after re-shooting the three mobile surfaces side-by-side. Two visual mismatches remained on the docs drawer:

## Fixes

1. **Item indentation** — docs drawer items were rendered via `.docs-screen-group { margin: 12px 24px 0 }`, which center-indented them on a 375px viewport. Marketing and app drawers are left-aligned with ~16px inner padding. Now matches:
   - `.docs-screen-group` uses `margin: 0; padding: 16px`
   - `.docs-screen-nav-link` grows to 16px text, 12px/16px padding, rounded hover — same treatment as marketing's drawer links
2. **Top-bar control order** — Sign in sat *after* the VitePress Appearance toggle; marketing/app put Sign in *before* the toggle. On `<md` we now set `.VPNavBarAppearance { order: 2 }` and `.docs-nav-group { order: 1 }` so the row reads `logo · Hive · search · Sign in · theme · hamburger`.
3. **Vertical divider** — hid the VitePress `.divider-line` between search and the right-side controls on `<md` (marketing/app have no divider).

Search stays — the user confirmed it's a docs-specific feature.

## Test plan

- [x] `uv run inv pre-push` — 100% coverage both sides
- [ ] CI green
- [ ] Post-merge re-shoot confirms parity across all three drawers

No linked issue — user-driven polish continuing from #544.