### PR TITLE
chore: apply deferred Copilot review on FreshnessScatter (#600 follow-up)

### DIFF
--- a/ui/src/components/stats/FreshnessScatter.jsx
+++ b/ui/src/components/stats/FreshnessScatter.jsx
@@ -17,8 +17,10 @@ import {
 // #538 — freshness scatter: x = days since created, y = days since last
 // accessed. The stale-quadrant (upper-right) highlights memories that
 // are both old and have not been touched recently — candidate cleanup.
-// A scatter needs enough points to read as a distribution; sub-10 is
-// better served by the parent GraphCard's empty copy.
+// A scatter needs enough points to read as a distribution; when the
+// user has fewer than MIN_POINTS memories this component renders its
+// own min-points prompt instead of the chart (GraphCard's empty copy
+// only fires for a truly empty `data` prop, not for 1–9 entries).
 
 const MIN_POINTS = 10;
 const STALE_THRESHOLD_DAYS = 30;
@@ -114,9 +116,9 @@ export default function FreshnessScatter({ data }) {
             x2={maxAxis}
             y1={STALE_THRESHOLD_DAYS}
             y2={maxAxis}
-            fill="var(--danger)"
+            fill={STALE_FILL}
             fillOpacity={0.08}
-            stroke="var(--danger)"
+            stroke={STALE_FILL}
             strokeOpacity={0.25}
             strokeDasharray="4 4"
             ifOverflow="extendDomain"
@@ -156,18 +158,21 @@ export default function FreshnessScatter({ data }) {
             formatter={formatScatterTooltip}
           />
           <Scatter data={points} onClick={openMemory} cursor="pointer">
-            {points.map((p) => (
-              <Cell
-                key={p.memory_id}
-                fill={isStale(p) ? STALE_FILL : FRESH_FILL}
-                // Shape differs per-quadrant so users relying on
-                // high-contrast or colour-blind mode still see the
-                // stale distinction without depending on hue alone.
-                stroke={isStale(p) ? STALE_FILL : FRESH_FILL}
-                strokeWidth={isStale(p) ? 2 : 0}
-                fillOpacity={isStale(p) ? 0.95 : 0.75}
-              />
-            ))}
+            {points.map((p) => {
+              const stale = isStale(p);
+              return (
+                <Cell
+                  key={p.memory_id}
+                  fill={stale ? STALE_FILL : FRESH_FILL}
+                  // Shape differs per-quadrant so users relying on
+                  // high-contrast or colour-blind mode still see the
+                  // stale distinction without depending on hue alone.
+                  stroke={stale ? STALE_FILL : FRESH_FILL}
+                  strokeWidth={stale ? 2 : 0}
+                  fillOpacity={stale ? 0.95 : 0.75}
+                />
+              );
+            })}
           </Scatter>
         </ScatterChart>
       </ResponsiveContainer>


### PR DESCRIPTION
Closes #602

## Summary

Applies three Copilot-review findings on `FreshnessScatter.jsx` that
came in after #600 auto-merged:

- **Header comment** now accurately describes the sub-`MIN_POINTS`
  render path — `GraphCard`'s empty copy only fires for a truly empty
  `data` array, not for 1–9 entries, so this component owns the
  "not enough points" message.
- **`ReferenceArea`** uses `STALE_FILL` for `fill` / `stroke` instead
  of hard-coding `var(--danger)` twice (the constant already holds
  that token — keeps them from drifting).
- **`Cell` map** computes `const stale = isStale(p)` once per point
  and reuses it across `fill` / `stroke` / `strokeWidth` /
  `fillOpacity` rather than calling `isStale` four times per row.

No behaviour change — pure clarity / DRY.

## Approach

The underlying cause (auto-merge firing before the Copilot loop could
run) is already fixed by #601, so this is a one-time cleanup of the
threads that fell through the cracks on #600.

## Test plan

- [x] `uv run inv pre-push` clean (712 frontend tests pass, 100%
      coverage maintained)

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb