### PR TITLE
feat: Stats — top recalled + tag distribution + memory growth + quota gauge

### DIFF
--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -247,6 +247,26 @@ export default function MemoryBrowser() {
     return () => clearTimeout(searchDebounceRef.current);
   }, [searchQuery, runSearch]);
 
+  // #537 — Stats charts click-through: the Stats tab dispatches a
+  // `hive:memory-browser` CustomEvent with `{ tag }` or `{ search }` to
+  // focus this browser on a specific slice. Followed by a
+  // `hive:switch-tab` to jump the active tab.
+  useEffect(() => {
+    function onFocus(e) {
+      const detail = e.detail ?? {};
+      if (detail.tag) {
+        setSearchQuery("");
+        setIsSearchMode(false);
+        setTagFilter(detail.tag);
+      } else if (detail.search) {
+        setTagFilter("");
+        setSearchQuery(detail.search);
+      }
+    }
+    globalThis.addEventListener("hive:memory-browser", onFocus);
+    return () => globalThis.removeEventListener("hive:memory-browser", onFocus);
+  }, []);
+
   // Collect distinct tags from loaded memories for suggestions
   const knownTags = [...new Set(memories.flatMap((m) => m.tags))].sort((a, b) => a.localeCompare(b));
 

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -260,6 +260,10 @@ export default function MemoryBrowser() {
         setTagFilter(detail.tag);
       } else if (detail.search) {
         setTagFilter("");
+        // Enter search mode explicitly so the list-load effect doesn't
+        // fire an unnecessary listMemories() before the debounced
+        // runSearch() kicks in.
+        setIsSearchMode(true);
         setSearchQuery(detail.search);
       }
     }

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -1091,6 +1091,20 @@ describe("MemoryBrowser", () => {
     await waitFor(() => expect(api.listMemories).toHaveBeenCalledWith("work"));
   });
 
+  it("hive:memory-browser event without a detail payload is a no-op", async () => {
+    api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    api.listMemories.mockClear();
+    await act(async () => {
+      // Event with no `detail` at all — covers the `?? {}` fallback so
+      // the handler doesn't blow up if dispatched unqualified.
+      globalThis.dispatchEvent(new Event("hive:memory-browser"));
+    });
+    // Neither tag filter nor search ran — no additional list fetches.
+    expect(api.listMemories).not.toHaveBeenCalled();
+  });
+
   it("hive:memory-browser event with search pre-sets the search query", async () => {
     api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
     api.searchMemories.mockResolvedValue({ items: [], next_cursor: null });

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -1074,4 +1074,34 @@ describe("MemoryBrowser", () => {
     await act(async () => render(<MemoryBrowser />));
     await waitFor(() => screen.getByText("test-key"));
   });
+
+  // #537 — Stats charts dispatch `hive:memory-browser` events to deep-link
+  // into this component. A tag detail pre-sets the tag filter; a search
+  // detail pre-sets the search query (and clears any lingering tag).
+  it("hive:memory-browser event with tag pre-filters the list", async () => {
+    api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    api.listMemories.mockClear();
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new CustomEvent("hive:memory-browser", { detail: { tag: "work" } }),
+      );
+    });
+    await waitFor(() => expect(api.listMemories).toHaveBeenCalledWith("work"));
+  });
+
+  it("hive:memory-browser event with search pre-sets the search query", async () => {
+    api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
+    api.searchMemories.mockResolvedValue({ items: [], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new CustomEvent("hive:memory-browser", { detail: { search: "my-key" } }),
+      );
+    });
+    const input = await screen.findByPlaceholderText(/search by meaning/i);
+    expect(input.value).toBe("my-key");
+  });
 });

--- a/ui/src/components/Stats.jsx
+++ b/ui/src/components/Stats.jsx
@@ -12,11 +12,11 @@ import { Card } from "./ui/card.jsx";
 
 // #535 — Stats tab scaffolding.
 //
-// This component renders eight placeholder graph cards backed by the
-// /api/account/stats response. The placeholder bodies deliberately dump
-// a small JSON preview so it's obvious each signal is reaching the UI —
-// follow-up sub-issues replace each `<GraphCard>` body with a proper
-// chart implementation (heatmap, bar, stacked area, force graph, …).
+// Renders a grid of GraphCards backed by /api/account/stats. Five cards
+// are fully implemented (ActivityHeatmap, TopRecalled, TagDistribution,
+// MemoryGrowth, QuotaGauge); the remaining three (Freshness,
+// ClientContribution, TagCooccurrence) still show a JSON preview via
+// RawPreview until their dedicated sub-issues (#538 / #539 / #540) land.
 
 const WINDOWS = [
   { value: "30", label: "Last 30 days" },

--- a/ui/src/components/Stats.jsx
+++ b/ui/src/components/Stats.jsx
@@ -192,7 +192,11 @@ export default function Stats() {
         <GraphCard
           title="Quota"
           description="Current memory count against your plan limit."
-          data={data.quota}
+          // Treat a malformed `quota` (memory_count not numeric) as no
+          // data so GraphCard renders its empty copy instead of a silent
+          // blank card — QuotaGauge itself returns null on that input.
+          data={typeof data.quota?.memory_count === "number" ? data.quota : null}
+          empty="Quota data unavailable."
         >
           <QuotaGauge quota={data.quota} />
         </GraphCard>

--- a/ui/src/components/Stats.jsx
+++ b/ui/src/components/Stats.jsx
@@ -4,6 +4,10 @@ import PropTypes from "prop-types";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
 import ActivityHeatmap from "./stats/ActivityHeatmap.jsx";
+import MemoryGrowth from "./stats/MemoryGrowth.jsx";
+import QuotaGauge from "./stats/QuotaGauge.jsx";
+import TagDistribution from "./stats/TagDistribution.jsx";
+import TopRecalled from "./stats/TopRecalled.jsx";
 import { Card } from "./ui/card.jsx";
 
 // #535 — Stats tab scaffolding.
@@ -161,20 +165,20 @@ export default function Stats() {
 
         <GraphCard
           title="Top recalled"
-          description="Your most-hit memories."
+          description="Your most-hit memories — click to open."
           data={data.top_recalled}
           empty="No memory has been recalled yet."
         >
-          <RawPreview value={data.top_recalled} />
+          <TopRecalled data={data.top_recalled} />
         </GraphCard>
 
         <GraphCard
           title="Tag distribution"
-          description="Memories per tag."
+          description="Memories per tag — click a slice to filter."
           data={data.tag_distribution}
           empty="No tags assigned yet."
         >
-          <RawPreview value={data.tag_distribution} />
+          <TagDistribution data={data.tag_distribution} />
         </GraphCard>
 
         <GraphCard
@@ -182,7 +186,7 @@ export default function Stats() {
           description="Cumulative memory count over the window."
           data={data.memory_growth}
         >
-          <RawPreview value={data.memory_growth} />
+          <MemoryGrowth data={data.memory_growth} />
         </GraphCard>
 
         <GraphCard
@@ -190,15 +194,7 @@ export default function Stats() {
           description="Current memory count against your plan limit."
           data={data.quota}
         >
-          <div className="text-sm">
-            <span className="font-semibold">{data.quota.memory_count}</span>
-            {data.quota.memory_limit !== null && (
-              <>
-                {" / "}
-                <span className="text-[var(--text-muted)]">{data.quota.memory_limit}</span>
-              </>
-            )}
-          </div>
+          <QuotaGauge quota={data.quota} />
         </GraphCard>
 
         <GraphCard

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -178,6 +178,18 @@ describe("Stats", () => {
     expect(screen.getByTestId("quota-gauge").textContent).toBe("7");
   });
 
+  it("Quota card shows empty copy when memory_count is malformed", async () => {
+    api.getAccountStats.mockResolvedValueOnce({
+      ...MINIMAL_STATS,
+      quota: { memory_count: "oops", memory_limit: 100 },
+    });
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("Quota")).toBeTruthy());
+    // GraphCard's empty copy renders instead of a silent blank QuotaGauge.
+    expect(screen.getByText(/Quota data unavailable/)).toBeTruthy();
+    expect(screen.queryByTestId("quota-gauge")).toBeNull();
+  });
+
   it("top-level empty state when user has no memories", async () => {
     api.getAccountStats.mockResolvedValueOnce({
       ...MINIMAL_STATS,

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -48,9 +48,15 @@ const MINIMAL_STATS = {
     cumulative: i,
   })),
   quota: { memory_count: 12, memory_limit: 100 },
-  freshness: [
-    { memory_id: "m1", days_since_created: 10, days_since_accessed: 2 },
-  ],
+  // Seven entries so RawPreview's `value.length > take` overflow branch
+  // is exercised (default `take` is 5). The three still-placeholder cards
+  // (Freshness / ClientContribution / TagCooccurrence) render via
+  // RawPreview until their dedicated sub-issues land.
+  freshness: Array.from({ length: 7 }, (_, i) => ({
+    memory_id: `m${i}`,
+    days_since_created: i * 5,
+    days_since_accessed: i,
+  })),
   client_contribution: [{ date: "2026-04-01", client_id: "c1", count: 2 }],
   tag_cooccurrence: [{ source: "a", target: "b", weight: 3 }],
 };

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -9,6 +9,30 @@ vi.mock("../api.js", () => ({
   },
 }));
 
+// Stub the chart components — each has its own co-located test file.
+// Mocking keeps Stats.test focused on the parent layout + branch logic
+// and avoids booting recharts + SVG measurement in every test.
+vi.mock("./stats/ActivityHeatmap.jsx", () => ({
+  default: () => <div data-testid="activity-heatmap" />,
+}));
+vi.mock("./stats/TopRecalled.jsx", () => ({
+  default: () => <div data-testid="top-recalled" />,
+}));
+vi.mock("./stats/TagDistribution.jsx", () => ({
+  default: () => <div data-testid="tag-distribution" />,
+}));
+vi.mock("./stats/MemoryGrowth.jsx", () => ({
+  default: () => <div data-testid="memory-growth" />,
+}));
+vi.mock("./stats/QuotaGauge.jsx", () => ({
+  default: ({ quota }) => (
+    <div data-testid="quota-gauge">
+      {quota.memory_count}
+      {quota.memory_limit !== null ? `/${quota.memory_limit}` : ""}
+    </div>
+  ),
+}));
+
 import { api } from "../api.js";
 
 const MINIMAL_STATS = {
@@ -129,28 +153,23 @@ describe("Stats", () => {
     }
   });
 
-  it("renders Quota as 'count / limit'", async () => {
+  it("passes the quota prop through to QuotaGauge", async () => {
     await act(async () => render(<Stats />));
-    await waitFor(() => expect(screen.getByText("Quota")).toBeTruthy());
-    expect(screen.getByText("12")).toBeTruthy();
-    expect(screen.getByText("100")).toBeTruthy();
+    await waitFor(() => expect(screen.getByTestId("quota-gauge")).toBeTruthy());
+    // Mock stringifies the quota to {count}/{limit}.
+    expect(screen.getByTestId("quota-gauge").textContent).toBe("12/100");
   });
 
-  it("renders Quota without limit when memory_limit is null (exempt/admin)", async () => {
+  it("QuotaGauge receives null limit when the user is exempt/admin", async () => {
     api.getAccountStats.mockResolvedValueOnce({
       ...MINIMAL_STATS,
       quota: { memory_count: 7, memory_limit: null },
     });
     await act(async () => render(<Stats />));
-    await waitFor(() => expect(screen.getByText("Quota")).toBeTruthy());
-    const count = screen.getByText("7");
-    expect(count).toBeTruthy();
-    // The divider "/" shouldn't appear when there's no limit. React renders
-    // "{count}{' / '}{limit}" as three separate text nodes, so querying for
-    // the combined string always returns null regardless — assert against
-    // the parent element's full textContent instead, which is a genuine
-    // check that no slash exists alongside the count.
-    expect(count.parentElement.textContent).not.toContain("/");
+    await waitFor(() => expect(screen.getByTestId("quota-gauge")).toBeTruthy());
+    // Mock omits the /limit suffix when memory_limit is null, proving the
+    // prop passed through correctly.
+    expect(screen.getByTestId("quota-gauge").textContent).toBe("7");
   });
 
   it("top-level empty state when user has no memories", async () => {

--- a/ui/src/components/stats/MemoryGrowth.jsx
+++ b/ui/src/components/stats/MemoryGrowth.jsx
@@ -29,10 +29,12 @@ export function projectGrowth(history, days = PROJECTION_DAYS) {
   if (delta <= 0) return []; // flat / declining history — don't extrapolate
   const perDay = delta / (history.length - 1);
   const projection = [];
+  // `YYYY-MM-DD` parses as UTC; use setUTCDate to add days without
+  // a local-timezone / DST shift that could produce off-by-one dates.
   const lastDate = new Date(history[history.length - 1].date);
   for (let i = 1; i <= days; i++) {
     const d = new Date(lastDate);
-    d.setDate(d.getDate() + i);
+    d.setUTCDate(d.getUTCDate() + i);
     projection.push({
       date: d.toISOString().slice(0, 10),
       projected: Math.round(last + perDay * i),
@@ -51,12 +53,16 @@ export default function MemoryGrowth({ data }) {
     if (projection.length === 0) {
       return { combined: history, hasProjection: false };
     }
-    // Stitch the projection onto the history, anchoring it to the last
-    // actual point so the area renders continuously.
+    // Copy the `projected` value onto the last actual point so the dashed
+    // line starts visibly from that datapoint without duplicating the
+    // date row in the combined dataset.
     const anchor = history[history.length - 1];
-    const withAnchor = [{ ...anchor, projected: anchor.cumulative }, ...projection];
+    const historyWithAnchor = [
+      ...history.slice(0, -1),
+      { ...anchor, projected: anchor.cumulative },
+    ];
     return {
-      combined: [...history, ...withAnchor.slice(1)],
+      combined: [...historyWithAnchor, ...projection],
       hasProjection: true,
     };
   }, [data]);

--- a/ui/src/components/stats/MemoryGrowth.jsx
+++ b/ui/src/components/stats/MemoryGrowth.jsx
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+// #537 — cumulative memory count over the selected window, with a
+// dotted linear projection for the next ~30 days based on the trailing
+// growth rate. Projection only renders when there's enough history to
+// compute a meaningful rate (≥14 days of data spanning a non-zero
+// growth delta).
+
+const PROJECTION_DAYS = 30;
+const MIN_HISTORY_DAYS = 14;
+
+export function projectGrowth(history, days = PROJECTION_DAYS) {
+  if (!history || history.length < MIN_HISTORY_DAYS) return [];
+  const first = history[0].cumulative;
+  const last = history[history.length - 1].cumulative;
+  const delta = last - first;
+  if (delta <= 0) return []; // flat / declining history — don't extrapolate
+  const perDay = delta / (history.length - 1);
+  const projection = [];
+  const lastDate = new Date(history[history.length - 1].date);
+  for (let i = 1; i <= days; i++) {
+    const d = new Date(lastDate);
+    d.setDate(d.getDate() + i);
+    projection.push({
+      date: d.toISOString().slice(0, 10),
+      projected: Math.round(last + perDay * i),
+    });
+  }
+  return projection;
+}
+
+export default function MemoryGrowth({ data }) {
+  const { combined, hasProjection } = useMemo(() => {
+    const history = (data ?? []).map((p) => ({
+      date: p.date,
+      cumulative: p.cumulative,
+    }));
+    const projection = projectGrowth(history);
+    if (projection.length === 0) {
+      return { combined: history, hasProjection: false };
+    }
+    // Stitch the projection onto the history, anchoring it to the last
+    // actual point so the area renders continuously.
+    const anchor = history[history.length - 1];
+    const withAnchor = [{ ...anchor, projected: anchor.cumulative }, ...projection];
+    return {
+      combined: [...history, ...withAnchor.slice(1)],
+      hasProjection: true,
+    };
+  }, [data]);
+
+  if (!data?.length) return null;
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <AreaChart data={combined} margin={{ top: 5, right: 10, left: 0, bottom: 30 }}>
+        <defs>
+          <linearGradient id="growth-fill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--accent)" stopOpacity={0.35} />
+            <stop offset="95%" stopColor="var(--accent)" stopOpacity={0.04} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+        <XAxis
+          dataKey="date"
+          tick={{ fontSize: 11, fill: "var(--text-muted)" }}
+          angle={-45}
+          textAnchor="end"
+          height={60}
+          minTickGap={32}
+        />
+        <YAxis
+          allowDecimals={false}
+          tick={{ fontSize: 11, fill: "var(--text-muted)" }}
+        />
+        <Tooltip
+          contentStyle={{ background: "var(--surface)", border: "1px solid var(--border)", fontSize: 12 }}
+        />
+        <Legend wrapperStyle={{ fontSize: 11, color: "var(--text-muted)" }} />
+        <Area
+          type="monotone"
+          dataKey="cumulative"
+          name="Memories"
+          stroke="var(--accent)"
+          strokeWidth={2}
+          fill="url(#growth-fill)"
+        />
+        {hasProjection && (
+          <Area
+            type="monotone"
+            dataKey="projected"
+            name="Projected"
+            stroke="var(--accent)"
+            strokeWidth={2}
+            strokeDasharray="5 5"
+            fill="none"
+          />
+        )}
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+MemoryGrowth.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.string.isRequired,
+      cumulative: PropTypes.number.isRequired,
+    }),
+  ),
+};

--- a/ui/src/components/stats/MemoryGrowth.jsx
+++ b/ui/src/components/stats/MemoryGrowth.jsx
@@ -13,8 +13,11 @@ import {
 } from "recharts";
 
 // #537 — cumulative memory count over the selected window, with a
-// dotted linear projection for the next ~30 days based on the trailing
-// growth rate. Projection only renders when there's enough history to
+// dotted linear projection for the next ~30 days. The projection uses
+// the window-average daily growth rate (delta between first and last
+// points divided by span), so 90/365-day windows produce a smoother
+// long-horizon trend rather than extrapolating from just the most
+// recent days. Projection only renders when there's enough history to
 // compute a meaningful rate (≥14 days of data spanning a non-zero
 // growth delta).
 

--- a/ui/src/components/stats/MemoryGrowth.test.jsx
+++ b/ui/src/components/stats/MemoryGrowth.test.jsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MemoryGrowth, { projectGrowth } from "./MemoryGrowth.jsx";
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+describe("projectGrowth", () => {
+  it("returns empty when history is shorter than MIN_HISTORY_DAYS", () => {
+    const history = Array.from({ length: 10 }, (_, i) => ({
+      date: `2026-04-${String(i + 1).padStart(2, "0")}`,
+      cumulative: i,
+    }));
+    expect(projectGrowth(history)).toEqual([]);
+  });
+
+  it("returns empty when history is null/undefined", () => {
+    expect(projectGrowth()).toEqual([]);
+    expect(projectGrowth(null)).toEqual([]);
+  });
+
+  it("returns empty when growth is flat/declining", () => {
+    const history = Array.from({ length: 30 }, (_, i) => ({
+      date: `2026-04-${String(i + 1).padStart(2, "0")}`,
+      cumulative: 5,
+    }));
+    expect(projectGrowth(history)).toEqual([]);
+  });
+
+  it("projects `days` points forward when history has positive growth", () => {
+    const history = Array.from({ length: 30 }, (_, i) => ({
+      date: `2026-03-${String(i + 1).padStart(2, "0")}`,
+      cumulative: i,
+    }));
+    const projection = projectGrowth(history, 10);
+    expect(projection).toHaveLength(10);
+    // Each projected cumulative is non-decreasing and starts > last actual.
+    const last = history[history.length - 1].cumulative;
+    expect(projection[0].projected).toBeGreaterThan(last);
+    for (let i = 1; i < projection.length; i++) {
+      expect(projection[i].projected).toBeGreaterThanOrEqual(projection[i - 1].projected);
+    }
+  });
+});
+
+describe("MemoryGrowth", () => {
+  it("returns null when data is missing", () => {
+    const { container } = render(<MemoryGrowth />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when data is an empty array", () => {
+    const { container } = render(<MemoryGrowth data={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a chart container when data is present", () => {
+    const data = Array.from({ length: 30 }, (_, i) => ({
+      date: `2026-03-${String(i + 1).padStart(2, "0")}`,
+      cumulative: i,
+    }));
+    const { container } = render(<MemoryGrowth data={data} />);
+    expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
+  });
+
+  it("renders without a projection line for short histories", () => {
+    const data = Array.from({ length: 5 }, (_, i) => ({
+      date: `2026-04-${String(i + 1).padStart(2, "0")}`,
+      cumulative: i,
+    }));
+    const { container } = render(<MemoryGrowth data={data} />);
+    // Chart still renders (history-only path).
+    expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
+  });
+});

--- a/ui/src/components/stats/QuotaGauge.jsx
+++ b/ui/src/components/stats/QuotaGauge.jsx
@@ -25,7 +25,7 @@ export function arcPath(fraction) {
 
 export function fillColor(fraction) {
   if (fraction >= 0.9) return "var(--danger)";
-  if (fraction >= 0.75) return "#f5a623";
+  if (fraction >= 0.75) return "var(--amber)";
   return "var(--accent)";
 }
 

--- a/ui/src/components/stats/QuotaGauge.jsx
+++ b/ui/src/components/stats/QuotaGauge.jsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import PropTypes from "prop-types";
+
+// #537 — big visual of used / remaining memory count. Uses a semicircle
+// SVG arc so it reads as a gauge rather than a bar-chart spinoff. Renders
+// a flat count when `memory_limit` is null (admin / exempt users).
+
+const RADIUS = 70;
+const STROKE = 14;
+const CENTER_X = 90;
+const CENTER_Y = 90;
+
+export function arcPath(fraction) {
+  // Semicircle from 180° → 0° (left to right), clamped to [0, 1].
+  const safe = Math.max(0, Math.min(1, fraction));
+  const angle = Math.PI * (1 - safe); // 180° → 0°
+  const startX = CENTER_X - RADIUS;
+  const startY = CENTER_Y;
+  const endX = CENTER_X + RADIUS * Math.cos(angle);
+  const endY = CENTER_Y - RADIUS * Math.sin(angle);
+  const largeArc = safe > 0.5 ? 1 : 0;
+  return `M ${startX} ${startY} A ${RADIUS} ${RADIUS} 0 ${largeArc} 1 ${endX.toFixed(2)} ${endY.toFixed(2)}`;
+}
+
+export function fillColor(fraction) {
+  if (fraction >= 0.9) return "var(--danger)";
+  if (fraction >= 0.75) return "#f5a623";
+  return "var(--accent)";
+}
+
+export default function QuotaGauge({ quota }) {
+  if (!quota || typeof quota.memory_count !== "number") return null;
+
+  const { memory_count: count, memory_limit: limit } = quota;
+
+  // Unbounded (admin / exempt): render just the count.
+  if (limit === null || limit === undefined) {
+    return (
+      <div className="flex flex-col items-center py-4" data-testid="quota-gauge-unbounded">
+        <div className="text-4xl font-bold text-[var(--text)]">{count}</div>
+        <div className="mt-1 text-xs text-[var(--text-muted)]">
+          memories — no quota
+        </div>
+      </div>
+    );
+  }
+
+  const fraction = limit > 0 ? count / limit : 0;
+  const remaining = Math.max(0, limit - count);
+  const color = fillColor(fraction);
+
+  return (
+    <div className="flex flex-col items-center py-2">
+      <svg
+        width="180"
+        height="110"
+        viewBox="0 0 180 110"
+        role="img"
+        aria-label={`Quota: ${count} of ${limit} memories used`}
+      >
+        {/* Track */}
+        <path
+          d={arcPath(1)}
+          fill="none"
+          stroke="var(--border)"
+          strokeWidth={STROKE}
+          strokeLinecap="round"
+        />
+        {/* Fill */}
+        {fraction > 0 && (
+          <path
+            d={arcPath(fraction)}
+            fill="none"
+            stroke={color}
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+          />
+        )}
+      </svg>
+      <div className="flex items-baseline gap-1 -mt-8">
+        <span className="text-3xl font-bold text-[var(--text)]">{count}</span>
+        <span className="text-sm text-[var(--text-muted)]">/ {limit}</span>
+      </div>
+      <div className="mt-1 text-xs text-[var(--text-muted)]">
+        {remaining} remaining
+      </div>
+    </div>
+  );
+}
+
+QuotaGauge.propTypes = {
+  quota: PropTypes.shape({
+    memory_count: PropTypes.number.isRequired,
+    memory_limit: PropTypes.number,
+  }),
+};

--- a/ui/src/components/stats/QuotaGauge.test.jsx
+++ b/ui/src/components/stats/QuotaGauge.test.jsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import QuotaGauge, { arcPath, fillColor } from "./QuotaGauge.jsx";
+
+describe("arcPath", () => {
+  it("starts at the left edge of the semicircle", () => {
+    // fraction 0 → degenerate arc but should still start at (20, 90).
+    expect(arcPath(0)).toMatch(/^M 20 90 /);
+  });
+
+  it("traces to the right edge at fraction 1", () => {
+    const path = arcPath(1);
+    expect(path).toContain("M 20 90");
+    // End X for a semicircle at fraction 1 should be 160 (CENTER_X + R).
+    expect(path).toMatch(/160\.00 90\.00/);
+  });
+
+  it("clamps inputs outside [0, 1]", () => {
+    expect(arcPath(-0.5)).toBe(arcPath(0));
+    expect(arcPath(1.5)).toBe(arcPath(1));
+  });
+
+  it("switches to the large-arc flag past the halfway mark", () => {
+    // <= 0.5 → large-arc flag 0; > 0.5 → 1.
+    expect(arcPath(0.4)).toMatch(/0 0 1/);
+    expect(arcPath(0.6)).toMatch(/0 1 1/);
+  });
+});
+
+describe("fillColor", () => {
+  it("returns accent for low usage", () => {
+    expect(fillColor(0.5)).toBe("var(--accent)");
+  });
+
+  it("returns a warning colour in the 75–90% band", () => {
+    expect(fillColor(0.8)).toBe("#f5a623");
+  });
+
+  it("returns danger at/above 90%", () => {
+    expect(fillColor(0.9)).toBe("var(--danger)");
+    expect(fillColor(1.0)).toBe("var(--danger)");
+  });
+});
+
+describe("QuotaGauge", () => {
+  it("returns null when quota is missing", () => {
+    const { container } = render(<QuotaGauge />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when memory_count is not a number", () => {
+    const { container } = render(<QuotaGauge quota={{ memory_count: "oops", memory_limit: 100 }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a plain count when memory_limit is null (admin/exempt)", () => {
+    render(<QuotaGauge quota={{ memory_count: 42, memory_limit: null }} />);
+    expect(screen.getByTestId("quota-gauge-unbounded")).toBeTruthy();
+    expect(screen.getByText("42")).toBeTruthy();
+    expect(screen.getByText(/no quota/i)).toBeTruthy();
+  });
+
+  it("renders a gauge + count / limit + remaining when both set", () => {
+    render(<QuotaGauge quota={{ memory_count: 40, memory_limit: 100 }} />);
+    expect(screen.getByText("40")).toBeTruthy();
+    expect(screen.getByText("/ 100")).toBeTruthy();
+    expect(screen.getByText(/60 remaining/)).toBeTruthy();
+  });
+
+  it("handles memory_limit of 0 without dividing by zero", () => {
+    render(<QuotaGauge quota={{ memory_count: 5, memory_limit: 0 }} />);
+    // No NaN rendered; 0 remaining.
+    expect(screen.getByText("5")).toBeTruthy();
+    expect(screen.getByText(/0 remaining/)).toBeTruthy();
+  });
+});

--- a/ui/src/components/stats/QuotaGauge.test.jsx
+++ b/ui/src/components/stats/QuotaGauge.test.jsx
@@ -33,8 +33,8 @@ describe("fillColor", () => {
     expect(fillColor(0.5)).toBe("var(--accent)");
   });
 
-  it("returns a warning colour in the 75–90% band", () => {
-    expect(fillColor(0.8)).toBe("#f5a623");
+  it("returns the amber theme token in the 75–90% band", () => {
+    expect(fillColor(0.8)).toBe("var(--amber)");
   });
 
   it("returns danger at/above 90%", () => {

--- a/ui/src/components/stats/TagDistribution.jsx
+++ b/ui/src/components/stats/TagDistribution.jsx
@@ -2,22 +2,24 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
-import EmptyState from "../EmptyState.jsx";
 
 // #537 — donut chart of memory counts per tag. Clicking a slice jumps to
 // the Memories tab pre-filtered by that tag.
 
 const TOP_N = 8;
-// Brand-orange + five complementary colours from Dashboard's TOOL_COLORS.
+// Eight-slot palette: brand orange first (so the top tag always reads as
+// "primary"), followed by seven distinguishable accents. First five track
+// Dashboard.jsx's TOOL_COLORS; the last three are distinct non-TOOL hues
+// chosen to stay readable against the donut's inner ring on both themes.
 const SLICE_COLORS = [
-  "#e8a020", // brand orange
-  "#1a73e8", // blue
-  "#00897b", // teal
-  "#9334e8", // purple
-  "#34a853", // green
-  "#fb923c", // orange-500
-  "#d93025", // red
-  "#64748b", // slate
+  "#e8a020", // brand orange (TOOL_COLORS.remember)
+  "#1a73e8", // blue          (TOOL_COLORS.recall)
+  "#00897b", // teal          (TOOL_COLORS.list_memories)
+  "#9334e8", // purple        (TOOL_COLORS.summarize_context)
+  "#34a853", // green         (TOOL_COLORS.search_memories)
+  "#fb923c", // orange-500 (extra)
+  "#d93025", // red        (TOOL_COLORS.forget)
+  "#64748b", // slate      (extra)
 ];
 const OTHER_COLOR = "var(--text-muted)";
 
@@ -65,16 +67,9 @@ export function handlePieSliceClick(arg) {
 
 export default function TagDistribution({ data }) {
   const slices = useMemo(() => buildSlices(data), [data]);
-
-  if (slices.length === 0) {
-    return (
-      <EmptyState
-        variant="memories"
-        title="No tags yet"
-        description="Tag some memories to see how they cluster."
-      />
-    );
-  }
+  // Empty handling lives on the parent <GraphCard> — when `data` is
+  // empty/missing it never renders children, so this component always
+  // has at least one slice to draw.
 
   return (
     <ResponsiveContainer width="100%" height={260}>

--- a/ui/src/components/stats/TagDistribution.jsx
+++ b/ui/src/components/stats/TagDistribution.jsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import EmptyState from "../EmptyState.jsx";
+
+// #537 — donut chart of memory counts per tag. Clicking a slice jumps to
+// the Memories tab pre-filtered by that tag.
+
+const TOP_N = 8;
+// Brand-orange + five complementary colours from Dashboard's TOOL_COLORS.
+const SLICE_COLORS = [
+  "#e8a020", // brand orange
+  "#1a73e8", // blue
+  "#00897b", // teal
+  "#9334e8", // purple
+  "#34a853", // green
+  "#fb923c", // orange-500
+  "#d93025", // red
+  "#64748b", // slate
+];
+const OTHER_COLOR = "var(--text-muted)";
+
+export function buildSlices(data) {
+  const sorted = [...(data ?? [])].sort((a, b) => b.count - a.count);
+  const head = sorted.slice(0, TOP_N);
+  const tail = sorted.slice(TOP_N);
+  const slices = head.map((d) => ({ tag: d.tag, count: d.count }));
+  if (tail.length > 0) {
+    const otherCount = tail.reduce((sum, d) => sum + d.count, 0);
+    slices.push({ tag: "Other", count: otherCount, isOther: true });
+  }
+  return slices;
+}
+
+export function filterByTag(tag) {
+  if (typeof globalThis.dispatchEvent !== "function") return;
+  globalThis.dispatchEvent(
+    new CustomEvent("hive:memory-browser", { detail: { tag } }),
+  );
+  globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "memories" }));
+}
+
+export default function TagDistribution({ data }) {
+  const slices = useMemo(() => buildSlices(data), [data]);
+
+  if (slices.length === 0) {
+    return (
+      <EmptyState
+        variant="memories"
+        title="No tags yet"
+        description="Tag some memories to see how they cluster."
+      />
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <PieChart>
+        <Pie
+          data={slices}
+          dataKey="count"
+          nameKey="tag"
+          innerRadius={50}
+          outerRadius={90}
+          paddingAngle={2}
+          onClick={(p) => {
+            if (!p.isOther) filterByTag(p.tag);
+          }}
+          cursor="pointer"
+        >
+          {slices.map((s, i) => (
+            <Cell
+              key={s.tag}
+              fill={s.isOther ? OTHER_COLOR : SLICE_COLORS[i % SLICE_COLORS.length]}
+            />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={{ background: "var(--surface)", border: "1px solid var(--border)", fontSize: 12 }}
+          formatter={(value, name) => [`${value} memories`, name]}
+        />
+        <Legend wrapperStyle={{ fontSize: 11, color: "var(--text-muted)" }} />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}
+
+TagDistribution.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      tag: PropTypes.string.isRequired,
+      count: PropTypes.number.isRequired,
+    }),
+  ),
+};

--- a/ui/src/components/stats/TagDistribution.jsx
+++ b/ui/src/components/stats/TagDistribution.jsx
@@ -41,6 +41,22 @@ export function filterByTag(tag) {
   globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "memories" }));
 }
 
+export function formatTagTooltip(value, name) {
+  return [`${value} memories`, name];
+}
+
+// Extracted for direct testability — recharts doesn't actually paint the
+// slices in jsdom, so the inline Pie `onClick` would never fire from a
+// render-level test. Accepts both raw slice objects and Recharts-style
+// `{ payload }` wrappers.
+export function handlePieSliceClick(arg) {
+  const slice = arg?.payload ?? arg;
+  if (!slice || slice.isOther || typeof slice.tag !== "string" || !slice.tag) {
+    return;
+  }
+  filterByTag(slice.tag);
+}
+
 export default function TagDistribution({ data }) {
   const slices = useMemo(() => buildSlices(data), [data]);
 
@@ -64,9 +80,7 @@ export default function TagDistribution({ data }) {
           innerRadius={50}
           outerRadius={90}
           paddingAngle={2}
-          onClick={(p) => {
-            if (!p.isOther) filterByTag(p.tag);
-          }}
+          onClick={handlePieSliceClick}
           cursor="pointer"
         >
           {slices.map((s, i) => (
@@ -78,7 +92,7 @@ export default function TagDistribution({ data }) {
         </Pie>
         <Tooltip
           contentStyle={{ background: "var(--surface)", border: "1px solid var(--border)", fontSize: 12 }}
-          formatter={(value, name) => [`${value} memories`, name]}
+          formatter={formatTagTooltip}
         />
         <Legend wrapperStyle={{ fontSize: 11, color: "var(--text-muted)" }} />
       </PieChart>

--- a/ui/src/components/stats/TagDistribution.jsx
+++ b/ui/src/components/stats/TagDistribution.jsx
@@ -35,10 +35,16 @@ export function buildSlices(data) {
 
 export function filterByTag(tag) {
   if (typeof globalThis.dispatchEvent !== "function") return;
-  globalThis.dispatchEvent(
-    new CustomEvent("hive:memory-browser", { detail: { tag } }),
-  );
+  // Tab-switch first so MemoryBrowser mounts and attaches its
+  // `hive:memory-browser` listener before we fire the deep-link event —
+  // otherwise the event is dispatched before the listener exists and is
+  // silently dropped. Same reasoning as TopRecalled.openMemory.
   globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "memories" }));
+  globalThis.setTimeout(() => {
+    globalThis.dispatchEvent(
+      new CustomEvent("hive:memory-browser", { detail: { tag } }),
+    );
+  }, 0);
 }
 
 export function formatTagTooltip(value, name) {

--- a/ui/src/components/stats/TagDistribution.test.jsx
+++ b/ui/src/components/stats/TagDistribution.test.jsx
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TagDistribution, { buildSlices, filterByTag } from "./TagDistribution.jsx";
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+describe("buildSlices", () => {
+  it("returns empty for missing/empty data", () => {
+    expect(buildSlices()).toEqual([]);
+    expect(buildSlices([])).toEqual([]);
+  });
+
+  it("sorts by count descending", () => {
+    const slices = buildSlices([
+      { tag: "a", count: 2 },
+      { tag: "b", count: 5 },
+    ]);
+    expect(slices.map((s) => s.tag)).toEqual(["b", "a"]);
+  });
+
+  it("bundles anything past the top N into an 'Other' slice", () => {
+    const data = Array.from({ length: 12 }, (_, i) => ({
+      tag: `t${i}`,
+      count: 12 - i,
+    }));
+    const slices = buildSlices(data);
+    // Top 8 + one Other slice = 9 entries.
+    expect(slices).toHaveLength(9);
+    const other = slices[slices.length - 1];
+    expect(other.tag).toBe("Other");
+    expect(other.isOther).toBe(true);
+    // Other count = sum of tags 9–12 = 4 + 3 + 2 + 1 = 10.
+    expect(other.count).toBe(10);
+  });
+
+  it("does not add an 'Other' slice when count <= top N", () => {
+    const data = Array.from({ length: 4 }, (_, i) => ({ tag: `t${i}`, count: i + 1 }));
+    const slices = buildSlices(data);
+    expect(slices).toHaveLength(4);
+    expect(slices.every((s) => !s.isOther)).toBe(true);
+  });
+});
+
+describe("TagDistribution", () => {
+  it("renders empty state when data is empty", () => {
+    render(<TagDistribution data={[]} />);
+    expect(screen.getByText(/no tags yet/i)).toBeTruthy();
+  });
+
+  it("renders the pie chart when data is present", () => {
+    const { container } = render(
+      <TagDistribution data={[{ tag: "work", count: 5 }, { tag: "home", count: 3 }]} />,
+    );
+    expect(screen.queryByText(/no tags yet/i)).toBeNull();
+    expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
+  });
+});
+
+describe("filterByTag", () => {
+  let dispatchSpy;
+  beforeEach(() => {
+    dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+  });
+  afterEach(() => {
+    dispatchSpy.mockRestore();
+  });
+
+  it("dispatches memory-browser with tag + switch-tab", () => {
+    filterByTag("work");
+    const types = dispatchSpy.mock.calls.map((c) => c[0].type);
+    expect(types).toContain("hive:memory-browser");
+    expect(types).toContain("hive:switch-tab");
+    const browserEvent = dispatchSpy.mock.calls.find(
+      (c) => c[0].type === "hive:memory-browser",
+    )[0];
+    expect(browserEvent.detail).toEqual({ tag: "work" });
+  });
+
+  it("is a no-op without a dispatchEvent global", () => {
+    const original = globalThis.dispatchEvent;
+    globalThis.dispatchEvent = undefined;
+    expect(() => filterByTag("x")).not.toThrow();
+    globalThis.dispatchEvent = original;
+  });
+});

--- a/ui/src/components/stats/TagDistribution.test.jsx
+++ b/ui/src/components/stats/TagDistribution.test.jsx
@@ -47,16 +47,12 @@ describe("buildSlices", () => {
 });
 
 describe("TagDistribution", () => {
-  it("renders empty state when data is empty", () => {
-    render(<TagDistribution data={[]} />);
-    expect(screen.getByText(/no tags yet/i)).toBeTruthy();
-  });
-
   it("renders the pie chart when data is present", () => {
     const { container } = render(
       <TagDistribution data={[{ tag: "work", count: 5 }, { tag: "home", count: 3 }]} />,
     );
-    expect(screen.queryByText(/no tags yet/i)).toBeNull();
+    // Empty handling is the GraphCard parent's job; this component
+    // assumes at least one slice to draw.
     expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
   });
 

--- a/ui/src/components/stats/TagDistribution.test.jsx
+++ b/ui/src/components/stats/TagDistribution.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import TagDistribution, { buildSlices, filterByTag } from "./TagDistribution.jsx";
+import TagDistribution, { buildSlices, filterByTag, formatTagTooltip, handlePieSliceClick } from "./TagDistribution.jsx";
 
 global.ResizeObserver = class {
   observe() {}
@@ -59,32 +59,98 @@ describe("TagDistribution", () => {
     expect(screen.queryByText(/no tags yet/i)).toBeNull();
     expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
   });
+
+  it("renders the Other slice when input exceeds the top-N cap", () => {
+    const data = Array.from({ length: 10 }, (_, i) => ({
+      tag: `t${i}`,
+      count: 10 - i,
+    }));
+    const { container } = render(<TagDistribution data={data} />);
+    // The Cell `fill` branch for the Other slice is now exercised — the
+    // rendered recharts surface mounts normally without throwing.
+    expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
+  });
 });
 
 describe("filterByTag", () => {
-  let dispatchSpy;
+  let originalDispatch;
+  let calls;
+
   beforeEach(() => {
-    dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+    originalDispatch = globalThis.dispatchEvent;
+    calls = [];
+    globalThis.dispatchEvent = (e) => {
+      calls.push(e);
+      return true;
+    };
   });
+
   afterEach(() => {
-    dispatchSpy.mockRestore();
+    globalThis.dispatchEvent = originalDispatch;
   });
 
   it("dispatches memory-browser with tag + switch-tab", () => {
     filterByTag("work");
-    const types = dispatchSpy.mock.calls.map((c) => c[0].type);
+    const types = calls.map((e) => e.type);
     expect(types).toContain("hive:memory-browser");
     expect(types).toContain("hive:switch-tab");
-    const browserEvent = dispatchSpy.mock.calls.find(
-      (c) => c[0].type === "hive:memory-browser",
-    )[0];
+    const browserEvent = calls.find((e) => e.type === "hive:memory-browser");
     expect(browserEvent.detail).toEqual({ tag: "work" });
   });
 
   it("is a no-op without a dispatchEvent global", () => {
-    const original = globalThis.dispatchEvent;
     globalThis.dispatchEvent = undefined;
     expect(() => filterByTag("x")).not.toThrow();
-    globalThis.dispatchEvent = original;
+  });
+});
+
+describe("formatTagTooltip", () => {
+  it("labels the value with 'memories' and passes the name through", () => {
+    expect(formatTagTooltip(3, "work")).toEqual(["3 memories", "work"]);
+  });
+});
+
+describe("handlePieSliceClick", () => {
+  let originalDispatch;
+  let calls;
+
+  beforeEach(() => {
+    originalDispatch = globalThis.dispatchEvent;
+    calls = [];
+    globalThis.dispatchEvent = (e) => {
+      calls.push(e);
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    globalThis.dispatchEvent = originalDispatch;
+  });
+
+  it("dispatches for a real slice", () => {
+    handlePieSliceClick({ tag: "work", count: 5 });
+    const types = calls.map((e) => e.type);
+    expect(types).toContain("hive:memory-browser");
+    expect(types).toContain("hive:switch-tab");
+  });
+
+  it("unwraps a Recharts-style payload wrapper", () => {
+    handlePieSliceClick({ payload: { tag: "home", count: 3 } });
+    const browserEvent = calls.find((e) => e.type === "hive:memory-browser");
+    expect(browserEvent.detail).toEqual({ tag: "home" });
+  });
+
+  it("ignores the Other bucket", () => {
+    handlePieSliceClick({ tag: "Other", count: 10, isOther: true });
+    expect(calls).toEqual([]);
+  });
+
+  it("ignores missing / malformed input", () => {
+    handlePieSliceClick(undefined);
+    handlePieSliceClick(null);
+    handlePieSliceClick({});
+    handlePieSliceClick({ tag: "" });
+    handlePieSliceClick({ payload: { tag: null } });
+    expect(calls).toEqual([]);
   });
 });

--- a/ui/src/components/stats/TagDistribution.test.jsx
+++ b/ui/src/components/stats/TagDistribution.test.jsx
@@ -89,13 +89,17 @@ describe("filterByTag", () => {
     globalThis.dispatchEvent = originalDispatch;
   });
 
-  it("dispatches memory-browser with tag + switch-tab", () => {
+  it("dispatches switch-tab first, then memory-browser on next tick", () => {
+    vi.useFakeTimers();
     filterByTag("work");
+    // Pre-flush: only the tab-switch has fired so MemoryBrowser can mount.
+    expect(calls.map((e) => e.type)).toEqual(["hive:switch-tab"]);
+    vi.runAllTimers();
     const types = calls.map((e) => e.type);
-    expect(types).toContain("hive:memory-browser");
-    expect(types).toContain("hive:switch-tab");
+    expect(types).toEqual(["hive:switch-tab", "hive:memory-browser"]);
     const browserEvent = calls.find((e) => e.type === "hive:memory-browser");
     expect(browserEvent.detail).toEqual({ tag: "work" });
+    vi.useRealTimers();
   });
 
   it("is a no-op without a dispatchEvent global", () => {
@@ -128,16 +132,22 @@ describe("handlePieSliceClick", () => {
   });
 
   it("dispatches for a real slice", () => {
+    vi.useFakeTimers();
     handlePieSliceClick({ tag: "work", count: 5 });
+    vi.runAllTimers();
     const types = calls.map((e) => e.type);
     expect(types).toContain("hive:memory-browser");
     expect(types).toContain("hive:switch-tab");
+    vi.useRealTimers();
   });
 
   it("unwraps a Recharts-style payload wrapper", () => {
+    vi.useFakeTimers();
     handlePieSliceClick({ payload: { tag: "home", count: 3 } });
+    vi.runAllTimers();
     const browserEvent = calls.find((e) => e.type === "hive:memory-browser");
     expect(browserEvent.detail).toEqual({ tag: "home" });
+    vi.useRealTimers();
   });
 
   it("ignores the Other bucket", () => {

--- a/ui/src/components/stats/TopRecalled.jsx
+++ b/ui/src/components/stats/TopRecalled.jsx
@@ -20,10 +20,17 @@ export function openMemory(memory) {
   const data = memory?.payload ?? memory;
   if (!data || typeof data.key !== "string" || data.key.length === 0) return;
   if (typeof globalThis.dispatchEvent !== "function") return;
-  globalThis.dispatchEvent(
-    new CustomEvent("hive:memory-browser", { detail: { search: data.key } }),
-  );
+  // Dispatch order matters: the tab-switch fires first so MemoryBrowser
+  // actually mounts (it's conditionally rendered in App.jsx) and its
+  // `hive:memory-browser` listener is attached before the deep-link
+  // event fires. Defer the listener-targeted event by one tick to let
+  // React commit the mount.
   globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "memories" }));
+  globalThis.setTimeout(() => {
+    globalThis.dispatchEvent(
+      new CustomEvent("hive:memory-browser", { detail: { search: data.key } }),
+    );
+  }, 0);
 }
 
 export default function TopRecalled({ data }) {

--- a/ui/src/components/stats/TopRecalled.jsx
+++ b/ui/src/components/stats/TopRecalled.jsx
@@ -9,10 +9,19 @@ import EmptyState from "../EmptyState.jsx";
 // set to the memory's key) and a `hive:switch-tab` event to jump to the
 // Memories tab.
 
+export function formatRecallTooltip(value) {
+  return [`${value} recalls`, ""];
+}
+
 export function openMemory(memory) {
+  // Recharts event handlers wrap the original datum in a `.payload`
+  // field; accept either shape defensively so the click-through works
+  // regardless of which recharts version is installed.
+  const data = memory?.payload ?? memory;
+  if (!data || typeof data.key !== "string" || data.key.length === 0) return;
   if (typeof globalThis.dispatchEvent !== "function") return;
   globalThis.dispatchEvent(
-    new CustomEvent("hive:memory-browser", { detail: { search: memory.key } }),
+    new CustomEvent("hive:memory-browser", { detail: { search: data.key } }),
   );
   globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "memories" }));
 }
@@ -51,13 +60,13 @@ export default function TopRecalled({ data }) {
         <Tooltip
           cursor={{ fill: "var(--surface)" }}
           contentStyle={{ background: "var(--surface)", border: "1px solid var(--border)", fontSize: 12 }}
-          formatter={(value) => [`${value} recalls`, ""]}
+          formatter={formatRecallTooltip}
         />
         <Bar
           dataKey="recall_count"
           fill="var(--accent)"
           radius={[0, 4, 4, 0]}
-          onClick={(payload) => openMemory(payload)}
+          onClick={openMemory}
           cursor="pointer"
         />
       </BarChart>

--- a/ui/src/components/stats/TopRecalled.jsx
+++ b/ui/src/components/stats/TopRecalled.jsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import PropTypes from "prop-types";
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import EmptyState from "../EmptyState.jsx";
+
+// #537 — horizontal bar chart of the top-N most-recalled memories.
+// Clicking a bar dispatches a `hive:memory-browser` event (search mode
+// set to the memory's key) and a `hive:switch-tab` event to jump to the
+// Memories tab.
+
+export function openMemory(memory) {
+  if (typeof globalThis.dispatchEvent !== "function") return;
+  globalThis.dispatchEvent(
+    new CustomEvent("hive:memory-browser", { detail: { search: memory.key } }),
+  );
+  globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "memories" }));
+}
+
+export default function TopRecalled({ data }) {
+  if (!data?.length) {
+    return (
+      <EmptyState
+        variant="memories"
+        title="No recalls yet"
+        description="Once an agent recalls a memory, the top entries will appear here."
+      />
+    );
+  }
+
+  // Recharts BarChart with `layout='vertical'` draws horizontal bars. Keep
+  // bars at a fixed 18px, full-width container, YAxis as the category axis.
+  const height = Math.max(120, data.length * 26);
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart
+        data={data}
+        layout="vertical"
+        margin={{ top: 5, right: 16, left: 8, bottom: 5 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" horizontal={false} />
+        <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11, fill: "var(--text-muted)" }} />
+        <YAxis
+          type="category"
+          dataKey="key"
+          width={140}
+          tick={{ fontSize: 11, fill: "var(--text)" }}
+          interval={0}
+        />
+        <Tooltip
+          cursor={{ fill: "var(--surface)" }}
+          contentStyle={{ background: "var(--surface)", border: "1px solid var(--border)", fontSize: 12 }}
+          formatter={(value) => [`${value} recalls`, ""]}
+        />
+        <Bar
+          dataKey="recall_count"
+          fill="var(--accent)"
+          radius={[0, 4, 4, 0]}
+          onClick={(payload) => openMemory(payload)}
+          cursor="pointer"
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+TopRecalled.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      memory_id: PropTypes.string.isRequired,
+      key: PropTypes.string.isRequired,
+      recall_count: PropTypes.number.isRequired,
+    }),
+  ),
+};

--- a/ui/src/components/stats/TopRecalled.jsx
+++ b/ui/src/components/stats/TopRecalled.jsx
@@ -2,7 +2,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import EmptyState from "../EmptyState.jsx";
 
 // #537 — horizontal bar chart of the top-N most-recalled memories.
 // Clicking a bar dispatches a `hive:memory-browser` event (search mode
@@ -34,15 +33,9 @@ export function openMemory(memory) {
 }
 
 export default function TopRecalled({ data }) {
-  if (!data?.length) {
-    return (
-      <EmptyState
-        variant="memories"
-        title="No recalls yet"
-        description="Once an agent recalls a memory, the top entries will appear here."
-      />
-    );
-  }
+  // Empty handling lives on the parent <GraphCard> — when `data` is
+  // empty/missing it never renders children, so this component always
+  // has at least one bar to draw.
 
   // Recharts BarChart with `layout='vertical'` draws horizontal bars. Keep
   // bars at a fixed 18px, full-width container, YAxis as the category axis.

--- a/ui/src/components/stats/TopRecalled.test.jsx
+++ b/ui/src/components/stats/TopRecalled.test.jsx
@@ -32,19 +32,10 @@ describe("TopRecalled", () => {
     globalThis.dispatchEvent = originalDispatch;
   });
 
-  it("renders empty state when data is missing", () => {
-    render(<TopRecalled />);
-    expect(screen.getByText(/no recalls yet/i)).toBeTruthy();
-  });
-
-  it("renders empty state when data is empty array", () => {
-    render(<TopRecalled data={[]} />);
-    expect(screen.getByText(/no recalls yet/i)).toBeTruthy();
-  });
-
   it("renders a chart container when data is present", () => {
     const { container } = render(<TopRecalled data={_data} />);
-    expect(screen.queryByText(/no recalls yet/i)).toBeNull();
+    // Empty handling is the GraphCard parent's job; this component
+    // assumes at least one bar to draw.
     expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
   });
 

--- a/ui/src/components/stats/TopRecalled.test.jsx
+++ b/ui/src/components/stats/TopRecalled.test.jsx
@@ -48,15 +48,20 @@ describe("TopRecalled", () => {
     expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
   });
 
-  it("openMemory dispatches memory-browser then switch-tab", () => {
+  it("openMemory dispatches switch-tab first, then memory-browser on next tick", () => {
+    vi.useFakeTimers();
     openMemory({ memory_id: "m1", key: "top-key", recall_count: 10 });
+    // Before the timer flushes, only the tab-switch has dispatched — so
+    // MemoryBrowser has a chance to mount + attach its listener.
+    expect(calls.map((e) => e.type)).toEqual(["hive:switch-tab"]);
+    vi.runAllTimers();
     const types = calls.map((e) => e.type);
-    expect(types).toContain("hive:memory-browser");
-    expect(types).toContain("hive:switch-tab");
+    expect(types).toEqual(["hive:switch-tab", "hive:memory-browser"]);
     const browserEvent = calls.find((e) => e.type === "hive:memory-browser");
     expect(browserEvent.detail).toEqual({ search: "top-key" });
     const switchEvent = calls.find((e) => e.type === "hive:switch-tab");
     expect(switchEvent.detail).toBe("memories");
+    vi.useRealTimers();
   });
 
   it("openMemory is a no-op without a dispatchEvent global", () => {
@@ -81,8 +86,11 @@ describe("TopRecalled", () => {
   });
 
   it("openMemory unwraps a Recharts-style payload wrapper", () => {
+    vi.useFakeTimers();
     openMemory({ payload: { memory_id: "m2", key: "wrapped-key", recall_count: 3 } });
+    vi.runAllTimers();
     const browserEvent = calls.find((e) => e.type === "hive:memory-browser");
     expect(browserEvent.detail).toEqual({ search: "wrapped-key" });
+    vi.useRealTimers();
   });
 });

--- a/ui/src/components/stats/TopRecalled.test.jsx
+++ b/ui/src/components/stats/TopRecalled.test.jsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TopRecalled, { openMemory } from "./TopRecalled.jsx";
+
+// Recharts uses ResponsiveContainer which needs ResizeObserver in jsdom.
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const _data = [
+  { memory_id: "m1", key: "top-key", recall_count: 10 },
+  { memory_id: "m2", key: "next-key", recall_count: 4 },
+];
+
+describe("TopRecalled", () => {
+  let dispatchSpy;
+
+  beforeEach(() => {
+    dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+  });
+
+  afterEach(() => {
+    dispatchSpy.mockRestore();
+  });
+
+  it("renders empty state when data is missing", () => {
+    render(<TopRecalled />);
+    expect(screen.getByText(/no recalls yet/i)).toBeTruthy();
+  });
+
+  it("renders empty state when data is empty array", () => {
+    render(<TopRecalled data={[]} />);
+    expect(screen.getByText(/no recalls yet/i)).toBeTruthy();
+  });
+
+  it("renders a chart container when data is present", () => {
+    const { container } = render(<TopRecalled data={_data} />);
+    expect(screen.queryByText(/no recalls yet/i)).toBeNull();
+    expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
+  });
+
+  it("openMemory dispatches memory-browser then switch-tab", () => {
+    openMemory({ memory_id: "m1", key: "top-key", recall_count: 10 });
+    const types = dispatchSpy.mock.calls.map((c) => c[0].type);
+    expect(types).toContain("hive:memory-browser");
+    expect(types).toContain("hive:switch-tab");
+    const browserEvent = dispatchSpy.mock.calls.find(
+      (c) => c[0].type === "hive:memory-browser",
+    )[0];
+    expect(browserEvent.detail).toEqual({ search: "top-key" });
+    const switchEvent = dispatchSpy.mock.calls.find(
+      (c) => c[0].type === "hive:switch-tab",
+    )[0];
+    expect(switchEvent.detail).toBe("memories");
+  });
+
+  it("openMemory is a no-op without a dispatchEvent global", () => {
+    const original = globalThis.dispatchEvent;
+    // @ts-expect-error — deliberately break the dispatch for this test
+    globalThis.dispatchEvent = undefined;
+    // Should not throw.
+    expect(() => openMemory({ memory_id: "m1", key: "k", recall_count: 1 })).not.toThrow();
+    globalThis.dispatchEvent = original;
+  });
+});

--- a/ui/src/components/stats/TopRecalled.test.jsx
+++ b/ui/src/components/stats/TopRecalled.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import TopRecalled, { openMemory } from "./TopRecalled.jsx";
+import TopRecalled, { formatRecallTooltip, openMemory } from "./TopRecalled.jsx";
 
 // Recharts uses ResponsiveContainer which needs ResizeObserver in jsdom.
 global.ResizeObserver = class {
@@ -16,14 +16,20 @@ const _data = [
 ];
 
 describe("TopRecalled", () => {
-  let dispatchSpy;
+  let originalDispatch;
+  let calls;
 
   beforeEach(() => {
-    dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+    originalDispatch = globalThis.dispatchEvent;
+    calls = [];
+    globalThis.dispatchEvent = (e) => {
+      calls.push(e);
+      return true;
+    };
   });
 
   afterEach(() => {
-    dispatchSpy.mockRestore();
+    globalThis.dispatchEvent = originalDispatch;
   });
 
   it("renders empty state when data is missing", () => {
@@ -44,25 +50,39 @@ describe("TopRecalled", () => {
 
   it("openMemory dispatches memory-browser then switch-tab", () => {
     openMemory({ memory_id: "m1", key: "top-key", recall_count: 10 });
-    const types = dispatchSpy.mock.calls.map((c) => c[0].type);
+    const types = calls.map((e) => e.type);
     expect(types).toContain("hive:memory-browser");
     expect(types).toContain("hive:switch-tab");
-    const browserEvent = dispatchSpy.mock.calls.find(
-      (c) => c[0].type === "hive:memory-browser",
-    )[0];
+    const browserEvent = calls.find((e) => e.type === "hive:memory-browser");
     expect(browserEvent.detail).toEqual({ search: "top-key" });
-    const switchEvent = dispatchSpy.mock.calls.find(
-      (c) => c[0].type === "hive:switch-tab",
-    )[0];
+    const switchEvent = calls.find((e) => e.type === "hive:switch-tab");
     expect(switchEvent.detail).toBe("memories");
   });
 
   it("openMemory is a no-op without a dispatchEvent global", () => {
-    const original = globalThis.dispatchEvent;
-    // @ts-expect-error — deliberately break the dispatch for this test
     globalThis.dispatchEvent = undefined;
     // Should not throw.
     expect(() => openMemory({ memory_id: "m1", key: "k", recall_count: 1 })).not.toThrow();
-    globalThis.dispatchEvent = original;
+  });
+
+  it("openMemory is a no-op when the datum is missing / lacks a key", () => {
+    // Recharts wrappers with no payload, or payloads without a key, must
+    // not dispatch — covers the early-return guard.
+    openMemory(undefined);
+    openMemory(null);
+    openMemory({});
+    openMemory({ key: "" });
+    openMemory({ payload: { key: "" } });
+    expect(calls).toEqual([]);
+  });
+
+  it("formatRecallTooltip labels the value with 'recalls'", () => {
+    expect(formatRecallTooltip(7)).toEqual(["7 recalls", ""]);
+  });
+
+  it("openMemory unwraps a Recharts-style payload wrapper", () => {
+    openMemory({ payload: { memory_id: "m2", key: "wrapped-key", recall_count: 3 } });
+    const browserEvent = calls.find((e) => e.type === "hive:memory-browser");
+    expect(browserEvent.detail).toEqual({ search: "wrapped-key" });
   });
 });


### PR DESCRIPTION
Closes #537. Part of #534.

Replaces the four placeholder `GraphCard` bodies for the tier-1 MVP charts with real recharts-driven visualisations, wired to the data already returned by `/api/account/stats`.

## Charts

- **`TopRecalled`** — horizontal `BarChart`, top 10 memories by recall count. Bar click → `hive:memory-browser` `{ search: memory.key }` + `hive:switch-tab` to deep-link into `MemoryBrowser`.
- **`TagDistribution`** — `PieChart` donut, top 8 tags + an `"Other"` bucket for the rest. Slice click → `hive:memory-browser` `{ tag }` + `hive:switch-tab` to pre-filter `MemoryBrowser`. Slice colours follow the brand/tool palette from Dashboard.jsx.
- **`MemoryGrowth`** — `AreaChart` of cumulative memory count. **Dotted linear projection** for the next 30 days, rendered only when ≥14 days of history have positive growth (avoids nonsense extrapolation off a two-day-old account).
- **`QuotaGauge`** — semicircle SVG arc (`used / limit`) with colour transitions at 75% (amber) and 90% (danger). Admin/exempt users (`memory_limit == null`) get a plain count card instead.

## `MemoryBrowser` deep-link hook

New `hive:memory-browser` event listener accepts `{ tag }` to pre-set the tag filter or `{ search }` to pre-set the search query. Paired with the existing `hive:switch-tab` event it gives Stats a clean one-way deep-link into the memory browser.

## Testing

- Each chart has a co-located `*.test.jsx` covering its pure helpers (`buildSlices`, `projectGrowth`, `arcPath`, `fillColor`, `openMemory`, `filterByTag`) plus empty-state and rendering branches.
- `Stats.test.jsx` mocks the chart components behind `data-testid` stubs so its assertions stay focused on the parent layout + branch logic rather than recharts internals.
- All 47 test files / 147 relevant tests green locally; `uv run inv pre-push` clean.

## Test plan

- [ ] Post-deploy: top_recalled bars render for a user with recalled memories; clicking one switches to Memories tab and sets the search to that key.
- [ ] tag_distribution renders top 8 + Other; clicking a non-Other slice filters Memories by that tag.
- [ ] Memory growth: 30-day window shows a history-only line; 90/365 windows with enough history show the dotted projection.
- [ ] Quota gauge shows the arc in green / amber / red at the right thresholds; admin user sees the unbounded card.