### PR TITLE
docs(claude): require reply-before-resolve on every Copilot review thread

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -841,10 +841,16 @@ gradually instead of flipping every autonomous PR onto it at once.
 
 1. After CI is green, request a Copilot review on the PR via
    `mcp__github__request_copilot_review`.
-2. Poll `mcp__github__pull_request_read` with `method=get_reviews`
-   every ~60s until a review from the `copilot-pull-request-reviewer`
-   actor appears in `SUBMITTED` state (typically 2–5 min).
-3. Fetch the review comments via `get_review_comments` and triage
+2. Wait for the Copilot **`Agent` check-run** to move to
+   `completed` (`get_check_runs`, typically 2–5 min). **Do not rely
+   on `get_reviews` alone** — subsequent Copilot iterations can post
+   line-level comments without creating a new top-level review object,
+   so `get_reviews` will look empty even when new findings exist. The
+   authoritative signal is: Agent check completed + a fresh
+   `get_review_comments` call shows threads from
+   `copilot-pull-request-reviewer` whose `created_at` is after the
+   last fix commit's timestamp.
+3. Call `get_review_comments` and triage
    each unresolved thread. **Every thread gets a reply before it's
    resolved** — never silently close a thread. Use
    `mcp__github__add_reply_to_pull_request_comment`, then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -860,7 +860,9 @@ gradually instead of flipping every autonomous PR onto it at once.
      safety gate — if it breaks, revert the fix and reply `This would
      introduce a regression; declining.`), push, reply on the thread
      with `Fixed in <SHA> — <one-line summary>`, resolve the thread,
-     then re-request Copilot review.
+     re-enable auto-merge via `mcp__github__enable_pr_auto_merge`
+     (pushing to a PR with a pending `COMMENTED` review often disarms
+     it), then re-request Copilot review.
    - **Pure style nit** (Tailwind class order, const-vs-let, naming
      preference, import sort) — reply with a short canned decline
      citing project conventions, then resolve the thread.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -845,19 +845,24 @@ gradually instead of flipping every autonomous PR onto it at once.
    every ~60s until a review from the `copilot-pull-request-reviewer`
    actor appears in `SUBMITTED` state (typically 2–5 min).
 3. Fetch the review comments via `get_review_comments` and triage
-   each unresolved thread:
+   each unresolved thread. **Every thread gets a reply before it's
+   resolved** — never silently close a thread. Use
+   `mcp__github__add_reply_to_pull_request_comment`, then
+   `mcp__github__resolve_review_thread`.
    - **Correctness / security / clarity finding** — write the fix on
      the same branch, run `uv run inv pre-push` locally (the post-fix
-     safety gate — if it breaks, revert the fix, reply `This would
-     introduce a regression; declining.`, resolve the thread), push,
+     safety gate — if it breaks, revert the fix and reply `This would
+     introduce a regression; declining.`), push, reply on the thread
+     with `Fixed in <SHA> — <one-line summary>`, resolve the thread,
      then re-request Copilot review.
    - **Pure style nit** (Tailwind class order, const-vs-let, naming
-     preference, import sort) — decline with a short canned reply
+     preference, import sort) — reply with a short canned decline
      citing project conventions, then resolve the thread.
    - **Ambiguous, architecturally significant, or would meaningfully
      change scope** — emit
      `HUMAN_INPUT_REQUIRED: Copilot flagged X on #NNN — unclear call`
-     and stop.
+     and stop. Do **not** resolve the thread — leave it open so the
+     human reviewer sees exactly what was flagged.
 4. **Hard iteration cap: 3.** After the third Copilot review
    round-trip, stop and ask — prevents ping-pong where each fix
    surfaces a new finding.


### PR DESCRIPTION
Tightens `CLAUDE.md §Autonomous issue workflow §7.5` based on a gap spotted while running the flow on PR #581 for the first time.

## Problem

The §7.5 workflow I shipped in #580 only spelled out reply behaviour for the **decline-regression** and **style-nit** paths. For correctness / security / clarity findings it said *"write the fix, push, re-request review"* — silent on whether to reply on the thread.

Running it end-to-end on #581, I addressed all 7 Copilot comments with fixes, pushed, re-requested review — and left every thread unresolved with no acknowledgement. That's a bad audit trail: a human reviewer has to cross-reference commit diffs against the original suggestion to verify action was taken, and it looks like the agent ignored the feedback.

## Fix

Rule: **every triaged thread gets a reply before it's resolved.** Never silently close a thread.

- **Correctness / security / clarity** — reply with `Fixed in <SHA> — <one-line summary>`, then resolve.
- **Style nit** — reply with a short canned decline, then resolve.
- **Ambiguous** — emit `HUMAN_INPUT_REQUIRED` and stop. **Do not** resolve — leave the thread open so the operator sees exactly what was flagged.

Also names the `add_reply_to_pull_request_comment` and `resolve_review_thread` tools explicitly in §7.5 so the flow is grep-able.

## ⚠️ Do not auto-merge

Per **CLAUDE.md §Keeping CLAUDE.md current**, changes to `§Autonomous issue workflow` require human review. Auto-merge is deliberately not enabled on this PR.