### PR TITLE
test(e2e): double tag-filter retry window for GSI propagation

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -119,8 +119,10 @@ class TestUIE2E:
         # Apply tag filter and retry to handle DynamoDB GSI eventual consistency.
         # The TagIndex GSI may not immediately reflect a new write; if the filtered
         # list comes back empty, clear the chip and reapply the filter until the
-        # memory appears (or we exhaust retries).
-        for attempt in range(6):
+        # memory appears (or we exhaust retries). 12 × 5s = 60s total — GSI
+        # occasionally takes close to a minute under load.
+        _RETRIES = 12
+        for attempt in range(_RETRIES):
             # If a chip is already showing, clear it first so we can re-type.
             if page.locator("[aria-label='Clear tag filter']").count() > 0:
                 page.locator("[aria-label='Clear tag filter']").click()
@@ -131,7 +133,7 @@ class TestUIE2E:
             page.wait_for_load_state("networkidle")
             if page.locator(f"text={memory_key}").count() > 0:
                 break
-            if attempt < 5:
+            if attempt < _RETRIES - 1:
                 time.sleep(5)  # wait for GSI propagation before retrying
         assert page.locator(f"text={memory_key}").first.is_visible(), (
             f"Memory '{memory_key}' not visible after filtering by tag '{unique_tag}'"


### PR DESCRIPTION
E2E `test_create_and_see_memory` flaked on the dev pipeline after #544 landed — the failure was in the tag-filter retry loop waiting on DynamoDB GSI propagation, not anything in the UI changes themselves.

Existing window: 6 × 5s = 30s.
New window: 12 × 5s = 60s.

The GSI (TagIndex) occasionally takes close to a minute to reflect a fresh write under load; 30s was cutting it too close. Doubling the window keeps the test deterministic without changing the tooling or the underlying flow.

## Test plan

- [x] `uv run inv pre-push`
- [ ] Dev e2e re-run should pass