### PR TITLE
fix(e2e): double GSI-propagation retry budget to 120s

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -119,9 +119,9 @@ class TestUIE2E:
         # Apply tag filter and retry to handle DynamoDB GSI eventual consistency.
         # The TagIndex GSI may not immediately reflect a new write; if the filtered
         # list comes back empty, clear the chip and reapply the filter until the
-        # memory appears (or we exhaust retries). 12 × 5s = 60s total — GSI
-        # occasionally takes close to a minute under load.
-        _RETRIES = 12
+        # memory appears (or we exhaust retries). 24 × 5s = 120s total — GSI has
+        # been observed taking north of 60s under load in the dev pipeline.
+        _RETRIES = 24
         for attempt in range(_RETRIES):
             # If a chip is already showing, clear it first so we can re-type.
             if page.locator("[aria-label='Clear tag filter']").count() > 0:


### PR DESCRIPTION
`test_create_and_see_memory` flaked again in the dev pipeline. The current 60s retry budget (12 × 5s) for DynamoDB GSI propagation wasn't enough — the filtered memory list never returned the newly-created memory before the test ran out of retries. The existing code comment already warned "GSI occasionally takes close to a minute under load"; this run crossed that threshold.

## Fix

Bump `_RETRIES` from 12 to 24 → 120s total retry window. Still bounded (won't hang CI indefinitely), but gives a comfortable margin above the worst observed GSI propagation time we've seen.

Longer-term, a more robust fix would re-query through the primary table (by key) instead of the TagIndex GSI — but that would change what the test covers (the filter UI path specifically exercises the GSI). Bumping the budget keeps the test's coverage surface intact.

## Test plan

- [ ] Dev pipeline e2e run no longer flakes on GSI propagation for this test.
- [ ] Happy-path runs complete quickly — the retry loop exits on the first attempt when GSI is fast, so the higher cap doesn't slow normal runs.