### PR TITLE
fix(e2e): raise httpx timeout to 30s to absorb Lambda cold starts

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -18,6 +18,13 @@ import pytest
 API_URL = os.environ.get("HIVE_API_URL", "")
 ADMIN_EMAIL = os.environ.get("HIVE_ADMIN_EMAIL", "")
 
+# The deployed API runs on AWS Lambda, and the first request after a quiet
+# period pays a cold-start cost that can run 5–10s on a fresh container. The
+# httpx default 5s read timeout occasionally flakes the very first DCR call
+# in a test run; bumping to 30s comfortably absorbs that without masking real
+# backend slowness.
+_E2E_TIMEOUT = 30.0
+
 
 def _pkce_pair() -> tuple[str, str]:
     verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
@@ -38,7 +45,7 @@ async def _issue_token(client_name: str) -> str:
 
     verifier, challenge = _pkce_pair()
 
-    async with httpx.AsyncClient(base_url=API_URL, follow_redirects=False) as http:
+    async with httpx.AsyncClient(base_url=API_URL, follow_redirects=False, timeout=_E2E_TIMEOUT) as http:
         reg = await http.post(
             "/oauth/register",
             json={"client_name": client_name, "redirect_uris": ["http://localhost/cb"]},
@@ -101,7 +108,7 @@ def issue_token_sync() -> str:
 
     verifier, challenge = _pkce_pair()
 
-    with httpx.Client(base_url=API_URL, follow_redirects=False) as http:
+    with httpx.Client(base_url=API_URL, follow_redirects=False, timeout=_E2E_TIMEOUT) as http:
         reg = http.post(
             "/oauth/register",
             json={"client_name": "E2E UI Client", "redirect_uris": ["http://localhost/cb"]},
@@ -151,7 +158,7 @@ async def live_admin_token() -> str:
     if not ADMIN_EMAIL:
         pytest.skip("HIVE_ADMIN_EMAIL not set")
 
-    async with httpx.AsyncClient(base_url=API_URL, follow_redirects=False) as http:
+    async with httpx.AsyncClient(base_url=API_URL, follow_redirects=False, timeout=_E2E_TIMEOUT) as http:
         resp = await http.get("/auth/login", params={"test_email": ADMIN_EMAIL})
         if resp.status_code in (301, 302, 307, 308):
             pytest.skip("Google OAuth redirect — HIVE_BYPASS_GOOGLE_AUTH not enabled")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -45,7 +45,9 @@ async def _issue_token(client_name: str) -> str:
 
     verifier, challenge = _pkce_pair()
 
-    async with httpx.AsyncClient(base_url=API_URL, follow_redirects=False, timeout=_E2E_TIMEOUT) as http:
+    async with httpx.AsyncClient(
+        base_url=API_URL, follow_redirects=False, timeout=_E2E_TIMEOUT
+    ) as http:
         reg = await http.post(
             "/oauth/register",
             json={"client_name": client_name, "redirect_uris": ["http://localhost/cb"]},
@@ -158,7 +160,9 @@ async def live_admin_token() -> str:
     if not ADMIN_EMAIL:
         pytest.skip("HIVE_ADMIN_EMAIL not set")
 
-    async with httpx.AsyncClient(base_url=API_URL, follow_redirects=False, timeout=_E2E_TIMEOUT) as http:
+    async with httpx.AsyncClient(
+        base_url=API_URL, follow_redirects=False, timeout=_E2E_TIMEOUT
+    ) as http:
         resp = await http.get("/auth/login", params={"test_email": ADMIN_EMAIL})
         if resp.status_code in (301, 302, 307, 308):
             pytest.skip("Google OAuth redirect — HIVE_BYPASS_GOOGLE_AUTH not enabled")


### PR DESCRIPTION
Intermittent `httpx.ReadTimeout` flake on the first DCR call (`/oauth/register`) during e2e test setup — flagged multiple times in the dev pipeline. Stack trace consistently points to the 5s httpx default read timeout tripping during a Lambda cold-start. Every test that ran after the first one on the same dev deploy passed, which is the signature of a cold-container warm-up cost, not a backend fault.

## Fix

Shared `_E2E_TIMEOUT = 30.0` constant applied to all three httpx client constructors in `tests/e2e/conftest.py`:

- `_issue_token` (async) — used by `live_token` + `live_token_b` fixtures.
- `issue_token_sync` — used by Playwright UI e2e setup.
- `live_admin_token` fixture — management-JWT bypass flow.

30s comfortably absorbs the 5–10s Lambda cold-start cost without masking genuinely slow backend responses. No behaviour change for warm requests.

## Test plan

- [ ] Dev pipeline e2e run no longer flakes on cold-start.
- [ ] Warm test runs complete in the same wall-clock time as before (no regression from the higher timeout, since it only caps how long we *wait*).
- [ ] Local `inv e2e` against a warm dev env still passes.