### PR TITLE
fix(docs): keep Swagger base CSS loaded under the dark overlay

### DIFF
--- a/docs-site/api-reference.md
+++ b/docs-site/api-reference.md
@@ -37,9 +37,13 @@ function ensureCss(id, href) {
 }
 
 function applyTheme() {
-  const light = ensureCss(CSS_LIGHT_ID, SWAGGER_CSS_LIGHT);
+  // Keep the base (light) stylesheet loaded always — SwaggerDark is a set
+  // of layered overrides, not a complete replacement. Disabling the base
+  // left Swagger UI totally unstyled in dark mode. Ordering matters: the
+  // dark link is appended after the light one, so its rules win in the
+  // cascade whenever it's enabled.
+  ensureCss(CSS_LIGHT_ID, SWAGGER_CSS_LIGHT);
   const dark = ensureCss(CSS_DARK_ID, SWAGGER_CSS_DARK);
-  light.disabled = isDark();
   dark.disabled = !isDark();
 }
 


### PR DESCRIPTION
Follow-up to #558. Light mode looked good; dark mode rendered Swagger UI completely unstyled (plain text labels, no method badges, no panels, no borders) — the screenshot confirmed it.

## Root cause

`applyTheme()` was disabling `swagger-ui.css` when flipping to dark, but `SwaggerDark` is a set of *layered overrides* on top of the base stylesheet, not a complete replacement. With the base disabled, Swagger UI had no foundation styles left for the dark overlay to override — so everything collapsed to browser defaults.

## Fix

Keep the base (light) stylesheet always enabled. Only toggle the dark overlay's `disabled` flag. Append order (light first, dark second) means the dark rules win in the cascade whenever the overlay is enabled, and light mode still looks clean because the overlay is disabled.

## Test plan

- [ ] Dark mode: Swagger UI renders fully styled — method badges, panel borders, contrast all intact — matching Amoenus/SwaggerDark's look.
- [ ] Light mode: unchanged from #558.
- [ ] Theme toggle flips between the two without a page reload.