### PR TITLE
fix(ui): stop Activity Log page overflowing viewport on mobile

### DIFF
--- a/ui/src/components/ActivityLog.jsx
+++ b/ui/src/components/ActivityLog.jsx
@@ -56,14 +56,14 @@ export default function ActivityLog() {
 
       {/* Stats bar */}
       {stats && (
-        <div className="flex gap-4 mb-5">
+        <div className="flex flex-wrap gap-4 mb-5">
           {[
             { label: "Total Memories", value: stats.total_memories },
             { label: "Total Clients", value: stats.total_clients },
             { label: "Events Today", value: stats.events_today },
             { label: "Events (7 days)", value: stats.events_last_7_days },
           ].map(({ label, value }) => (
-            <Card key={label} className="flex-1 text-center">
+            <Card key={label} className="flex-1 min-w-[120px] text-center">
               <div className="text-[28px] font-bold">{value}</div>
               <div className="text-xs text-[var(--text-muted)] mt-1">{label}</div>
             </Card>
@@ -73,7 +73,7 @@ export default function ActivityLog() {
 
       {error && <p className="text-[var(--danger)] mb-3">{error}</p>}
 
-      <div className="flex gap-2.5 items-center mb-3">
+      <div className="flex flex-wrap gap-2.5 items-center mb-3">
         <Label htmlFor="activity-days" className="mb-0">Show last</Label>
         <Select
           id="activity-days"


### PR DESCRIPTION
Same overflow pattern we just fixed on Dashboard (#562) — Activity Log had two flex rows with no `flex-wrap`, so on mobile the page scrolled horizontally with the "Activ" of "Activity Log", stat-card numbers, and left column of the event table all clipped at the viewport edge.

## Summary

1. **Stats bar** (Total Memories / Total Clients / Events Today / Events (7 days)) — `flex gap-4` → `flex flex-wrap gap-4`. Cards also get `min-w-[120px]` so they collapse to **2-per-row** on mobile instead of all four shrinking to unreadable slivers.
2. **Filter controls row** (`Show last / 7 days / Limit / 100 / N events / Refresh`) — `flex gap-2.5` → `flex flex-wrap gap-2.5`.
3. Table below already has `overflow-x-auto` on its Card — unaffected.

## Test plan

- [ ] Mobile Activity Log: page fits the viewport, no horizontal scroll. Stat cards wrap to 2 × 2. Filter row wraps.
- [ ] Desktop: unchanged — flex-wrap is a no-op when there's room on one line.
- [ ] Existing ActivityLog tests (13) still pass — verified locally.