### PR TITLE
docs: wait ~90s after Copilot Agent check before polling comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -852,11 +852,17 @@ enable auto-merge once the Copilot loop below completes.
 1. After CI is green, request a Copilot review on the PR via
    `mcp__github__request_copilot_review`.
 2. Wait for the Copilot **`Agent` check-run** to move to
-   `completed` (`get_check_runs`, typically 2–5 min). **Do not rely
-   on `get_reviews` alone** — subsequent Copilot iterations can post
-   line-level comments without creating a new top-level review object,
-   so `get_reviews` will look empty even when new findings exist. The
-   authoritative signal is: Agent check completed + a fresh
+   `completed` (`get_check_runs`, typically 2–5 min), **then wait an
+   additional ~90s** before the first `get_review_comments` call —
+   the Agent check closes before Copilot finishes writing individual
+   line-level comments to the PR, so polling immediately on
+   completion returns an empty thread list even when findings are
+   incoming (observed on #606: Agent completed at 12:41:52, comments
+   posted at 12:43:03). **Do not rely on `get_reviews` alone** —
+   subsequent Copilot iterations can post line-level comments without
+   creating a new top-level review object, so `get_reviews` will
+   look empty even when new findings exist. The authoritative
+   signal is: Agent check completed + ≥90s elapsed + a fresh
    `get_review_comments` call shows threads from
    `copilot-pull-request-reviewer` whose `created_at` is after the
    last fix commit's timestamp.


### PR DESCRIPTION
## Summary

On #606 I polled `get_review_comments` right after Copilot's `Agent`
check completed and saw 0 findings — then armed auto-merge. About a
minute later Copilot posted **6 real findings** (including an
infeasible workflow in `/forget-older-than`). The PR would have
shipped with those findings unseen had you not caught it.

Root cause: the **Agent check closes before Copilot finishes writing
the individual line-level review comments to the PR**. On #606
specifically:

- Agent check `completed` at `12:41:52Z`
- First comment posted at `12:43:03Z` — a ~70s gap

Polling on the `completed` event alone is therefore unsafe.

## Change

Add an explicit **~90s wait** after the Agent check completes before
the first `get_review_comments` call in §7.5 step 2. Rephrase the
"authoritative signal" line to include the delay so future reads
don't regress.

This modifies the Autonomous issue workflow section, so per CLAUDE.md's
own "Keeping CLAUDE.md current" rules this is a **human-review PR** —
auto-merge is intentionally not armed.

## Test plan

- [ ] Reviewer confirms the ~90s buffer is the right floor (could go
      higher; Copilot's post-check latency isn't documented anywhere
      I can find)
- [ ] Next `agent-safe` PR's Copilot loop actually waits and catches
      the first-pass findings

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb