### PR TITLE
feat(docs): Redoc follows the docs-site dark mode

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -112,7 +112,10 @@ export default defineConfig({
     ],
 
     socialLinks: [],
-    appearance: false,
+    // Enable dark-mode toggle so the docs site matches the dark management
+    // app + marketing surfaces — and so the Redoc API reference can flip
+    // into its dark palette. Default to user's OS preference.
+    appearance: true,
 
     footer: {
       message: "Hive — shared persistent memory for AI agents",

--- a/docs-site/api-reference.md
+++ b/docs-site/api-reference.md
@@ -4,36 +4,109 @@ outline: deep
 ---
 
 <script setup>
-import { onMounted } from "vue";
+import { onMounted, onBeforeUnmount } from "vue";
+
+const SCRIPT_ID = "redoc-standalone";
+const CONTAINER_ID = "redoc-container";
+const SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js";
+
+// Redoc theme presets. Light uses brand orange on white; dark pulls the
+// VitePress dark palette (#1b1b1f body / #202127 surface / #e0e0e0 text) so
+// the reference visually belongs to the dark docs chrome instead of the
+// default eye-bleach-white rectangle.
+const LIGHT_THEME = {
+  colors: {
+    primary: { main: "#e8a020" },
+  },
+};
+
+const DARK_THEME = {
+  colors: {
+    primary: { main: "#f5a623" },
+    text: { primary: "#e0e0e0", secondary: "#a8a8b3" },
+    border: { dark: "#2f2f36", light: "#2f2f36" },
+    http: {
+      get: "#60a5fa",
+      post: "#4ade80",
+      put: "#facc15",
+      delete: "#f87171",
+      options: "#c084fc",
+      patch: "#fb923c",
+      basic: "#a8a8b3",
+      link: "#60a5fa",
+      head: "#a8a8b3",
+    },
+  },
+  sidebar: {
+    backgroundColor: "#202127",
+    textColor: "#e0e0e0",
+  },
+  rightPanel: {
+    backgroundColor: "#0f0f17",
+    textColor: "#e0e0e0",
+  },
+  typography: {
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    code: {
+      color: "#f5a623",
+      backgroundColor: "rgba(245, 166, 35, 0.1)",
+    },
+  },
+};
+
+function isDark() {
+  return document.documentElement.classList.contains("dark");
+}
+
+function mountRedoc() {
+  const container = document.getElementById(CONTAINER_ID);
+  if (!window.Redoc || !container) return;
+  // Redoc doesn't expose unmount — clear the target and re-init so a theme
+  // flip renders a fully rebuilt tree instead of stacking on top of the
+  // previous one.
+  container.innerHTML = "";
+  container.style.backgroundColor = isDark() ? "#1b1b1f" : "transparent";
+  window.Redoc.init(
+    "/docs/openapi.json",
+    { theme: isDark() ? DARK_THEME : LIGHT_THEME },
+    container,
+  );
+}
+
+let observer = null;
 
 onMounted(() => {
-  // Load Redoc once, then initialise it into the #redoc-container div.
-  // Using Redoc.init() avoids VitePress/Vue stripping the custom <redoc>
-  // web-component element during build.
-  function mount() {
-    if (window.Redoc && document.getElementById("redoc-container")) {
-      window.Redoc.init(
-        "/docs/openapi.json",
-        { theme: { colors: { primary: { main: "#e8a020" } } } },
-        document.getElementById("redoc-container"),
-      );
-    }
+  function startObserving() {
+    mountRedoc();
+    // Watch <html> for `.dark` toggling and re-init Redoc when it flips.
+    observer = new MutationObserver(() => mountRedoc());
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
   }
 
   if (window.Redoc) {
-    mount();
+    startObserving();
     return;
   }
-  const existing = document.getElementById("redoc-standalone");
+  const existing = document.getElementById(SCRIPT_ID);
   if (existing) {
-    existing.addEventListener("load", mount, { once: true });
+    existing.addEventListener("load", startObserving, { once: true });
     return;
   }
   const script = document.createElement("script");
-  script.id = "redoc-standalone";
-  script.src = "https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js";
-  script.addEventListener("load", mount, { once: true });
+  script.id = SCRIPT_ID;
+  script.src = SCRIPT_SRC;
+  script.addEventListener("load", startObserving, { once: true });
   document.body.appendChild(script);
+});
+
+onBeforeUnmount(() => {
+  if (observer) {
+    observer.disconnect();
+    observer = null;
+  }
 });
 </script>
 


### PR DESCRIPTION
Follow-up to #552. Redoc's OSS standalone only ships a light theme; on a dark docs page the API reference rendered as a white rectangle orphaned from the dark chrome around it.

## Summary

- Two theme presets in `docs-site/api-reference.md`: **light** (brand orange on white, unchanged) and **dark** (VitePress dark palette, navy right-panel, orange-accented code samples, soft HTTP-method colours tuned for a dark surface).
- At mount, the page checks `html.dark` and picks the matching preset.
- A `MutationObserver` on `<html>`'s class list watches for theme toggles; on flip, the container is emptied and Redoc is re-initialised with the new theme. Redoc doesn't expose an unmount, so rebuild-in-place is the cleanest fidelity path.
- Observer is torn down in `onBeforeUnmount` so a stale mount can't re-fire after navigating away.

## Approach

Narrower path than switching to Swagger UI or forcing `color-scheme: light` on the page. Same library, same deployment story, theme keys are stable (Redoc hasn't changed the `theme` contract in several majors). Only knobs set are colours + typography — no structural overrides.

## Test plan

- [ ] Deploy → `/docs/api-reference` in light mode renders as before (white body, orange accents).
- [ ] Toggle the site to dark mode → Redoc rebuilds into dark palette in-place, no full page reload needed.
- [ ] Toggle back → returns to light cleanly, no stacking artefacts.
- [ ] Sidebar search, code-sample switching, method-badge contrast all readable in both modes.