### PR TITLE
fix(docs): pad API-reference intro so it doesn't sit flush against viewport edge

### DIFF
--- a/docs-site/api-reference.md
+++ b/docs-site/api-reference.md
@@ -120,18 +120,19 @@ onBeforeUnmount(() => {
   display: none !important;
 }
 
-.api-reference-page main > h1,
-.api-reference-page main > p {
-  padding: 24px 24px 0;
-  margin: 0;
+.api-reference-page .vp-doc > h1,
+.api-reference-page .vp-doc > p {
+  padding: 0 32px;
+  margin: 24px 0 0;
 }
 
-.api-reference-page main > p {
-  padding-bottom: 16px;
+.api-reference-page .vp-doc > p {
+  margin-bottom: 24px;
 }
 
 .api-reference-page #swagger-ui-container {
   width: 100%;
+  margin-top: 24px;
 }
 </style>
 


### PR DESCRIPTION
Tiny follow-up: the API-reference H1 + intro paragraph rendered flush against the viewport edges with no breathing room. The previous padding rule targeted `main > h1` / `main > p`, but VitePress wraps markdown content in a `.vp-doc` div — so neither element is a direct child of `main` and the rule never matched.

## Summary

- Switch selector to `.api-reference-page .vp-doc > h1` / `.vp-doc > p` so it actually applies.
- 32px horizontal padding + 24px top margin on the intro so it breathes.
- 24px top margin on `#swagger-ui-container` so the widget doesn't butt straight into the intro paragraph.

## Test plan

- [ ] On deploy, "API reference" heading and intro paragraph have visible left/top whitespace, matching other docs pages.
- [ ] Swagger UI starts a comfortable distance below the intro, not flush.
- [ ] Layout still spans full width below the intro.