### PR TITLE
fix(docs): left-align drawer items + force hamburger to rightmost control

### DIFF
--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -157,24 +157,52 @@
     font-size: 13px;
   }
 
-  /* Navbar parity with the management app (#544 follow-up): on mobile
-     the row should read `logo · Hive · [search] · Sign in · theme ·
-     hamburger`, matching marketing/app. Two adjustments:
-       (a) Hide the VitePress vertical divider between search and the
-           right-side controls.
-       (b) Re-order so Sign in sits before the Appearance toggle.
-     Search is kept — it's a docs-specific affordance. */
-  .VPNavBar .content-body > .divider,
-  .VPNavBar .content-body .divider-line {
+  /* Navbar parity with the management app (#544 follow-up). The target
+     order at <md is `logo · Hive · [search] · Sign in · theme ·
+     hamburger` — matching marketing/app. Four adjustments:
+       (a) Hide every VitePress vertical divider between groups on the
+           mobile navbar (matches marketing/app, which have none).
+       (b) Re-order so Sign in sits before the Appearance toggle inside
+           .content-body; VPNavBarHamburger lives in a sibling outside
+           .content-body, so also reorder it to land last in .container.
+       (c) Hide the VitePress search button while the mobile drawer is
+           open so the row collapses cleanly to Sign in + theme + X.
+           Search is kept for drawer-closed state (docs-specific).
+       (d) Zero out VitePress's .VPNavScreen container padding + menu
+           margin so our drawer items sit flush to the left like the
+           marketing/app drawers. */
+  .VPNavBar .divider,
+  .VPNavBar .divider-line,
+  .VPNavBar .content-body > .divider {
     display: none !important;
   }
 
+  .VPNavBarSearch {
+    order: 0 !important;
+  }
+  .docs-nav-group {
+    order: 1 !important;
+  }
   .VPNavBarAppearance {
     order: 2 !important;
   }
 
-  .docs-nav-group {
+  .VPNavBar .container {
+    display: flex !important;
+  }
+  .VPNavBar .container > .title {
+    order: 0 !important;
+  }
+  .VPNavBar .container > .content {
     order: 1 !important;
+    flex: 1 1 auto !important;
+  }
+  .VPNavBarHamburger {
+    order: 2 !important;
+  }
+
+  .VPNavBar.screen-open .VPNavBarSearch {
+    display: none !important;
   }
 }
 
@@ -218,21 +246,36 @@
   border-color: #fff;
 }
 
-/* Mobile drawer nav list — matches the management app's drawer exactly:
-   items start at the left edge with 16px inner padding, 16px text,
-   white/85 on hover rather than centered/indented. */
+/* Mobile drawer nav list — matches the management app's drawer exactly.
+   VitePress's .VPNavScreen .container + .VPNavScreenMenu ship their own
+   horizontal padding/max-width that centre-indent the items; zero those
+   out so our 16px inner padding on .docs-screen-group is the only
+   horizontal spacing. */
+.VPNavScreen .container {
+  padding: 0 !important;
+  max-width: none !important;
+}
+
+.VPNavScreen .VPNavScreenMenu,
+.VPNavScreen .VPNavScreenTranslations,
+.VPNavScreen .VPNavScreenSocialLinks {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
 .docs-screen-group {
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  margin: 0;
-  padding: 16px;
+  gap: 2px;
+  margin: 0 !important;
+  padding: 16px !important;
 }
 
 .docs-screen-nav-link {
   display: block;
   padding: 12px 16px;
-  font-size: 16px;
+  font-size: 16px !important;
+  line-height: 1.4 !important;
   font-weight: 500;
   color: rgba(255, 255, 255, 0.85);
   text-decoration: none;

--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -156,6 +156,26 @@
     padding: 4px 10px;
     font-size: 13px;
   }
+
+  /* Navbar parity with the management app (#544 follow-up): on mobile
+     the row should read `logo · Hive · [search] · Sign in · theme ·
+     hamburger`, matching marketing/app. Two adjustments:
+       (a) Hide the VitePress vertical divider between search and the
+           right-side controls.
+       (b) Re-order so Sign in sits before the Appearance toggle.
+     Search is kept — it's a docs-specific affordance. */
+  .VPNavBar .content-body > .divider,
+  .VPNavBar .content-body .divider-line {
+    display: none !important;
+  }
+
+  .VPNavBarAppearance {
+    order: 2 !important;
+  }
+
+  .docs-nav-group {
+    order: 1 !important;
+  }
 }
 
 .docs-nav-link {
@@ -198,38 +218,31 @@
   border-color: #fff;
 }
 
-/* Mobile nav screen group */
+/* Mobile drawer nav list — matches the management app's drawer exactly:
+   items start at the left edge with 16px inner padding, 16px text,
+   white/85 on hover rather than centered/indented. */
 .docs-screen-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin: 12px 24px 0;
+  gap: 1px;
+  margin: 0;
+  padding: 16px;
 }
 
 .docs-screen-nav-link {
-  padding: 8px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.75);
-  text-decoration: none;
-}
-
-.docs-signin-screen-btn {
   display: block;
-  padding: 8px 16px;
-  font-size: 14px;
+  padding: 12px 16px;
+  font-size: 16px;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.85);
   text-decoration: none;
-  text-align: center;
-  transition: color 0.25s, border-color 0.25s;
+  border-radius: 6px;
+  transition: color 0.15s, background-color 0.15s;
 }
 
-.docs-signin-screen-btn:hover {
+.docs-screen-nav-link:hover {
   color: #fff;
-  border-color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 /* Show the VitePress appearance (dark/light) toggle in the navbar at every


### PR DESCRIPTION
Re-shoot showed two remaining mismatches between the docs drawer and the management app's drawer:

1. **Drawer items still center-indented.** My earlier CSS set `.docs-screen-group { padding: 16px }` but VitePress's parent `.VPNavScreen .container` and `.VPNavScreenMenu` ship their own horizontal padding/max-width that were pushing the items rightward. Zero those out so the 16px inner padding on the group is the only horizontal space.

2. **Hamburger rendered between search and Sign in instead of at the far right.** VitePress renders `.VPNavBarHamburger` as a sibling of the title/content wrappers (outside `.content-body`), so the earlier `order` rules inside `.content-body` never reached it. Reorder at `.VPNavBar .container` level so the hamburger lands at the end.

3. **Hide search while the drawer is open.** With the drawer open the row was `search + X + Sign in + divider + theme`; now it collapses cleanly to `Sign in + theme + X` via `.VPNavBar.screen-open .VPNavBarSearch { display: none }`. Search stays visible in drawer-closed state — the user confirmed it's a docs-specific affordance.

4. Force `.docs-screen-nav-link` font-size to 16px and line-height 1.4 so the text weight matches the app/marketing drawer rows.

## Test plan

- [x] `uv run inv pre-push` — lint + typecheck + 100% coverage
- [ ] Post-merge re-shoot confirms the docs drawer matches marketing + app

No linked issue — continuing user-driven polish from #544 / #545.