### PR TITLE
feat: RateLimitedRequests metric + Dashboard card for 429 events

### DIFF
--- a/src/hive/api/_auth.py
+++ b/src/hive/api/_auth.py
@@ -36,6 +36,10 @@ async def require_token(
     try:
         check_rate_limit(token.client_id, storage)
     except RateLimitExceeded as exc:
+        # #367 — surface rate-limit pressure in the admin dashboard. Emit
+        # twice: aggregate (Environment only) + drill-down (endpoint + reason).
+        await emit_metric("RateLimitedRequests")
+        await emit_metric("RateLimitedRequests", endpoint="/api", reason="rate_limit")
         raise HTTPException(
             status_code=429,
             detail="Rate limit exceeded",

--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -156,6 +156,24 @@ def _build_metric_queries(period_label: str) -> list[dict[str, Any]]:
             },
         }
     )
+    # RateLimitedRequests (#367) — count of 429-equivalent responses from the
+    # MCP server, the management-API auth path, and /api/memories quota checks.
+    # Same twin-emit pattern as CSP: aggregate here, drill-down by endpoint
+    # available via CloudWatch directly.
+    queries.append(
+        {
+            "Id": "rate_limited_requests",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": NAMESPACE,
+                    "MetricName": "RateLimitedRequests",
+                    "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+                },
+                "Period": stat_period,
+                "Stat": "Sum",
+            },
+        }
+    )
 
     return queries
 

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 
 from hive.api._auth import require_mgmt_user
+from hive.metrics import emit_metric
 from hive.models import (
     ActivityEvent,
     EventType,
@@ -158,6 +159,11 @@ async def create_memory(
     try:
         check_memory_quota(owner_user_id, storage)
     except QuotaExceeded as exc:
+        # #367 — track 429s so admins can see quota pressure in the dashboard.
+        # Emit twice: aggregate (Environment only) for the dashboard count, and
+        # a fully-dimensioned record for drill-down (endpoint + reason).
+        await emit_metric("RateLimitedRequests")
+        await emit_metric("RateLimitedRequests", endpoint="/api/memories", reason="quota")
         raise HTTPException(status_code=429, detail=exc.detail) from exc
     expires_at = None
     if body.ttl_seconds is not None:

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -192,6 +192,11 @@ async def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple
     try:
         check_rate_limit(token.client_id, storage)
     except RateLimitExceeded as exc:
+        # #367 — track 429-equivalent events so admins can see pressure in the
+        # dashboard. Emit twice: aggregate (Environment only) + drill-down
+        # dimensions (endpoint + reason).
+        await emit_metric("RateLimitedRequests")
+        await emit_metric("RateLimitedRequests", endpoint="mcp", reason="rate_limit")
         raise ToolError(f"Rate limit exceeded. Retry after {exc.retry_after}s.") from exc
 
     set_request_context(request_id, token.client_id)

--- a/tests/unit/test_admin_api.py
+++ b/tests/unit/test_admin_api.py
@@ -178,6 +178,8 @@ class TestAdminMetrics:
             "p99_summarizecontext",
             "tokens_issued",
             "token_failures",
+            "csp_violations",
+            "rate_limited_requests",
         ]
         cw_resp = _make_cw_response(metric_ids)
         with patch("hive.api.admin._cloudwatch_client") as mock_cw_factory:
@@ -193,6 +195,9 @@ class TestAdminMetrics:
         assert "metrics" in body
         assert "inv_remember" in body["metrics"]
         assert body["metrics"]["inv_remember"]["values"] == [1.0]
+        # #367 — Rate-limited requests surface as a Dashboard stat card, so
+        # the admin metrics endpoint must include the aggregate query.
+        assert "rate_limited_requests" in body["metrics"]
 
     def test_returns_metrics_for_1h(self, admin_tc):
         with patch("hive.api.admin._cloudwatch_client") as mock_cw_factory:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -275,13 +275,23 @@ class TestMemories:
 
     def test_create_returns_429_when_memory_quota_exceeded(self, client):
         import os
-        from unittest.mock import patch
+        from unittest.mock import AsyncMock, patch
 
-        with patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "0"}):
+        mock_emit = AsyncMock()
+        with (
+            patch.dict(os.environ, {"HIVE_QUOTA_MAX_MEMORIES": "0"}),
+            patch("hive.api.memories.emit_metric", mock_emit),
+        ):
             tc, *_ = client
             resp = tc.post("/api/memories", json={"key": "blocked", "value": "v"})
         assert resp.status_code == 429
         assert "quota" in resp.json()["detail"].lower()
+        # #367 — RateLimitedRequests is emitted twice: aggregate + drill-down.
+        assert mock_emit.await_count == 2
+        assert mock_emit.await_args_list[0].args == ("RateLimitedRequests",)
+        drilldown = mock_emit.await_args_list[1]
+        assert drilldown.args == ("RateLimitedRequests",)
+        assert drilldown.kwargs == {"endpoint": "/api/memories", "reason": "quota"}
 
     def test_update_does_not_check_quota(self, client):
         """Updating an existing memory must not be blocked by quota."""

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -205,16 +205,18 @@ class TestApiRateLimitIntegration:
 
     def test_require_token_returns_429_on_rate_limit(self):
         import asyncio
+        from unittest.mock import AsyncMock
 
         from fastapi import HTTPException
         from fastapi.security import HTTPAuthorizationCredentials
 
         from hive.rate_limiter import RateLimitExceeded
 
+        mock_emit = AsyncMock()
         with (
             patch("hive.api._auth.validate_bearer_token") as mock_validate,
             patch("hive.api._auth.check_rate_limit") as mock_rl,
-            patch("hive.api._auth.emit_metric") as _,
+            patch("hive.api._auth.emit_metric", mock_emit),
         ):
             mock_token = MagicMock()
             mock_token.client_id = "test-client"
@@ -231,3 +233,10 @@ class TestApiRateLimitIntegration:
                 asyncio.get_event_loop().run_until_complete(require_token(creds, storage))
             assert exc_info.value.status_code == 429
             assert exc_info.value.headers["Retry-After"] == "30"
+            # #367 — RateLimitedRequests emitted twice: aggregate + drill-down.
+            calls = [(c.args, c.kwargs) for c in mock_emit.call_args_list]
+            assert (("RateLimitedRequests",), {}) in calls
+            assert (
+                ("RateLimitedRequests",),
+                {"endpoint": "/api", "reason": "rate_limit"},
+            ) in calls

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -190,6 +190,35 @@ class TestPing:
         names_emitted = [call.args[0] for call in mock_emit.call_args_list]
         assert "TokenValidationFailures" in names_emitted
 
+    async def test_rate_limit_emits_rate_limited_requests_metric(self, server_env):
+        """#367 — the admin Dashboard reads the RateLimitedRequests metric to
+        surface 429 pressure; the MCP auth path must actually emit it on
+        RateLimitExceeded."""
+        from unittest.mock import AsyncMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.rate_limiter import RateLimitExceeded
+        from hive.server import ping
+
+        _, _, jwt = server_env
+        ctx = MagicMock()
+        ctx.request_context.meta = {"Authorization": f"Bearer {jwt}"}
+        mock_emit = AsyncMock()
+        with (
+            patch("hive.server.emit_metric", mock_emit),
+            patch("hive.server.check_rate_limit", side_effect=RateLimitExceeded(retry_after=42)),
+            pytest.raises(ToolError, match="Rate limit exceeded"),
+        ):
+            await ping(ctx=ctx)
+        calls = [(c.args, c.kwargs) for c in mock_emit.call_args_list]
+        # Aggregate emit + drill-down with endpoint/reason dimensions.
+        assert (("RateLimitedRequests",), {}) in calls
+        assert (
+            ("RateLimitedRequests",),
+            {"endpoint": "mcp", "reason": "rate_limit"},
+        ) in calls
+
 
 # ---------------------------------------------------------------------------
 # remember

--- a/ui/src/components/Dashboard.jsx
+++ b/ui/src/components/Dashboard.jsx
@@ -493,6 +493,13 @@ export default function Dashboard() {
           name: "CSP Violations",
           value: (metrics.metrics?.csp_violations?.values ?? []).reduce((s, v) => s + v, 0),
         },
+        {
+          name: "Rate Limited Requests",
+          value: (metrics.metrics?.rate_limited_requests?.values ?? []).reduce(
+            (s, v) => s + v,
+            0,
+          ),
+        },
       ]
     : [];
 

--- a/ui/src/components/Dashboard.test.jsx
+++ b/ui/src/components/Dashboard.test.jsx
@@ -55,6 +55,7 @@ const METRICS = {
     tokens_issued: { timestamps: ["2026-04-01T12:00:00Z"], values: [7] },
     token_failures: { timestamps: ["2026-04-01T12:00:00Z"], values: [2] },
     csp_violations: { timestamps: ["2026-04-01T12:00:00Z"], values: [17] },
+    rate_limited_requests: { timestamps: ["2026-04-01T12:00:00Z"], values: [23] },
   },
 };
 
@@ -300,6 +301,28 @@ describe("Dashboard", () => {
   it("renders CSP violations stat card from metric data", async () => {
     await act(async () => render(<Dashboard />));
     await waitFor(() => expect(screen.getByText("CSP Violations")).toBeTruthy());
+  });
+
+  it("renders Rate Limited Requests stat card (#367)", async () => {
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("Rate Limited Requests")).toBeTruthy());
+    // Aggregate value = sum of metric series; mock returns a single [23].
+    expect(screen.getByText("23")).toBeTruthy();
+  });
+
+  it("Rate Limited Requests defaults to 0 when metric series missing", async () => {
+    api.getMetrics.mockResolvedValueOnce({
+      period: "24h",
+      environment: "test",
+      metrics: {}, // no rate_limited_requests key at all
+    });
+    await act(async () => render(<Dashboard />));
+    await waitFor(() => expect(screen.getByText("Rate Limited Requests")).toBeTruthy());
+    // Fallback (… .values ?? []).reduce(sum, 0) → 0 when the series is absent.
+    // The StatCard renders two divs; label's parent is the card, whose
+    // textContent concatenates value + label.
+    const cardLabel = screen.getByText("Rate Limited Requests");
+    expect(cardLabel.parentElement.textContent).toBe("0Rate Limited Requests");
   });
 
   it("renders cost note", async () => {


### PR DESCRIPTION
Closes #367

## Summary

Admin Dashboard had no signal for rate-limit / quota 429 events. When a free-tier client burns through its RPM/RPD cap — or a user hits the memory quota — the 429 went out silently and admins had no way to see it short of grepping CloudWatch Logs Insights.

Emit a new `RateLimitedRequests` CloudWatch EMF metric **twice** per event (matching the `CSPViolations` pattern from #488):

- **Aggregate** (Environment only) — fetched by the admin metrics endpoint for the Dashboard count.
- **Drill-down** (`endpoint` + `reason`) — available via CloudWatch directly for ad-hoc querying.

Three emit sites cover the paths the issue called out plus one adjacent:

| Location | Endpoint dim | Reason dim |
| --- | --- | --- |
| `src/hive/server.py` (MCP tools) | `mcp` | `rate_limit` |
| `src/hive/api/_auth.py` (mgmt API auth) | `/api` | `rate_limit` |
| `src/hive/api/memories.py` (quota) | `/api/memories` | `quota` |

Admin metrics endpoint adds a `rate_limited_requests` query alongside `csp_violations`; Dashboard Security section gets a new `Rate Limited Requests` StatCard.

## Skipped for this PR

The per-user **Top-N table** the issue sketched as a suggestion. CloudWatch `GetMetricData` needs `client_ids` known upfront, so Top-N is a separate design (probably Logs Insights against the drill-down dimension). The acceptance criteria don't require it.

## Test plan

- [x] Unit: POST `/api/memories` 429 emits `RateLimitedRequests` twice (aggregate + drill-down kwargs).
- [x] Unit: MCP rate-limit path emits the same.
- [x] Unit: management-API `require_token` 429 path asserts the emit (tightened a previously-silenced mock).
- [x] Unit: `/api/admin/metrics` response includes `rate_limited_requests`.
- [x] Frontend: Dashboard card renders with data, falls back to 0 when series missing.
- [x] `uv run inv pre-push` green locally (620 frontend + all backend tests passing).
- [ ] Post-deploy: verify the metric starts appearing on the dev Dashboard the next time a client trips a rate limit (or force one via a seeded low-RPM client).