### PR TITLE
fix: audit-log endpoint misses events near midnight UTC

### DIFF
--- a/src/hive/api/admin.py
+++ b/src/hive/api/admin.py
@@ -5,6 +5,7 @@ Admin-only endpoints for CloudWatch metrics and AWS Cost Explorer data.
 
 from __future__ import annotations
 
+import datetime as _dt
 import os
 import time
 from typing import Annotated, Any
@@ -399,19 +400,30 @@ async def get_audit_log(
     client_id: Annotated[str | None, Query(description="Filter by client_id")] = None,
     event_type: Annotated[str | None, Query(description="Filter by event_type")] = None,
 ) -> dict[str, Any]:
-    import datetime as _dt
-
-    today = _dt.date.today()
+    # Anchor on UTC "today" — audit shards are keyed by the event's UTC
+    # date (see storage.log_audit_event) so any local-time anchor drifts
+    # away from the partition keys whenever the host TZ isn't UTC.
+    # Query ``days + 1`` shards so a request made just after midnight UTC
+    # still sees events that landed on yesterday's shard a few seconds
+    # earlier — otherwise the endpoint silently drops near-boundary
+    # audit events (observed failure: tests/unit/test_admin_api.py
+    # ::TestAdminAuditLog at 2026-04-20T00:00:01Z).
+    today = _dt.datetime.now(_dt.timezone.utc).date()
     dates = [
         (today - _dt.timedelta(days=i)).isoformat()
-        for i in range(days)  # NOSONAR — days bounded by FastAPI Query(ge=1, le=90)
+        for i in range(days + 1)  # NOSONAR — days bounded by FastAPI Query(ge=1, le=90)
     ]
+    cutoff = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=days)
     events = storage.get_audit_events_for_dates(
         dates,
         client_id=client_id,
         event_type=event_type,
         limit=limit + 1,
     )
+    # Trim events older than the rolling window — the extra shard
+    # captures anything that tipped over midnight, but we shouldn't
+    # include events from beyond `days * 24h` ago.
+    events = [e for e in events if e.timestamp >= cutoff]
     has_more = len(events) > limit
     events = events[:limit]
     return {

--- a/tests/unit/test_admin_api.py
+++ b/tests/unit/test_admin_api.py
@@ -544,6 +544,46 @@ class TestAdminAuditLog:
         resp = user_tc.get("/api/admin/audit-log?days=1")
         assert resp.status_code == 403
 
+    def test_returns_events_straddling_midnight_utc(self, admin_tc, audit_storage):
+        """Regression for #583.
+
+        Events written a few seconds before midnight UTC land in the
+        previous UTC date's shard. If the endpoint only queries "today"
+        UTC, those events are invisible to a ``days=1`` query made just
+        after midnight. The fix widens the shard scan by one day and
+        applies a time-based cutoff.
+        """
+        from datetime import datetime, timedelta, timezone
+        from unittest.mock import patch
+
+        from hive.models import ActivityEvent, EventType
+
+        # Three events straddling the midnight UTC boundary. The first
+        # two land on the pre-midnight shard, the last two on the
+        # post-midnight shard.
+        midnight = datetime(2026, 4, 20, 0, 0, 0, tzinfo=timezone.utc)
+        for offset_seconds in (-2, -1, 0, 1, 2):
+            audit_storage.log_audit_event(
+                ActivityEvent(
+                    event_type=EventType.memory_created,
+                    client_id="c",
+                    timestamp=midnight + timedelta(seconds=offset_seconds),
+                    metadata={"offset": offset_seconds},
+                )
+            )
+
+        # Simulate a request made 1.1 seconds after midnight UTC.
+        just_after_midnight = midnight + timedelta(seconds=1, microseconds=100_000)
+        with patch("hive.api.admin._dt.datetime", wraps=datetime) as mock_dt:
+            mock_dt.now.return_value = just_after_midnight
+            resp = admin_tc.get("/api/admin/audit-log?days=1&limit=50")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        # All five events should surface — both pre- and post-midnight
+        # shards are scanned and none fall outside the 24h cutoff.
+        assert body["count"] == 5, body
+
     def test_storage_factory_returns_storage(self):
         """_storage() dep factory returns a HiveStorage so the endpoint can run in prod."""
         from hive.api.admin import _storage


### PR DESCRIPTION
Closes #583

## Summary

The development pipeline failed two `TestAdminAuditLog` cases on a run
that started at `2026-04-20T00:00:01Z`. Root cause: the `/api/admin/audit-log`
endpoint anchored its shard scan on `date.today()` (local-time) and
only queried `days` date shards backwards. Events written seconds
before midnight UTC live on the previous UTC date's shard and were
silently dropped from `days=1` queries that arrived just after
midnight.

## Approach

- Anchor on UTC: `datetime.now(timezone.utc).date()`
- Scan `days + 1` shards so the rolling window always covers events
  that crossed midnight
- Trim results older than `now - days` so the effective window stays
  at `days * 24h` even with the extra shard

## Test plan

- [x] `tests/unit/test_admin_api.py::TestAdminAuditLog` — all 7 pass
- [x] New regression test `test_returns_events_straddling_midnight_utc`
      pins `datetime.now` to 1.1s after midnight, writes 5 events
      straddling the boundary, asserts all 5 surface
- [x] `uv run inv pre-push` clean

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb