### PR TITLE
feat(ci): design + scaffold Copilot PR review in the autonomous flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,69 @@
+# Copilot review instructions for Hive
+
+Hive is an MCP memory server (FastMCP + FastAPI + React + DynamoDB on AWS
+Lambda). Use the rules below when reviewing pull requests in this repo so
+the autonomous agent can act on your feedback cleanly.
+
+## What to flag
+
+- **Correctness** — logic errors the test suite wouldn't catch: wrong auth
+  scope, race conditions on DynamoDB writes, mis-handled Pydantic models,
+  off-by-one in pagination, missing timezone handling.
+- **Security** — hardcoded secrets, SQL-ish injection (DynamoDB filter
+  expressions are our analog), overly-broad OAuth scopes, missing auth on
+  new endpoints, PII leaking into logs.
+- **Clarity** — ambiguous naming, unreachable branches, missing
+  invariants, API responses that would surprise a caller.
+- **Missing tests** — new Python module without `tests/unit/` coverage;
+  new React component without a co-located `*.test.jsx`.
+
+## What NOT to flag
+
+The agent will auto-dismiss these as style-only nits and move on.
+
+- **Tailwind class order** — the project doesn't enforce a class-sorting
+  convention.
+- **`const` vs `let`** — both are fine; don't suggest re-writes.
+- **Import order** inside Python or JS modules — `ruff` handles Python;
+  the JS side isn't linted on import order.
+- **Naming preferences** that don't clarify intent (e.g. `handleClick`
+  vs `onClick`).
+- **"Prefer early return"** style rewrites when the current code is already
+  clear.
+
+## Project conventions (summary)
+
+- **Python deps**: `uv` only. Never `pip` or `requirements.txt`.
+- **Lint / type**: `ruff` + `mypy`, strict mode. Both run in CI and must
+  pass.
+- **Tests**: 100% coverage enforced (`pytest --cov-fail-under=100` for
+  Python, vitest v8 threshold for JS). CI fails below.
+- **UI components**: Every `.jsx` component has a co-located `.test.jsx`.
+- **UI styling**: Use CSS variables (`var(--text-muted)`, `var(--border)`,
+  `var(--accent)`); never hardcode hex colours. Use `lucide-react` icons —
+  never emojis as UI elements. Prefer `shadcn/ui` primitives
+  (`Button`, `Card`, `Table`) over raw HTML.
+- **Copyright headers**: Every new source file carries
+  `// Copyright (c) 2026 John Carter. All rights reserved.` (or `#` for
+  Python).
+- **No new `README.md` / `docs/*.md` files** unless the issue explicitly
+  asks for them — this repo dislikes drive-by documentation.
+- **Storage model**: Single-table DynamoDB design. `PK=MEMORY#{id}`,
+  `SK=TAG#{tag}` for memories; changes to the key schema need explicit
+  justification in the PR body.
+- **Auth**: OAuth 2.1 + PKCE for MCP clients, Google OAuth for mgmt UI.
+  Any changes near `src/hive/auth/` warrant extra scrutiny.
+
+## Agent-specific rule
+
+If you spot a change to `CLAUDE.md §Autonomous issue workflow` or
+`§Stop and ask`, **flag it**. Those sections must go through human
+review — the autonomous agent is not allowed to auto-merge changes to
+its own operating rules. The agent already knows this; if it slipped
+through, that's a regression the human reviewer needs to see.
+
+## Tone
+
+Short, specific, actionable. One suggestion per comment when possible —
+the agent triages comments individually, and a comment bundling three
+findings is harder to act on than three separate ones.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,6 +832,42 @@ Repeat until all checks pass. Auto-merge fires automatically once they do.
 
 If the same check fails 3 times without a clear fix, stop and ask.
 
+#### 7.5 Request Copilot review (only for `agent-safe` PRs)
+
+Runs **only** when the linked issue is labelled `agent-safe`. For every
+other PR, skip straight to step 8. The gate is intentional — Copilot
+review is opt-in via the label so the team can grow the surface
+gradually instead of flipping every autonomous PR onto it at once.
+
+1. After CI is green, request a Copilot review on the PR via
+   `mcp__github__request_copilot_review`.
+2. Poll `mcp__github__pull_request_read` with `method=get_reviews`
+   every ~60s until a review from the `copilot-pull-request-reviewer`
+   actor appears in `SUBMITTED` state (typically 2–5 min).
+3. Fetch the review comments via `get_review_comments` and triage
+   each unresolved thread:
+   - **Correctness / security / clarity finding** — write the fix on
+     the same branch, run `uv run inv pre-push` locally (the post-fix
+     safety gate — if it breaks, revert the fix, reply `This would
+     introduce a regression; declining.`, resolve the thread), push,
+     then re-request Copilot review.
+   - **Pure style nit** (Tailwind class order, const-vs-let, naming
+     preference, import sort) — decline with a short canned reply
+     citing project conventions, then resolve the thread.
+   - **Ambiguous, architecturally significant, or would meaningfully
+     change scope** — emit
+     `HUMAN_INPUT_REQUIRED: Copilot flagged X on #NNN — unclear call`
+     and stop.
+4. **Hard iteration cap: 3.** After the third Copilot review
+   round-trip, stop and ask — prevents ping-pong where each fix
+   surfaces a new finding.
+5. Once all threads resolved AND CI green, auto-merge fires.
+
+Apply fixes to real findings even if they're small — Copilot's value
+is catching the subtle correctness issues the test suite won't.
+Default to disagreeing on style-only comments; default to agreeing on
+security / correctness / clarity.
+
 #### 8. Monitor development branch CI/CD post-merge
 
 After the PR merges, the `development` branch pipeline triggers. Record the
@@ -995,6 +1031,13 @@ queue trustworthy.
 
 - `epic` — tracking issue with sub-issue checklist; never queue-eligible
 - `bug` / `enhancement` / `chore` — issue type
+- `agent-safe` — PR from this issue runs through the autonomous-flow
+  Copilot review step (§Autonomous issue workflow §7.5). Apply when
+  the work is low-risk enough that an LLM reviewer's feedback is
+  actionable without human judgement: `priority:p2` / `p3`,
+  `size:xs` / `s` / `m`, and not touching `infra/stacks/hive_stack.py`,
+  `.github/workflows/`, or any auth / token-issuance path. Leave off
+  anything that warrants full human review.
 
 ### Issue creation rules
 


### PR DESCRIPTION
Closes #486.

Introduces a **gated** Copilot-review step between CI-pass and auto-merge for PRs originating from issues labelled `agent-safe`. The gate is intentional — we grow the surface gradually rather than flipping every autonomous PR onto Copilot at once.

## ⚠️ Do not auto-merge

Per **CLAUDE.md §Keeping CLAUDE.md current**, changes to `§Autonomous issue workflow` and any expansion of what Claude does unattended require human review. **Review and merge manually** when ready — auto-merge is deliberately not enabled on this PR.

## What's in the PR

### CLAUDE.md

- New `§Autonomous issue workflow §7.5` "Request Copilot review" — triage rubric (correctness → fix + re-push; style → decline; unclear → stop-and-ask), post-fix `inv pre-push` safety gate, hard 3-round iteration cap.
- New `agent-safe` entry in `§Special labels` documenting the gate criteria: `priority:p2 / p3`, `size:xs / s / m`, not touching `infra/stacks/hive_stack.py`, `.github/workflows/`, or the auth surface.

### `.github/copilot-instructions.md`

Tight review brief for Copilot — **what to flag** (correctness / security / clarity / missing tests), **what NOT to flag** (style-only nits the agent will auto-decline), project conventions summary (`uv` / `ruff` / `mypy`, 100% coverage, shadcn + lucide, CSS vars only), and a guardrail: if Copilot spots a change to CLAUDE.md's autonomous workflow, **flag it** — the agent knows to escalate those.

### Starter label set

Six issues in v0.24 flipped to `agent-safe`:

- **#537 / #538 / #539 / #540** — remaining Stats chart sub-issues
- **#447 / #452** — the two MCP-tool features

Deliberately not labelled: anything touching auth / infra / CI wiring, this PR's own work, or `size:l`+.

## Design decisions (from the issue's open questions)

| # | Question | Decision |
| --- | --- | --- |
| 1 | Billing | Monthly Pro plan includes Copilot PR review, bundled — no per-review cost concern. |
| 2 | `copilot-instructions.md` format | Tight summary ~100 lines with conventions + what-to / what-not-to flag, not full CLAUDE.md. |
| 3 | Style-comment dismissal policy | Auto-dismiss pure style nits with a canned reply; act on correctness / security / clarity. |
| 4 | "Review complete" API signal | Poll `pull_request_read.get_reviews` until the `copilot-pull-request-reviewer` actor's review is `SUBMITTED`. |
| 5 | Multi-iteration | Agent explicitly re-requests via `mcp__github__request_copilot_review` after each fix. 3-iteration cap. |

## Test plan

- [ ] On merge, the next PR from an `agent-safe` issue (e.g. #537) runs through the new §7.5 flow end-to-end: Copilot review fires, agent triages comments, auto-merge fires after all threads resolved.
- [ ] PRs from non-`agent-safe` issues skip §7.5 entirely — unchanged behaviour.
- [ ] The guardrail holds: an LLM-suggested change to `§Autonomous issue workflow` either gets flagged by Copilot or gets caught in review.