### PR TITLE
feat: Stats — client contribution breakdown

### DIFF
--- a/docs-site/public/openapi.json
+++ b/docs-site/public/openapi.json
@@ -806,7 +806,7 @@
     },
     "/api/account/stats": {
       "get": {
-        "description": "Return eight pre-aggregated graph datasets for the authenticated user (activity heatmap, top-recalled memories, tag distribution, memory growth, quota, freshness, client contribution, tag co-occurrence). Results are cached server-side for 60s per (user, window) pair.",
+        "description": "Return eight pre-aggregated graph datasets for the authenticated user (activity heatmap, top-recalled memories, tag distribution, memory growth, quota, freshness, client contribution, tag co-occurrence) plus a ``client_names`` lookup map so chart labels can resolve client IDs without a second round-trip. Results are cached server-side for 60s per (user, window) pair.",
         "operationId": "get_account_stats_api_account_stats_get",
         "parameters": [
           {

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -337,6 +337,11 @@ def _compute_account_stats(
     client_contribution = [
         {"date": d, "client_id": cid, "count": n} for (d, cid), n in sorted(contrib.items())
     ]
+    # client_names — display-name lookup so the ClientContribution chart
+    # can label each stacked segment without a second round-trip. Falls
+    # back to the client_id prefix on the UI side for ids we can't
+    # resolve (e.g. deleted clients, or the user_id actor itself).
+    client_names: dict[str, str] = {c.client_id: c.client_name for c in clients}
 
     # tag_cooccurrence — undirected edges between tags that share a memory,
     # weighted by how many memories they co-appear in. Sorted by weight
@@ -361,6 +366,7 @@ def _compute_account_stats(
         "quota": quota,
         "freshness": freshness,
         "client_contribution": client_contribution,
+        "client_names": client_names,
         "tag_cooccurrence": tag_cooccurrence,
     }
 

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -216,8 +216,9 @@ async def export_account(
 # #535 — /account/stats
 #
 # Personal usage analytics for the Stats tab. Returns eight pre-aggregated
-# graph datasets in a single response so the UI renders without chained
-# round-trips. Results are cached for ``_STATS_CACHE_TTL`` seconds per
+# graph datasets plus a ``client_names`` lookup map (for
+# ClientContribution's legend) in a single response so the UI renders
+# without chained round-trips. Results are cached for ``_STATS_CACHE_TTL`` seconds per
 # ``(user_id, window_days)`` key — the aggregation walks every memory and
 # a windowed slice of the activity log, so the cache shields the table
 # from repeated panel refreshes.
@@ -377,7 +378,9 @@ def _compute_account_stats(
     description=(
         "Return eight pre-aggregated graph datasets for the authenticated user "
         "(activity heatmap, top-recalled memories, tag distribution, memory "
-        "growth, quota, freshness, client contribution, tag co-occurrence). "
+        "growth, quota, freshness, client contribution, tag co-occurrence) "
+        "plus a ``client_names`` lookup map so chart labels can resolve "
+        "client IDs without a second round-trip. "
         "Results are cached server-side for 60s per (user, window) pair."
     ),
     responses={401: {"description": "Unauthorized"}, 422: {"description": "Invalid window"}},

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -457,6 +457,19 @@ class TestAccountStats:
         # out; only the hot memory should surface.
         assert keys == ["hot-key"]
 
+    def test_client_names_maps_client_id_to_display_name(self, client):
+        from hive.models import OAuthClient
+
+        tc, storage = client
+        # Register a named client owned by the user so the stats endpoint
+        # has a display name to surface.
+        oc = OAuthClient(client_name="Claude Code", owner_user_id=_USER_ID)
+        storage.put_client(oc)
+
+        resp = tc.get("/api/account/stats")
+        names = resp.json()["client_names"]
+        assert names.get(oc.client_id) == "Claude Code"
+
     def test_tag_cooccurrence_edges(self, client):
         from hive.models import Memory
 

--- a/ui/src/components/Stats.jsx
+++ b/ui/src/components/Stats.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
 import ActivityHeatmap from "./stats/ActivityHeatmap.jsx";
+import ClientContribution from "./stats/ClientContribution.jsx";
 import FreshnessScatter from "./stats/FreshnessScatter.jsx";
 import MemoryGrowth from "./stats/MemoryGrowth.jsx";
 import QuotaGauge from "./stats/QuotaGauge.jsx";
@@ -13,11 +14,11 @@ import { Card } from "./ui/card.jsx";
 
 // #535 — Stats tab scaffolding.
 //
-// Renders a grid of GraphCards backed by /api/account/stats. Six cards
-// are fully implemented (ActivityHeatmap, TopRecalled, TagDistribution,
-// MemoryGrowth, QuotaGauge, FreshnessScatter); the remaining two
-// (ClientContribution, TagCooccurrence) still show a JSON preview via
-// RawPreview until their dedicated sub-issues (#539 / #540) land.
+// Renders a grid of GraphCards backed by /api/account/stats. Seven
+// cards are fully implemented (ActivityHeatmap, TopRecalled,
+// TagDistribution, MemoryGrowth, QuotaGauge, FreshnessScatter,
+// ClientContribution); the remaining one (TagCooccurrence) still shows
+// a JSON preview via RawPreview until #540 lands.
 
 const WINDOWS = [
   { value: "30", label: "Last 30 days" },
@@ -217,7 +218,10 @@ export default function Stats() {
           data={data.client_contribution}
           empty="No client activity in this window."
         >
-          <RawPreview value={data.client_contribution} />
+          <ClientContribution
+            data={data.client_contribution}
+            clientNames={data.client_names}
+          />
         </GraphCard>
 
         <GraphCard

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -27,6 +27,9 @@ vi.mock("./stats/MemoryGrowth.jsx", () => ({
 vi.mock("./stats/FreshnessScatter.jsx", () => ({
   default: () => <div data-testid="freshness-scatter" />,
 }));
+vi.mock("./stats/ClientContribution.jsx", () => ({
+  default: () => <div data-testid="client-contribution" />,
+}));
 vi.mock("./stats/QuotaGauge.jsx", () => ({
   default: ({ quota }) => (
     <div data-testid="quota-gauge">
@@ -58,16 +61,16 @@ const MINIMAL_STATS = {
     days_since_created: i * 5,
     days_since_accessed: i,
   })),
+  client_contribution: [{ date: "2026-04-01", client_id: "c1", count: 2 }],
+  client_names: { c1: "Claude Code" },
   // Seven entries so RawPreview's `value.length > take` overflow branch
-  // is exercised (default `take` is 5). The two remaining placeholder
-  // cards (ClientContribution / TagCooccurrence) still render via
-  // RawPreview until #539 / #540 land.
-  client_contribution: Array.from({ length: 7 }, (_, i) => ({
-    date: `2026-04-${String(i + 1).padStart(2, "0")}`,
-    client_id: `c${i}`,
-    count: i + 1,
+  // is exercised (default `take` is 5). TagCooccurrence is the last
+  // placeholder card still rendering via RawPreview (until #540 lands).
+  tag_cooccurrence: Array.from({ length: 7 }, (_, i) => ({
+    source: `s${i}`,
+    target: `t${i}`,
+    weight: i + 1,
   })),
-  tag_cooccurrence: [{ source: "a", target: "b", weight: 3 }],
 };
 
 describe("GraphCard", () => {

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -63,14 +63,12 @@ const MINIMAL_STATS = {
   })),
   client_contribution: [{ date: "2026-04-01", client_id: "c1", count: 2 }],
   client_names: { c1: "Claude Code" },
-  // Seven entries so RawPreview's `value.length > take` overflow branch
-  // is exercised (default `take` is 5). TagCooccurrence is the last
-  // placeholder card still rendering via RawPreview (until #540 lands).
-  tag_cooccurrence: Array.from({ length: 7 }, (_, i) => ({
-    source: `s${i}`,
-    target: `t${i}`,
-    weight: i + 1,
-  })),
+  // Small tag_cooccurrence exercises RawPreview's `else` branch
+  // (`value.length <= take`). A dedicated test below overrides this
+  // with 7 entries to exercise the `>` overflow branch. TagCooccurrence
+  // is the last placeholder card still rendering via RawPreview
+  // (until #540 lands).
+  tag_cooccurrence: [{ source: "a", target: "b", weight: 1 }],
 };
 
 describe("GraphCard", () => {
@@ -244,5 +242,22 @@ describe("Stats", () => {
     await act(async () => render(<Stats />));
     await waitFor(() => expect(screen.getByText("Activity heatmap")).toBeTruthy());
     expect(screen.getByText("No activity in this window yet.")).toBeTruthy();
+  });
+
+  it("RawPreview renders the '…more' suffix when tag_cooccurrence overflows", async () => {
+    // Exercises RawPreview's `value.length > take` branch — the
+    // default fixture keeps tag_cooccurrence small so the opposite
+    // branch is covered too.
+    api.getAccountStats.mockResolvedValueOnce({
+      ...MINIMAL_STATS,
+      tag_cooccurrence: Array.from({ length: 7 }, (_, i) => ({
+        source: `s${i}`,
+        target: `t${i}`,
+        weight: i + 1,
+      })),
+    });
+    await act(async () => render(<Stats />));
+    await waitFor(() => expect(screen.getByText("Tag co-occurrence")).toBeTruthy());
+    expect(screen.getByText(/\+2 more/)).toBeTruthy();
   });
 });

--- a/ui/src/components/stats/ClientContribution.jsx
+++ b/ui/src/components/stats/ClientContribution.jsx
@@ -59,7 +59,7 @@ export function pivotByDate(data) {
   }
   return {
     rows: Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date)),
-    clientIds: Array.from(clientIds).sort(),
+    clientIds: Array.from(clientIds).sort((a, b) => a.localeCompare(b)),
   };
 }
 

--- a/ui/src/components/stats/ClientContribution.jsx
+++ b/ui/src/components/stats/ClientContribution.jsx
@@ -13,10 +13,11 @@ import {
 } from "recharts";
 import { SLICE_COLORS } from "../../lib/chartPalette.js";
 
-// #539 — stacked bar chart showing "Claude Code wrote X, Cursor wrote Y"
-// over time, one stacked bar per day in the window. Auto-hides with an
-// explanatory caption when the user has only one OAuth client actor,
-// since a single-colour stack reads as noise.
+// #539 — stacked bar chart of activity events per day, segmented by
+// OAuth client (reads, writes, deletes — anything that shows up in the
+// activity log). Auto-hides with an explanatory caption when the user
+// has only one OAuth client actor, since a single-colour stack reads
+// as noise.
 
 // Short fallback label when we have no display name for a client id —
 // the first 8 chars keeps client ids distinguishable on the legend
@@ -64,7 +65,7 @@ export default function ClientContribution({ data, clientNames }) {
     return (
       <div className="text-xs text-[var(--text-muted)] italic py-2">
         Contribution breakdown appears once two or more OAuth clients have
-        written memories on your behalf.
+        recorded activity on your behalf.
       </div>
     );
   }

--- a/ui/src/components/stats/ClientContribution.jsx
+++ b/ui/src/components/stats/ClientContribution.jsx
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+// #539 — stacked bar chart showing "Claude Code wrote X, Cursor wrote Y"
+// over time, one stacked bar per day in the window. Auto-hides with an
+// explanatory caption when the user has only one OAuth client actor,
+// since a single-colour stack reads as noise.
+
+// Same colour palette as TagDistribution so the Stats tab feels cohesive.
+// Keep the brand orange first so the most-active client reads as "primary".
+const CLIENT_COLORS = [
+  "#e8a020", // brand orange
+  "#1a73e8", // blue
+  "#00897b", // teal
+  "#9334e8", // purple
+  "#34a853", // green
+  "#fb923c", // orange-500
+  "#d93025", // red
+  "#64748b", // slate
+];
+
+// Short fallback label when we have no display name for a client id —
+// the first 8 chars keeps client ids distinguishable on the legend
+// without overflowing to a long uuid.
+export function resolveClientName(clientId, nameMap) {
+  const name = nameMap?.[clientId];
+  if (typeof name === "string" && name.length > 0) return name;
+  if (typeof clientId !== "string" || clientId.length === 0) return "unknown";
+  return clientId.slice(0, 8);
+}
+
+// Pivot the flat `[{date, client_id, count}]` entries into
+// `[{date, <client_id>: count, ...}]` rows so recharts' Bar stacking
+// works (recharts needs one column per stack key).
+export function pivotByDate(data) {
+  const byDate = new Map();
+  const clientIds = new Set();
+  for (const entry of data ?? []) {
+    clientIds.add(entry.client_id);
+    if (!byDate.has(entry.date)) byDate.set(entry.date, { date: entry.date });
+    byDate.get(entry.date)[entry.client_id] = entry.count;
+  }
+  return {
+    rows: Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date)),
+    clientIds: Array.from(clientIds).sort(),
+  };
+}
+
+export default function ClientContribution({ data, clientNames }) {
+  const { rows, clientIds } = useMemo(() => pivotByDate(data), [data]);
+
+  if (clientIds.length < 2) {
+    return (
+      <div className="text-xs text-[var(--text-muted)] italic py-2">
+        Contribution breakdown appears once two or more OAuth clients have
+        written memories on your behalf.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <BarChart data={rows} margin={{ top: 5, right: 10, left: 0, bottom: 30 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+        <XAxis
+          dataKey="date"
+          tick={{ fontSize: 11, fill: "var(--text-muted)" }}
+          angle={-45}
+          textAnchor="end"
+          height={60}
+          minTickGap={32}
+        />
+        <YAxis
+          allowDecimals={false}
+          tick={{ fontSize: 11, fill: "var(--text-muted)" }}
+        />
+        <Tooltip
+          cursor={{ fill: "var(--surface)" }}
+          contentStyle={{
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            fontSize: 12,
+          }}
+          formatter={(value, name) => [value, resolveClientName(name, clientNames)]}
+        />
+        <Legend
+          wrapperStyle={{ fontSize: 11, color: "var(--text-muted)" }}
+          formatter={(value) => resolveClientName(value, clientNames)}
+        />
+        {clientIds.map((cid, i) => (
+          <Bar
+            key={cid}
+            dataKey={cid}
+            name={cid}
+            stackId="events"
+            fill={CLIENT_COLORS[i % CLIENT_COLORS.length]}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+ClientContribution.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.string.isRequired,
+      client_id: PropTypes.string.isRequired,
+      count: PropTypes.number.isRequired,
+    }),
+  ),
+  clientNames: PropTypes.objectOf(PropTypes.string),
+};

--- a/ui/src/components/stats/ClientContribution.jsx
+++ b/ui/src/components/stats/ClientContribution.jsx
@@ -11,24 +11,12 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { SLICE_COLORS } from "../../lib/chartPalette.js";
 
 // #539 — stacked bar chart showing "Claude Code wrote X, Cursor wrote Y"
 // over time, one stacked bar per day in the window. Auto-hides with an
 // explanatory caption when the user has only one OAuth client actor,
 // since a single-colour stack reads as noise.
-
-// Same colour palette as TagDistribution so the Stats tab feels cohesive.
-// Keep the brand orange first so the most-active client reads as "primary".
-const CLIENT_COLORS = [
-  "#e8a020", // brand orange
-  "#1a73e8", // blue
-  "#00897b", // teal
-  "#9334e8", // purple
-  "#34a853", // green
-  "#fb923c", // orange-500
-  "#d93025", // red
-  "#64748b", // slate
-];
 
 // Short fallback label when we have no display name for a client id —
 // the first 8 chars keeps client ids distinguishable on the legend
@@ -116,7 +104,7 @@ export default function ClientContribution({ data, clientNames }) {
             dataKey={cid}
             name={cid}
             stackId="events"
-            fill={CLIENT_COLORS[i % CLIENT_COLORS.length]}
+            fill={SLICE_COLORS[i % SLICE_COLORS.length]}
           />
         ))}
       </BarChart>

--- a/ui/src/components/stats/ClientContribution.jsx
+++ b/ui/src/components/stats/ClientContribution.jsx
@@ -49,8 +49,13 @@ export function pivotByDate(data) {
   const clientIds = new Set();
   for (const entry of data ?? []) {
     clientIds.add(entry.client_id);
-    if (!byDate.has(entry.date)) byDate.set(entry.date, { date: entry.date });
-    byDate.get(entry.date)[entry.client_id] = entry.count;
+    // Resolve the row via a single Map read so we don't chain a
+    // nullable .get() into a property write — keeps SonarCloud's
+    // null-deref check happy without changing behaviour (the row
+    // always exists after the ?? below).
+    const row = byDate.get(entry.date) ?? { date: entry.date };
+    row[entry.client_id] = entry.count;
+    byDate.set(entry.date, row);
   }
   return {
     rows: Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date)),

--- a/ui/src/components/stats/ClientContribution.jsx
+++ b/ui/src/components/stats/ClientContribution.jsx
@@ -40,6 +40,18 @@ export function resolveClientName(clientId, nameMap) {
   return clientId.slice(0, 8);
 }
 
+// Recharts calls Tooltip/Legend formatters once per rendered segment;
+// jsdom doesn't paint the SVG so those inline arrows would never fire
+// from a component render test. Extract named factories so tests hit
+// them directly (same pattern as TagDistribution.handlePieSliceClick).
+export function makeTooltipFormatter(nameMap) {
+  return (value, name) => [value, resolveClientName(name, nameMap)];
+}
+
+export function makeLegendFormatter(nameMap) {
+  return (value) => resolveClientName(value, nameMap);
+}
+
 // Pivot the flat `[{date, client_id, count}]` entries into
 // `[{date, <client_id>: count, ...}]` rows so recharts' Bar stacking
 // works (recharts needs one column per stack key).
@@ -92,11 +104,11 @@ export default function ClientContribution({ data, clientNames }) {
             border: "1px solid var(--border)",
             fontSize: 12,
           }}
-          formatter={(value, name) => [value, resolveClientName(name, clientNames)]}
+          formatter={makeTooltipFormatter(clientNames)}
         />
         <Legend
           wrapperStyle={{ fontSize: 11, color: "var(--text-muted)" }}
-          formatter={(value) => resolveClientName(value, clientNames)}
+          formatter={makeLegendFormatter(clientNames)}
         />
         {clientIds.map((cid, i) => (
           <Bar

--- a/ui/src/components/stats/ClientContribution.test.jsx
+++ b/ui/src/components/stats/ClientContribution.test.jsx
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ClientContribution, {
+  pivotByDate,
+  resolveClientName,
+} from "./ClientContribution.jsx";
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const TWO_CLIENT_DATA = [
+  { date: "2026-04-01", client_id: "c1", count: 3 },
+  { date: "2026-04-01", client_id: "c2", count: 2 },
+  { date: "2026-04-02", client_id: "c1", count: 1 },
+];
+
+describe("resolveClientName", () => {
+  it("returns the display name when present", () => {
+    expect(resolveClientName("c1", { c1: "Claude Code" })).toBe("Claude Code");
+  });
+
+  it("falls back to the first 8 chars of the client id", () => {
+    expect(resolveClientName("abcdefghij", {})).toBe("abcdefgh");
+  });
+
+  it("handles missing name map and missing id gracefully", () => {
+    expect(resolveClientName("c1")).toBe("c1");
+    expect(resolveClientName("", { c1: "n" })).toBe("unknown");
+    expect(resolveClientName(undefined, { c1: "n" })).toBe("unknown");
+  });
+
+  it("treats empty-string display name as missing", () => {
+    // A blank `client_name` (seen when a client is registered without
+    // one) shouldn't surface as a blank legend entry — fall back to id.
+    expect(resolveClientName("abcdefgh9", { abcdefgh9: "" })).toBe("abcdefgh");
+  });
+});
+
+describe("pivotByDate", () => {
+  it("pivots flat entries into per-date rows keyed by client id", () => {
+    const { rows, clientIds } = pivotByDate(TWO_CLIENT_DATA);
+    expect(clientIds).toEqual(["c1", "c2"]);
+    expect(rows).toEqual([
+      { date: "2026-04-01", c1: 3, c2: 2 },
+      { date: "2026-04-02", c1: 1 },
+    ]);
+  });
+
+  it("returns empty rows + empty ids for missing/empty input", () => {
+    expect(pivotByDate(undefined)).toEqual({ rows: [], clientIds: [] });
+    expect(pivotByDate([])).toEqual({ rows: [], clientIds: [] });
+  });
+
+  it("sorts rows ascending by date even when input is out of order", () => {
+    const { rows } = pivotByDate([
+      { date: "2026-04-03", client_id: "c1", count: 1 },
+      { date: "2026-04-01", client_id: "c1", count: 2 },
+    ]);
+    expect(rows.map((r) => r.date)).toEqual(["2026-04-01", "2026-04-03"]);
+  });
+});
+
+describe("ClientContribution", () => {
+  it("renders an explanatory caption when fewer than 2 clients", () => {
+    render(<ClientContribution data={[{ date: "d", client_id: "c1", count: 1 }]} />);
+    expect(
+      screen.getByText(/two or more OAuth clients have written memories/),
+    ).toBeTruthy();
+  });
+
+  it("renders the caption when data is missing", () => {
+    render(<ClientContribution />);
+    expect(
+      screen.getByText(/two or more OAuth clients have written memories/),
+    ).toBeTruthy();
+  });
+
+  it("renders the chart container when 2+ clients are present", () => {
+    const { container } = render(
+      <ClientContribution
+        data={TWO_CLIENT_DATA}
+        clientNames={{ c1: "Claude Code", c2: "Cursor" }}
+      />,
+    );
+    expect(container.querySelector(".recharts-responsive-container")).toBeTruthy();
+  });
+});

--- a/ui/src/components/stats/ClientContribution.test.jsx
+++ b/ui/src/components/stats/ClientContribution.test.jsx
@@ -92,14 +92,14 @@ describe("ClientContribution", () => {
   it("renders an explanatory caption when fewer than 2 clients", () => {
     render(<ClientContribution data={[{ date: "d", client_id: "c1", count: 1 }]} />);
     expect(
-      screen.getByText(/two or more OAuth clients have written memories/),
+      screen.getByText(/two or more OAuth clients have recorded activity/),
     ).toBeTruthy();
   });
 
   it("renders the caption when data is missing", () => {
     render(<ClientContribution />);
     expect(
-      screen.getByText(/two or more OAuth clients have written memories/),
+      screen.getByText(/two or more OAuth clients have recorded activity/),
     ).toBeTruthy();
   });
 

--- a/ui/src/components/stats/ClientContribution.test.jsx
+++ b/ui/src/components/stats/ClientContribution.test.jsx
@@ -2,6 +2,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import ClientContribution, {
+  makeLegendFormatter,
+  makeTooltipFormatter,
   pivotByDate,
   resolveClientName,
 } from "./ClientContribution.jsx";
@@ -61,6 +63,28 @@ describe("pivotByDate", () => {
       { date: "2026-04-01", client_id: "c1", count: 2 },
     ]);
     expect(rows.map((r) => r.date)).toEqual(["2026-04-01", "2026-04-03"]);
+  });
+});
+
+describe("makeTooltipFormatter / makeLegendFormatter", () => {
+  it("tooltip formatter wraps value + resolved name tuple", () => {
+    const fmt = makeTooltipFormatter({ c1: "Claude Code" });
+    expect(fmt(5, "c1")).toEqual([5, "Claude Code"]);
+  });
+
+  it("tooltip formatter falls back to id prefix when no name map", () => {
+    const fmt = makeTooltipFormatter();
+    expect(fmt(1, "abcdefghijkl")).toEqual([1, "abcdefgh"]);
+  });
+
+  it("legend formatter resolves the value against the name map", () => {
+    const fmt = makeLegendFormatter({ c1: "Claude Code" });
+    expect(fmt("c1")).toBe("Claude Code");
+  });
+
+  it("legend formatter falls back for unknown ids", () => {
+    const fmt = makeLegendFormatter({});
+    expect(fmt("cursorclient")).toBe("cursorcl");
   });
 });
 

--- a/ui/src/components/stats/TagDistribution.jsx
+++ b/ui/src/components/stats/TagDistribution.jsx
@@ -2,25 +2,12 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { SLICE_COLORS } from "../../lib/chartPalette.js";
 
 // #537 — donut chart of memory counts per tag. Clicking a slice jumps to
 // the Memories tab pre-filtered by that tag.
 
 const TOP_N = 8;
-// Eight-slot palette: brand orange first (so the top tag always reads as
-// "primary"), followed by seven distinguishable accents. First five track
-// Dashboard.jsx's TOOL_COLORS; the last three are distinct non-TOOL hues
-// chosen to stay readable against the donut's inner ring on both themes.
-const SLICE_COLORS = [
-  "#e8a020", // brand orange (TOOL_COLORS.remember)
-  "#1a73e8", // blue          (TOOL_COLORS.recall)
-  "#00897b", // teal          (TOOL_COLORS.list_memories)
-  "#9334e8", // purple        (TOOL_COLORS.summarize_context)
-  "#34a853", // green         (TOOL_COLORS.search_memories)
-  "#fb923c", // orange-500 (extra)
-  "#d93025", // red        (TOOL_COLORS.forget)
-  "#64748b", // slate      (extra)
-];
 const OTHER_COLOR = "var(--text-muted)";
 
 export function buildSlices(data) {

--- a/ui/src/lib/chartPalette.js
+++ b/ui/src/lib/chartPalette.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+
+// Shared colour palette for categorical charts on the Stats tab
+// (tag distribution, client contribution, and future force graphs).
+// Brand orange leads so the largest / most-active slice always reads
+// as "primary". The next four slots track Dashboard.jsx's TOOL_COLORS
+// so the two tabs feel cohesive; the last three are distinct non-TOOL
+// hues that stay readable against both light + dark backgrounds.
+export const SLICE_COLORS = [
+  "#e8a020", // brand orange (TOOL_COLORS.remember)
+  "#1a73e8", // blue          (TOOL_COLORS.recall)
+  "#00897b", // teal          (TOOL_COLORS.list_memories)
+  "#9334e8", // purple        (TOOL_COLORS.summarize_context)
+  "#34a853", // green         (TOOL_COLORS.search_memories)
+  "#fb923c", // orange-500 (extra)
+  "#d93025", // red        (TOOL_COLORS.forget)
+  "#64748b", // slate      (extra)
+];

--- a/ui/src/lib/chartPalette.test.js
+++ b/ui/src/lib/chartPalette.test.js
@@ -4,10 +4,11 @@ import { SLICE_COLORS } from "./chartPalette.js";
 
 describe("SLICE_COLORS", () => {
   it("exports an 8-slot palette of hex strings", () => {
-    // Eight slots matches TagDistribution's TOP_N + "Other" capacity
-    // and ClientContribution's same-module consumption — keeping the
-    // length locked prevents a silent reshuffle if a colour is ever
-    // inserted in the middle.
+    // Eight slots cover the ranked slice colours consumed by
+    // TagDistribution and ClientContribution (the "Other" bucket uses
+    // OTHER_COLOR, not SLICE_COLORS) — keeping the length locked
+    // prevents a silent reshuffle if a colour is ever inserted in the
+    // middle.
     expect(SLICE_COLORS).toHaveLength(8);
     for (const c of SLICE_COLORS) {
       expect(c).toMatch(/^#[0-9a-f]{6}$/i);

--- a/ui/src/lib/chartPalette.test.js
+++ b/ui/src/lib/chartPalette.test.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { describe, expect, it } from "vitest";
+import { SLICE_COLORS } from "./chartPalette.js";
+
+describe("SLICE_COLORS", () => {
+  it("exports an 8-slot palette of hex strings", () => {
+    // Eight slots matches TagDistribution's TOP_N + "Other" capacity
+    // and ClientContribution's same-module consumption — keeping the
+    // length locked prevents a silent reshuffle if a colour is ever
+    // inserted in the middle.
+    expect(SLICE_COLORS).toHaveLength(8);
+    for (const c of SLICE_COLORS) {
+      expect(c).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+
+  it("leads with the brand orange so the primary slice always reads consistently", () => {
+    expect(SLICE_COLORS[0]).toBe("#e8a020");
+  });
+});


### PR DESCRIPTION
Closes #539

## Summary

Stacked `BarChart` on the Stats tab's **Client contribution** card
showing events per day split by OAuth `client_id`. Users with two or
more client actors see the breakdown; users with only one get a short
caption explaining why the chart is hidden.

## Approach

- Endpoint now returns a `client_names` map (`{client_id → display
  name}`) so the chart can label stacked segments without a second
  API round-trip. Names come from `list_clients(owner_user_id=...)`
  which was already fetched inside `_compute_account_stats`.
- UI pivots the flat `[{date, client_id, count}]` rows into
  per-date rows keyed by client id — recharts' `Bar stackId` wiring
  needs one column per stack key.
- `resolveClientName` falls back to the first 8 chars of the client
  id when the name is missing (deleted client, management-UI actor,
  blank `client_name`).
- Auto-hide threshold: `clientIds.length < 2`. Empty state is a
  dedicated caption rather than GraphCard's generic copy so users
  understand *why* there's no chart.

## Test plan

- [x] `tests/unit/test_account_api.py::test_client_names_maps_client_id_to_display_name`
      — asserts the map carries through from storage
- [x] `ui/src/components/stats/ClientContribution.test.jsx` — 10
      tests covering `resolveClientName` (present/missing/empty/prefix
      fallback), `pivotByDate` (normal/empty/sort), and the
      single-vs-multi-client render branch
- [x] `uv run inv pre-push` clean (723 frontend tests, 100% coverage)

Per §7.5, auto-merge is **not** armed at PR creation — step 7.5
arms it after the Copilot loop resolves.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb