### PR TITLE
fix(docs): light-mode Redoc palette — drop jarring dark right panel

### DIFF
--- a/docs-site/api-reference.md
+++ b/docs-site/api-reference.md
@@ -19,6 +19,27 @@ const LIGHT_THEME = {
   colors: {
     primary: { main: "#e8a020" },
   },
+  sidebar: {
+    backgroundColor: "#f8f8fa",
+    textColor: "#1f1f23",
+  },
+  // Redoc's default right panel is dark-grey (#263238) even in light mode —
+  // the "classic" three-pane look. That clashes with the rest of the light
+  // docs chrome, so override to a soft light surface. Code blocks inside
+  // keep their own darker background via codeBlock.backgroundColor below.
+  rightPanel: {
+    backgroundColor: "#f0f0f3",
+    textColor: "#1f1f23",
+  },
+  codeBlock: {
+    backgroundColor: "#2a2a33",
+  },
+  typography: {
+    code: {
+      color: "#b8560f",
+      backgroundColor: "rgba(232, 160, 32, 0.1)",
+    },
+  },
 };
 
 const DARK_THEME = {


### PR DESCRIPTION
Follow-up to #556. After the dark-mode pass, light mode regressed: the Redoc right panel (Request/Response samples) stayed dark-grey even in light mode, clashing with the white docs chrome around it. Root cause was `LIGHT_THEME` only setting `primary.main` — everything else fell through to Redoc's "classic" defaults, which keep the right panel at `#263238` regardless of page theme.

## Summary

Explicit light-mode surfaces:

- `sidebar` → `#f8f8fa` / `#1f1f23` text (soft light, clearly subordinate to content)
- `rightPanel` → `#f0f0f3` / `#1f1f23` text (drop the dark-grey default)
- `codeBlock` → `#2a2a33` so request/response code still reads as "code" even inside a light right panel
- `typography.code` → tinted orange inline code matching brand

`DARK_THEME` untouched — it was already correct.

## Test plan

- [ ] Light mode: right panel renders as soft-light surface matching the rest of the page; code samples still clearly demarcated as dark code blocks inside.
- [ ] Light mode: sidebar reads as light / subtle; content pane remains white.
- [ ] Dark mode: unchanged — same as post-#556.