### PR TITLE
feat: MCP Prompts — slash commands for common Hive workflows

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
           { text: "list_memories", link: "/tools/list-memories" },
           { text: "search_memories", link: "/tools/search-memories" },
           { text: "summarize_context", link: "/tools/summarize-context" },
+          { text: "Prompts (slash commands)", link: "/tools/prompts" },
         ],
       },
       {

--- a/docs-site/tools/prompts.md
+++ b/docs-site/tools/prompts.md
@@ -53,7 +53,7 @@ Tags are comma-separated; blank entries are trimmed. If you omit tags the memory
 
 ## `/forget-older-than`
 
-Interactive prune using only Hive's actual MCP tools: the agent calls `list_tags`, walks each tag with `list_memories(tag)`, compares every memory's `last_accessed_at` (the closest proxy to last-touched that the tool response exposes), shows the key + timestamp, and asks for per-memory confirmation before calling `forget`.
+Interactive prune using only Hive's actual MCP tools: the agent calls `list_tags`, walks each tag with `list_memories(tag)`, and compares every memory's `last_accessed_at` to the threshold. If `last_accessed_at` is null (memory written but never recalled), the agent falls back to the `version` timestamp — a UTC ISO string that updates on every write and is always present in the response. The agent shows the key + the timestamp it used and asks for per-memory confirmation before calling `forget`.
 
 **Example**
 
@@ -61,7 +61,7 @@ Interactive prune using only Hive's actual MCP tools: the agent calls `list_tags
 /forget-older-than days=180
 ```
 
-The template explicitly forbids batch-delete without confirmation, so even if the agent returns many stale memories you stay in control. Memories whose `last_accessed_at` is null count as stale when their implicit age exceeds the threshold.
+The template explicitly forbids batch-delete without confirmation, so even if the agent returns many stale memories you stay in control.
 
 ## Client support
 

--- a/docs-site/tools/prompts.md
+++ b/docs-site/tools/prompts.md
@@ -1,0 +1,80 @@
+# MCP Prompts
+
+Hive ships four MCP **Prompts** — pre-built, parameterised templates that supported clients (Claude Code, Cursor) surface as slash commands. Prompts let you kick off a Hive workflow with one keystroke instead of asking your agent to pick a tool name.
+
+::: tip What's the difference between a Tool and a Prompt?
+A [Tool](/tools/overview) is something the agent *calls* — a function with a JSON response. A Prompt is a template the *client* surfaces to the user; the user picks it, the client sends the rendered template to the agent, and the agent then calls the appropriate tool. Tools do work; Prompts route you to the right tool.
+:::
+
+## Available prompts
+
+| Prompt | Arguments | What it does |
+| --- | --- | --- |
+| `/recall-context` | `topic` | Summarises everything Hive knows about `topic` and makes the agent use it as foreground context. |
+| `/what-do-you-know-about` | `query` | Runs a semantic search and weaves the top hits into the agent's next response. |
+| `/remember-this` | `key`, `value`, `tags` (optional) | Stores the current selection under `key`, tagged if you provide comma-separated tags. |
+| `/forget-older-than` | `days` | Enumerates memories older than `days` and interactively asks you to confirm each deletion. |
+
+## `/recall-context`
+
+Pulls in everything Hive already knows about a subject so the agent can answer follow-up questions from that context.
+
+**Example**
+
+```
+/recall-context topic="the billing rewrite"
+```
+
+The agent calls `summarize_context(topic='the billing rewrite')` and uses the returned summary as its working context. If no memories match, the agent tells you so rather than hallucinating.
+
+## `/what-do-you-know-about`
+
+Semantic search across your memories; handy when you remember a concept but not a specific key.
+
+**Example**
+
+```
+/what-do-you-know-about query="our stance on Redis"
+```
+
+Runs `search_memories(query='our stance on Redis', top_k=10)` and cites each result by memory key.
+
+## `/remember-this`
+
+Stores a memory without you having to say "remember that…" in prose. Most clients default `value` to the current editor selection.
+
+**Example**
+
+```
+/remember-this key="release-cadence" value="Weekly, Thursdays at 2pm UTC" tags="ops,release"
+```
+
+Tags are comma-separated; blank entries are trimmed. If you omit tags the memory is still stored — the template always passes `tags=[]` to the `remember` tool so the argument never drifts.
+
+## `/forget-older-than`
+
+Interactive prune: the agent lists every memory whose `updated_at` is older than the threshold, shows the key + timestamp, and asks for per-memory confirmation before calling `forget`.
+
+**Example**
+
+```
+/forget-older-than days=180
+```
+
+The template explicitly forbids batch-delete without confirmation, so even if the agent returns many stale memories you stay in control.
+
+## Client support
+
+Prompts only appear in clients that implement the MCP Prompts capability:
+
+- **Claude Code** — surfaces prompts in the slash-command menu when Hive is connected.
+- **Cursor** — shows prompts under the MCP panel.
+- **Claude Desktop** — lists prompts alongside tools in the connector picker.
+
+Clients that don't support Prompts ignore them — nothing breaks. You can still invoke the underlying tools directly by asking the agent in prose.
+
+## Why we ship Prompts
+
+- **Lower friction.** "What does Hive know about X?" takes one slash command, not a sentence of natural language that the agent has to parse.
+- **Consistent invocation.** The template passes the right tool name and parameters every time, so agents never forget to set `top_k` or `tags`.
+- **Discoverable.** Connect Hive, type `/`, and see everything Hive can do for you — no need to read docs first.

--- a/docs-site/tools/prompts.md
+++ b/docs-site/tools/prompts.md
@@ -53,7 +53,7 @@ Tags are comma-separated; blank entries are trimmed. If you omit tags the memory
 
 ## `/forget-older-than`
 
-Interactive prune: the agent lists every memory whose `updated_at` is older than the threshold, shows the key + timestamp, and asks for per-memory confirmation before calling `forget`.
+Interactive prune using only Hive's actual MCP tools: the agent calls `list_tags`, walks each tag with `list_memories(tag)`, compares every memory's `last_accessed_at` (the closest proxy to last-touched that the tool response exposes), shows the key + timestamp, and asks for per-memory confirmation before calling `forget`.
 
 **Example**
 
@@ -61,7 +61,7 @@ Interactive prune: the agent lists every memory whose `updated_at` is older than
 /forget-older-than days=180
 ```
 
-The template explicitly forbids batch-delete without confirmation, so even if the agent returns many stale memories you stay in control.
+The template explicitly forbids batch-delete without confirmation, so even if the agent returns many stale memories you stay in control. Memories whose `last_accessed_at` is null count as stale when their implicit age exceeds the threshold.
 
 ## Client support
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1401,9 +1401,13 @@ async def relate_memories(
 def recall_context_prompt(
     topic: Annotated[str, "Topic to summarise memories about"],
 ) -> str:
+    # `!r` renders the string as a Python repr so apostrophes, quotes,
+    # and newlines in the user input don't produce an ambiguous
+    # pseudo-call signature. The agent still interprets the instruction
+    # in prose — `!r` just keeps the argument boundaries unambiguous.
     return (
-        f"Use Hive to recall what I know about '{topic}'. Call the "
-        f"`summarize_context` tool with topic='{topic}', then treat the "
+        f"Use Hive to recall what I know about {topic!r}. Call the "
+        f"`summarize_context` tool with topic={topic!r}, then treat the "
         "result as foreground context for the rest of this conversation. "
         "If the summary is empty, say so and ask what I'd like to remember."
     )
@@ -1421,7 +1425,7 @@ def what_do_you_know_about_prompt(
     query: Annotated[str, "Free-text query to search memories for"],
 ) -> str:
     return (
-        f"Search Hive for '{query}'. Call `search_memories` with query='{query}' "
+        f"Search Hive for {query!r}. Call `search_memories` with query={query!r} "
         "and top_k=10. Read the highest-scoring results and incorporate them "
         "into your next response, citing each memory's key. If no memory "
         "scores above the default threshold, say so plainly."
@@ -1448,9 +1452,9 @@ def remember_this_prompt(
     tag_list = [t.strip() for t in tags.split(",") if t.strip()]
     tag_clause = f" tags={tag_list!r}" if tag_list else " tags=[]"
     return (
-        f"Store this in Hive. Call `remember` with key='{key}',{tag_clause}, "
-        f"and value set to: <<<{value}>>>. Confirm once the memory is "
-        "written, quoting the returned memory_id."
+        f"Store this in Hive. Call `remember` with key={key!r},{tag_clause}, "
+        f"and value={value!r}. Confirm once the memory is written, quoting "
+        "the returned memory_id."
     )
 
 
@@ -1464,14 +1468,19 @@ def remember_this_prompt(
     ),
 )
 def forget_older_than_prompt(
-    days: Annotated[int, "Drop memories last updated more than this many days ago"],
+    days: Annotated[int, "Drop memories whose last access is older than this many days"],
 ) -> str:
+    # Uses only tools Hive actually exposes: `list_memories` needs a
+    # tag, so iterate `list_tags()` → `list_memories(tag)` and compare
+    # each item's `last_accessed_at` (the closest proxy to
+    # last-touched). `updated_at` isn't surfaced through the MCP layer.
     return (
-        f"Help me prune old memories. Call `list_memories` (no tag filter) "
-        f"and identify any memory whose `updated_at` is more than {days} days "
-        "ago. For each, show me the key + last-updated timestamp and ask "
-        "'forget this?' — only call `forget` when I reply yes. Do not "
-        "batch-delete without confirmation."
+        f"Help me prune stale memories. Call `list_tags` to discover my tag "
+        f"namespace, then for each tag call `list_memories(tag)`. For every "
+        f"memory whose `last_accessed_at` is more than {days} days ago (or "
+        f"is null and whose implicit age exceeds {days} days), show me the "
+        "key + last-accessed timestamp and ask 'forget this?' — only call "
+        "`forget` when I reply yes. Do not batch-delete without confirmation."
     )
 
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1426,9 +1426,9 @@ def what_do_you_know_about_prompt(
 ) -> str:
     return (
         f"Search Hive for {query!r}. Call `search_memories` with query={query!r} "
-        "and top_k=10. Read the highest-scoring results and incorporate them "
-        "into your next response, citing each memory's key. If no memory "
-        "scores above the default threshold, say so plainly."
+        "and top_k=10. Read the returned memories and incorporate them into "
+        "your next response, citing each memory's key. If the returned items "
+        "list is empty, say so plainly."
     )
 
 
@@ -1436,9 +1436,8 @@ def what_do_you_know_about_prompt(
     name="remember-this",
     title="Remember this",
     description=(
-        "Store a memory in Hive under a given key, optionally tagged. The "
-        "value defaults to the current selection or the most recent agent "
-        "message if the client supplies no explicit value."
+        "Store a memory in Hive under a given key, optionally tagged. Supply "
+        "the value explicitly; tags may be omitted."
     ),
 )
 def remember_this_prompt(
@@ -1470,17 +1469,21 @@ def remember_this_prompt(
 def forget_older_than_prompt(
     days: Annotated[int, "Drop memories whose last access is older than this many days"],
 ) -> str:
-    # Uses only tools Hive actually exposes: `list_memories` needs a
-    # tag, so iterate `list_tags()` → `list_memories(tag)` and compare
-    # each item's `last_accessed_at` (the closest proxy to
-    # last-touched). `updated_at` isn't surfaced through the MCP layer.
+    # Uses only tools Hive actually exposes. `list_memories` needs a
+    # tag, so iterate `list_tags()` → `list_memories(tag)`. The tool
+    # response surfaces `last_accessed_at` and `version` (a UTC ISO
+    # timestamp that updates on every write); `version` is the
+    # well-defined fallback when `last_accessed_at` is null (memory
+    # written but never recalled).
     return (
         f"Help me prune stale memories. Call `list_tags` to discover my tag "
         f"namespace, then for each tag call `list_memories(tag)`. For every "
-        f"memory whose `last_accessed_at` is more than {days} days ago (or "
-        f"is null and whose implicit age exceeds {days} days), show me the "
-        "key + last-accessed timestamp and ask 'forget this?' — only call "
-        "`forget` when I reply yes. Do not batch-delete without confirmation."
+        f"memory whose `last_accessed_at` is more than {days} days ago — or "
+        f"whose `last_accessed_at` is null and whose `version` timestamp is "
+        f"more than {days} days ago — show me the key plus the timestamp "
+        "you used (`last_accessed_at` or `version`) and ask 'forget this?' — "
+        "only call `forget` when I reply yes. Do not batch-delete without "
+        "confirmation."
     )
 
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1376,6 +1376,106 @@ async def relate_memories(
 
 
 # ---------------------------------------------------------------------------
+# MCP Prompts (#447)
+# ---------------------------------------------------------------------------
+#
+# MCP Prompts are pre-built, parameterised prompt templates that supported
+# clients (e.g. Claude Code, Cursor) surface as slash commands. Each prompt
+# returns a string; FastMCP wraps it as a single user-role message under the
+# hood. The agent then executes the template by calling the named Hive tool.
+#
+# These prompts are pure templates — they do not hit DynamoDB, and
+# deliberately do not require auth (the underlying tool call does). That
+# keeps the prompt renderer cheap and means unauthenticated clients can
+# still discover + inspect them.
+
+
+@mcp.prompt(
+    name="recall-context",
+    title="Recall context",
+    description=(
+        "Recall everything Hive knows about a topic and use it as foreground "
+        "context for the rest of the conversation."
+    ),
+)
+def recall_context_prompt(
+    topic: Annotated[str, "Topic to summarise memories about"],
+) -> str:
+    return (
+        f"Use Hive to recall what I know about '{topic}'. Call the "
+        f"`summarize_context` tool with topic='{topic}', then treat the "
+        "result as foreground context for the rest of this conversation. "
+        "If the summary is empty, say so and ask what I'd like to remember."
+    )
+
+
+@mcp.prompt(
+    name="what-do-you-know-about",
+    title="What do you know about…",
+    description=(
+        "Semantic-search Hive's memories for a free-text query and weave the "
+        "top results into the next response."
+    ),
+)
+def what_do_you_know_about_prompt(
+    query: Annotated[str, "Free-text query to search memories for"],
+) -> str:
+    return (
+        f"Search Hive for '{query}'. Call `search_memories` with query='{query}' "
+        "and top_k=10. Read the highest-scoring results and incorporate them "
+        "into your next response, citing each memory's key. If no memory "
+        "scores above the default threshold, say so plainly."
+    )
+
+
+@mcp.prompt(
+    name="remember-this",
+    title="Remember this",
+    description=(
+        "Store a memory in Hive under a given key, optionally tagged. The "
+        "value defaults to the current selection or the most recent agent "
+        "message if the client supplies no explicit value."
+    ),
+)
+def remember_this_prompt(
+    key: Annotated[str, "Unique key to store the memory under"],
+    value: Annotated[str, "Content of the memory — pass the current selection"],
+    tags: Annotated[
+        str,
+        "Optional comma-separated tags (e.g. 'work,roadmap'). Empty for none.",
+    ] = "",
+) -> str:
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+    tag_clause = f" tags={tag_list!r}" if tag_list else " tags=[]"
+    return (
+        f"Store this in Hive. Call `remember` with key='{key}',{tag_clause}, "
+        f"and value set to: <<<{value}>>>. Confirm once the memory is "
+        "written, quoting the returned memory_id."
+    )
+
+
+@mcp.prompt(
+    name="forget-older-than",
+    title="Forget older than…",
+    description=(
+        "Enumerate memories older than N days and interactively forget them. "
+        "Pairs with the bulk-delete flow (#427) — agent must confirm each "
+        "deletion with the user before calling `forget`."
+    ),
+)
+def forget_older_than_prompt(
+    days: Annotated[int, "Drop memories last updated more than this many days ago"],
+) -> str:
+    return (
+        f"Help me prune old memories. Call `list_memories` (no tag filter) "
+        f"and identify any memory whose `updated_at` is more than {days} days "
+        "ago. For each, show me the key + last-updated timestamp and ask "
+        "'forget this?' — only call `forget` when I reply yes. Do not "
+        "batch-delete without confirmation."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Entry points
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2081,7 +2081,7 @@ class TestMcpPrompts:
         assert '"Bob\'s query"' in out
 
         key = "note's-key"
-        value = 'a "double-quoted" value with \'apostrophes\''
+        value = "a \"double-quoted\" value with 'apostrophes'"
         out = remember_this_prompt(key, value)
         # Both key + value must survive the boundary unambiguously.
         assert "note's-key" in out

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1959,3 +1959,100 @@ class TestHiveTokenVerifier:
         verifier = HiveTokenVerifier()
         result = await verifier.verify_token("not-a-valid-token")
         assert result is None
+
+
+class TestMcpPrompts:
+    """#447 — MCP Prompts for common Hive workflows.
+
+    Each prompt is a pure template function; the tests exercise the
+    rendering logic directly (string return) and also round-trip through
+    ``FastMCP.render_prompt`` to confirm it registers as an advertised
+    prompt with the expected argument schema.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_prompts_exposes_four_workflows(self):
+        from hive.server import mcp
+
+        prompts = await mcp.list_prompts()
+        names = sorted(p.name for p in prompts)
+        assert names == [
+            "forget-older-than",
+            "recall-context",
+            "remember-this",
+            "what-do-you-know-about",
+        ]
+        # Every prompt carries a non-empty description so clients can
+        # render a menu entry without re-deriving from the docstring.
+        for p in prompts:
+            assert p.description, f"missing description on {p.name}"
+
+    def test_recall_context_template_names_topic_and_tool(self):
+        from hive.server import recall_context_prompt
+
+        out = recall_context_prompt("release checklist")
+        assert "release checklist" in out
+        # Must name the exact tool the agent should call — if we rename
+        # the MCP tool, this test surfaces the prompt drift.
+        assert "`summarize_context`" in out
+
+    def test_what_do_you_know_about_calls_search_memories(self):
+        from hive.server import what_do_you_know_about_prompt
+
+        out = what_do_you_know_about_prompt("Stats tab")
+        assert "Stats tab" in out
+        assert "`search_memories`" in out
+        # top_k must be explicit so agents don't fall back to whatever
+        # default they implement.
+        assert "top_k=10" in out
+
+    def test_remember_this_renders_tags_when_provided(self):
+        from hive.server import remember_this_prompt
+
+        out = remember_this_prompt("release-cadence", "weekly", tags="ops,release")
+        assert "release-cadence" in out
+        assert "weekly" in out
+        # tags list must survive verbatim, in canonical list form.
+        assert "['ops', 'release']" in out
+        assert "`remember`" in out
+
+    def test_remember_this_trims_blank_tag_entries(self):
+        from hive.server import remember_this_prompt
+
+        # Blank entries between commas are dropped so clients sending
+        # " , a , " don't produce an empty tag that write-through
+        # validation would later reject.
+        out = remember_this_prompt("k", "v", tags=" , a , ")
+        assert "['a']" in out
+
+    def test_remember_this_with_empty_tags_renders_empty_list(self):
+        from hive.server import remember_this_prompt
+
+        out = remember_this_prompt("k", "v", tags="")
+        # No tag-specific keyword-arg drift: the prompt always includes
+        # tags=... so the agent never forgets to pass the parameter.
+        assert "tags=[]" in out
+
+    def test_forget_older_than_names_list_and_forget_tools(self):
+        from hive.server import forget_older_than_prompt
+
+        out = forget_older_than_prompt(30)
+        assert "30 days" in out
+        assert "`list_memories`" in out
+        assert "`forget`" in out
+        # Safety: the template must explicitly forbid bulk-delete
+        # without user confirmation.
+        assert "confirmation" in out.lower() or "confirm" in out.lower()
+
+    @pytest.mark.asyncio
+    async def test_render_prompt_roundtrip_produces_user_message(self):
+        from hive.server import mcp
+
+        # End-to-end through FastMCP's render pipeline — confirms the
+        # prompt is discoverable by name, accepts the declared arguments,
+        # and wraps the string return as a single user-role message.
+        result = await mcp.render_prompt("recall-context", {"topic": "ops"})
+        assert len(result.messages) == 1
+        msg = result.messages[0]
+        assert msg.role == "user"
+        assert "ops" in msg.content.text

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2033,16 +2033,59 @@ class TestMcpPrompts:
         # tags=... so the agent never forgets to pass the parameter.
         assert "tags=[]" in out
 
-    def test_forget_older_than_names_list_and_forget_tools(self):
+    def test_forget_older_than_names_feasible_tool_sequence(self):
         from hive.server import forget_older_than_prompt
 
         out = forget_older_than_prompt(30)
         assert "30 days" in out
-        assert "`list_memories`" in out
+        # Must call only tools Hive actually exposes — `list_memories`
+        # requires a `tag`, so the template walks the namespace via
+        # `list_tags` first, then filters on `last_accessed_at` (not
+        # `updated_at`, which the tool response doesn't surface).
+        assert "`list_tags`" in out
+        assert "`list_memories(tag)`" in out
         assert "`forget`" in out
+        assert "last_accessed_at" in out
+        assert "updated_at" not in out
         # Safety: the template must explicitly forbid bulk-delete
         # without user confirmation.
         assert "confirmation" in out.lower() or "confirm" in out.lower()
+
+    def test_prompts_escape_inputs_with_apostrophes(self):
+        """Regression for Copilot iter-1 on #606.
+
+        User input containing an apostrophe must render unambiguously —
+        ``topic='O'Reilly'`` is malformed; Python ``repr`` produces
+        ``topic="O'Reilly"`` which survives through Markdown-aware MCP
+        clients without breaking the pseudo-call signature.
+        """
+        from hive.server import (
+            recall_context_prompt,
+            remember_this_prompt,
+            what_do_you_know_about_prompt,
+        )
+
+        # Each template round-trips the apostrophe losslessly via `!r`;
+        # the rendered text contains the exact input, just safely quoted.
+        topic = "O'Reilly's stance"
+        assert "O'Reilly's stance" in recall_context_prompt(topic)
+
+        query = "Bob's query"
+        out = what_do_you_know_about_prompt(query)
+        # Confirm repr quoting — should render `"Bob's query"`, not
+        # `'Bob's query'` which would be a Python syntax error.
+        assert '"Bob\'s query"' in out
+
+        key = "note's-key"
+        value = 'a "double-quoted" value with \'apostrophes\''
+        out = remember_this_prompt(key, value)
+        # Both key + value must survive the boundary unambiguously.
+        assert "note's-key" in out
+        # Value escaping uses repr — apostrophes and double-quotes both
+        # present means repr wraps in whichever delimiter avoids most
+        # escaping; either is fine as long as the input is recoverable.
+        # Assert the raw substring is present in the rendered output.
+        assert '"double-quoted"' in out or '\\"double-quoted\\"' in out
 
     @pytest.mark.asyncio
     async def test_render_prompt_roundtrip_produces_user_message(self):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2046,6 +2046,10 @@ class TestMcpPrompts:
         assert "`list_memories(tag)`" in out
         assert "`forget`" in out
         assert "last_accessed_at" in out
+        # `version` is the well-defined fallback when `last_accessed_at`
+        # is null — without it the template would hand-wave at
+        # "implicit age" with no field to compute it from.
+        assert "`version`" in out
         assert "updated_at" not in out
         # Safety: the template must explicitly forbid bulk-delete
         # without user confirmation.


### PR DESCRIPTION
Closes #447

## Summary

Ships four MCP **Prompts** as `@mcp.prompt` templates — Claude Code
and similar clients surface them as slash commands so users hit one
keystroke to kick off a Hive workflow instead of asking the agent to
pick a tool name.

| Prompt | Arguments | Calls |
| --- | --- | --- |
| `/recall-context` | `topic` | `summarize_context(topic=…)` |
| `/what-do-you-know-about` | `query` | `search_memories(query=…, top_k=10)` |
| `/remember-this` | `key`, `value`, `tags` (opt) | `remember(key, value, [tags])` |
| `/forget-older-than` | `days` | interactive `list_memories` + `forget` per confirmation |

## Approach

- Prompts are pure templates — each function returns a string, FastMCP
  wraps it as a single user-role message. No storage reads or writes.
- Deliberately **don't require auth on the prompt render** — discovery
  should be cheap and unauthed clients still see the menu. The tool
  call the agent issues next still enforces the Bearer token.
- `/remember-this` parses comma-separated tags into a canonical Python
  list and always passes `tags=[]` when none are provided, so the
  agent never forgets to set the kwarg.
- `/forget-older-than` template explicitly forbids batch-delete —
  every candidate must be confirmed by the user before `forget` fires.

Tool names are quoted with backticks in each template so they survive
verbatim through Markdown-aware MCP clients.

## Approach trade-offs

Prompts deliberately duplicate the tool call they target rather than
call the tool themselves — FastMCP's prompt runtime doesn't have the
auth context a tool expects, and having the agent make the call keeps
the existing token / scope / quota enforcement intact.

## Test plan

- [x] `tests/unit/test_server.py::TestMcpPrompts` — 8 tests covering:
  - `list_prompts()` exposes all four names with non-empty descriptions
  - Each template names the correct tool + passes the user input
  - `/remember-this` tag parsing (present, blank-trimmed, empty)
  - `/forget-older-than` safety copy
  - End-to-end `render_prompt()` round-trip produces a user-role message
- [x] `docs-site/tools/prompts.md` added + linked from the sidebar
- [x] `uv run inv pre-push` clean (730 frontend tests, 100% Python + JS
      coverage)

Per §7.5, auto-merge is **not** armed at PR creation — step 7.5
arms it after the Copilot loop resolves.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb