### PR TITLE
feat: Stats — activity heatmap (12-month calendar)

### DIFF
--- a/ui/src/components/Stats.jsx
+++ b/ui/src/components/Stats.jsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
+import ActivityHeatmap from "./stats/ActivityHeatmap.jsx";
 import { Card } from "./ui/card.jsx";
 
 // #535 — Stats tab scaffolding.
@@ -151,11 +152,11 @@ export default function Stats() {
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <GraphCard
           title="Activity heatmap"
-          description="Events per day in the selected window."
+          description="Events per day across the past year."
           data={data.activity_heatmap?.filter((d) => d.count > 0)}
           empty="No activity in this window yet."
         >
-          <RawPreview value={data.activity_heatmap} />
+          <ActivityHeatmap data={data.activity_heatmap} />
         </GraphCard>
 
         <GraphCard

--- a/ui/src/components/stats/ActivityHeatmap.jsx
+++ b/ui/src/components/stats/ActivityHeatmap.jsx
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+
+// #536 — GitHub-style 7×N calendar grid: one cell per day for the past
+// 12 months. Colour intensity scales with event count; older days
+// outside the 90-day activity-log retention simply render as empty.
+
+const HEATMAP_DAYS = 365;
+const CELL_PX = 11;
+const CELL_GAP_PX = 3;
+const DAY_LABELS = ["Mon", "Wed", "Fri"];
+
+// Five opacity stops — mirrors GitHub's five-tier heatmap.
+const OPACITY_STOPS = [0.3, 0.5, 0.7, 0.85, 1.0];
+
+export function opacityForCount(count, max) {
+  if (count <= 0) return 0;
+  if (max <= 0) return 0;
+  const ratio = count / max;
+  // Map ratio ∈ (0, 1] onto the five stops.
+  for (let i = 0; i < OPACITY_STOPS.length - 1; i++) {
+    if (ratio <= (i + 1) / OPACITY_STOPS.length) return OPACITY_STOPS[i];
+  }
+  return OPACITY_STOPS[OPACITY_STOPS.length - 1];
+}
+
+function isoDate(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+export function buildGrid(data, today = new Date()) {
+  const byDate = new Map((data ?? []).map((d) => [d.date, d.count]));
+  const cells = [];
+  for (let i = HEATMAP_DAYS - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    cells.push({
+      date: isoDate(d),
+      count: byDate.get(isoDate(d)) ?? 0,
+      dayOfWeek: d.getDay(), // Sunday=0 … Saturday=6
+    });
+  }
+  // Arrange into columns of seven rows (Sun–Sat). Pad the first column
+  // with nulls so the calendar aligns to the real weekday of the oldest
+  // rendered day.
+  const weeks = [];
+  let col = new Array(7).fill(null);
+  for (let i = 0; i < cells.length; i++) {
+    const cell = cells[i];
+    col[cell.dayOfWeek] = cell;
+    if (cell.dayOfWeek === 6) {
+      weeks.push(col);
+      col = new Array(7).fill(null);
+    }
+  }
+  // Flush trailing partial column.
+  if (col.some((c) => c !== null)) weeks.push(col);
+  return { cells, weeks };
+}
+
+export default function ActivityHeatmap({ data }) {
+  const { cells, weeks } = useMemo(() => buildGrid(data), [data]);
+  const maxCount = useMemo(
+    () => Math.max(0, ...cells.map((c) => c.count)),
+    [cells],
+  );
+  const totalEvents = useMemo(
+    () => cells.reduce((s, c) => s + c.count, 0),
+    [cells],
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="overflow-x-auto -mx-1 px-1">
+        <div className="inline-flex gap-[3px]" role="grid" aria-label="Activity heatmap">
+          {/* Day-of-week labels column */}
+          <div
+            className="flex flex-col gap-[3px] pr-1 text-[9px] text-[var(--text-muted)] select-none"
+            aria-hidden="true"
+          >
+            {[0, 1, 2, 3, 4, 5, 6].map((dow) => (
+              <div
+                key={dow}
+                className="flex items-center"
+                style={{ height: CELL_PX }}
+              >
+                {DAY_LABELS.includes(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][dow])
+                  ? ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][dow]
+                  : ""}
+              </div>
+            ))}
+          </div>
+          {weeks.map((col, wi) => (
+            <div key={wi} className="flex flex-col gap-[3px]" role="row">
+              {col.map((cell, dow) => {
+                if (!cell) {
+                  return (
+                    <div
+                      key={dow}
+                      role="gridcell"
+                      className="rounded-[2px]"
+                      style={{ width: CELL_PX, height: CELL_PX }}
+                    />
+                  );
+                }
+                const opacity = opacityForCount(cell.count, maxCount);
+                const background =
+                  cell.count > 0
+                    ? `color-mix(in srgb, var(--accent) ${Math.round(opacity * 100)}%, transparent)`
+                    : "var(--surface)";
+                return (
+                  <div
+                    key={dow}
+                    role="gridcell"
+                    title={`${cell.date}: ${cell.count} event${cell.count === 1 ? "" : "s"}`}
+                    aria-label={`${cell.date}: ${cell.count} events`}
+                    data-count={cell.count}
+                    className="rounded-[2px] border border-[var(--border)]"
+                    style={{
+                      width: CELL_PX,
+                      height: CELL_PX,
+                      backgroundColor: background,
+                    }}
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 text-[10px] text-[var(--text-muted)]">
+        <span>
+          {totalEvents} event{totalEvents === 1 ? "" : "s"} in the past year.
+        </span>
+        <span className="flex items-center gap-1">
+          <span>Less</span>
+          {OPACITY_STOPS.map((op) => (
+            <span
+              key={op}
+              className="rounded-[2px] border border-[var(--border)]"
+              style={{
+                width: CELL_PX,
+                height: CELL_PX,
+                backgroundColor: `color-mix(in srgb, var(--accent) ${Math.round(op * 100)}%, transparent)`,
+              }}
+            />
+          ))}
+          <span>More</span>
+        </span>
+      </div>
+      <div className="text-[10px] text-[var(--text-muted)] italic">
+        Activity log retention is 90 days — older months render as empty until retention extends.
+      </div>
+    </div>
+  );
+}
+
+ActivityHeatmap.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.string.isRequired,
+      count: PropTypes.number.isRequired,
+    }),
+  ),
+};
+
+ActivityHeatmap.HEATMAP_DAYS = HEATMAP_DAYS;

--- a/ui/src/components/stats/ActivityHeatmap.test.jsx
+++ b/ui/src/components/stats/ActivityHeatmap.test.jsx
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ActivityHeatmap, { buildGrid, opacityForCount } from "./ActivityHeatmap.jsx";
+
+describe("opacityForCount", () => {
+  it("returns 0 for zero count", () => {
+    expect(opacityForCount(0, 10)).toBe(0);
+  });
+
+  it("returns 0 when max is 0 even if count > 0", () => {
+    // Defensive — max should be >= count, but guard against degenerate data.
+    expect(opacityForCount(3, 0)).toBe(0);
+  });
+
+  it("returns smallest stop for the lightest bucket", () => {
+    expect(opacityForCount(1, 10)).toBe(0.3);
+  });
+
+  it("returns highest stop for count === max", () => {
+    expect(opacityForCount(10, 10)).toBe(1);
+  });
+
+  it("monotonically increases across the five stops", () => {
+    const opacities = [2, 4, 6, 8, 10].map((c) => opacityForCount(c, 10));
+    for (let i = 1; i < opacities.length; i++) {
+      expect(opacities[i]).toBeGreaterThanOrEqual(opacities[i - 1]);
+    }
+  });
+});
+
+describe("buildGrid", () => {
+  it("produces 365 cells for the default HEATMAP_DAYS span", () => {
+    const { cells } = buildGrid([]);
+    expect(cells).toHaveLength(365);
+  });
+
+  it("puts today's cell at the end of the cells array", () => {
+    const today = new Date("2026-04-19T12:00:00Z");
+    const { cells } = buildGrid([{ date: "2026-04-19", count: 7 }], today);
+    expect(cells[cells.length - 1].date).toBe("2026-04-19");
+    expect(cells[cells.length - 1].count).toBe(7);
+  });
+
+  it("leaves cells without matching data at count 0", () => {
+    const today = new Date("2026-04-19T12:00:00Z");
+    const { cells } = buildGrid([{ date: "2026-04-19", count: 3 }], today);
+    const hit = cells.filter((c) => c.count > 0);
+    expect(hit).toHaveLength(1);
+  });
+
+  it("arranges cells into columns of seven days each", () => {
+    const { weeks } = buildGrid([]);
+    // 365 days across 7-day columns = 53 partial/full columns.
+    expect(weeks.length).toBeGreaterThanOrEqual(52);
+    expect(weeks.length).toBeLessThanOrEqual(54);
+    // Every column has exactly 7 slots (some may be null for partial weeks).
+    for (const col of weeks) {
+      expect(col).toHaveLength(7);
+    }
+  });
+});
+
+const _sampleData = [
+  { date: "2026-04-19", count: 10 },
+  { date: "2026-04-18", count: 3 },
+  { date: "2026-04-17", count: 1 },
+];
+
+describe("ActivityHeatmap", () => {
+  it("renders the calendar grid with role='grid'", () => {
+    render(<ActivityHeatmap data={_sampleData} />);
+    expect(screen.getByRole("grid", { name: /activity heatmap/i })).toBeTruthy();
+  });
+
+  it("renders the 90-day retention footnote", () => {
+    render(<ActivityHeatmap data={_sampleData} />);
+    expect(
+      screen.getByText(/activity log retention is 90 days/i),
+    ).toBeTruthy();
+  });
+
+  it("renders a Less/More legend with one swatch per opacity stop", () => {
+    const { container } = render(<ActivityHeatmap data={_sampleData} />);
+    expect(screen.getByText("Less")).toBeTruthy();
+    expect(screen.getByText("More")).toBeTruthy();
+    // 5 opacity stops in the legend, plus the cells in the grid. Count the
+    // legend swatches specifically: they're the siblings of the Less label.
+    const legendLabel = screen.getByText("Less");
+    const legend = legendLabel.parentElement;
+    const swatches = legend.querySelectorAll("span.rounded-\\[2px\\]");
+    expect(swatches.length).toBe(5);
+    // Sanity check — should find both spans in document.
+    expect(container.textContent).toMatch(/Less.*More/);
+  });
+
+  it("shows a total-events summary (pluralised)", () => {
+    render(<ActivityHeatmap data={_sampleData} />);
+    // 10 + 3 + 1 = 14
+    expect(screen.getByText(/14 events in the past year/i)).toBeTruthy();
+  });
+
+  it("uses singular 'event' when total is 1", () => {
+    render(<ActivityHeatmap data={[{ date: "2026-04-19", count: 1 }]} />);
+    expect(screen.getByText(/1 event in the past year/i)).toBeTruthy();
+  });
+
+  it("handles undefined data without error", () => {
+    render(<ActivityHeatmap />);
+    expect(screen.getByText(/0 events in the past year/i)).toBeTruthy();
+  });
+
+  it("handles empty data array without error", () => {
+    render(<ActivityHeatmap data={[]} />);
+    expect(screen.getByText(/0 events in the past year/i)).toBeTruthy();
+  });
+
+  it("sets a tooltip title with date and singular event for count=1", () => {
+    render(<ActivityHeatmap data={[{ date: "2026-04-19", count: 1 }]} />);
+    const cell = document.querySelector('[data-count="1"]');
+    expect(cell).toBeTruthy();
+    expect(cell.getAttribute("title")).toBe("2026-04-19: 1 event");
+  });
+
+  it("uses plural 'events' in the tooltip for count>1", () => {
+    render(<ActivityHeatmap data={[{ date: "2026-04-19", count: 5 }]} />);
+    const cell = document.querySelector('[data-count="5"]');
+    expect(cell.getAttribute("title")).toBe("2026-04-19: 5 events");
+  });
+
+  it("applies color-mix accent background to non-zero cells", () => {
+    render(<ActivityHeatmap data={[{ date: "2026-04-19", count: 10 }]} />);
+    const cell = document.querySelector('[data-count="10"]');
+    // The inline style string is set verbatim by React even if jsdom doesn't
+    // evaluate color-mix — assert the substring is present.
+    expect(cell.getAttribute("style")).toContain("color-mix");
+    expect(cell.getAttribute("style")).toContain("var(--accent)");
+  });
+
+  it("zero-count cells do NOT carry the accent color-mix", () => {
+    render(<ActivityHeatmap data={[{ date: "2026-04-19", count: 5 }]} />);
+    // Find any cell with data-count="0"; there should be plenty (365 - 1).
+    const cell = document.querySelector('[data-count="0"]');
+    expect(cell).toBeTruthy();
+    expect(cell.getAttribute("style")).not.toContain("color-mix");
+  });
+});


### PR DESCRIPTION
Closes #536. Part of #534.

Replaces the `RawPreview` placeholder in the Stats tab's **Activity heatmap** card with a GitHub-style 7×53 calendar: one cell per day for the past 365 days, colour intensity scaled by that day's event count.

## Summary

- **Five opacity stops** (0.3 … 1.0) mixed against `var(--accent)` via `color-mix(in srgb, …, transparent)` so the palette auto-adapts to dark and light themes — no per-theme asset.
- Sun–Sat rows; **Mon / Wed / Fri** labels on the left edge.
- **Tooltip** on every cell shows `{date}: {N} event(s)` (singular/plural).
- **Footer line**: total event count in the window (pluralised) + `Less` / `More` legend swatches.
- **Retention footnote**: "Activity log retention is 90 days — older months render as empty until retention extends" — so users don't mistake empty cells beyond day 90 for a bug.
- `overflow-x-auto` wrapper keeps the 53-column grid scrollable on narrow viewports without pushing the parent card wider.

## Approach

`buildGrid` + `opacityForCount` are exported from the module so the pure-logic branches (five stops, 365-cell span, today-at-end, weekly column layout) can be tested directly without going through a React render.

## Test plan

- [x] 20 unit tests (pure logic + rendering).
- [x] `uv run inv pre-push` green locally (658 frontend tests passing).
- [ ] Post-deploy: heatmap shows recent activity for a user with memories; older cells render empty; dark + light themes both readable; tooltip on hover works.