### PR TITLE
fix(docs): actually match intro padding with descendant selector

### DIFF
--- a/docs-site/api-reference.md
+++ b/docs-site/api-reference.md
@@ -120,13 +120,16 @@ onBeforeUnmount(() => {
   display: none !important;
 }
 
-.api-reference-page .vp-doc > h1,
-.api-reference-page .vp-doc > p {
-  padding: 0 32px;
+/* Intro H1 + paragraph: VitePress wraps them in .vp-doc > div > … so a
+   direct-child selector off .vp-doc misses. Descendant selector it is —
+   there's only one H1 and the intro <p> on this page, so no collateral. */
+.api-reference-page .vp-doc h1,
+.api-reference-page .vp-doc div > p {
+  padding: 0 24px;
   margin: 24px 0 0;
 }
 
-.api-reference-page .vp-doc > p {
+.api-reference-page .vp-doc div > p {
   margin-bottom: 24px;
 }
 


### PR DESCRIPTION
#560 didn't take effect after deploy — inspecting the built HTML revealed why: VitePress wraps markdown content in `.vp-doc > div > h1/p` (an extra Vue-fragment `<div>` layer between `.vp-doc` and the content nodes). My `.vp-doc > h1` direct-child selector skipped that intermediate div, so the rule never matched and the heading + intro paragraph kept hugging the viewport edges.

## Fix

Switch to descendant selectors: `.vp-doc h1` and `.vp-doc div > p`. Safe on this page — it has exactly one `<h1>` and one intro `<p>`, so no collateral styling of other elements.

Padding dropped from 32px to 24px since it reads better on mobile where the intro was most flagrantly edge-hugging.

## Test plan

- [ ] After deploy, mobile + desktop: "API reference" heading and intro paragraph have visible 24px horizontal padding, not flush against the viewport edge.
- [ ] Swagger UI container still spans full width below.