### PR TITLE
feat: Stats — tag co-occurrence network

### DIFF
--- a/ui/src/components/Stats.jsx
+++ b/ui/src/components/Stats.jsx
@@ -8,17 +8,17 @@ import ClientContribution from "./stats/ClientContribution.jsx";
 import FreshnessScatter from "./stats/FreshnessScatter.jsx";
 import MemoryGrowth from "./stats/MemoryGrowth.jsx";
 import QuotaGauge from "./stats/QuotaGauge.jsx";
+import TagCooccurrence from "./stats/TagCooccurrence.jsx";
 import TagDistribution from "./stats/TagDistribution.jsx";
 import TopRecalled from "./stats/TopRecalled.jsx";
 import { Card } from "./ui/card.jsx";
 
 // #535 — Stats tab scaffolding.
 //
-// Renders a grid of GraphCards backed by /api/account/stats. Seven
+// Renders a grid of GraphCards backed by /api/account/stats. All eight
 // cards are fully implemented (ActivityHeatmap, TopRecalled,
 // TagDistribution, MemoryGrowth, QuotaGauge, FreshnessScatter,
-// ClientContribution); the remaining one (TagCooccurrence) still shows
-// a JSON preview via RawPreview until #540 lands.
+// ClientContribution, TagCooccurrence).
 
 const WINDOWS = [
   { value: "30", label: "Last 30 days" },
@@ -56,27 +56,6 @@ GraphCard.propTypes = {
   data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   empty: PropTypes.string,
   children: PropTypes.node,
-};
-
-// Stub body shared by every graph until a sub-issue ships the real chart.
-// Shows a compact JSON preview so we can eyeball the aggregate shape on
-// the deployed page without waiting for all the chart work.
-function RawPreview({ value, take = 5 }) {
-  // Called with arrays only — the <GraphCard> parent suppresses us when
-  // its `data` prop is empty/missing, so non-array cases can't reach
-  // here.
-  const overflow = value.length > take ? `\n…(+${value.length - take} more)` : "";
-  return (
-    <pre className="text-[11px] leading-snug text-[var(--text-muted)] overflow-x-auto m-0">
-      {JSON.stringify(value.slice(0, take), null, 2)}
-      {overflow}
-    </pre>
-  );
-}
-
-RawPreview.propTypes = {
-  value: PropTypes.array,
-  take: PropTypes.number,
 };
 
 export default function Stats() {
@@ -230,7 +209,7 @@ export default function Stats() {
           data={data.tag_cooccurrence}
           empty="No co-tagged memories yet."
         >
-          <RawPreview value={data.tag_cooccurrence} />
+          <TagCooccurrence data={data.tag_cooccurrence} />
         </GraphCard>
       </div>
     </div>

--- a/ui/src/components/Stats.test.jsx
+++ b/ui/src/components/Stats.test.jsx
@@ -30,6 +30,9 @@ vi.mock("./stats/FreshnessScatter.jsx", () => ({
 vi.mock("./stats/ClientContribution.jsx", () => ({
   default: () => <div data-testid="client-contribution" />,
 }));
+vi.mock("./stats/TagCooccurrence.jsx", () => ({
+  default: () => <div data-testid="tag-cooccurrence" />,
+}));
 vi.mock("./stats/QuotaGauge.jsx", () => ({
   default: ({ quota }) => (
     <div data-testid="quota-gauge">
@@ -63,11 +66,6 @@ const MINIMAL_STATS = {
   })),
   client_contribution: [{ date: "2026-04-01", client_id: "c1", count: 2 }],
   client_names: { c1: "Claude Code" },
-  // Small tag_cooccurrence exercises RawPreview's `else` branch
-  // (`value.length <= take`). A dedicated test below overrides this
-  // with 7 entries to exercise the `>` overflow branch. TagCooccurrence
-  // is the last placeholder card still rendering via RawPreview
-  // (until #540 lands).
   tag_cooccurrence: [{ source: "a", target: "b", weight: 1 }],
 };
 
@@ -244,20 +242,4 @@ describe("Stats", () => {
     expect(screen.getByText("No activity in this window yet.")).toBeTruthy();
   });
 
-  it("RawPreview renders the '…more' suffix when tag_cooccurrence overflows", async () => {
-    // Exercises RawPreview's `value.length > take` branch — the
-    // default fixture keeps tag_cooccurrence small so the opposite
-    // branch is covered too.
-    api.getAccountStats.mockResolvedValueOnce({
-      ...MINIMAL_STATS,
-      tag_cooccurrence: Array.from({ length: 7 }, (_, i) => ({
-        source: `s${i}`,
-        target: `t${i}`,
-        weight: i + 1,
-      })),
-    });
-    await act(async () => render(<Stats />));
-    await waitFor(() => expect(screen.getByText("Tag co-occurrence")).toBeTruthy());
-    expect(screen.getByText(/\+2 more/)).toBeTruthy();
-  });
 });

--- a/ui/src/components/stats/TagCooccurrence.jsx
+++ b/ui/src/components/stats/TagCooccurrence.jsx
@@ -1,21 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useMemo, useState } from "react";
 import PropTypes from "prop-types";
-
-// Palette mirrors TagDistribution's — #604 consolidates the two into
-// `ui/src/lib/chartPalette.js`; this file picks up the shared import
-// when this branch rebases onto #604. Inline here so #540 doesn't
-// block on that merge.
-const SLICE_COLORS = [
-  "#e8a020", // brand orange
-  "#1a73e8", // blue
-  "#00897b", // teal
-  "#9334e8", // purple
-  "#34a853", // green
-  "#fb923c", // orange-500
-  "#d93025", // red
-  "#64748b", // slate
-];
+import { SLICE_COLORS } from "../../lib/chartPalette.js";
 
 // #540 — tag co-occurrence network. Nodes = tags, edges = the number
 // of memories that carry both tags. A custom SVG with a circular
@@ -164,6 +150,8 @@ export default function TagCooccurrence({ data }) {
                 onFocus={() => setHovered(n.tag)}
                 onBlur={() => setHovered(null)}
                 tabIndex={0}
+                role="img"
+                aria-label={`${n.tag}: ${n.weight} co-occurrences`}
                 data-tag={n.tag}
                 style={{ cursor: "pointer" }}
               >
@@ -210,6 +198,3 @@ TagCooccurrence.propTypes = {
     }),
   ),
 };
-
-TagCooccurrence.MIN_TAGS = MIN_TAGS;
-TagCooccurrence.TOP_K_TAGS = TOP_K_TAGS;

--- a/ui/src/components/stats/TagCooccurrence.jsx
+++ b/ui/src/components/stats/TagCooccurrence.jsx
@@ -63,11 +63,7 @@ export function buildGraph(data) {
   const topTags = Array.from(nodeWeights.entries())
     .sort((a, b) => b[1] - a[1])
     .slice(0, TOP_K_TAGS)
-    .map(([tag], i) => ({
-      tag,
-      index: i,
-      weight: nodeWeights.get(tag) ?? 0,
-    }));
+    .map(([tag, weight], i) => ({ tag, index: i, weight }));
   const tagSet = new Set(topTags.map((n) => n.tag));
   const edges = rows
     .filter((e) => tagSet.has(e.source) && tagSet.has(e.target))

--- a/ui/src/components/stats/TagCooccurrence.jsx
+++ b/ui/src/components/stats/TagCooccurrence.jsx
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useMemo, useState } from "react";
+import PropTypes from "prop-types";
+
+// Palette mirrors TagDistribution's — #604 consolidates the two into
+// `ui/src/lib/chartPalette.js`; this file picks up the shared import
+// when this branch rebases onto #604. Inline here so #540 doesn't
+// block on that merge.
+const SLICE_COLORS = [
+  "#e8a020", // brand orange
+  "#1a73e8", // blue
+  "#00897b", // teal
+  "#9334e8", // purple
+  "#34a853", // green
+  "#fb923c", // orange-500
+  "#d93025", // red
+  "#64748b", // slate
+];
+
+// #540 — tag co-occurrence network. Nodes = tags, edges = the number
+// of memories that carry both tags. A custom SVG with a circular
+// layout keeps the bundle delta at zero (no react-force-graph /
+// d3-force dependency) and gives us deterministic positions that
+// render identically under jsdom — the acceptance criteria explicitly
+// asks to minimise bundle weight, and a force sim would be a bad
+// trade for what's a fundamentally small visualisation (≤ TOP_K tags).
+//
+// Bundle delta: **0 bytes** — everything is custom SVG + React + the
+// existing shared colour palette.
+
+const MIN_TAGS = 5;
+const TOP_K_TAGS = 15; // keep the chart readable on a sm:col-2 card
+const TOP_K_EDGES = 40; // drop the long tail of weight=1 edges past this
+const VIEWBOX = 260; // SVG is rendered square; height == width
+const NODE_RADIUS = 5;
+const RING_RADIUS = VIEWBOX / 2 - 40; // leave room for labels
+const LABEL_RADIUS = RING_RADIUS + 14;
+
+// Project a node index onto the ring. Rotate by -π/2 so the first
+// node renders at 12 o'clock rather than 3 o'clock (matches how users
+// expect a "first" slice to be positioned on a clock face).
+export function polarPosition(index, total, radius = RING_RADIUS) {
+  const angle = (index / total) * 2 * Math.PI - Math.PI / 2;
+  const cx = VIEWBOX / 2 + radius * Math.cos(angle);
+  const cy = VIEWBOX / 2 + radius * Math.sin(angle);
+  return { cx, cy, angle };
+}
+
+// Build node + edge lists from the raw `[{source, target, weight}]`
+// rows. Endpoint already sorts rows weight-desc so trimming the tail
+// keeps the most interesting co-occurrences. Each unique tag becomes
+// a node; the node's `weight` is the sum of its incident edges (used
+// for hover emphasis + colour assignment order).
+export function buildGraph(data) {
+  const rows = data ?? [];
+  const nodeWeights = new Map();
+  for (const { source, target, weight } of rows) {
+    nodeWeights.set(source, (nodeWeights.get(source) ?? 0) + weight);
+    nodeWeights.set(target, (nodeWeights.get(target) ?? 0) + weight);
+  }
+  // Highest total-weight tags first. Trim to TOP_K so the ring stays
+  // readable; edges touching dropped nodes fall away automatically.
+  const topTags = Array.from(nodeWeights.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, TOP_K_TAGS)
+    .map(([tag], i) => ({
+      tag,
+      index: i,
+      weight: nodeWeights.get(tag) ?? 0,
+    }));
+  const tagSet = new Set(topTags.map((n) => n.tag));
+  const edges = rows
+    .filter((e) => tagSet.has(e.source) && tagSet.has(e.target))
+    .slice(0, TOP_K_EDGES);
+  return { nodes: topTags, edges };
+}
+
+// Map weight → [1, 3] stroke width so heavy edges read as bolder
+// without any individual line dominating the chart. Gracefully
+// handles the degenerate single-edge case (maxWeight === 1).
+export function edgeStrokeWidth(weight, maxWeight) {
+  if (maxWeight <= 0) return 1;
+  const ratio = Math.min(1, weight / maxWeight);
+  return 1 + ratio * 2;
+}
+
+export default function TagCooccurrence({ data }) {
+  const [hovered, setHovered] = useState(null);
+  const { nodes, edges } = useMemo(() => buildGraph(data), [data]);
+
+  if (nodes.length < MIN_TAGS) {
+    return (
+      <div className="text-xs text-[var(--text-muted)] italic py-2">
+        Tag co-occurrence appears once you've tagged {MIN_TAGS} distinct
+        tags across your memories.
+      </div>
+    );
+  }
+
+  // Precompute node positions so hover lookups are O(1) instead of
+  // recomputing trig per pointer-enter.
+  const positions = nodes.map((n) => ({
+    ...n,
+    ...polarPosition(n.index, nodes.length),
+  }));
+  const positionByTag = new Map(positions.map((p) => [p.tag, p]));
+  const maxWeight = edges.reduce((m, e) => Math.max(m, e.weight), 0);
+
+  // Edges touching the hovered tag stay bright; everything else dims.
+  // Same rule for nodes — the hovered one plus its neighbours keep
+  // their colour/opacity, unrelated tags fade.
+  const neighbourTags = new Set();
+  if (hovered) {
+    neighbourTags.add(hovered);
+    for (const e of edges) {
+      if (e.source === hovered) neighbourTags.add(e.target);
+      if (e.target === hovered) neighbourTags.add(e.source);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <svg
+        viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+        role="img"
+        aria-label="Tag co-occurrence network"
+        className="w-full h-auto"
+        style={{ maxHeight: 300 }}
+      >
+        <g>
+          {edges.map((e) => {
+            const a = positionByTag.get(e.source);
+            const b = positionByTag.get(e.target);
+            const touched =
+              !hovered || e.source === hovered || e.target === hovered;
+            return (
+              <line
+                key={`${e.source}--${e.target}`}
+                x1={a.cx}
+                y1={a.cy}
+                x2={b.cx}
+                y2={b.cy}
+                stroke="var(--accent)"
+                strokeOpacity={touched ? 0.55 : 0.08}
+                strokeWidth={edgeStrokeWidth(e.weight, maxWeight)}
+              >
+                <title>
+                  {`${e.source} + ${e.target}: ${e.weight} shared memor${e.weight === 1 ? "y" : "ies"}`}
+                </title>
+              </line>
+            );
+          })}
+        </g>
+        <g>
+          {positions.map((n) => {
+            const active = !hovered || neighbourTags.has(n.tag);
+            const fill = SLICE_COLORS[n.index % SLICE_COLORS.length];
+            const labelPos = polarPosition(n.index, nodes.length, LABEL_RADIUS);
+            // Anchor labels toward the outside of the ring so they
+            // don't overlap the nodes. `text-anchor` flips based on
+            // which half of the circle the node lives in.
+            const anchor = labelPos.cx < VIEWBOX / 2 ? "end" : "start";
+            return (
+              <g
+                key={n.tag}
+                onMouseEnter={() => setHovered(n.tag)}
+                onMouseLeave={() => setHovered(null)}
+                onFocus={() => setHovered(n.tag)}
+                onBlur={() => setHovered(null)}
+                tabIndex={0}
+                data-tag={n.tag}
+                style={{ cursor: "pointer" }}
+              >
+                <circle
+                  cx={n.cx}
+                  cy={n.cy}
+                  r={hovered === n.tag ? NODE_RADIUS + 2 : NODE_RADIUS}
+                  fill={fill}
+                  fillOpacity={active ? 1 : 0.2}
+                  stroke={hovered === n.tag ? "var(--text)" : "none"}
+                  strokeWidth={1}
+                />
+                <text
+                  x={labelPos.cx}
+                  y={labelPos.cy}
+                  textAnchor={anchor}
+                  dominantBaseline="central"
+                  fontSize="10"
+                  fill="var(--text-muted)"
+                  fillOpacity={active ? 1 : 0.3}
+                >
+                  {n.tag}
+                </text>
+                <title>{`${n.tag}: ${n.weight} co-occurrences`}</title>
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+      <div className="text-[10px] text-[var(--text-muted)] italic">
+        Hover a tag to highlight its connections.
+        {nodes.length === TOP_K_TAGS && " Showing the top 15 tags by co-occurrence."}
+      </div>
+    </div>
+  );
+}
+
+TagCooccurrence.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      source: PropTypes.string.isRequired,
+      target: PropTypes.string.isRequired,
+      weight: PropTypes.number.isRequired,
+    }),
+  ),
+};
+
+TagCooccurrence.MIN_TAGS = MIN_TAGS;
+TagCooccurrence.TOP_K_TAGS = TOP_K_TAGS;

--- a/ui/src/components/stats/TagCooccurrence.jsx
+++ b/ui/src/components/stats/TagCooccurrence.jsx
@@ -46,13 +46,26 @@ export function buildGraph(data) {
   }
   // Highest total-weight tags first. Trim to TOP_K so the ring stays
   // readable; edges touching dropped nodes fall away automatically.
+  // Ties are broken alphabetically by tag so DynamoDB scan-order
+  // shuffling doesn't cause node positions / colours to drift between
+  // otherwise-identical requests.
   const topTags = Array.from(nodeWeights.entries())
-    .sort((a, b) => b[1] - a[1])
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .slice(0, TOP_K_TAGS)
     .map(([tag, weight], i) => ({ tag, index: i, weight }));
   const tagSet = new Set(topTags.map((n) => n.tag));
+  // Same tie-breaker rule on edges — weight first, then
+  // (source, target) — so equal-weight edges render in a stable order
+  // and the trim at TOP_K_EDGES is deterministic.
   const edges = rows
     .filter((e) => tagSet.has(e.source) && tagSet.has(e.target))
+    .slice()
+    .sort(
+      (a, b) =>
+        b.weight - a.weight ||
+        a.source.localeCompare(b.source) ||
+        a.target.localeCompare(b.target),
+    )
     .slice(0, TOP_K_EDGES);
   return { nodes: topTags, edges };
 }
@@ -73,8 +86,8 @@ export default function TagCooccurrence({ data }) {
   if (nodes.length < MIN_TAGS) {
     return (
       <div className="text-xs text-[var(--text-muted)] italic py-2">
-        Tag co-occurrence appears once you've tagged {MIN_TAGS} distinct
-        tags across your memories.
+        Tag co-occurrence appears once at least {MIN_TAGS} tags have
+        co-occurred across your memories.
       </div>
     );
   }

--- a/ui/src/components/stats/TagCooccurrence.jsx
+++ b/ui/src/components/stats/TagCooccurrence.jsx
@@ -67,7 +67,14 @@ export function buildGraph(data) {
         a.target.localeCompare(b.target),
     )
     .slice(0, TOP_K_EDGES);
-  return { nodes: topTags, edges };
+  // Surface whether we actually trimmed — the caption below mentions
+  // the top-15 cap, and that's only honest when the input had >15
+  // tags (exactly-15 should NOT read as "trimmed").
+  return {
+    nodes: topTags,
+    edges,
+    trimmed: nodeWeights.size > TOP_K_TAGS,
+  };
 }
 
 // Map weight → [1, 3] stroke width so heavy edges read as bolder
@@ -81,7 +88,7 @@ export function edgeStrokeWidth(weight, maxWeight) {
 
 export default function TagCooccurrence({ data }) {
   const [hovered, setHovered] = useState(null);
-  const { nodes, edges } = useMemo(() => buildGraph(data), [data]);
+  const { nodes, edges, trimmed } = useMemo(() => buildGraph(data), [data]);
 
   if (nodes.length < MIN_TAGS) {
     return (
@@ -196,7 +203,7 @@ export default function TagCooccurrence({ data }) {
       </svg>
       <div className="text-[10px] text-[var(--text-muted)] italic">
         Hover a tag to highlight its connections.
-        {nodes.length === TOP_K_TAGS && " Showing the top 15 tags by co-occurrence."}
+        {trimmed && ` Showing the top ${TOP_K_TAGS} tags by co-occurrence.`}
       </div>
     </div>
   );

--- a/ui/src/components/stats/TagCooccurrence.test.jsx
+++ b/ui/src/components/stats/TagCooccurrence.test.jsx
@@ -9,7 +9,7 @@ import TagCooccurrence, {
 
 // Six distinct tags reaches the MIN_TAGS threshold (5) — pair
 // everything up so each tag carries at least one edge.
-const FIVE_TAG_DATA = [
+const SIX_TAG_DATA = [
   { source: "a", target: "b", weight: 3 },
   { source: "a", target: "c", weight: 2 },
   { source: "b", target: "c", weight: 1 },
@@ -42,7 +42,7 @@ describe("polarPosition", () => {
 
 describe("buildGraph", () => {
   it("returns sorted nodes + matching edges from flat rows", () => {
-    const { nodes, edges } = buildGraph(FIVE_TAG_DATA);
+    const { nodes, edges } = buildGraph(SIX_TAG_DATA);
     // Six unique tags in the dataset, all within TOP_K_TAGS=15.
     expect(nodes.map((n) => n.tag).sort()).toEqual(["a", "b", "c", "d", "e", "f"]);
     expect(edges).toHaveLength(5);
@@ -111,15 +111,15 @@ describe("TagCooccurrence", () => {
   });
 
   it("renders an SVG with one node per tag when the threshold is met", () => {
-    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
-    // Six unique tags across FIVE_TAG_DATA → six circles.
+    const { container } = render(<TagCooccurrence data={SIX_TAG_DATA} />);
+    // Six unique tags across SIX_TAG_DATA → six circles.
     expect(container.querySelectorAll("circle")).toHaveLength(6);
     // All five edges show up as <line> elements.
     expect(container.querySelectorAll("line")).toHaveLength(5);
   });
 
   it("hover dims unrelated edges and nodes", () => {
-    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    const { container } = render(<TagCooccurrence data={SIX_TAG_DATA} />);
     // Hover node "a". Tags a, b, c are its neighbours; d/e/f are not.
     const aGroup = container.querySelector('g[data-tag="a"]');
     fireEvent.mouseEnter(aGroup);
@@ -138,9 +138,9 @@ describe("TagCooccurrence", () => {
 
   it("hovering a target-side tag still resolves its source neighbour", () => {
     // Covers the `e.target === hovered` branch — without this, the
-    // only path that fires in `FIVE_TAG_DATA` is the source-side
+    // only path that fires in `SIX_TAG_DATA` is the source-side
     // match because "a" is never on the target side.
-    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    const { container } = render(<TagCooccurrence data={SIX_TAG_DATA} />);
     const cGroup = container.querySelector('g[data-tag="c"]');
     fireEvent.mouseEnter(cGroup);
     const edges = container.querySelectorAll("line");
@@ -155,7 +155,7 @@ describe("TagCooccurrence", () => {
   });
 
   it("keyboard focus also triggers the hover emphasis", () => {
-    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    const { container } = render(<TagCooccurrence data={SIX_TAG_DATA} />);
     const aGroup = container.querySelector('g[data-tag="a"]');
     fireEvent.focus(aGroup);
     const aCircle = aGroup.querySelector("circle");
@@ -168,7 +168,7 @@ describe("TagCooccurrence", () => {
 
   it("mentions the top-15 cap only when the chart is actually trimmed", () => {
     const { container: small } = render(
-      <TagCooccurrence data={FIVE_TAG_DATA} />,
+      <TagCooccurrence data={SIX_TAG_DATA} />,
     );
     expect(small.textContent).not.toContain("Showing the top 15");
 
@@ -182,7 +182,7 @@ describe("TagCooccurrence", () => {
   });
 
   it("singular copy when an edge has weight 1", () => {
-    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    const { container } = render(<TagCooccurrence data={SIX_TAG_DATA} />);
     // Edge (b, c, 1) should produce "1 shared memory" (singular), not "memories".
     const edges = container.querySelectorAll("line");
     const bcEdge = Array.from(edges).find((line) => {
@@ -193,7 +193,7 @@ describe("TagCooccurrence", () => {
   });
 
   it("label anchors flip between 'start' and 'end' based on hemisphere", () => {
-    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    const { container } = render(<TagCooccurrence data={SIX_TAG_DATA} />);
     const texts = container.querySelectorAll("text");
     const anchors = new Set(
       Array.from(texts).map((t) => t.getAttribute("text-anchor")),

--- a/ui/src/components/stats/TagCooccurrence.test.jsx
+++ b/ui/src/components/stats/TagCooccurrence.test.jsx
@@ -99,14 +99,14 @@ describe("TagCooccurrence", () => {
       <TagCooccurrence data={[{ source: "a", target: "b", weight: 1 }]} />,
     );
     expect(
-      screen.getByText(/Tag co-occurrence appears once you've tagged 5 distinct/),
+      screen.getByText(/Tag co-occurrence appears once at least 5 tags have co-occurred/),
     ).toBeTruthy();
   });
 
   it("renders the caption for missing data", () => {
     render(<TagCooccurrence />);
     expect(
-      screen.getByText(/Tag co-occurrence appears once you've tagged 5 distinct/),
+      screen.getByText(/Tag co-occurrence appears once at least 5 tags have co-occurred/),
     ).toBeTruthy();
   });
 

--- a/ui/src/components/stats/TagCooccurrence.test.jsx
+++ b/ui/src/components/stats/TagCooccurrence.test.jsx
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import TagCooccurrence, {
+  buildGraph,
+  edgeStrokeWidth,
+  polarPosition,
+} from "./TagCooccurrence.jsx";
+
+// Six distinct tags reaches the MIN_TAGS threshold (5) — pair
+// everything up so each tag carries at least one edge.
+const FIVE_TAG_DATA = [
+  { source: "a", target: "b", weight: 3 },
+  { source: "a", target: "c", weight: 2 },
+  { source: "b", target: "c", weight: 1 },
+  { source: "d", target: "e", weight: 1 },
+  { source: "e", target: "f", weight: 1 },
+];
+
+describe("polarPosition", () => {
+  it("places the first node at 12 o'clock", () => {
+    // angle = -π/2 → cx = centre, cy = centre - r
+    const p = polarPosition(0, 4);
+    expect(Math.round(p.cx)).toBe(130);
+    expect(Math.round(p.cy)).toBeLessThan(130); // above the centre
+    expect(p.angle).toBeCloseTo(-Math.PI / 2);
+  });
+
+  it("places the second of four nodes at 3 o'clock", () => {
+    const p = polarPosition(1, 4);
+    expect(Math.round(p.cy)).toBe(130); // vertical centre
+    expect(p.cx).toBeGreaterThan(130); // right of centre
+  });
+
+  it("accepts a custom radius for label placement", () => {
+    const inner = polarPosition(0, 4, 50);
+    const outer = polarPosition(0, 4, 100);
+    // Both at 12 o'clock so cy is the only differentiator.
+    expect(inner.cy).toBeGreaterThan(outer.cy);
+  });
+});
+
+describe("buildGraph", () => {
+  it("returns sorted nodes + matching edges from flat rows", () => {
+    const { nodes, edges } = buildGraph(FIVE_TAG_DATA);
+    // Six unique tags in the dataset, all within TOP_K_TAGS=15.
+    expect(nodes.map((n) => n.tag).sort()).toEqual(["a", "b", "c", "d", "e", "f"]);
+    expect(edges).toHaveLength(5);
+    // Highest-weight tag is "a" (3 + 2 = 5) — should be first node.
+    expect(nodes[0].tag).toBe("a");
+  });
+
+  it("drops edges whose endpoints fall outside the top-K tag slice", () => {
+    // Build 17 tags so the TOP_K_TAGS=15 cap kicks in. The last two
+    // tags (p, q) should get dropped and any edges touching them
+    // should drop with them.
+    const rows = [];
+    for (let i = 0; i < 17; i++) {
+      const a = `t${i}`;
+      const b = `t${(i + 1) % 17}`;
+      rows.push({ source: a, target: b, weight: 20 - i });
+    }
+    const { nodes, edges } = buildGraph(rows);
+    expect(nodes).toHaveLength(15);
+    const tagSet = new Set(nodes.map((n) => n.tag));
+    for (const e of edges) {
+      expect(tagSet.has(e.source) && tagSet.has(e.target)).toBe(true);
+    }
+  });
+
+  it("returns empty lists for missing / empty input", () => {
+    expect(buildGraph()).toEqual({ nodes: [], edges: [] });
+    expect(buildGraph([])).toEqual({ nodes: [], edges: [] });
+  });
+});
+
+describe("edgeStrokeWidth", () => {
+  it("returns 1 as the floor for zero max weight", () => {
+    expect(edgeStrokeWidth(5, 0)).toBe(1);
+  });
+
+  it("scales from 1 to 3 as weight approaches max", () => {
+    expect(edgeStrokeWidth(0, 10)).toBe(1);
+    expect(edgeStrokeWidth(10, 10)).toBe(3);
+    expect(edgeStrokeWidth(5, 10)).toBe(2);
+  });
+
+  it("clamps over-max weights to the top of the range", () => {
+    // Defensive: callers might feed max that lags behind the edge
+    // array on a re-render. Don't let a weight ratio > 1 produce a
+    // stroke width > 3.
+    expect(edgeStrokeWidth(20, 10)).toBe(3);
+  });
+});
+
+describe("TagCooccurrence", () => {
+  it("renders an explanatory caption when fewer than MIN_TAGS tags", () => {
+    render(
+      <TagCooccurrence data={[{ source: "a", target: "b", weight: 1 }]} />,
+    );
+    expect(
+      screen.getByText(/Tag co-occurrence appears once you've tagged 5 distinct/),
+    ).toBeTruthy();
+  });
+
+  it("renders the caption for missing data", () => {
+    render(<TagCooccurrence />);
+    expect(
+      screen.getByText(/Tag co-occurrence appears once you've tagged 5 distinct/),
+    ).toBeTruthy();
+  });
+
+  it("renders an SVG with one node per tag when the threshold is met", () => {
+    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    // Six unique tags across FIVE_TAG_DATA → six circles.
+    expect(container.querySelectorAll("circle")).toHaveLength(6);
+    // All five edges show up as <line> elements.
+    expect(container.querySelectorAll("line")).toHaveLength(5);
+  });
+
+  it("hover dims unrelated edges and nodes", () => {
+    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    // Hover node "a". Tags a, b, c are its neighbours; d/e/f are not.
+    const aGroup = container.querySelector('g[data-tag="a"]');
+    fireEvent.mouseEnter(aGroup);
+    // The edge between d and e touches neither "a" nor any of a's
+    // neighbours — it should be dimmed (opacity 0.08).
+    const edges = container.querySelectorAll("line");
+    const deEdge = Array.from(edges).find((line) => {
+      const title = line.querySelector("title")?.textContent ?? "";
+      return title.includes("d + e") || title.includes("e + d");
+    });
+    expect(deEdge.getAttribute("stroke-opacity")).toBe("0.08");
+    fireEvent.mouseLeave(aGroup);
+    // After leave, all edges return to the un-dimmed opacity.
+    expect(deEdge.getAttribute("stroke-opacity")).toBe("0.55");
+  });
+
+  it("keyboard focus also triggers the hover emphasis", () => {
+    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    const aGroup = container.querySelector('g[data-tag="a"]');
+    fireEvent.focus(aGroup);
+    const aCircle = aGroup.querySelector("circle");
+    // Hovered node's radius bumps from 5 to 7 so screen-reader users
+    // navigating via tab can see the current focus.
+    expect(aCircle.getAttribute("r")).toBe("7");
+    fireEvent.blur(aGroup);
+    expect(aCircle.getAttribute("r")).toBe("5");
+  });
+
+  it("mentions the top-15 cap only when the chart is actually trimmed", () => {
+    const { container: small } = render(
+      <TagCooccurrence data={FIVE_TAG_DATA} />,
+    );
+    expect(small.textContent).not.toContain("Showing the top 15");
+
+    // Fill past the cap.
+    const rows = [];
+    for (let i = 0; i < 17; i++) {
+      rows.push({ source: `t${i}`, target: `t${(i + 1) % 17}`, weight: 20 - i });
+    }
+    const { container: large } = render(<TagCooccurrence data={rows} />);
+    expect(large.textContent).toContain("Showing the top 15");
+  });
+
+  it("singular copy when an edge has weight 1", () => {
+    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    // Edge (b, c, 1) should produce "1 shared memory" (singular), not "memories".
+    const edges = container.querySelectorAll("line");
+    const bcEdge = Array.from(edges).find((line) => {
+      const title = line.querySelector("title")?.textContent ?? "";
+      return title.includes("b + c");
+    });
+    expect(bcEdge.querySelector("title").textContent).toMatch(/1 shared memory/);
+  });
+
+  it("label anchors flip between 'start' and 'end' based on hemisphere", () => {
+    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    const texts = container.querySelectorAll("text");
+    const anchors = new Set(
+      Array.from(texts).map((t) => t.getAttribute("text-anchor")),
+    );
+    // With six tags distributed around the ring we expect both
+    // anchor values to appear — "end" on the left side, "start" on
+    // the right.
+    expect(anchors.has("start")).toBe(true);
+    expect(anchors.has("end")).toBe(true);
+  });
+});

--- a/ui/src/components/stats/TagCooccurrence.test.jsx
+++ b/ui/src/components/stats/TagCooccurrence.test.jsx
@@ -68,6 +68,21 @@ describe("buildGraph", () => {
     }
   });
 
+  it("breaks equal-weight ties by source then target for edge ordering", () => {
+    // Two edges share both weight (5) AND source ("a"), so the third
+    // tie-breaker (`target.localeCompare`) decides order. Without it
+    // the output would depend on input order, which is non-stable
+    // once the data comes from a DynamoDB scan.
+    const { edges } = buildGraph([
+      { source: "a", target: "z", weight: 5 },
+      { source: "a", target: "b", weight: 5 },
+      { source: "c", target: "d", weight: 1 },
+    ]);
+    const ab = edges.findIndex((e) => e.source === "a" && e.target === "b");
+    const az = edges.findIndex((e) => e.source === "a" && e.target === "z");
+    expect(ab).toBeLessThan(az);
+  });
+
   it("returns empty lists for missing / empty input", () => {
     expect(buildGraph()).toEqual({ nodes: [], edges: [] });
     expect(buildGraph([])).toEqual({ nodes: [], edges: [] });

--- a/ui/src/components/stats/TagCooccurrence.test.jsx
+++ b/ui/src/components/stats/TagCooccurrence.test.jsx
@@ -84,8 +84,8 @@ describe("buildGraph", () => {
   });
 
   it("returns empty lists for missing / empty input", () => {
-    expect(buildGraph()).toEqual({ nodes: [], edges: [] });
-    expect(buildGraph([])).toEqual({ nodes: [], edges: [] });
+    expect(buildGraph()).toEqual({ nodes: [], edges: [], trimmed: false });
+    expect(buildGraph([])).toEqual({ nodes: [], edges: [], trimmed: false });
   });
 });
 
@@ -187,7 +187,21 @@ describe("TagCooccurrence", () => {
     );
     expect(small.textContent).not.toContain("Showing the top 15");
 
-    // Fill past the cap.
+    // Exactly 15 tags — should NOT read as trimmed, even though
+    // `nodes.length === TOP_K_TAGS` (15). Build 15 tags in a ring
+    // so each has at least one edge.
+    const exactly15 = [];
+    for (let i = 0; i < 15; i++) {
+      exactly15.push({
+        source: `t${i}`,
+        target: `t${(i + 1) % 15}`,
+        weight: 20 - i,
+      });
+    }
+    const { container: fifteen } = render(<TagCooccurrence data={exactly15} />);
+    expect(fifteen.textContent).not.toContain("Showing the top 15");
+
+    // Fill past the cap — 17 tags, TOP_K_TAGS trims to 15.
     const rows = [];
     for (let i = 0; i < 17; i++) {
       rows.push({ source: `t${i}`, target: `t${(i + 1) % 17}`, weight: 20 - i });

--- a/ui/src/components/stats/TagCooccurrence.test.jsx
+++ b/ui/src/components/stats/TagCooccurrence.test.jsx
@@ -136,6 +136,24 @@ describe("TagCooccurrence", () => {
     expect(deEdge.getAttribute("stroke-opacity")).toBe("0.55");
   });
 
+  it("hovering a target-side tag still resolves its source neighbour", () => {
+    // Covers the `e.target === hovered` branch — without this, the
+    // only path that fires in `FIVE_TAG_DATA` is the source-side
+    // match because "a" is never on the target side.
+    const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
+    const cGroup = container.querySelector('g[data-tag="c"]');
+    fireEvent.mouseEnter(cGroup);
+    const edges = container.querySelectorAll("line");
+    // (a, c) edge should stay bright because "a" is a target-side
+    // neighbour of "c"; the 117-branch add on source must fire.
+    const acEdge = Array.from(edges).find((line) => {
+      const title = line.querySelector("title")?.textContent ?? "";
+      return title.includes("a + c");
+    });
+    expect(acEdge.getAttribute("stroke-opacity")).toBe("0.55");
+    fireEvent.mouseLeave(cGroup);
+  });
+
   it("keyboard focus also triggers the hover emphasis", () => {
     const { container } = render(<TagCooccurrence data={FIVE_TAG_DATA} />);
     const aGroup = container.querySelector('g[data-tag="a"]');


### PR DESCRIPTION
Closes #540

## Summary

Final v0.24 Stats sub-issue — an SVG network diagram on the **Tag
co-occurrence** card showing which tags appear together on the same
memory. Nodes = tags, edges = shared-memory count, weight drives
stroke width. Hover a node to highlight its connections; the rest of
the graph dims so the neighbourhood reads cleanly.

Also removes the obsolete `RawPreview` stub from `Stats.jsx` — with
all eight cards now wired to real components, it was dead code.

## Bundle delta: **0 bytes**

The issue explicitly flagged react-force-graph-2d / d3-force as
candidate graph libs, but both would add 10–50KB+ of physics-sim code
the chart doesn't need. Went with a **custom SVG using a circular
layout** instead:

- Deterministic — nodes project onto a ring via `polarPosition` (trig
  only). No physics, no animation frames, no ResizeObserver dance.
- Renders identically under jsdom, so coverage stays at 100% without
  mocking anything heavyweight.
- Bundle size unchanged versus `main` — only `SLICE_COLORS` reused
  from the existing `ui/src/lib/chartPalette.js`.

## Approach

- `buildGraph` turns the flat `[{source, target, weight}]` rows into
  node + edge lists, caps at the top 15 tags by summed edge weight
  (`TOP_K_TAGS`) and top 40 edges (`TOP_K_EDGES`) so dense datasets
  stay readable.
- Hover state (`useState`) computes the neighbour set on render;
  edges touching the hovered tag stay bright, everything else drops
  to `strokeOpacity = 0.08`. Nodes dim to `fillOpacity = 0.2`.
- Keyboard `onFocus` / `onBlur` mirror `onMouseEnter` / `onMouseLeave`
  so tab-navigation users see the same emphasis (addresses "don't
  rely on colour alone").
- Auto-hide below `MIN_TAGS = 5` with a short caption; caption below
  also shows the top-15 trimming note when the cap is hit.

## Test plan

- [x] `ui/src/components/stats/TagCooccurrence.test.jsx` — 14 tests
      covering `polarPosition` (12-o'clock anchor, radius scaling),
      `buildGraph` (top-K trim, empty/missing input), `edgeStrokeWidth`
      (zero-max floor, over-max clamp), hover dimming via mouse +
      focus, singular-vs-plural copy, label anchor hemisphere flip
- [x] `ui/src/components/Stats.test.jsx` updated — TagCooccurrence
      added to the mock set, obsolete RawPreview overflow test removed
      alongside the RawPreview component
- [x] `uv run inv pre-push` clean (746 frontend tests pass, 100%
      coverage across Python + JS)

Per §7.5, auto-merge is **not** armed at PR creation — step 7.5
arms it after the Copilot loop resolves.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb