### PR TITLE
fix(docs): drawer parity — inline flow, left-flush items, orange active indicator

### DIFF
--- a/docs-site/.vitepress/theme/index.js
+++ b/docs-site/.vitepress/theme/index.js
@@ -30,7 +30,10 @@ export default {
           ),
           h("a", { href: "/app", class: "docs-signin-btn docs-signin-btn--always" }, "Sign in"),
         ]),
-      // Mobile expanded menu — nav links only (Sign in is always in navbar)
+      // Mobile expanded menu — nav links only (Sign in is always in navbar).
+      // The Docs link carries --active on this site so it gets an orange
+      // left-border indicator matching the marketing site's current-page
+      // affordance (instead of VitePress's default gray background fill).
       "nav-screen-content-after": () =>
         h("div", { class: "docs-screen-group" }, [
           h("a", { href: "/use-cases", class: "docs-screen-nav-link" }, "Use cases"),
@@ -39,7 +42,10 @@ export default {
           h("a", { href: "/faq", class: "docs-screen-nav-link" }, "FAQ"),
           h(
             "a",
-            { href: "/docs/getting-started/what-is-hive", class: "docs-screen-nav-link" },
+            {
+              href: "/docs/getting-started/what-is-hive",
+              class: "docs-screen-nav-link docs-screen-nav-link--active",
+            },
             "Docs",
           ),
         ]),

--- a/docs-site/.vitepress/theme/style.css
+++ b/docs-site/.vitepress/theme/style.css
@@ -246,14 +246,30 @@
   border-color: #fff;
 }
 
-/* Mobile drawer nav list — matches the management app's drawer exactly.
-   VitePress's .VPNavScreen .container + .VPNavScreenMenu ship their own
-   horizontal padding/max-width that centre-indent the items; zero those
-   out so our 16px inner padding on .docs-screen-group is the only
-   horizontal spacing. */
-.VPNavScreen .container {
+/* Mobile drawer — matches the management app/marketing drawer exactly:
+   items flush to the left edge (no centre indent), 16px text weight 500,
+   orange left-border indicator on the active page instead of VitePress's
+   default gray background fill, and the drawer slides into document flow
+   so content below pushes down instead of being covered. */
+.VPNavScreen,
+.VPNavScreen .container,
+.VPNavScreen .VPNavScreenContent {
   padding: 0 !important;
+  margin: 0 !important;
   max-width: none !important;
+}
+
+/* Put the drawer in document flow so open state shifts content down
+   (marketing parity). Closed state keeps VitePress's display toggle. */
+.VPNavScreen {
+  position: static !important;
+  height: auto !important;
+  max-height: none !important;
+  top: auto !important;
+  bottom: auto !important;
+  transform: none !important;
+  overflow: visible !important;
+  background-color: #1a1a2e !important;
 }
 
 .VPNavScreen .VPNavScreenMenu,
@@ -280,12 +296,21 @@
   color: rgba(255, 255, 255, 0.85);
   text-decoration: none;
   border-radius: 6px;
+  border-left: 2px solid transparent;
+  background-color: transparent !important;
   transition: color 0.15s, background-color 0.15s;
 }
 
-.docs-screen-nav-link:hover {
+.docs-screen-nav-link:hover,
+.docs-screen-nav-link:focus {
   color: #fff;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgba(255, 255, 255, 0.05) !important;
+}
+
+/* Current-page indicator — matches marketing's 2px orange left border
+   (no background fill). */
+.docs-screen-nav-link--active {
+  border-left-color: #e8a020 !important;
 }
 
 /* Show the VitePress appearance (dark/light) toggle in the navbar at every


### PR DESCRIPTION
Re-shoot showed three remaining drawer mismatches between docs and marketing:

1. **Drawer covered the page instead of pushing content down.** VitePress ships `.VPNavScreen` as a fullscreen overlay; marketing's drawer is inline and expands the header so page content shifts down. Force `.VPNavScreen { position: static }` + auto height + no transform so the drawer lives in document flow.

2. **Items still centre-indented.** Tightened the parent-padding clobber to include `.VPNavScreen` itself and `.VPNavScreenContent`, not just `.container`. With all parents zeroed, the 16px padding on `.docs-screen-group` is the only horizontal spacing and items sit flush-left.

3. **Active page rendered as a gray rounded fill (VitePress default) instead of marketing's 2px orange left border.** Added `docs-screen-nav-link--active` class to the Docs link (which is always the active page on this site) and CSS that overrides the background to transparent and uses `border-left: 2px solid #e8a020`.

## Test plan

- [x] `uv run inv pre-push` — 100% coverage both sides
- [ ] Post-merge re-shoot