### PR TITLE
fix(ui): stop Dashboard page overflowing viewport on mobile

### DIFF
--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -321,7 +321,7 @@ export function AlarmOkCountBadge({ count }) {
 function AlarmStatusRow({ alarms, loading, error }) {
   if (loading && !alarms) {
     return (
-      <div style={{ display: "flex", gap: 8, marginBottom: 20 }}>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 20 }}>
         {[1, 2, 3, 4].map((i) => <SkeletonBlock key={i} height={36} width={160} />)}
       </div>
     );
@@ -509,7 +509,7 @@ export default function Dashboard() {
     <div>
       <style>{`@keyframes pulse { 0%,100%{opacity:.5} 50%{opacity:.25} }`}</style>
 
-      <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 20 }}>
+      <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 16, rowGap: 12, marginBottom: 20 }}>
         <h2 style={{ fontSize: 18, margin: 0, color: "var(--text)" }}>Dashboard</h2>
         <div style={{ display: "flex", gap: 4 }}>
           {PERIOD_OPTIONS.map((p) => (


### PR DESCRIPTION
Dashboard page horizontally overflowed on mobile — the Hive logo, "Da" of "Dashboard", and the left edge of stat-card numbers were all clipped by the viewport. Two rows were flex containers without `flex-wrap`, so on narrow screens they refused to break and forced the whole page into horizontal scroll.

## Summary

- **Header row** (`Dashboard` h2 + 1h / 24h / 7d / 30d buttons + `just now` timestamp + `Refresh` button) easily exceeds 375px; now wraps with `flexWrap: "wrap"` + `rowGap: 12` so it stacks cleanly.
- **Alarm skeleton loader** (4 × 160px `SkeletonBlock`s) was ~660px wide during load; now wraps too.
- Every other flex row on this page already had `flexWrap: "wrap"`.

## Test plan

- [ ] Mobile Dashboard: page fits the viewport, no horizontal scroll.
- [ ] Header row wraps onto multiple lines on narrow screens; stays single-line on desktop.
- [ ] Alarm skeletons wrap during load; post-load single-badge state unaffected.
- [ ] Existing Dashboard unit tests (57) still pass — verified locally.