### PR TITLE
feat: collapse OK alarms on Dashboard into a summary badge

### DIFF
--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -279,6 +279,45 @@ export function AlarmBadge({ alarm }) {
   );
 }
 
+export function AlarmSummaryBadge({ count }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        padding: "7px 12px",
+        fontSize: 13,
+      }}
+    >
+      <CheckCircle size={14} style={{ color: "var(--success)", flexShrink: 0 }} />
+      <span>{count} {count === 1 ? "alarm" : "alarms"} OK</span>
+    </div>
+  );
+}
+
+export function AlarmOkCountBadge({ count }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        background: "transparent",
+        border: "1px dashed var(--border)",
+        borderRadius: 8,
+        padding: "7px 12px",
+        fontSize: 13,
+        color: "var(--text-muted)",
+      }}
+    >
+      <span>+{count} OK</span>
+    </div>
+  );
+}
+
 function AlarmStatusRow({ alarms, loading, error }) {
   if (loading && !alarms) {
     return (
@@ -289,9 +328,15 @@ function AlarmStatusRow({ alarms, loading, error }) {
   }
   if (error) return <ErrorBanner msg={error} />;
   if (!alarms?.alarms?.length) return null;
+  const firing = alarms.alarms.filter((a) => a.state !== "OK");
+  const okCount = alarms.alarms.length - firing.length;
   return (
     <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 20 }}>
-      {alarms.alarms.map((a) => <AlarmBadge key={a.name} alarm={a} />)}
+      {firing.map((a) => <AlarmBadge key={a.name} alarm={a} />)}
+      {okCount > 0 && (firing.length === 0
+        ? <AlarmSummaryBadge count={okCount} />
+        : <AlarmOkCountBadge count={okCount} />
+      )}
     </div>
   );
 }

--- a/ui/src/components/Dashboard.test.jsx
+++ b/ui/src/components/Dashboard.test.jsx
@@ -20,7 +20,7 @@ vi.mock("../api.js", () => ({
 }));
 
 import { api } from "../api.js";
-import { formatCostTick, formatCostTooltip, CustomTooltip, CustomCostTooltip, CustomDailyCostTooltip, AlarmBadge, ALARM_STATE_STYLE } from "./Dashboard.jsx";
+import { formatCostTick, formatCostTooltip, CustomTooltip, CustomCostTooltip, CustomDailyCostTooltip, AlarmBadge, AlarmSummaryBadge, AlarmOkCountBadge, ALARM_STATE_STYLE } from "./Dashboard.jsx";
 
 const STATS = {
   total_memories: 42,
@@ -119,6 +119,25 @@ describe("AlarmBadge", () => {
   it("strips env prefix from name when description is empty", () => {
     render(<AlarmBadge alarm={{ name: "Hive-dev-McpErrorRate", description: "", state: "OK" }} />);
     expect(screen.getByText("McpErrorRate")).toBeTruthy();
+  });
+});
+
+describe("AlarmSummaryBadge", () => {
+  it("pluralises the alarm count", () => {
+    render(<AlarmSummaryBadge count={12} />);
+    expect(screen.getByText("12 alarms OK")).toBeTruthy();
+  });
+
+  it("uses singular form for one alarm", () => {
+    render(<AlarmSummaryBadge count={1} />);
+    expect(screen.getByText("1 alarm OK")).toBeTruthy();
+  });
+});
+
+describe("AlarmOkCountBadge", () => {
+  it("renders the muted +N OK pill", () => {
+    render(<AlarmOkCountBadge count={10} />);
+    expect(screen.getByText("+10 OK")).toBeTruthy();
   });
 });
 
@@ -463,9 +482,39 @@ describe("Dashboard", () => {
     expect(screen.getByText("Tool Invocations")).toBeTruthy();
   });
 
-  it("shows alarm badge with description after load", async () => {
+  it("collapses all-OK alarms into a single summary badge", async () => {
     await act(async () => render(<Dashboard />));
-    await waitFor(() => expect(screen.getByText("MCP error rate > 5%")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("1 alarm OK")).toBeTruthy());
+    // Individual OK alarm label must not appear — that's the whole point of collapsing.
+    expect(screen.queryByText("MCP error rate > 5%")).toBeNull();
+  });
+
+  it("shows firing alarms individually with a muted OK count when mixed", async () => {
+    api.getAlarms.mockResolvedValue({
+      environment: "test",
+      alarms: [
+        { name: "Hive-test-McpErrorRate", description: "MCP error rate > 5%", state: "OK" },
+        { name: "Hive-test-McpErrorRate", description: "MCP error rate > 5%", state: "OK" },
+        { name: "Hive-test-ToolErrors", description: "Tool errors high", state: "ALARM" },
+      ],
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("Tool errors high")).toBeTruthy());
+    expect(screen.getByText("+2 OK")).toBeTruthy();
+    // Firing-state view never shows the summary badge.
+    expect(screen.queryByText("2 alarms OK")).toBeNull();
+  });
+
+  it("renders only firing alarms when none are OK", async () => {
+    api.getAlarms.mockResolvedValue({
+      environment: "test",
+      alarms: [
+        { name: "Hive-test-ToolErrors", description: "Tool errors high", state: "ALARM" },
+      ],
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("Tool errors high")).toBeTruthy());
+    expect(screen.queryByText(/OK/)).toBeNull();
   });
 
   it("shows alarm skeleton while loading", async () => {


### PR DESCRIPTION
Closes #369

## Summary

The Dashboard alarm row was noisy during healthy operation — 12+ green badges competing for attention even when nothing was wrong. Scaling the row with signal:

- **All OK** → single badge: `✓ N alarms OK` (singular for `N=1`, plural otherwise)
- **Any firing** → render the `ALARM` / `INSUFFICIENT_DATA` badges individually, with a muted dashed `+N OK` pill trailing them
- **No alarms at all** → unchanged; row still collapses to `null`

## Approach

Split out two tiny presentational components, `AlarmSummaryBadge` and `AlarmOkCountBadge`, both exported so tests can exercise the pluralisation and the muted-count rendering directly without relying on Dashboard state. `AlarmStatusRow` partitions `alarms.alarms` into firing vs OK (`state !== "OK"` counts as firing, which covers both `ALARM` and `INSUFFICIENT_DATA`), then picks the right summary variant based on whether anything is firing.

## Test plan

- [x] Unit: `AlarmSummaryBadge` pluralises ("12 alarms OK") and uses singular ("1 alarm OK")
- [x] Unit: `AlarmOkCountBadge` renders `+N OK`
- [x] Dashboard: all-OK fixture renders the summary badge and hides the individual OK label
- [x] Dashboard: mixed (2 OK + 1 firing) renders the firing badge + `+2 OK` pill, never the summary badge
- [x] Dashboard: all-firing renders no OK text
- [x] Existing skeleton / error / empty-list branches untouched