### PR TITLE
feat: pack_context tool — token-budget-aware memory retrieval

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
           { text: "list_memories", link: "/tools/list-memories" },
           { text: "search_memories", link: "/tools/search-memories" },
           { text: "summarize_context", link: "/tools/summarize-context" },
+          { text: "pack_context", link: "/tools/pack-context" },
           { text: "Prompts (slash commands)", link: "/tools/prompts" },
         ],
       },

--- a/docs-site/tools/overview.md
+++ b/docs-site/tools/overview.md
@@ -1,6 +1,6 @@
 # MCP tools overview
 
-Hive exposes six tools that your AI agent can call during a conversation. You don't invoke these directly — your agent decides when to use them based on your instructions.
+Hive exposes seven tools that your AI agent can call during a conversation. You don't invoke these directly — your agent decides when to use them based on your instructions.
 
 ## Tool summary
 
@@ -12,6 +12,7 @@ Hive exposes six tools that your AI agent can call during a conversation. You do
 | [`list_memories`](/tools/list-memories) | List all memories with a given tag |
 | [`search_memories`](/tools/search-memories) | Search memories by semantic similarity |
 | [`summarize_context`](/tools/summarize-context) | Summarise all memories on a topic |
+| [`pack_context`](/tools/pack-context) | Token-budget-aware context pack for agents |
 
 ## Scopes
 

--- a/docs-site/tools/overview.md
+++ b/docs-site/tools/overview.md
@@ -20,7 +20,7 @@ Each OAuth token has one or both of the following scopes:
 
 | Scope | Grants access to |
 | --- | --- |
-| `memories:read` | `recall`, `list_memories`, `search_memories`, `summarize_context` |
+| `memories:read` | `recall`, `list_memories`, `search_memories`, `summarize_context`, `pack_context` |
 | `memories:write` | `remember`, `forget` |
 
 Tokens issued through the standard OAuth flow get both scopes by default.
@@ -34,6 +34,7 @@ You typically don't need to tell your agent which tool to use — just give natu
 - *"List everything tagged..."* → `list_memories`
 - *"Forget the..."* → `forget`
 - *"Give me a summary of..."* → `summarize_context`
+- *"Fill my remaining context window with..."* → `pack_context`
 
 ## Progress notifications
 

--- a/docs-site/tools/pack-context.md
+++ b/docs-site/tools/pack-context.md
@@ -1,0 +1,83 @@
+# `pack_context`
+
+Retrieve as many relevant memories as fit within a token budget, ordered for usefulness, returned as a ready-to-paste markdown block.
+
+`pack_context` is the token-aware counterpart to [`search_memories`](/tools/search-memories) and [`list_memories`](/tools/list-memories). Use it when your agent wants **"fill my remaining context window with the most useful memories about X"** — not top-K, not every memory with a tag, but "as much as will fit".
+
+## Signature
+
+```python
+pack_context(
+    topic: str,
+    budget_tokens: int = 2000,       # 1 – 100_000
+    ordering: str = "relevance+recency",
+) -> str
+```
+
+| Argument | Default | Notes |
+| --- | --- | --- |
+| `topic` | — | Search query / subject to retrieve context for |
+| `budget_tokens` | `2000` | Upper bound on the response token count |
+| `ordering` | `"relevance+recency"` | One of `relevance`, `recency`, or `relevance+recency` |
+
+The tool returns a single markdown-formatted string; the agent can drop it straight into its working context.
+
+## How it works
+
+1. Hybrid vector search finds the top ~50 candidate memories for `topic` (same retrieval backbone as `search_memories`)
+2. Candidates are re-ranked by the chosen `ordering` strategy
+3. Each candidate is token-estimated (4 chars ≈ 1 token — conservative, no `tiktoken` dependency)
+4. The tool greedily packs memories into the budget, **skipping** any individual memory too big for the remaining budget rather than truncating it
+5. The packed result is rendered as markdown with a summary header
+
+## Output shape
+
+```
+## Context for 'release process' (8 memories, ~1847 tokens)
+
+- **release/cadence**: Weekly on Thursdays at 2pm UTC
+- **release/back-merge**: main → development immediately after every prod deploy
+- **release/smoke-tests**: Playwright suite runs against dev after each deploy
+- ...
+```
+
+## Ordering modes
+
+| Mode | Picks by |
+| --- | --- |
+| `relevance` | Pure semantic similarity to `topic`. Useful when recency doesn't matter. |
+| `recency` | Pure exponential decay on `last_accessed_at` / `updated_at`. Useful for "what did I touch recently about X". |
+| `relevance+recency` | Weighted blend (default, matches `search_memories`). Recommended for most callers. |
+
+## Why not do this client-side
+
+- The agent doesn't know how expensive each memory is without fetching them all first — a single packing tool avoids the N+1 round-trip
+- Token-aware truncation logic belongs where memory metadata is cheap to inspect
+- Centralising it means every MCP client benefits equally
+
+## Example workflow
+
+An agent asked to summarise what it knows about a feature:
+
+```
+user: What do we know about the stats tab?
+
+agent (internally):
+  → pack_context(topic="stats tab", budget_tokens=1500)
+  ← ## Context for 'stats tab' (6 memories, ~1423 tokens)
+    - **stats/scaffolding**: Endpoint at /api/account/stats...
+    - **stats/activity-heatmap**: GitHub-style 7×N grid with...
+    ...
+
+agent (response):
+  The stats tab is a React SPA surface backed by /api/account/stats...
+```
+
+The agent's response is grounded in the packed memories, not its base training data.
+
+## Edge cases
+
+- **Budget smaller than any single memory** — returns an empty block with an explanatory note; the agent can retry with a higher budget.
+- **Vector index unavailable** — returns an empty block silently (matches `search_memories`'s non-fatal behaviour).
+- **Redacted memories** — always excluded; there is intentionally no `include_redacted` override.
+- **`budget_tokens` out of range** — clamps to `[1, 100_000]` server-side.

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1581,11 +1581,24 @@ async def pack_context(
     # Reserve budget for the header + trailing blank line so the total
     # rendered tokens stay under the advertised `budget`. Use the most
     # expensive possible header (assumes 5-digit `used_tokens` and
-    # 3-digit count) so we never under-reserve. Floor the effective
-    # budget at 1 so degenerate callers still get an empty block.
+    # 3-digit count) so we never under-reserve.
     header_reserve = estimate_tokens(f"## Context for {topic!r} (000 memories, ~00000 tokens)\n\n")
-    effective_budget = max(1, budget - header_reserve)
-    packed, used_tokens = pack_memories_within_budget(scored, effective_budget)
+    if budget <= header_reserve:
+        # Tiny budget — can't even fit the header. Degrade straight
+        # through the same fallback ladder as the vector-error branches.
+        rendered = _render_empty_within_budget(topic, budget)
+        packed: list[Memory] = []
+        used_tokens = 0
+    else:
+        packed, used_tokens = pack_memories_within_budget(scored, budget - header_reserve)
+        rendered = _render_packed_context(topic, packed, used_tokens)
+        # Belt-and-braces: if our token estimate still overshoots the
+        # rendered output (e.g. weird unicode the heuristic mis-counts),
+        # collapse to the empty fallback so the contract holds.
+        if estimate_tokens(rendered) > budget:
+            rendered = _render_empty_within_budget(topic, budget)
+            packed = []
+            used_tokens = 0
 
     _log(
         storage,
@@ -1622,7 +1635,7 @@ async def pack_context(
         unit="Milliseconds",
         operation="pack_context",
     )
-    return _tool_result(_render_packed_context(topic, packed, used_tokens), storage, client_id)
+    return _tool_result(rendered, storage, client_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -13,6 +13,7 @@ Tools:
   list_memories(tag)          — list memories by tag
   list_tags()                 — list distinct tags for the caller's memories
   summarize_context(topic)    — synthesise memories into a summary
+  pack_context(topic, ...)    — token-budget-aware context pack (#452)
 """
 
 from __future__ import annotations
@@ -1374,6 +1375,209 @@ async def relate_memories(
         storage,
         client_id,
     )
+
+
+# ---------------------------------------------------------------------------
+# pack_context (#452)
+# ---------------------------------------------------------------------------
+#
+# Token-budget-aware retrieval: agents ask for "as much relevant context
+# as fits in N tokens" rather than top-K or everything-under-a-tag. The
+# tool runs the same hybrid search as `search_memories`, re-orders by
+# the caller's preferred strategy, estimates tokens per candidate, and
+# greedily packs until the budget is exhausted.
+
+
+_PACK_CONTEXT_CANDIDATE_POOL = 50
+_PACK_CONTEXT_DEFAULT_BUDGET = 2000
+_PACK_CONTEXT_MAX_BUDGET = 100_000
+# Conservative char-per-token ratio that covers both English prose and
+# code/JSON fragments without pulling in tiktoken (a ~10MB C extension).
+# Over-estimating is fine — agents prefer under-budget to over-budget.
+_PACK_CONTEXT_CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count for a block of text.
+
+    Uses a simple chars-per-token heuristic (4 chars ≈ 1 token, the
+    long-run Anthropic/OpenAI English average) instead of tiktoken so
+    the Lambda bundle stays slim. Slightly conservative — the packer
+    would rather leave budget on the table than overflow.
+    """
+    if not text:
+        return 0
+    # ceil so a 3-char string still costs 1 token, not 0.
+    return (len(text) + _PACK_CONTEXT_CHARS_PER_TOKEN - 1) // _PACK_CONTEXT_CHARS_PER_TOKEN
+
+
+def _score_for_ordering(
+    ordering: str,
+    *,
+    semantic: float,
+    recency: float,
+    blended: float,
+) -> float:
+    """Pick the sort key for a candidate memory based on the ordering mode.
+
+    Extracted so the pack-context unit tests can assert each mode
+    directly without walking the full pipeline.
+    """
+    if ordering == "relevance":
+        return semantic
+    if ordering == "recency":
+        return recency
+    # Default: relevance+recency blend (matches search_memories default).
+    return blended
+
+
+def pack_memories_within_budget(
+    memories: list[tuple[Memory, float]],
+    budget_tokens: int,
+) -> tuple[list[Memory], int]:
+    """Greedily pack memories into a token budget, preserving input order.
+
+    ``memories`` is a pre-sorted list of (Memory, score) tuples; the
+    score is only carried for the header and ignored here. Returns the
+    subset that fits and the sum of their estimated tokens.
+
+    Items larger than the remaining budget are skipped — we don't
+    truncate individual memories because a half-quoted decision is
+    worse than a missing one. The caller can drop the budget lower or
+    adjust ordering to surface smaller candidates.
+    """
+    packed: list[Memory] = []
+    used = 0
+    for memory, _score in memories:
+        entry_tokens = estimate_tokens(_render_memory_entry(memory))
+        if used + entry_tokens > budget_tokens:
+            continue
+        packed.append(memory)
+        used += entry_tokens
+    return packed, used
+
+
+def _render_memory_entry(memory: Memory) -> str:
+    """Render a single memory as the line shape used in the packed block."""
+    return f"- **{memory.key}**: {memory.value}"
+
+
+def _render_packed_context(topic: str, packed: list[Memory], used_tokens: int) -> str:
+    """Render the full packed-context string the tool returns.
+
+    Separated from the tool body so the formatting is unit-testable
+    without any storage or auth plumbing.
+    """
+    if not packed:
+        return (
+            f"## Context for {topic!r} (0 memories, ~0 tokens)\n\n"
+            "_No relevant memories fit within the token budget._"
+        )
+    header = f"## Context for {topic!r} ({len(packed)} memories, ~{used_tokens} tokens)"
+    body = "\n".join(_render_memory_entry(m) for m in packed)
+    return f"{header}\n\n{body}"
+
+
+@mcp.tool(
+    title="Pack context",
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+async def pack_context(
+    topic: Annotated[str, "Topic / query to retrieve context for"],
+    budget_tokens: Annotated[
+        int,
+        "Maximum tokens in the returned context block (1–100000). Defaults to 2000.",
+    ] = _PACK_CONTEXT_DEFAULT_BUDGET,
+    ordering: Annotated[
+        str,
+        "How to rank candidates before packing: 'relevance' (pure semantic), "
+        "'recency' (pure last-accessed decay), or 'relevance+recency' (blend, default).",
+    ] = "relevance+recency",
+    ctx: Context | None = None,
+) -> str:
+    """Retrieve as many relevant memories as fit within ``budget_tokens``.
+
+    Unlike ``search_memories`` (fixed top-K) or ``list_memories`` (full
+    tag slice), ``pack_context`` lets the agent ask for "fill my
+    remaining context window with the most useful memories about X".
+    The return is a markdown block ready to drop straight into a
+    prompt — caller doesn't need to post-process JSON.
+    """
+    t0 = time.monotonic()
+    storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    budget = max(1, min(int(budget_tokens), _PACK_CONTEXT_MAX_BUDGET))
+    mode = (
+        ordering
+        if ordering in {"relevance", "recency", "relevance+recency"}
+        else ("relevance+recency")
+    )
+
+    try:
+        pairs = _vector_store().search(topic, client_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL)
+    except VectorIndexNotFoundError:
+        return _tool_result(_render_packed_context(topic, [], 0), storage, client_id)
+    except Exception:
+        logger.warning("Vector search failed in pack_context (non-fatal)", exc_info=True)
+        return _tool_result(_render_packed_context(topic, [], 0), storage, client_id)
+
+    hydrated = storage.hydrate_memory_ids(pairs)
+
+    # Score every candidate through the standard blend pipeline so the
+    # `relevance+recency` mode matches search_memories exactly.
+    query_tokens = tokenize(topic)
+    now = datetime.now(timezone.utc)
+    scored: list[tuple[Memory, float]] = []
+    for memory, sem in hydrated:
+        if memory.is_redacted:
+            continue
+        kw = keyword_score(query_tokens, memory.value)
+        rec = recency_score(memory, now=now)
+        blended = blend_score(semantic=sem, keyword=kw, recency=rec)
+        scored.append(
+            (memory, _score_for_ordering(mode, semantic=sem, recency=rec, blended=blended))
+        )
+
+    # Sort descending by chosen score; `reverse=True` keeps the highest
+    # scorer first for the greedy packer to fit first.
+    scored.sort(key=lambda row: row[1], reverse=True)
+    packed, used_tokens = pack_memories_within_budget(scored, budget)
+
+    _log(
+        storage,
+        ActivityEvent(
+            event_type=EventType.memory_searched,
+            client_id=client_id,
+            metadata={
+                "tool": "pack_context",
+                "topic": topic,
+                "budget_tokens": budget,
+                "ordering": mode,
+                "packed_count": len(packed),
+                "used_tokens": used_tokens,
+            },
+        ),
+    )
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "pack_context for '%s': %d memories in %d/%d tokens",
+        topic,
+        len(packed),
+        used_tokens,
+        budget,
+        extra={
+            "tool": "pack_context",
+            "duration_ms": duration_ms,
+            "status": "success",
+        },
+    )
+    await emit_metric("ToolInvocations", operation="pack_context")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="pack_context",
+    )
+    return _tool_result(_render_packed_context(topic, packed, used_tokens), storage, client_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1437,23 +1437,30 @@ def pack_memories_within_budget(
 ) -> tuple[list[Memory], int]:
     """Greedily pack memories into a token budget, preserving input order.
 
-    ``memories`` is a pre-sorted list of (Memory, score) tuples; the
-    score is only carried for the header and ignored here. Returns the
-    subset that fits and the sum of their estimated tokens.
+    ``memories`` is a pre-sorted list of ``(Memory, score)`` tuples.
+    The function preserves the upstream ordering and ignores ``score``
+    itself — the caller is responsible for sorting. Returns the subset
+    that fits and the sum of their estimated tokens (including the
+    ``\\n`` separators that ``_render_packed_context`` inserts between
+    entries, so the returned token count matches the rendered block).
 
     Items larger than the remaining budget are skipped — we don't
     truncate individual memories because a half-quoted decision is
     worse than a missing one. The caller can raise the budget or
     adjust ordering to surface smaller candidates.
     """
+    separator_tokens = estimate_tokens("\n")
     packed: list[Memory] = []
     used = 0
     for memory, _score in memories:
         entry_tokens = estimate_tokens(_render_memory_entry(memory))
-        if used + entry_tokens > budget_tokens:
+        # First entry has no preceding separator; subsequent ones do,
+        # matching what `_render_packed_context` will actually emit.
+        additional = entry_tokens + (separator_tokens if packed else 0)
+        if used + additional > budget_tokens:
             continue
         packed.append(memory)
-        used += entry_tokens
+        used += additional
     return packed, used
 
 
@@ -1483,6 +1490,30 @@ def _render_packed_context(topic: str, packed: list[Memory], used_tokens: int) -
     header = f"## Context for {topic!r} ({count} {label}, ~{used_tokens} tokens)"
     body = "\n".join(_render_memory_entry(m) for m in packed)
     return f"{header}\n\n{body}"
+
+
+def _render_empty_within_budget(topic: str, budget_tokens: int) -> str:
+    """Render the best empty-state response that fits in the budget.
+
+    Tries the full ``_render_packed_context(topic, [], 0)`` first
+    (header + explanatory body). If that overshoots the budget, falls
+    back to progressively shorter strings so the advertised budget
+    contract holds even on the vector-error / no-index branches.
+    """
+    full = _render_packed_context(topic, [], 0)
+    if estimate_tokens(full) <= budget_tokens:
+        return full
+    # Drop the explanatory body; header alone is usually well under 20 tokens.
+    header_only = f"## Context for {topic!r} (0 memories, ~0 tokens)"
+    if estimate_tokens(header_only) <= budget_tokens:
+        return header_only
+    # Last-resort terse fallback for single-digit budgets. Agents asking
+    # for <5 tokens of context are doing something pathological, but we
+    # still honour the contract.
+    terse = "_no context_"
+    if estimate_tokens(terse) <= budget_tokens:
+        return terse
+    return ""
 
 
 @mcp.tool(
@@ -1522,10 +1553,10 @@ async def pack_context(
     try:
         pairs = _vector_store().search(topic, client_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL)
     except VectorIndexNotFoundError:
-        return _tool_result(_render_packed_context(topic, [], 0), storage, client_id)
+        return _tool_result(_render_empty_within_budget(topic, budget), storage, client_id)
     except Exception:
         logger.warning("Vector search failed in pack_context (non-fatal)", exc_info=True)
-        return _tool_result(_render_packed_context(topic, [], 0), storage, client_id)
+        return _tool_result(_render_empty_within_budget(topic, budget), storage, client_id)
 
     hydrated = storage.hydrate_memory_ids(pairs)
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1552,9 +1552,7 @@ async def pack_context(
     # expensive possible header (assumes 5-digit `used_tokens` and
     # 3-digit count) so we never under-reserve. Floor the effective
     # budget at 1 so degenerate callers still get an empty block.
-    header_reserve = estimate_tokens(
-        f"## Context for {topic!r} (000 memories, ~00000 tokens)\n\n"
-    )
+    header_reserve = estimate_tokens(f"## Context for {topic!r} (000 memories, ~00000 tokens)\n\n")
     effective_budget = max(1, budget - header_reserve)
     packed, used_tokens = pack_memories_within_budget(scored, effective_budget)
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1443,7 +1443,7 @@ def pack_memories_within_budget(
 
     Items larger than the remaining budget are skipped — we don't
     truncate individual memories because a half-quoted decision is
-    worse than a missing one. The caller can drop the budget lower or
+    worse than a missing one. The caller can raise the budget or
     adjust ordering to surface smaller candidates.
     """
     packed: list[Memory] = []
@@ -1462,18 +1462,25 @@ def _render_memory_entry(memory: Memory) -> str:
     return f"- **{memory.key}**: {memory.value}"
 
 
+def _memory_label(count: int) -> str:
+    """Return the correctly pluralised label for a memory count."""
+    return "memory" if count == 1 else "memories"
+
+
 def _render_packed_context(topic: str, packed: list[Memory], used_tokens: int) -> str:
     """Render the full packed-context string the tool returns.
 
     Separated from the tool body so the formatting is unit-testable
     without any storage or auth plumbing.
     """
+    count = len(packed)
+    label = _memory_label(count)
     if not packed:
         return (
-            f"## Context for {topic!r} (0 memories, ~0 tokens)\n\n"
+            f"## Context for {topic!r} (0 {label}, ~0 tokens)\n\n"
             "_No relevant memories fit within the token budget._"
         )
-    header = f"## Context for {topic!r} ({len(packed)} memories, ~{used_tokens} tokens)"
+    header = f"## Context for {topic!r} ({count} {label}, ~{used_tokens} tokens)"
     body = "\n".join(_render_memory_entry(m) for m in packed)
     return f"{header}\n\n{body}"
 
@@ -1540,7 +1547,16 @@ async def pack_context(
     # Sort descending by chosen score; `reverse=True` keeps the highest
     # scorer first for the greedy packer to fit first.
     scored.sort(key=lambda row: row[1], reverse=True)
-    packed, used_tokens = pack_memories_within_budget(scored, budget)
+    # Reserve budget for the header + trailing blank line so the total
+    # rendered tokens stay under the advertised `budget`. Use the most
+    # expensive possible header (assumes 5-digit `used_tokens` and
+    # 3-digit count) so we never under-reserve. Floor the effective
+    # budget at 1 so degenerate callers still get an empty block.
+    header_reserve = estimate_tokens(
+        f"## Context for {topic!r} (000 memories, ~00000 tokens)\n\n"
+    )
+    effective_budget = max(1, budget - header_reserve)
+    packed, used_tokens = pack_memories_within_budget(scored, effective_budget)
 
     _log(
         storage,

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2494,10 +2494,17 @@ class TestPackContextHelpers:
         from hive.models import Memory
         from hive.server import _render_packed_context
 
+        # Singular copy — `1 memory`, not the grammatically wrong
+        # "1 memories" the first draft would have shown.
         m = Memory(key="k", value="v", tags=[], owner_client_id="c1")
         out = _render_packed_context("ops", [m], 3)
-        assert out.startswith("## Context for 'ops' (1 memories, ~3 tokens)")
+        assert out.startswith("## Context for 'ops' (1 memory, ~3 tokens)")
         assert "- **k**: v" in out
+
+        # Plural copy — ≥2 memories → `memories`.
+        m2 = Memory(key="k2", value="v2", tags=[], owner_client_id="c1")
+        plural = _render_packed_context("ops", [m, m2], 6)
+        assert plural.startswith("## Context for 'ops' (2 memories, ~6 tokens)")
 
 
 class TestPackContext:
@@ -2567,11 +2574,14 @@ class TestPackContext:
         m_h = storage.get_memory_by_key("huge")
         mock_vs = _make_mock_vector_store([(m_s.memory_id, 0.9), (m_h.memory_id, 0.8)])
         with patch("hive.server._vector_store", return_value=mock_vs):
-            result = await pack_context("topic", budget_tokens=60, ctx=ctx)
+            # Each entry is ~54 tokens (13-char prefix + 200-char value).
+            # Budget 100 minus the ~14-token header reserve leaves ~86
+            # tokens — enough for one memory, but two would need ~108.
+            result = await pack_context("topic", budget_tokens=100, ctx=ctx)
         text = _text(result)
         # Only the first (higher-scoring) memory fits; the second is
         # skipped silently rather than truncated.
-        assert "1 memories" in text
+        assert "1 memory" in text
         assert "- **small**" in text
         assert "- **huge**" not in text
 
@@ -2663,4 +2673,4 @@ class TestPackContext:
             # silently falls back to the default blend. Agents that
             # typo "relevancy" should still get a usable response.
             result = await pack_context("content", ordering="nonsense", ctx=ctx)
-        assert "1 memories" in _text(result)
+        assert "1 memory" in _text(result)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2399,3 +2399,268 @@ class TestMcpResources:
                 body = list_memory_resources()
         # Truncation note mentions the actual limit, not a hard-coded 500.
         assert "Index capped at 2" in body
+
+
+class TestPackContextHelpers:
+    """#452 — unit tests for the pack_context pure-function helpers.
+
+    Split from the integration tests below so token-budget logic can be
+    verified without any auth or storage plumbing.
+    """
+
+    def test_estimate_tokens_empty(self):
+        from hive.server import estimate_tokens
+
+        assert estimate_tokens("") == 0
+
+    def test_estimate_tokens_rounds_up(self):
+        from hive.server import estimate_tokens
+
+        # Ceil arithmetic — 1 char still costs 1 token so the packer
+        # never under-counts a fragment.
+        assert estimate_tokens("a") == 1
+        assert estimate_tokens("abcd") == 1  # exactly 1 token at 4 cpt
+        assert estimate_tokens("abcde") == 2  # 5 chars → 2 tokens
+
+    def test_score_for_ordering_all_modes(self):
+        from hive.server import _score_for_ordering
+
+        kwargs = dict(semantic=0.9, recency=0.4, blended=0.6)
+        assert _score_for_ordering("relevance", **kwargs) == 0.9
+        assert _score_for_ordering("recency", **kwargs) == 0.4
+        assert _score_for_ordering("relevance+recency", **kwargs) == 0.6
+        # Unknown modes fall through to the blended default so a client
+        # passing `ordering="garbage"` still gets sensible output.
+        assert _score_for_ordering("garbage", **kwargs) == 0.6
+
+    def test_pack_memories_greedy_fits_within_budget(self):
+        from hive.models import Memory
+        from hive.server import pack_memories_within_budget
+
+        # Entry lines are `- **{key}**: {value}` so the char count is
+        # 9 + len(value). With 4 chars/token:
+        #   a → ceil(49/4) = 13 tokens
+        #   b → ceil(409/4) = 103 tokens  (too big)
+        #   c → ceil(29/4) = 8 tokens
+        a = Memory(key="a", value="x" * 40, tags=[], owner_client_id="c1")
+        b = Memory(key="b", value="y" * 400, tags=[], owner_client_id="c1")
+        c = Memory(key="c", value="z" * 20, tags=[], owner_client_id="c1")
+
+        packed, used = pack_memories_within_budget(
+            [(a, 1.0), (b, 0.9), (c, 0.8)],
+            budget_tokens=25,
+        )
+        # `a` fits (13 tokens), `b` overflows and is skipped, `c` fits
+        # in the remaining budget (13 + 8 = 21 ≤ 25).
+        assert [m.key for m in packed] == ["a", "c"]
+        assert used == 21
+
+    def test_pack_memories_empty_when_budget_below_smallest(self):
+        from hive.models import Memory
+        from hive.server import pack_memories_within_budget
+
+        packed, used = pack_memories_within_budget(
+            [(Memory(key="a", value="x" * 1000, tags=[], owner_client_id="c1"), 1.0)],
+            budget_tokens=1,
+        )
+        assert packed == []
+        assert used == 0
+
+    def test_pack_memories_skips_oversized_mid_stream(self):
+        from hive.models import Memory
+        from hive.server import pack_memories_within_budget
+
+        # Test that a mid-stream memory too big for the remaining budget
+        # is skipped without aborting the loop — later small ones still
+        # fit.
+        small = Memory(key="s1", value="x" * 10, tags=[], owner_client_id="c1")
+        huge = Memory(key="huge", value="y" * 1000, tags=[], owner_client_id="c1")
+        also_small = Memory(key="s2", value="z" * 10, tags=[], owner_client_id="c1")
+        packed, _ = pack_memories_within_budget(
+            [(small, 1.0), (huge, 0.9), (also_small, 0.8)],
+            budget_tokens=50,
+        )
+        assert [m.key for m in packed] == ["s1", "s2"]
+
+    def test_render_packed_context_empty_has_explanatory_body(self):
+        from hive.server import _render_packed_context
+
+        out = _render_packed_context("ops", [], 0)
+        assert "0 memories" in out
+        # Users should get a reason, not just an empty block.
+        assert "No relevant memories" in out
+
+    def test_render_packed_context_formats_entries(self):
+        from hive.models import Memory
+        from hive.server import _render_packed_context
+
+        m = Memory(key="k", value="v", tags=[], owner_client_id="c1")
+        out = _render_packed_context("ops", [m], 3)
+        assert out.startswith("## Context for 'ops' (1 memories, ~3 tokens)")
+        assert "- **k**: v" in out
+
+
+class TestPackContext:
+    """#452 — integration tests for the pack_context MCP tool."""
+
+    async def test_returns_empty_block_when_no_index(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import pack_context
+        from hive.vector_store import VectorIndexNotFoundError
+
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+        mock_vs.search.side_effect = VectorIndexNotFoundError("no index")
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await pack_context("anything", ctx=_make_ctx(jwt))
+        assert "0 memories" in _text(result)
+
+    async def test_returns_empty_block_on_vector_error(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import pack_context
+
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+        mock_vs.search.side_effect = RuntimeError("bedrock down")
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await pack_context("anything", ctx=_make_ctx(jwt))
+        # Non-fatal degradation — we return an empty block rather than a
+        # ToolError, matching search_memories' behaviour.
+        assert "0 memories" in _text(result)
+
+    async def test_packs_memories_matching_topic(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import pack_context, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("alpha", "alpha content about topic", [], ctx=ctx)
+        await remember("beta", "beta content about topic", [], ctx=ctx)
+        m_alpha = storage.get_memory_by_key("alpha")
+        m_beta = storage.get_memory_by_key("beta")
+
+        mock_vs = _make_mock_vector_store([(m_alpha.memory_id, 0.9), (m_beta.memory_id, 0.8)])
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await pack_context("topic", budget_tokens=500, ctx=ctx)
+
+        text = _text(result)
+        assert "2 memories" in text
+        assert "- **alpha**: alpha content about topic" in text
+        assert "- **beta**: beta content about topic" in text
+
+    async def test_packs_within_budget_when_memories_overflow(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import pack_context, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        # Each value is 200 chars ≈ 50 tokens; two of these plus the
+        # line-format wrapper will blow a 30-token budget, so only one
+        # should land.
+        await remember("small", "x" * 200, [], ctx=ctx)
+        await remember("huge", "y" * 200, [], ctx=ctx)
+        m_s = storage.get_memory_by_key("small")
+        m_h = storage.get_memory_by_key("huge")
+        mock_vs = _make_mock_vector_store([(m_s.memory_id, 0.9), (m_h.memory_id, 0.8)])
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await pack_context("topic", budget_tokens=60, ctx=ctx)
+        text = _text(result)
+        # Only the first (higher-scoring) memory fits; the second is
+        # skipped silently rather than truncated.
+        assert "1 memories" in text
+        assert "- **small**" in text
+        assert "- **huge**" not in text
+
+    async def test_skips_redacted_memories(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import pack_context, redact_memory, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("visible", "visible content", [], ctx=ctx)
+        await remember("tombstoned", "private content", [], ctx=ctx)
+        await redact_memory("tombstoned", ctx=ctx)
+
+        m_v = storage.get_memory_by_key("visible")
+        m_t = storage.get_memory_by_key("tombstoned")
+        mock_vs = _make_mock_vector_store([(m_v.memory_id, 0.9), (m_t.memory_id, 0.85)])
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await pack_context("content", budget_tokens=500, ctx=ctx)
+        text = _text(result)
+        assert "- **visible**" in text
+        # Tombstoned memories must never surface — pack_context has no
+        # include_redacted escape hatch on purpose; redacted memories
+        # belong out of reach.
+        assert "tombstoned" not in text
+        assert "private content" not in text
+
+    async def test_ordering_modes_sort_candidates_differently(self, server_env):
+        """Pure-relevance puts high-semantic first; pure-recency inverts it."""
+        from unittest.mock import patch
+
+        from hive.server import pack_context, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("old-but-relevant", "very relevant content", [], ctx=ctx)
+        await remember("new-but-off-topic", "less relevant content", [], ctx=ctx)
+        m_old = storage.get_memory_by_key("old-but-relevant")
+        m_new = storage.get_memory_by_key("new-but-off-topic")
+        # Manually backdate `old-but-relevant` so recency score rewards
+        # the newer entry even though its semantic score is lower.
+        m_old.updated_at = datetime.now(timezone.utc) - timedelta(days=365)
+        m_old.created_at = m_old.updated_at
+        storage.put_memory(m_old)
+
+        mock_vs = _make_mock_vector_store([(m_old.memory_id, 0.95), (m_new.memory_id, 0.4)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            relevance_first = await pack_context(
+                "relevant", budget_tokens=40, ordering="relevance", ctx=ctx
+            )
+        # `relevance` ranking puts the high-semantic memory first, so
+        # it's the one that lands in the 40-token budget.
+        assert "- **old-but-relevant**" in _text(relevance_first)
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            recency_first = await pack_context(
+                "relevant", budget_tokens=40, ordering="recency", ctx=ctx
+            )
+        # `recency` ranking picks the newer-but-off-topic one instead.
+        assert "- **new-but-off-topic**" in _text(recency_first)
+
+    async def test_clamps_budget_to_valid_range(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import pack_context
+
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        mock_vs = _make_mock_vector_store([])
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            # Budget 0 clamps to 1; should still render the empty block
+            # (no memories, no tokens) rather than crash.
+            result = await pack_context("x", budget_tokens=0, ctx=ctx)
+        assert "0 memories" in _text(result)
+
+    async def test_invalid_ordering_falls_back_to_blend(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import pack_context, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "content", [], ctx=ctx)
+        m = storage.get_memory_by_key("a")
+        mock_vs = _make_mock_vector_store([(m.memory_id, 0.9)])
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            # Unknown ordering string must not crash the tool — it
+            # silently falls back to the default blend. Agents that
+            # typo "relevancy" should still get a usable response.
+            result = await pack_context("content", ordering="nonsense", ctx=ctx)
+        assert "1 memories" in _text(result)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2451,9 +2451,10 @@ class TestPackContextHelpers:
             budget_tokens=25,
         )
         # `a` fits (13 tokens), `b` overflows and is skipped, `c` fits
-        # in the remaining budget (13 + 8 = 21 ≤ 25).
+        # in the remaining budget. Token count includes the `\n`
+        # separator between entries: 13 (a) + 1 (sep) + 8 (c) = 22.
         assert [m.key for m in packed] == ["a", "c"]
-        assert used == 21
+        assert used == 22
 
     def test_pack_memories_empty_when_budget_below_smallest(self):
         from hive.models import Memory
@@ -2489,6 +2490,37 @@ class TestPackContextHelpers:
         assert "0 memories" in out
         # Users should get a reason, not just an empty block.
         assert "No relevant memories" in out
+
+    def test_render_empty_within_budget_returns_full_when_it_fits(self):
+        from hive.server import _render_empty_within_budget
+
+        out = _render_empty_within_budget("ops", 1000)
+        assert "No relevant memories" in out
+
+    def test_render_empty_within_budget_drops_body_when_too_tight(self):
+        from hive.server import _render_empty_within_budget, estimate_tokens
+
+        # Budget between "header only" and "header + explanatory body".
+        out = _render_empty_within_budget("ops", 15)
+        # The explanatory body is gone but the header survives.
+        assert "No relevant memories" not in out
+        assert "## Context for 'ops'" in out
+        assert estimate_tokens(out) <= 15
+
+    def test_render_empty_within_budget_falls_back_to_terse(self):
+        from hive.server import _render_empty_within_budget
+
+        # 5-token budget is too tight for the header; falls back to the
+        # single-line terse message.
+        out = _render_empty_within_budget("ops", 5)
+        assert out == "_no context_"
+
+    def test_render_empty_within_budget_returns_empty_for_zero_budget(self):
+        from hive.server import _render_empty_within_budget
+
+        # 1-token budget can't fit even "_no context_" (3 tokens) so
+        # the tool returns an empty string rather than break contract.
+        assert _render_empty_within_budget("ops", 1) == ""
 
     def test_render_packed_context_formats_entries(self):
         from hive.models import Memory

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2721,6 +2721,44 @@ class TestPackContext:
         # Contract holds: rendered output fits in the advertised budget.
         assert estimate_tokens(rendered) <= 5
 
+    async def test_rendered_overshoot_collapses_to_empty(self, server_env):
+        """Belt-and-braces: if the token heuristic mis-counts the rendered
+        output (e.g. weird unicode the 4-chars-per-token heuristic
+        overshoots), the final rendered block is recomputed from
+        `_render_empty_within_budget` so the advertised budget still
+        holds. Exercised by injecting a mid-stream spike into
+        ``estimate_tokens`` after the greedy packer has already fit.
+        """
+        from unittest.mock import patch
+
+        from hive.server import pack_context, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "content", [], ctx=ctx)
+        m = storage.get_memory_by_key("a")
+        mock_vs = _make_mock_vector_store([(m.memory_id, 0.9)])
+
+        # First call = header_reserve probe (small); subsequent calls
+        # (per-memory + final rendered check) return a spike that
+        # tricks the "rendered > budget" guard into firing.
+        call_count = {"n": 0}
+
+        def fake_estimate(text: str) -> int:
+            call_count["n"] += 1
+            return 1 if call_count["n"] == 1 else 10_000
+
+        with (
+            patch("hive.server._vector_store", return_value=mock_vs),
+            patch("hive.server.estimate_tokens", side_effect=fake_estimate),
+        ):
+            result = await pack_context("t", budget_tokens=500, ctx=ctx)
+
+        # Overshoot branch fired — result is the empty-fallback header,
+        # not the packed-memories block.
+        rendered = _text(result)
+        assert "- **" not in rendered  # no packed bullets
+
     async def test_invalid_ordering_falls_back_to_blend(self, server_env):
         from unittest.mock import patch
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2685,10 +2685,41 @@ class TestPackContext:
         ctx = _make_ctx(jwt)
         mock_vs = _make_mock_vector_store([])
         with patch("hive.server._vector_store", return_value=mock_vs):
-            # Budget 0 clamps to 1; should still render the empty block
-            # (no memories, no tokens) rather than crash.
+            # Budget 0 clamps to 1 — the tiny-budget fallback returns an
+            # empty string rather than overshooting the advertised
+            # budget with header text. No crash, contract honoured.
             result = await pack_context("x", budget_tokens=0, ctx=ctx)
+        assert _text(result) == ""
+
+        # A sub-default but reasonable budget (say, 50) should still
+        # render the empty block when there are no candidates.
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await pack_context("x", budget_tokens=50, ctx=ctx)
         assert "0 memories" in _text(result)
+
+    async def test_tiny_budget_falls_back_to_empty_within_budget(self, server_env):
+        """Regression for iter-3 r3111445601 — budget ≤ header_reserve.
+
+        When `budget_tokens` is tiny (< header_reserve ~14 tokens), the
+        successful path used to call pack_memories_within_budget with
+        an artificially floored budget of 1 and then render the full
+        header, overshooting the advertised budget. Now it degrades to
+        `_render_empty_within_budget` like the vector-error branches.
+        """
+        from unittest.mock import patch
+
+        from hive.server import estimate_tokens, pack_context, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("a", "some-content", [], ctx=ctx)
+        m = storage.get_memory_by_key("a")
+        mock_vs = _make_mock_vector_store([(m.memory_id, 0.9)])
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await pack_context("t", budget_tokens=5, ctx=ctx)
+        rendered = _text(result)
+        # Contract holds: rendered output fits in the advertised budget.
+        assert estimate_tokens(rendered) <= 5
 
     async def test_invalid_ordering_falls_back_to_blend(self, server_env):
         from unittest.mock import patch


### PR DESCRIPTION
Closes #452

## Summary

Ships a new `pack_context` MCP tool that retrieves **as many relevant
memories as fit in a caller-supplied token budget**, returned as a
markdown block ready to drop into the agent's prompt. Unlike
`search_memories` (fixed top-K) and `list_memories` (full tag slice),
this is the first retrieval surface that understands the agent's
remaining context window.

| Arg | Default | Notes |
| --- | --- | --- |
| `topic` | — | Search query / subject |
| `budget_tokens` | `2000` | Clamped to `[1, 100_000]` |
| `ordering` | `"relevance+recency"` | Or `"relevance"` / `"recency"` |

Returns a markdown string, e.g.

```
## Context for 'release process' (8 memories, ~1847 tokens)

- **release/cadence**: Weekly on Thursdays at 2pm UTC
- **release/back-merge**: main → development after every prod deploy
- ...
```

## Approach

- **4-chars-per-token heuristic** instead of `tiktoken` — keeps the
  Lambda bundle slim and errs on the conservative side (the packer
  would rather leave budget on the table than overflow)
- **Greedy fit, not truncate** — a mid-stream memory too big for the
  remaining budget is skipped, not cropped. A half-quoted decision is
  worse than a missing one; the caller can rerun with a higher budget
  or different ordering
- **Redacted memories always excluded** — no `include_redacted`
  escape hatch on purpose
- **Same retrieval backbone as `search_memories`** — hybrid vector
  + keyword + recency blend; the `relevance+recency` mode matches the
  search default 1:1
- **Pure-function helpers extracted** (`estimate_tokens`,
  `pack_memories_within_budget`, `_render_packed_context`,
  `_score_for_ordering`) so the token-budget logic is unit-testable
  without auth or storage plumbing

## Test plan

- [x] `tests/unit/test_server.py::TestPackContextHelpers` — 8 tests:
  token estimator (empty / rounds-up), score-ordering dispatcher (all
  three modes + fallback), greedy pack (happy path / budget-too-small /
  mid-stream skip), render-block (empty / non-empty formatting)
- [x] `tests/unit/test_server.py::TestPackContext` — 8 integration
  tests: no-index / vector-error non-fatal, happy-path pack, budget
  overflow skips lower-ranked memory, redacted memories excluded,
  ordering modes sort candidates differently, budget clamp, invalid
  `ordering` falls back to blend
- [x] Docs: `docs-site/tools/pack-context.md` + sidebar entry + tool
  count in overview
- [x] `uv run inv pre-push` clean locally (format + lint + typecheck +
  unit + frontend)

Per §7.5, auto-merge is **not** armed at PR creation — step 7.5
arms it after the Copilot loop resolves.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb