### PR TITLE
fix: render API reference with Redoc instead of Scalar

### DIFF
--- a/docs-site/api-reference.md
+++ b/docs-site/api-reference.md
@@ -7,23 +7,38 @@ outline: deep
 import { onMounted } from "vue";
 
 onMounted(() => {
-  const existing = document.getElementById("scalar-api-reference");
-  if (existing) return;
+  // Load Redoc once, then initialise it into the #redoc-container div.
+  // Using Redoc.init() avoids VitePress/Vue stripping the custom <redoc>
+  // web-component element during build.
+  function mount() {
+    if (window.Redoc && document.getElementById("redoc-container")) {
+      window.Redoc.init(
+        "/docs/openapi.json",
+        { theme: { colors: { primary: { main: "#e8a020" } } } },
+        document.getElementById("redoc-container"),
+      );
+    }
+  }
+
+  if (window.Redoc) {
+    mount();
+    return;
+  }
+  const existing = document.getElementById("redoc-standalone");
+  if (existing) {
+    existing.addEventListener("load", mount, { once: true });
+    return;
+  }
   const script = document.createElement("script");
-  script.id = "scalar-api-reference";
-  script.src = "https://cdn.jsdelivr.net/npm/@scalar/api-reference";
-  script.setAttribute("data-url", "/docs/openapi.json");
-  script.setAttribute("data-configuration", JSON.stringify({
-    theme: "purple",
-    hideDownloadButton: false,
-    layout: "classic",
-  }));
-  document.getElementById("hive-api-reference").appendChild(script);
+  script.id = "redoc-standalone";
+  script.src = "https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js";
+  script.addEventListener("load", mount, { once: true });
+  document.body.appendChild(script);
 });
 </script>
 
 # API reference
 
-Every endpoint the Hive management API exposes, generated straight from the deployed FastAPI app. Use it alongside the [MCP tools reference](/tools/overview) if you're building SDKs or bots against the REST surface.
+Every endpoint the Hive management API exposes, auto-generated from the deployed FastAPI app. Use it alongside the [MCP tools reference](/tools/overview) if you're building SDKs or bots against the REST surface.
 
-<div id="hive-api-reference"></div>
+<div id="redoc-container"></div>


### PR DESCRIPTION
Follow-up to #421 — the issue explicitly listed Redoc, Scalar, or Swagger UI as the rendering options; the initial implementation shipped Scalar. Switching to Redoc to match the spec.

## Summary

- `docs-site/api-reference.md` now loads the Redoc standalone bundle in `onMounted` and calls `Redoc.init("/docs/openapi.json", …, container)` against a plain `<div id="redoc-container">`.
- Brand-tinted to Hive orange (`#e8a020`) via Redoc's `theme.colors.primary.main` option.

## Approach

Redoc documents a `<redoc spec-url="…">` web component, but VitePress/Vue 3 strips unknown custom elements without hyphens during build — the tag never made it into the rendered HTML. Using `Redoc.init()` with a plain `<div>` target sidesteps that: Vue only sees a normal div, and the bundle wires itself up on mount.

## Test plan

- [ ] After deploy, `/docs/api-reference` renders the three-pane Redoc layout (sidebar / endpoint docs / request-response samples) inside the VitePress chrome.
- [ ] Method badges + header accent match Hive orange.
- [ ] Sidebar search + footer still present (VitePress layout preserved).