### PR TITLE
fix(ui): app drawer active tab uses orange left-border (parity with marketing/docs)

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -184,8 +184,10 @@ function AppShell() {
               <button
                 key={t.id}
                 type="button"
-                className={`w-full text-left px-6 py-3 text-sm text-white bg-transparent border-none cursor-pointer font-[inherit] min-h-[44px] hover:bg-white/10 ${
-                  tab === t.id ? "font-semibold bg-white/5" : ""
+                className={`w-full text-left px-6 py-3 text-sm text-white bg-transparent cursor-pointer font-[inherit] min-h-[44px] hover:bg-white/5 border-l-2 ${
+                  tab === t.id
+                    ? "font-semibold border-l-brand"
+                    : "border-l-transparent"
                 }`}
                 onClick={() => { switchTab(t.id); setMenuOpen(false); }}
               >

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -424,4 +424,16 @@ describe("AppShell", () => {
     expect(screen.queryByTestId("mobile-nav")).toBeNull();
     expect(screen.getByTestId("client-manager")).toBeTruthy();
   });
+
+  it("mobile nav active tab has an orange left-border indicator (not a gray fill)", async () => {
+    await act(async () => render(<App />));
+    await waitFor(() => expect(screen.getByTestId("memory-browser")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /toggle navigation/i }));
+    const mobileNav = screen.getByTestId("mobile-nav");
+    const buttons = mobileNav.querySelectorAll("button[type='button']");
+    // Memories is the default active tab; OAuth Clients is inactive.
+    expect(buttons[0].className).toContain("border-l-brand");
+    expect(buttons[0].className).not.toContain("bg-white/5");
+    expect(buttons[1].className).toContain("border-l-transparent");
+  });
 });

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -433,7 +433,10 @@ describe("AppShell", () => {
     const buttons = mobileNav.querySelectorAll("button[type='button']");
     // Memories is the default active tab; OAuth Clients is inactive.
     expect(buttons[0].className).toContain("border-l-brand");
-    expect(buttons[0].className).not.toContain("bg-white/5");
+    // `hover:bg-white/5` stays on all rows; the active state no longer
+    // has a bare `bg-white/5` fill — so the class list splits by space
+    // must not contain that utility as its own token.
+    expect(buttons[0].className.split(/\s+/)).not.toContain("bg-white/5");
     expect(buttons[1].className).toContain("border-l-transparent");
   });
 });


### PR DESCRIPTION
Final leg of the three-surface drawer parity pass.

The management app's mobile drawer rendered the current tab with a gray fill (`bg-white/5` + `font-semibold`), while marketing and docs both use a 2px orange left border with no background fill. Swapped the app drawer to match:

- Every tab gets `border-l-2`
- Active tab flips `border-l-transparent` → `border-l-brand` and keeps the bold weight
- `bg-white/5` removed from the active state

New test in `App.test.jsx` locks in the new behaviour (asserts `border-l-brand` on Memories, `border-l-transparent` on OAuth Clients, and no `bg-white/5`).

## Test plan

- [x] `uv run inv pre-push` — 100% coverage both sides; 39 App.test.jsx tests
- [ ] Post-merge re-shoot confirms active tab now uses the orange border across all three surfaces