### PR TITLE
feat: Stats tab scaffolding + /api/account/stats endpoint

### DIFF
--- a/docs-site/public/openapi.json
+++ b/docs-site/public/openapi.json
@@ -804,6 +804,56 @@
         ]
       }
     },
+    "/api/account/stats": {
+      "get": {
+        "description": "Return eight pre-aggregated graph datasets for the authenticated user (activity heatmap, top-recalled memories, tag distribution, memory growth, quota, freshness, client contribution, tag co-occurrence). Results are cached server-side for 60s per (user, window) pair.",
+        "operationId": "get_account_stats_api_account_stats_get",
+        "parameters": [
+          {
+            "description": "Time window for date-scoped series: 30 | 90 | 365 (days).",
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "default": "90",
+              "description": "Time window for date-scoped series: 30 | 90 | 365 (days).",
+              "pattern": "^(30|90|365)$",
+              "title": "Window",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Account Stats Api Account Stats Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "description": "Invalid window"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Personal usage analytics",
+        "tags": [
+          "account"
+        ]
+      }
+    },
     "/api/activity": {
       "get": {
         "description": "Return recent activity events (memory creates, updates, deletes, client registrations, etc.) for the configured number of days.",

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Iterator
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -224,7 +224,9 @@ async def export_account(
 # ---------------------------------------------------------------------------
 
 
-def _compute_account_stats(user_id: str, window_days: int, storage: HiveStorage) -> dict[str, Any]:
+def _compute_account_stats(
+    user_id: str, window_days: int, storage: HiveStorage, is_admin: bool = False
+) -> dict[str, Any]:
     """Walk storage once and assemble the eight aggregate series.
 
     Each series is small ( ≤ number of memories or ≤ window_days entries ),
@@ -233,12 +235,26 @@ def _compute_account_stats(user_id: str, window_days: int, storage: HiveStorage)
     """
     memories = list(storage.iter_all_memories(owner_user_id=user_id))
     clients, _ = storage.list_clients(owner_user_id=user_id, limit=EXPORT_CLIENTS_LIMIT)
-    client_ids = {c.client_id for c in clients}
 
-    today = date.today()
+    # Activity events can be logged under a variety of actor ids depending
+    # on the code path: management-API memory CRUD writes ``client_id =
+    # claims['sub']`` (the user id), MCP tool calls write the OAuth client
+    # id, and memories may retain an ``owner_client_id`` for a client that
+    # has since been deleted. Broaden the actor set so none of these fall
+    # silently off the heatmap / contribution charts.
+    activity_actor_ids: set[str] = {c.client_id for c in clients}
+    activity_actor_ids.add(user_id)
+    for m in memories:
+        if m.owner_client_id:
+            activity_actor_ids.add(m.owner_client_id)
+
+    # Anchor the window in UTC — the rest of the module uses UTC for day
+    # math, and `date.today()` in local time can shift the heatmap /
+    # days_since_* buckets by one day around midnight.
+    today = datetime.now(timezone.utc).date()
     window_dates = [(today - timedelta(days=i)).isoformat() for i in range(window_days)]
     events = storage.get_events_for_dates(window_dates, limit=_STATS_EVENT_LIMIT)
-    own_events = [e for e in events if e.client_id in client_ids]
+    own_events = [e for e in events if e.client_id in activity_actor_ids]
 
     # activity_heatmap — one row per date in the window, count of own events.
     per_date: dict[str, int] = {}
@@ -286,7 +302,9 @@ def _compute_account_stats(user_id: str, window_days: int, storage: HiveStorage)
             idx += 1
         memory_growth.append({"date": day.isoformat(), "cumulative": cumulative})
 
-    is_exempt = user_id in _exempt_users()
+    # Admins and explicitly-exempted users both get an unbounded limit —
+    # matches the exemption logic in /api/stats (#535 follow-up).
+    is_exempt = is_admin or user_id in _exempt_users()
     quota = {
         "memory_count": len(memories),
         "memory_limit": None if is_exempt else get_memory_limit(),
@@ -368,13 +386,18 @@ async def get_account_stats(
     ] = "90",
 ) -> dict[str, Any]:
     user_id: str = claims["sub"]
+    is_admin = claims.get("role") == "admin"
     window_days = int(window)
 
     cache_key = f"{user_id}:{window_days}"
     cached = _STATS_CACHE.get(cache_key)
-    if cached and time.time() - cached[0] < _STATS_CACHE_TTL:
-        return cached[1]
+    if cached is not None:
+        if time.time() - cached[0] < _STATS_CACHE_TTL:
+            return cached[1]
+        # Drop the expired entry so the cache doesn't grow unbounded as
+        # new (user, window) keys are seen over the Lambda's lifetime.
+        _STATS_CACHE.pop(cache_key, None)
 
-    data = _compute_account_stats(user_id, window_days, storage)
+    data = _compute_account_stats(user_id, window_days, storage, is_admin=is_admin)
     _STATS_CACHE[cache_key] = (time.time(), data)
     return data

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -243,9 +243,11 @@ def _compute_account_stats(user_id: str, window_days: int, storage: HiveStorage)
     # activity_heatmap — one row per date in the window, count of own events.
     per_date: dict[str, int] = {}
     for e in own_events:
-        d = e.timestamp.date().isoformat()
-        per_date[d] = per_date.get(d, 0) + 1
-    activity_heatmap = [{"date": d, "count": per_date.get(d, 0)} for d in window_dates]
+        iso_day = e.timestamp.date().isoformat()
+        per_date[iso_day] = per_date.get(iso_day, 0) + 1
+    activity_heatmap = [
+        {"date": iso_day, "count": per_date.get(iso_day, 0)} for iso_day in window_dates
+    ]
 
     # top_recalled — N most-hit memories by recall_count.
     top_recalled = [
@@ -261,11 +263,10 @@ def _compute_account_stats(user_id: str, window_days: int, storage: HiveStorage)
     for m in memories:
         for t in m.tags:
             tag_counts[t] = tag_counts.get(t, 0) + 1
-    tag_distribution = sorted(
-        ({"tag": t, "count": c} for t, c in tag_counts.items()),
-        key=lambda x: x["count"],
-        reverse=True,
-    )
+    tag_distribution: list[dict[str, Any]] = [
+        {"tag": t, "count": c}
+        for t, c in sorted(tag_counts.items(), key=lambda kv: kv[1], reverse=True)
+    ]
 
     # memory_growth — cumulative count at end of each day in the window.
     # Baseline = memories created before the window start; then advance one
@@ -277,13 +278,13 @@ def _compute_account_stats(user_id: str, window_days: int, storage: HiveStorage)
     while idx < len(sorted_mems) and sorted_mems[idx].created_at.date() < window_start:
         cumulative += 1
         idx += 1
-    memory_growth = []
+    memory_growth: list[dict[str, Any]] = []
     for i in range(window_days):
-        d = window_start + timedelta(days=i)
-        while idx < len(sorted_mems) and sorted_mems[idx].created_at.date() <= d:
+        day = window_start + timedelta(days=i)
+        while idx < len(sorted_mems) and sorted_mems[idx].created_at.date() <= day:
             cumulative += 1
             idx += 1
-        memory_growth.append({"date": d.isoformat(), "cumulative": cumulative})
+        memory_growth.append({"date": day.isoformat(), "cumulative": cumulative})
 
     is_exempt = user_id in _exempt_users()
     quota = {
@@ -326,11 +327,10 @@ def _compute_account_stats(user_id: str, window_days: int, storage: HiveStorage)
         for i, src in enumerate(tags):
             for tgt in tags[i + 1 :]:
                 cooccur[(src, tgt)] = cooccur.get((src, tgt), 0) + 1
-    tag_cooccurrence = sorted(
-        ({"source": s, "target": t, "weight": w} for (s, t), w in cooccur.items()),
-        key=lambda x: x["weight"],
-        reverse=True,
-    )
+    tag_cooccurrence: list[dict[str, Any]] = [
+        {"source": s, "target": t, "weight": w}
+        for (s, t), w in sorted(cooccur.items(), key=lambda kv: kv[1], reverse=True)
+    ]
 
     return {
         "window_days": window_days,

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -4,21 +4,24 @@ Account self-service endpoints.
 
 - DELETE /api/account        — GDPR Article 17 right-to-erasure
 - GET    /api/account/export — GDPR Article 20 right-to-portability / CCPA §1798.100
+- GET    /api/account/stats  — Personal usage analytics (#535)
 """
 
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Iterator
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from hive.api._auth import require_mgmt_user
 from hive.models import ActivityEvent, EventType
+from hive.quota import _exempt_users, get_memory_limit
 from hive.storage import HiveStorage
 
 router = APIRouter(tags=["account"])
@@ -27,9 +30,21 @@ EXPORT_RATE_LIMIT_SECONDS = 300  # one export per 5 minutes per user
 EXPORT_ACTIVITY_LOOKBACK_DAYS = 90  # activity-log retention per Privacy Policy §9
 EXPORT_CLIENTS_LIMIT = 1000  # safety cap; quota is much lower in practice
 
+# #535 — stats endpoint config
+_STATS_CACHE_TTL = 60.0  # seconds; per-user, per-window
+_STATS_EVENT_LIMIT = 100_000  # upper bound when pulling events for aggregation
+_STATS_TOP_RECALLED_N = 10
+
 
 def _storage() -> HiveStorage:
     return HiveStorage()
+
+
+# Module-level cache keyed by ``f"{user_id}:{window_days}"``; stores
+# (timestamp, data) tuples. ``_STATS_CACHE_TTL`` is honoured on read.
+# Separate from ``_auth``-flow caches so a delete_account can wipe all
+# entries for a user in a single loop.
+_STATS_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 
 
 class AccountDeleteRequest(BaseModel):
@@ -195,3 +210,171 @@ async def export_account(
         media_type="application/json",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+# ---------------------------------------------------------------------------
+# #535 — /account/stats
+#
+# Personal usage analytics for the Stats tab. Returns eight pre-aggregated
+# graph datasets in a single response so the UI renders without chained
+# round-trips. Results are cached for ``_STATS_CACHE_TTL`` seconds per
+# ``(user_id, window_days)`` key — the aggregation walks every memory and
+# a windowed slice of the activity log, so the cache shields the table
+# from repeated panel refreshes.
+# ---------------------------------------------------------------------------
+
+
+def _compute_account_stats(user_id: str, window_days: int, storage: HiveStorage) -> dict[str, Any]:
+    """Walk storage once and assemble the eight aggregate series.
+
+    Each series is small ( ≤ number of memories or ≤ window_days entries ),
+    so the full response stays well under a reasonable Lambda response size.
+    Individual graph widgets slice further on the client as they render.
+    """
+    memories = list(storage.iter_all_memories(owner_user_id=user_id))
+    clients, _ = storage.list_clients(owner_user_id=user_id, limit=EXPORT_CLIENTS_LIMIT)
+    client_ids = {c.client_id for c in clients}
+
+    today = date.today()
+    window_dates = [(today - timedelta(days=i)).isoformat() for i in range(window_days)]
+    events = storage.get_events_for_dates(window_dates, limit=_STATS_EVENT_LIMIT)
+    own_events = [e for e in events if e.client_id in client_ids]
+
+    # activity_heatmap — one row per date in the window, count of own events.
+    per_date: dict[str, int] = {}
+    for e in own_events:
+        d = e.timestamp.date().isoformat()
+        per_date[d] = per_date.get(d, 0) + 1
+    activity_heatmap = [{"date": d, "count": per_date.get(d, 0)} for d in window_dates]
+
+    # top_recalled — N most-hit memories by recall_count.
+    top_recalled = [
+        {"memory_id": m.memory_id, "key": m.key, "recall_count": m.recall_count}
+        for m in sorted(memories, key=lambda m: m.recall_count, reverse=True)[
+            :_STATS_TOP_RECALLED_N
+        ]
+        if m.recall_count > 0
+    ]
+
+    # tag_distribution — count of memories per tag, descending.
+    tag_counts: dict[str, int] = {}
+    for m in memories:
+        for t in m.tags:
+            tag_counts[t] = tag_counts.get(t, 0) + 1
+    tag_distribution = sorted(
+        ({"tag": t, "count": c} for t, c in tag_counts.items()),
+        key=lambda x: x["count"],
+        reverse=True,
+    )
+
+    # memory_growth — cumulative count at end of each day in the window.
+    # Baseline = memories created before the window start; then advance one
+    # day at a time adding anything whose created_at falls on-or-before it.
+    sorted_mems = sorted(memories, key=lambda m: m.created_at)
+    window_start = today - timedelta(days=window_days - 1)
+    idx = 0
+    cumulative = 0
+    while idx < len(sorted_mems) and sorted_mems[idx].created_at.date() < window_start:
+        cumulative += 1
+        idx += 1
+    memory_growth = []
+    for i in range(window_days):
+        d = window_start + timedelta(days=i)
+        while idx < len(sorted_mems) and sorted_mems[idx].created_at.date() <= d:
+            cumulative += 1
+            idx += 1
+        memory_growth.append({"date": d.isoformat(), "cumulative": cumulative})
+
+    is_exempt = user_id in _exempt_users()
+    quota = {
+        "memory_count": len(memories),
+        "memory_limit": None if is_exempt else get_memory_limit(),
+    }
+
+    # freshness — days since creation + days since last access per memory.
+    # Falls back to days_since_created when the memory has never been
+    # recalled (last_accessed_at is None).
+    freshness = []
+    for m in memories:
+        age = (today - m.created_at.date()).days
+        accessed_age = (
+            (today - m.last_accessed_at.date()).days if m.last_accessed_at is not None else age
+        )
+        freshness.append(
+            {
+                "memory_id": m.memory_id,
+                "days_since_created": age,
+                "days_since_accessed": accessed_age,
+            }
+        )
+
+    # client_contribution — events-per-day-per-client-id for stacked chart.
+    contrib: dict[tuple[str, str], int] = {}
+    for e in own_events:
+        key = (e.timestamp.date().isoformat(), e.client_id)
+        contrib[key] = contrib.get(key, 0) + 1
+    client_contribution = [
+        {"date": d, "client_id": cid, "count": n} for (d, cid), n in sorted(contrib.items())
+    ]
+
+    # tag_cooccurrence — undirected edges between tags that share a memory,
+    # weighted by how many memories they co-appear in. Sorted by weight
+    # descending so the UI can pick a sensible top-K for a force-graph.
+    cooccur: dict[tuple[str, str], int] = {}
+    for m in memories:
+        tags = sorted(set(m.tags))
+        for i, src in enumerate(tags):
+            for tgt in tags[i + 1 :]:
+                cooccur[(src, tgt)] = cooccur.get((src, tgt), 0) + 1
+    tag_cooccurrence = sorted(
+        ({"source": s, "target": t, "weight": w} for (s, t), w in cooccur.items()),
+        key=lambda x: x["weight"],
+        reverse=True,
+    )
+
+    return {
+        "window_days": window_days,
+        "activity_heatmap": activity_heatmap,
+        "top_recalled": top_recalled,
+        "tag_distribution": tag_distribution,
+        "memory_growth": memory_growth,
+        "quota": quota,
+        "freshness": freshness,
+        "client_contribution": client_contribution,
+        "tag_cooccurrence": tag_cooccurrence,
+    }
+
+
+@router.get(
+    "/account/stats",
+    summary="Personal usage analytics",
+    description=(
+        "Return eight pre-aggregated graph datasets for the authenticated user "
+        "(activity heatmap, top-recalled memories, tag distribution, memory "
+        "growth, quota, freshness, client contribution, tag co-occurrence). "
+        "Results are cached server-side for 60s per (user, window) pair."
+    ),
+    responses={401: {"description": "Unauthorized"}, 422: {"description": "Invalid window"}},
+)
+async def get_account_stats(
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+    window: Annotated[
+        str,
+        Query(
+            pattern="^(30|90|365)$",
+            description="Time window for date-scoped series: 30 | 90 | 365 (days).",
+        ),
+    ] = "90",
+) -> dict[str, Any]:
+    user_id: str = claims["sub"]
+    window_days = int(window)
+
+    cache_key = f"{user_id}:{window_days}"
+    cached = _STATS_CACHE.get(cache_key)
+    if cached and time.time() - cached[0] < _STATS_CACHE_TTL:
+        return cached[1]
+
+    data = _compute_account_stats(user_id, window_days, storage)
+    _STATS_CACHE[cache_key] = (time.time(), data)
+    return data

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -344,3 +344,178 @@ class TestExportAccount:
         assert {c1.client_id, c2.client_id}.issubset(ids)
         event_client_ids = [e["client_id"] for e in body["activity_log"]]
         assert len(event_client_ids) >= 2
+
+
+# ---------------------------------------------------------------------------
+# GET /api/account/stats  (#535)
+# ---------------------------------------------------------------------------
+
+
+class TestAccountStats:
+    def setup_method(self):
+        # The endpoint caches results in a module-level dict keyed by
+        # (user_id, window). Wipe it between tests so cache-hit/miss
+        # assertions stay deterministic.
+        from hive.api.account import _STATS_CACHE
+
+        _STATS_CACHE.clear()
+
+    def test_unauthed_returns_401(self, unauthed_client):
+        resp = unauthed_client.get("/api/account/stats")
+        assert resp.status_code in (401, 403)
+
+    def test_returns_all_eight_series(self, client):
+        tc, _ = client
+        resp = tc.get("/api/account/stats")
+        assert resp.status_code == 200
+        body = resp.json()
+        for key in (
+            "activity_heatmap",
+            "top_recalled",
+            "tag_distribution",
+            "memory_growth",
+            "quota",
+            "freshness",
+            "client_contribution",
+            "tag_cooccurrence",
+        ):
+            assert key in body, f"missing series: {key}"
+        assert body["window_days"] == 90  # default
+
+    def test_default_window_is_90_days(self, client):
+        tc, _ = client
+        resp = tc.get("/api/account/stats")
+        assert len(resp.json()["activity_heatmap"]) == 90
+
+    def test_window_30(self, client):
+        tc, _ = client
+        resp = tc.get("/api/account/stats?window=30")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["window_days"] == 30
+        assert len(body["activity_heatmap"]) == 30
+        assert len(body["memory_growth"]) == 30
+
+    def test_window_365(self, client):
+        tc, _ = client
+        resp = tc.get("/api/account/stats?window=365")
+        assert resp.status_code == 200
+        assert resp.json()["window_days"] == 365
+
+    def test_invalid_window_returns_422(self, client):
+        tc, _ = client
+        resp = tc.get("/api/account/stats?window=7")
+        assert resp.status_code == 422
+
+    def test_quota_reports_memory_count_and_limit(self, client):
+        tc, _ = client
+        resp = tc.get("/api/account/stats")
+        quota = resp.json()["quota"]
+        assert quota["memory_count"] >= 1  # pre-seeded by the fixture
+        # Default memory_limit is set via get_memory_limit() — a positive int
+        # for a non-exempt, non-admin user.
+        assert isinstance(quota["memory_limit"], int)
+        assert quota["memory_limit"] > 0
+
+    def test_tag_distribution_counts_seeded_tag(self, client):
+        tc, _ = client
+        resp = tc.get("/api/account/stats")
+        tags = {t["tag"]: t["count"] for t in resp.json()["tag_distribution"]}
+        assert tags.get("t1") == 1  # from the fixture's pre-seeded memory
+
+    def test_freshness_has_entry_per_memory(self, client):
+        tc, storage = client
+        resp = tc.get("/api/account/stats")
+        body = resp.json()
+        assert len(body["freshness"]) == body["quota"]["memory_count"]
+        entry = body["freshness"][0]
+        assert entry["days_since_created"] >= 0
+        assert entry["days_since_accessed"] >= 0
+
+    def test_top_recalled_only_includes_recalled_memories(self, client):
+        from hive.models import Memory
+
+        tc, storage = client
+        # Add a second memory with recall_count > 0.
+        hot = Memory(
+            key="hot-key",
+            value="hot",
+            tags=["hot"],
+            owner_client_id=_USER_ID,
+            owner_user_id=_USER_ID,
+            recall_count=5,
+        )
+        storage.put_memory(hot)
+
+        resp = tc.get("/api/account/stats")
+        keys = [m["key"] for m in resp.json()["top_recalled"]]
+        # The pre-seeded "test-key" has recall_count=0 and must be filtered
+        # out; only the hot memory should surface.
+        assert keys == ["hot-key"]
+
+    def test_tag_cooccurrence_edges(self, client):
+        from hive.models import Memory
+
+        tc, storage = client
+        # A memory carrying two tags should produce one (a, b) edge.
+        storage.put_memory(
+            Memory(
+                key="pair",
+                value="v",
+                tags=["alpha", "beta"],
+                owner_client_id=_USER_ID,
+                owner_user_id=_USER_ID,
+            )
+        )
+
+        resp = tc.get("/api/account/stats")
+        edges = [(e["source"], e["target"], e["weight"]) for e in resp.json()["tag_cooccurrence"]]
+        assert ("alpha", "beta", 1) in edges
+
+    def test_cache_hit_returns_same_object(self, client):
+        # Two back-to-back calls with the same window must share the cache —
+        # we verify by mutating the response dict in-place after the first
+        # call and asserting the mutation survives into the second call.
+        tc, _ = client
+
+        first = tc.get("/api/account/stats").json()
+        second = tc.get("/api/account/stats").json()
+        # The same dict is served from the in-memory cache, so the two
+        # responses should be structurally identical.
+        assert first == second
+
+    def test_cache_miss_after_ttl_elapses(self, client, monkeypatch):
+        # Freeze `time.time()` so the cache ages past its TTL on the second
+        # call without actually sleeping.
+        from hive.api import account as account_mod
+
+        tc, _ = client
+
+        fake_time = [1_000_000.0]
+
+        def fake_now():
+            return fake_time[0]
+
+        monkeypatch.setattr(account_mod.time, "time", fake_now)
+
+        tc.get("/api/account/stats")
+        # Count cached entries.
+        assert len(account_mod._STATS_CACHE) == 1
+
+        # Jump past TTL; the next call should recompute (same payload, but
+        # the cache entry timestamp must advance).
+        prev_ts = next(iter(account_mod._STATS_CACHE.values()))[0]
+        fake_time[0] += account_mod._STATS_CACHE_TTL + 1
+
+        tc.get("/api/account/stats")
+        new_ts = next(iter(account_mod._STATS_CACHE.values()))[0]
+        assert new_ts > prev_ts
+
+    def test_different_windows_cached_independently(self, client):
+        from hive.api import account as account_mod
+
+        tc, _ = client
+        tc.get("/api/account/stats?window=30")
+        tc.get("/api/account/stats?window=90")
+        # One entry per (user, window).
+        assert len(account_mod._STATS_CACHE) == 2

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -519,3 +519,62 @@ class TestAccountStats:
         tc.get("/api/account/stats?window=90")
         # One entry per (user, window).
         assert len(account_mod._STATS_CACHE) == 2
+
+    def test_own_events_populate_heatmap_and_client_contribution(self, client):
+        """Exercises the `for e in own_events` loop bodies — needs both a
+        client owned by the user AND an activity event whose client_id
+        matches. Covers the activity_heatmap and client_contribution
+        aggregation paths."""
+        from hive.models import ActivityEvent, EventType, OAuthClient
+
+        tc, storage = client
+
+        owned_client = OAuthClient(client_name="my-agent", owner_user_id=_USER_ID)
+        storage.put_client(owned_client)
+        storage.log_event(
+            ActivityEvent(
+                event_type=EventType.memory_recalled,
+                client_id=owned_client.client_id,
+                metadata={"key": "test-key"},
+            )
+        )
+
+        resp = tc.get("/api/account/stats")
+        body = resp.json()
+
+        # activity_heatmap should carry a non-zero bucket for today.
+        today_bucket = next(
+            (b for b in body["activity_heatmap"] if b["count"] > 0), None
+        )
+        assert today_bucket is not None
+
+        # client_contribution should surface the owned client's event.
+        contrib_clients = {c["client_id"] for c in body["client_contribution"]}
+        assert owned_client.client_id in contrib_clients
+
+    def test_memory_predating_window_counts_as_baseline(self, client):
+        """Exercises the pre-window baseline bump in memory_growth — needs
+        a memory whose created_at is before the window start."""
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import Memory
+
+        tc, storage = client
+
+        old = Memory(
+            key="ancient",
+            value="v",
+            tags=[],
+            owner_client_id=_USER_ID,
+            owner_user_id=_USER_ID,
+        )
+        # Force created_at well before the default 90-day window.
+        old.created_at = datetime.now(timezone.utc) - timedelta(days=365)
+        storage.put_memory(old)
+
+        resp = tc.get("/api/account/stats?window=30")
+        growth = resp.json()["memory_growth"]
+        # The ancient memory is counted as baseline, so every point in the
+        # 30-day window must already be at least 1 (plus the fixture's
+        # pre-seeded memory).
+        assert growth[0]["cumulative"] >= 1

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -472,17 +472,32 @@ class TestAccountStats:
         edges = [(e["source"], e["target"], e["weight"]) for e in resp.json()["tag_cooccurrence"]]
         assert ("alpha", "beta", 1) in edges
 
-    def test_cache_hit_returns_same_object(self, client):
-        # Two back-to-back calls with the same window must share the cache —
-        # we verify by mutating the response dict in-place after the first
-        # call and asserting the mutation survives into the second call.
+    def test_cache_hit_returns_same_object(self, client, monkeypatch):
+        # Two back-to-back calls with the same window must share the cache.
+        # `assert first == second` alone isn't enough — deterministic input
+        # produces identical output with or without caching. Spy on
+        # `_compute_account_stats` and assert it runs exactly once across
+        # both requests.
+        from hive.api import account as account_mod
+
         tc, _ = client
 
-        first = tc.get("/api/account/stats").json()
-        second = tc.get("/api/account/stats").json()
-        # The same dict is served from the in-memory cache, so the two
-        # responses should be structurally identical.
-        assert first == second
+        calls = 0
+        original = account_mod._compute_account_stats
+
+        def counting_compute(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(account_mod, "_compute_account_stats", counting_compute)
+
+        first = tc.get("/api/account/stats")
+        second = tc.get("/api/account/stats")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert calls == 1
 
     def test_cache_miss_after_ttl_elapses(self, client, monkeypatch):
         # Freeze `time.time()` so the cache ages past its TTL on the second

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -558,9 +558,7 @@ class TestAccountStats:
         body = resp.json()
 
         # activity_heatmap should carry a non-zero bucket for today.
-        today_bucket = next(
-            (b for b in body["activity_heatmap"] if b["count"] > 0), None
-        )
+        today_bucket = next((b for b in body["activity_heatmap"] if b["count"] > 0), None)
         assert today_bucket is not None
 
         # client_contribution should surface the owned client's event.

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -23,6 +23,7 @@ import UseCasesPage from "./components/UseCasesPage.jsx";
 import ApiKeysPanel from "./components/ApiKeysPanel.jsx";
 import MemoryBrowser from "./components/MemoryBrowser.jsx";
 import SetupPanel from "./components/SetupPanel.jsx";
+import Stats from "./components/Stats.jsx";
 import UsersPanel from "./components/UsersPanel.jsx";
 import { Button } from "./components/ui/button.jsx";
 import { Toaster } from "./components/ui/sonner.jsx";
@@ -30,6 +31,7 @@ import { useTheme } from "./hooks/useTheme.js";
 
 const BASE_TABS = [
   { id: "memories", label: "Memories" },
+  { id: "stats", label: "Stats" },
   { id: "clients", label: "OAuth Clients" },
   { id: "api-keys", label: "API Keys" },
   { id: "activity", label: "Activity Log" },
@@ -200,6 +202,7 @@ function AppShell() {
 
       <main className="flex-1 p-4 md:p-6 max-w-[1100px] mx-auto w-full">
         {tab === "memories" && <MemoryBrowser />}
+        {tab === "stats" && <Stats />}
         {tab === "clients" && <ClientManager />}
         {tab === "api-keys" && <ApiKeysPanel />}
         {tab === "activity" && <ActivityLog />}

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -24,6 +24,9 @@ vi.mock("./components/UsersPanel.jsx", () => ({
 vi.mock("./components/SetupPanel.jsx", () => ({
   default: () => <div data-testid="setup-panel" />,
 }));
+vi.mock("./components/Stats.jsx", () => ({
+  default: () => <div data-testid="stats-panel" />,
+}));
 vi.mock("./components/HomePage.jsx", () => ({
   default: () => <div data-testid="home-page" />,
 }));
@@ -211,6 +214,13 @@ describe("AppShell", () => {
     await act(async () => render(<App />));
     fireEvent.click(screen.getByText("OAuth Clients"));
     expect(screen.getByTestId("client-manager")).toBeTruthy();
+    expect(screen.queryByTestId("memory-browser")).toBeNull();
+  });
+
+  it("switches to Stats when the Stats tab is clicked (#535)", async () => {
+    await act(async () => render(<App />));
+    fireEvent.click(screen.getByText("Stats"));
+    expect(screen.getByTestId("stats-panel")).toBeTruthy();
     expect(screen.queryByTestId("memory-browser")).toBeNull();
   });
 
@@ -418,9 +428,9 @@ describe("AppShell", () => {
     await waitFor(() => expect(screen.getByTestId("memory-browser")).toBeTruthy());
     fireEvent.click(screen.getByRole("button", { name: /toggle navigation/i }));
     const mobileNav = screen.getByTestId("mobile-nav");
-    // Click "OAuth Clients" (second tab button in mobile nav)
+    // Click "OAuth Clients" — third tab now that Stats sits at index 1 (#535).
     const mobileButtons = mobileNav.querySelectorAll("button[type='button']");
-    fireEvent.click(mobileButtons[1]);
+    fireEvent.click(mobileButtons[2]);
     expect(screen.queryByTestId("mobile-nav")).toBeNull();
     expect(screen.getByTestId("client-manager")).toBeTruthy();
   });

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -71,6 +71,8 @@ export const api = {
   getStats: () => request("GET", "/api/stats"),
   getActivity: (days = 7, { limit = 100 } = {}) =>
     request("GET", `/api/activity?days=${days}&limit=${limit}`),
+  getAccountStats: (windowDays = 90) =>
+    request("GET", `/api/account/stats?window=${windowDays}`),
 
   // Admin
   getMetrics: (period = "24h") => request("GET", `/api/admin/metrics?period=${period}`),

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -217,6 +217,18 @@ describe("api", () => {
     expect(fetchMock.mock.calls[0][0]).toContain("/api/stats");
   });
 
+  it("getAccountStats passes window through", async () => {
+    mockOk({ window_days: 30 });
+    await api.getAccountStats(30);
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/account/stats?window=30");
+  });
+
+  it("getAccountStats defaults to 90-day window", async () => {
+    mockOk({ window_days: 90 });
+    await api.getAccountStats();
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/account/stats?window=90");
+  });
+
   it("getActivity with default params", async () => {
     mockOk({ items: [] });
     await api.getActivity();

--- a/ui/src/components/Stats.jsx
+++ b/ui/src/components/Stats.jsx
@@ -22,7 +22,7 @@ const WINDOWS = [
 function hasData(value) {
   if (Array.isArray(value)) return value.length > 0;
   if (value && typeof value === "object") return Object.keys(value).length > 0;
-  return Boolean(value);
+  return false;
 }
 
 export function GraphCard({ title, description, data, empty, children }) {
@@ -55,17 +55,20 @@ GraphCard.propTypes = {
 // Shows a compact JSON preview so we can eyeball the aggregate shape on
 // the deployed page without waiting for all the chart work.
 function RawPreview({ value, take = 5 }) {
-  const sample = Array.isArray(value) ? value.slice(0, take) : value;
+  // Called with arrays only — the <GraphCard> parent suppresses us when
+  // its `data` prop is empty/missing, so non-array cases can't reach
+  // here.
+  const overflow = value.length > take ? `\n…(+${value.length - take} more)` : "";
   return (
     <pre className="text-[11px] leading-snug text-[var(--text-muted)] overflow-x-auto m-0">
-      {JSON.stringify(sample, null, 2)}
-      {Array.isArray(value) && value.length > take ? `\n…(+${value.length - take} more)` : ""}
+      {JSON.stringify(value.slice(0, take), null, 2)}
+      {overflow}
     </pre>
   );
 }
 
 RawPreview.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  value: PropTypes.array,
   take: PropTypes.number,
 };
 

--- a/ui/src/components/Stats.jsx
+++ b/ui/src/components/Stats.jsx
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useCallback, useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { api } from "../api.js";
+import EmptyState from "./EmptyState.jsx";
+import { Card } from "./ui/card.jsx";
+
+// #535 — Stats tab scaffolding.
+//
+// This component renders eight placeholder graph cards backed by the
+// /api/account/stats response. The placeholder bodies deliberately dump
+// a small JSON preview so it's obvious each signal is reaching the UI —
+// follow-up sub-issues replace each `<GraphCard>` body with a proper
+// chart implementation (heatmap, bar, stacked area, force graph, …).
+
+const WINDOWS = [
+  { value: "30", label: "Last 30 days" },
+  { value: "90", label: "Last 90 days" },
+  { value: "365", label: "Last year" },
+];
+
+function hasData(value) {
+  if (Array.isArray(value)) return value.length > 0;
+  if (value && typeof value === "object") return Object.keys(value).length > 0;
+  return Boolean(value);
+}
+
+export function GraphCard({ title, description, data, empty, children }) {
+  return (
+    <Card className="p-4 flex flex-col min-w-0">
+      <div className="mb-1 text-sm font-semibold text-[var(--text)]">{title}</div>
+      {description && (
+        <div className="mb-3 text-xs text-[var(--text-muted)]">{description}</div>
+      )}
+      {hasData(data) ? (
+        children
+      ) : (
+        <div className="text-xs text-[var(--text-muted)] italic py-2">
+          {empty ?? "No data yet."}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+GraphCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  empty: PropTypes.string,
+  children: PropTypes.node,
+};
+
+// Stub body shared by every graph until a sub-issue ships the real chart.
+// Shows a compact JSON preview so we can eyeball the aggregate shape on
+// the deployed page without waiting for all the chart work.
+function RawPreview({ value, take = 5 }) {
+  const sample = Array.isArray(value) ? value.slice(0, take) : value;
+  return (
+    <pre className="text-[11px] leading-snug text-[var(--text-muted)] overflow-x-auto m-0">
+      {JSON.stringify(sample, null, 2)}
+      {Array.isArray(value) && value.length > take ? `\n…(+${value.length - take} more)` : ""}
+    </pre>
+  );
+}
+
+RawPreview.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  take: PropTypes.number,
+};
+
+export default function Stats() {
+  const [windowDays, setWindowDays] = useState("90");
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      setData(await api.getAccountStats(windowDays));
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [windowDays]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (error) {
+    return (
+      <div>
+        <h2 className="text-lg font-semibold mb-4">My Stats</h2>
+        <p className="text-[var(--danger)]">{error}</p>
+      </div>
+    );
+  }
+
+  if (loading && !data) {
+    return (
+      <div>
+        <h2 className="text-lg font-semibold mb-4">My Stats</h2>
+        <p className="text-[var(--text-muted)]">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  // Top-level empty state: no memories means there's nothing to graph at all.
+  if (data.quota?.memory_count === 0) {
+    return (
+      <div>
+        <h2 className="text-lg font-semibold mb-4">My Stats</h2>
+        <EmptyState
+          variant="activity"
+          title="No data yet"
+          description="Stats will populate as you remember, recall, and tag memories."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 items-center mb-5">
+        <h2 className="text-lg font-semibold mr-2">My Stats</h2>
+        {WINDOWS.map((w) => (
+          <button
+            key={w.value}
+            type="button"
+            onClick={() => setWindowDays(w.value)}
+            className={`px-3 py-1 rounded-md border text-xs ${
+              windowDays === w.value
+                ? "bg-[var(--accent)] text-[#1a1a2e] border-[var(--accent)] font-semibold"
+                : "border-[var(--border)] text-[var(--text)]"
+            }`}
+          >
+            {w.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <GraphCard
+          title="Activity heatmap"
+          description="Events per day in the selected window."
+          data={data.activity_heatmap?.filter((d) => d.count > 0)}
+          empty="No activity in this window yet."
+        >
+          <RawPreview value={data.activity_heatmap} />
+        </GraphCard>
+
+        <GraphCard
+          title="Top recalled"
+          description="Your most-hit memories."
+          data={data.top_recalled}
+          empty="No memory has been recalled yet."
+        >
+          <RawPreview value={data.top_recalled} />
+        </GraphCard>
+
+        <GraphCard
+          title="Tag distribution"
+          description="Memories per tag."
+          data={data.tag_distribution}
+          empty="No tags assigned yet."
+        >
+          <RawPreview value={data.tag_distribution} />
+        </GraphCard>
+
+        <GraphCard
+          title="Memory growth"
+          description="Cumulative memory count over the window."
+          data={data.memory_growth}
+        >
+          <RawPreview value={data.memory_growth} />
+        </GraphCard>
+
+        <GraphCard
+          title="Quota"
+          description="Current memory count against your plan limit."
+          data={data.quota}
+        >
+          <div className="text-sm">
+            <span className="font-semibold">{data.quota.memory_count}</span>
+            {data.quota.memory_limit !== null && (
+              <>
+                {" / "}
+                <span className="text-[var(--text-muted)]">{data.quota.memory_limit}</span>
+              </>
+            )}
+          </div>
+        </GraphCard>
+
+        <GraphCard
+          title="Freshness"
+          description="Days since creation and last access per memory."
+          data={data.freshness}
+        >
+          <RawPreview value={data.freshness} />
+        </GraphCard>
+
+        <GraphCard
+          title="Client contribution"
+          description="Events per day, split by OAuth client."
+          data={data.client_contribution}
+          empty="No client activity in this window."
+        >
+          <RawPreview value={data.client_contribution} />
+        </GraphCard>
+
+        <GraphCard
+          title="Tag co-occurrence"
+          description="Tags that appear together on the same memory."
+          data={data.tag_cooccurrence}
+          empty="No co-tagged memories yet."
+        >
+          <RawPreview value={data.tag_cooccurrence} />
+        </GraphCard>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -143,9 +143,14 @@ describe("Stats", () => {
     });
     await act(async () => render(<Stats />));
     await waitFor(() => expect(screen.getByText("Quota")).toBeTruthy());
-    expect(screen.getByText("7")).toBeTruthy();
-    // The divider "/" shouldn't appear when there's no limit.
-    expect(screen.queryByText("/ 100")).toBeNull();
+    const count = screen.getByText("7");
+    expect(count).toBeTruthy();
+    // The divider "/" shouldn't appear when there's no limit. React renders
+    // "{count}{' / '}{limit}" as three separate text nodes, so querying for
+    // the combined string always returns null regardless — assert against
+    // the parent element's full textContent instead, which is a genuine
+    // check that no slash exists alongside the count.
+    expect(count.parentElement.textContent).not.toContain("/");
   });
 
   it("top-level empty state when user has no memories", async () => {

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Stats, { GraphCard } from "./Stats.jsx";
+
+vi.mock("../api.js", () => ({
+  api: {
+    getAccountStats: vi.fn(),
+  },
+}));
+
+import { api } from "../api.js";
+
+const MINIMAL_STATS = {
+  window_days: 90,
+  activity_heatmap: Array.from({ length: 90 }, (_, i) => ({
+    date: `2026-${String((i % 12) + 1).padStart(2, "0")}-01`,
+    count: i === 0 ? 3 : 0,
+  })),
+  top_recalled: [{ memory_id: "m1", key: "top-key", recall_count: 5 }],
+  tag_distribution: [{ tag: "work", count: 4 }],
+  memory_growth: Array.from({ length: 90 }, (_, i) => ({
+    date: `2026-${String((i % 12) + 1).padStart(2, "0")}-01`,
+    cumulative: i,
+  })),
+  quota: { memory_count: 12, memory_limit: 100 },
+  freshness: [
+    { memory_id: "m1", days_since_created: 10, days_since_accessed: 2 },
+  ],
+  client_contribution: [{ date: "2026-04-01", client_id: "c1", count: 2 }],
+  tag_cooccurrence: [{ source: "a", target: "b", weight: 3 }],
+};
+
+describe("GraphCard", () => {
+  it("renders children when data is present", () => {
+    render(
+      <GraphCard title="T" data={[1]}>
+        <div>body</div>
+      </GraphCard>,
+    );
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+
+  it("renders empty message when data is empty array", () => {
+    render(
+      <GraphCard title="T" data={[]} empty="nope">
+        <div>body</div>
+      </GraphCard>,
+    );
+    expect(screen.getByText("nope")).toBeTruthy();
+  });
+
+  it("falls back to default empty copy when no empty prop", () => {
+    render(
+      <GraphCard title="T" data={[]}>
+        <div>body</div>
+      </GraphCard>,
+    );
+    expect(screen.getByText("No data yet.")).toBeTruthy();
+  });
+
+  it("renders description when provided", () => {
+    render(<GraphCard title="T" description="sub" data={[1]}>body</GraphCard>);
+    expect(screen.getByText("sub")).toBeTruthy();
+  });
+
+  it("treats object data as present when non-empty", () => {
+    render(
+      <GraphCard title="T" data={{ foo: 1 }}>
+        <div>body</div>
+      </GraphCard>,
+    );
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+
+  it("treats empty object as no data", () => {
+    render(
+      <GraphCard title="T" data={{}}>
+        <div>body</div>
+      </GraphCard>,
+    );
+    expect(screen.getByText("No data yet.")).toBeTruthy();
+  });
+});
+
+describe("Stats", () => {
+  beforeEach(() => {
+    api.getAccountStats.mockResolvedValue(MINIMAL_STATS);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("shows loading state before data arrives", async () => {
+    let resolveFn;
+    api.getAccountStats.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFn = resolve;
+      }),
+    );
+    await act(async () => render(<Stats />));
+    expect(screen.getByText("Loading…")).toBeTruthy();
+    await act(async () => resolveFn(MINIMAL_STATS));
+  });
+
+  it("renders all eight graph-card titles once data arrives", async () => {
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("Activity heatmap")).toBeTruthy());
+    for (const title of [
+      "Top recalled",
+      "Tag distribution",
+      "Memory growth",
+      "Quota",
+      "Freshness",
+      "Client contribution",
+      "Tag co-occurrence",
+    ]) {
+      expect(screen.getByText(title)).toBeTruthy();
+    }
+  });
+
+  it("renders Quota as 'count / limit'", async () => {
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("Quota")).toBeTruthy());
+    expect(screen.getByText("12")).toBeTruthy();
+    expect(screen.getByText("100")).toBeTruthy();
+  });
+
+  it("renders Quota without limit when memory_limit is null (exempt/admin)", async () => {
+    api.getAccountStats.mockResolvedValueOnce({
+      ...MINIMAL_STATS,
+      quota: { memory_count: 7, memory_limit: null },
+    });
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("Quota")).toBeTruthy());
+    expect(screen.getByText("7")).toBeTruthy();
+    // The divider "/" shouldn't appear when there's no limit.
+    expect(screen.queryByText("/ 100")).toBeNull();
+  });
+
+  it("top-level empty state when user has no memories", async () => {
+    api.getAccountStats.mockResolvedValueOnce({
+      ...MINIMAL_STATS,
+      quota: { memory_count: 0, memory_limit: 100 },
+    });
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("No data yet")).toBeTruthy());
+    // Graph cards should NOT render in the empty-shell state.
+    expect(screen.queryByText("Activity heatmap")).toBeNull();
+  });
+
+  it("re-fetches with new window when a window button is clicked", async () => {
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("Activity heatmap")).toBeTruthy());
+    expect(api.getAccountStats).toHaveBeenLastCalledWith("90");
+    await act(async () => {
+      fireEvent.click(screen.getByText("Last 30 days"));
+    });
+    await waitFor(() =>
+      expect(api.getAccountStats).toHaveBeenLastCalledWith("30"),
+    );
+  });
+
+  it("shows error banner when API call fails", async () => {
+    api.getAccountStats.mockRejectedValueOnce(new Error("boom"));
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("boom")).toBeTruthy());
+    // No graph cards rendered in the error branch.
+    expect(screen.queryByText("Activity heatmap")).toBeNull();
+  });
+
+  it("renders empty card body for activity_heatmap when all counts are zero", async () => {
+    api.getAccountStats.mockResolvedValueOnce({
+      ...MINIMAL_STATS,
+      activity_heatmap: MINIMAL_STATS.activity_heatmap.map((d) => ({
+        ...d,
+        count: 0,
+      })),
+    });
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("Activity heatmap")).toBeTruthy());
+    expect(screen.getByText("No activity in this window yet.")).toBeTruthy();
+  });
+});

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -81,6 +81,15 @@ describe("GraphCard", () => {
     );
     expect(screen.getByText("No data yet.")).toBeTruthy();
   });
+
+  it("treats undefined data as no data (falls through both type checks)", () => {
+    render(
+      <GraphCard title="T">
+        <div>body</div>
+      </GraphCard>,
+    );
+    expect(screen.getByText("No data yet.")).toBeTruthy();
+  });
 });
 
 describe("Stats", () => {


### PR DESCRIPTION
Part of #534. Closes #535.

Scaffolds the personal analytics surface that's the v0.24 milestone theme. Backend aggregates all eight graph datasets in a single response so the UI renders without chained round-trips; UI lays out the eight placeholder cards ready for follow-up sub-issues to swap in real charts.

## Backend

- New `GET /api/account/stats?window=30|90|365` (default `90`). Returns `activity_heatmap`, `top_recalled`, `tag_distribution`, `memory_growth`, `quota`, `freshness`, `client_contribution`, `tag_cooccurrence` under their series names, plus `window_days`.
- **60s in-memory cache** keyed by `(user_id, window_days)`. Aggregation walks every memory and a windowed slice of the activity log, so a bare recomputation on every panel toggle would be wasteful.
- All aggregates computed in pure Python from existing storage helpers (`iter_all_memories`, `list_clients`, `get_events_for_dates`) — no new storage layer needed.
- `window` param validated with `pattern="^(30|90|365)$"` → `422` on anything else.

## Frontend

- New **`Stats.jsx`** tab in `BASE_TABS`, between Memories and OAuth Clients. Admin-only tabs (Users, Dashboard, Logs) untouched per the issue spec.
- Eight `GraphCard` placeholders, each backed by a small JSON preview of the matching series so we can eyeball the signal reaching the UI end-to-end. **Follow-up sub-issues replace each body with a real chart** (heatmap, bar, stacked area, force graph, …).
- Window selector (30 / 90 / 365) re-fetches on change.
- Top-level `EmptyState` (via `EmptyState.jsx`, `variant="activity"`) when `quota.memory_count === 0` — skips rendering the graph grid entirely in that case.

## Tests

- **14 backend** tests: endpoint shape, all eight series present, window validation (30/90/365 + 422 on invalid), quota math, freshness entries per memory, `top_recalled` filters recall_count=0, `tag_cooccurrence` edges, cache hit, cache miss after TTL (via `monkeypatch` on `time.time`), per-window cache isolation.
- **14 frontend** tests: `GraphCard` (present / empty array / empty object / falls back to default empty copy), loading state, all eight card titles render, Quota with and without limit, top-level empty state skips grid, window button re-fetches, error banner, per-card empty body when all counts are zero.
- Updated `App.test.jsx` to route the new `Stats` tab through a mock and bumped the mobile-nav index test past the newly-inserted tab.

## Test plan

- [x] `uv run inv pre-push` green locally.
- [ ] After deploy, non-admin user in dev sees a new **Stats** tab with a grid of placeholder cards populated from their data. Admin's Dashboard tab (now a separate surface) is unaffected.
- [ ] New user with zero memories sees the `No data yet` empty state instead of a mostly-empty grid.
- [ ] Window buttons flip between 30/90/365 without a page reload.