### PR TITLE
feat: expose memories as MCP Resources (not just Tools)

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -100,6 +100,7 @@ export default defineConfig({
           { text: "Tags and organisation", link: "/concepts/tags" },
           { text: "Key naming conventions", link: "/concepts/key-conventions" },
           { text: "Quotas and rate limits", link: "/concepts/quotas" },
+          { text: "MCP Resources", link: "/concepts/resources" },
         ],
       },
       {

--- a/docs-site/concepts/resources.md
+++ b/docs-site/concepts/resources.md
@@ -24,25 +24,27 @@ Resources are listed in two places:
 - `resources/list` returns the concrete `memory://index` resource
 - `resources/templates/list` returns the template `memory://{key}`
 
-Clients typically read `memory://index` first to discover what's available:
+Clients typically read `memory://index` first to discover what's available. Keys that contain `/` or `:` are [percent-encoded](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) so each URI is parseable by standard URI tooling and round-trips losslessly:
 
 ```
-memory://release/cadence
-memory://release/back-merge
-memory://release/smoke-tests
+memory://release-cadence
+memory://release-back-merge
+memory://release%2Fsmoke-tests
 ```
+
+(The third example shows a key `release/smoke-tests` with the `/` encoded as `%2F`. Clients should always read the URI verbatim from the index rather than reconstructing it — that's the only way to guarantee an exact match for the read.)
 
 Then read a specific entry:
 
 ```
-memory://release/cadence
+memory://release-cadence
 → "Weekly on Thursdays at 2pm UTC"
 ```
 
 ## Why resources, not just tools
 
 - **Lower latency** — clients can cache resources and stream them into context without a round-trip through the model
-- **Declarative referencing** — the agent can point at `memory://release/cadence` in a prompt instead of calling a tool and pasting the response
+- **Declarative referencing** — the agent can point at `memory://release-cadence` in a prompt instead of calling a tool and pasting the response
 - **MCP primitive alignment** — using the full primitive set (tools, resources, prompts) lets Hive slot into any compliant client without custom client glue
 
 ## Tenant isolation
@@ -58,7 +60,7 @@ Memories that have been tombstoned via the `redact_memory` tool are excluded fro
 
 ## Truncation
 
-`memory://index` caps at the first 500 URIs (sorted alphabetically). When truncation kicks in, the resource body ends with a note directing the agent to fall back to the [`list_memories`](/tools/list-memories) tool for narrower retrieval — tags are the right primitive for large corpora.
+`memory://index` caps at the first 500 entries (sorted alphabetically). Redacted and expired memories are filtered out of the rendered body, so the visible URI count is often smaller than the cap. When the cap triggers, the body ends with a note directing the agent to fall back to the [`list_memories`](/tools/list-memories) tool for narrower retrieval — tags are the right primitive for large corpora.
 
 ## Writes still go through tools
 

--- a/docs-site/concepts/resources.md
+++ b/docs-site/concepts/resources.md
@@ -12,7 +12,7 @@ Alongside its [tools](/tools/overview) and [prompts](/tools/prompts), Hive expos
 
 | URI | What it returns |
 | --- | --- |
-| `memory://index` | A newline-separated list of every `memory://{key}` URI the authenticated client owns |
+| `memory://_index` | A newline-separated list of every `memory://{key}` URI the authenticated client owns. The leading underscore is a reserved namespace — a user can still store a memory with the literal key `index` and read it via `memory://index`. |
 | `memory://{key}` | The value of one specific memory |
 
 All reads are scoped to the authenticated OAuth client (`client_id`) and require the `memories:read` scope. The token flows through the same `Authorization: Bearer <token>` header as the tools — nothing new to configure.
@@ -21,10 +21,10 @@ All reads are scoped to the authenticated OAuth client (`client_id`) and require
 
 Resources are listed in two places:
 
-- `resources/list` returns the concrete `memory://index` resource
+- `resources/list` returns the concrete `memory://_index` resource
 - `resources/templates/list` returns the template `memory://{key}`
 
-Clients typically read `memory://index` first to discover what's available. Keys that contain `/` or `:` are [percent-encoded](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) so each URI is parseable by standard URI tooling and round-trips losslessly:
+Clients typically read `memory://_index` first to discover what's available. Keys that contain `/` or `:` are [percent-encoded](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) so each URI is parseable by standard URI tooling and round-trips losslessly:
 
 ```
 memory://release-cadence
@@ -52,7 +52,7 @@ memory://release-cadence
 Resource reads enforce tenant isolation at the handler level:
 
 - `memory://{key}` returns "not found" (not "forbidden") when the key belongs to another OAuth client, so the existence of another tenant's keys never leaks
-- `memory://index` only enumerates memories owned by the authenticated client — other tenants' keys never appear
+- `memory://_index` only enumerates memories owned by the authenticated client — other tenants' keys never appear
 
 ## Redacted memories
 
@@ -60,7 +60,7 @@ Memories that have been tombstoned via the `redact_memory` tool are excluded fro
 
 ## Truncation
 
-`memory://index` caps at the first 500 entries (sorted alphabetically). Redacted and expired memories are filtered out of the rendered body, so the visible URI count is often smaller than the cap. When the cap triggers, the body ends with a note directing the agent to fall back to the [`list_memories`](/tools/list-memories) tool for narrower retrieval — tags are the right primitive for large corpora.
+`memory://_index` caps at the first 500 entries (sorted alphabetically). Redacted and expired memories are filtered out of the rendered body, so the visible URI count is often smaller than the cap. When the cap triggers, the body ends with a note directing the agent to fall back to the [`list_memories`](/tools/list-memories) tool for narrower retrieval — tags are the right primitive for large corpora.
 
 ## Writes still go through tools
 

--- a/docs-site/concepts/resources.md
+++ b/docs-site/concepts/resources.md
@@ -1,0 +1,75 @@
+# MCP Resources
+
+Alongside its [tools](/tools/overview) and [prompts](/tools/prompts), Hive exposes memories as **MCP Resources** — read-only, URI-addressable content that supporting clients can reference declaratively without a tool round-trip.
+
+::: tip Tool vs Resource vs Prompt
+- A **[Tool](/tools/overview)** is something the agent *calls*. It does work and returns a JSON response.
+- A **Resource** is *content* the agent can read by URI. Clients can pre-fetch or cache it.
+- A **[Prompt](/tools/prompts)** is a *template* the client surfaces as a slash command.
+:::
+
+## URI scheme
+
+| URI | What it returns |
+| --- | --- |
+| `memory://index` | A newline-separated list of every `memory://{key}` URI the authenticated client owns |
+| `memory://{key}` | The value of one specific memory |
+
+All reads are scoped to the authenticated OAuth client (`client_id`) and require the `memories:read` scope. The token flows through the same `Authorization: Bearer <token>` header as the tools — nothing new to configure.
+
+## Reading the index first
+
+Resources are listed in two places:
+
+- `resources/list` returns the concrete `memory://index` resource
+- `resources/templates/list` returns the template `memory://{key}`
+
+Clients typically read `memory://index` first to discover what's available:
+
+```
+memory://release/cadence
+memory://release/back-merge
+memory://release/smoke-tests
+```
+
+Then read a specific entry:
+
+```
+memory://release/cadence
+→ "Weekly on Thursdays at 2pm UTC"
+```
+
+## Why resources, not just tools
+
+- **Lower latency** — clients can cache resources and stream them into context without a round-trip through the model
+- **Declarative referencing** — the agent can point at `memory://release/cadence` in a prompt instead of calling a tool and pasting the response
+- **MCP primitive alignment** — using the full primitive set (tools, resources, prompts) lets Hive slot into any compliant client without custom client glue
+
+## Tenant isolation
+
+Resource reads enforce tenant isolation at the handler level:
+
+- `memory://{key}` returns "not found" (not "forbidden") when the key belongs to another OAuth client, so the existence of another tenant's keys never leaks
+- `memory://index` only enumerates memories owned by the authenticated client — other tenants' keys never appear
+
+## Redacted memories
+
+Memories that have been [redacted](/concepts/tags) are excluded from the index and reject `memory://{key}` reads with an explicit "redacted" error. The error distinguishes a redacted memory from a missing one so client UIs can surface the right message.
+
+## Truncation
+
+`memory://index` caps at the first 500 URIs (sorted alphabetically). When truncation kicks in, the resource body ends with a note directing the agent to fall back to the [`list_memories`](/tools/list-memories) tool for narrower retrieval — tags are the right primitive for large corpora.
+
+## Writes still go through tools
+
+Resources are intentionally read-only. Storing, updating, and deleting memories continues to go through [`remember`](/tools/remember) / [`forget`](/tools/forget) / [`redact_memory`](/tools/remember). Centralising writes in one place keeps the quota, TTL, version, and audit-log machinery in a single code path.
+
+## Client support
+
+Resources only appear in clients that implement the MCP Resources capability:
+
+- **Claude Code** — lists resources in the MCP panel
+- **Claude Desktop** — shows resources under connected servers
+- **Cursor** — lists resources in the MCP resources menu
+
+Clients that don't support Resources can still reach every memory via the tool surface; nothing breaks.

--- a/docs-site/concepts/resources.md
+++ b/docs-site/concepts/resources.md
@@ -54,7 +54,7 @@ Resource reads enforce tenant isolation at the handler level:
 
 ## Redacted memories
 
-Memories that have been [redacted](/concepts/tags) are excluded from the index and reject `memory://{key}` reads with an explicit "redacted" error. The error distinguishes a redacted memory from a missing one so client UIs can surface the right message.
+Memories that have been tombstoned via the `redact_memory` tool are excluded from the index and reject `memory://{key}` reads with an explicit "redacted" error. The error distinguishes a redacted memory from a missing one so client UIs can surface the right message.
 
 ## Truncation
 
@@ -62,7 +62,7 @@ Memories that have been [redacted](/concepts/tags) are excluded from the index a
 
 ## Writes still go through tools
 
-Resources are intentionally read-only. Storing, updating, and deleting memories continues to go through [`remember`](/tools/remember) / [`forget`](/tools/forget) / [`redact_memory`](/tools/remember). Centralising writes in one place keeps the quota, TTL, version, and audit-log machinery in a single code path.
+Resources are intentionally read-only. Storing, updating, and deleting memories continues to go through [`remember`](/tools/remember) / [`forget`](/tools/forget) plus the `redact_memory` tool (advertised via `tools/list` on supported clients). Centralising writes in one place keeps the quota, TTL, version, and audit-log machinery in a single code path.
 
 ## Client support
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -23,6 +23,7 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
+from urllib.parse import quote, unquote
 
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
@@ -1508,15 +1509,41 @@ def forget_older_than_prompt(
 _MEMORY_RESOURCE_LIST_LIMIT = 500
 
 
+def _encode_memory_key(key: str) -> str:
+    """Percent-encode a memory key for use in a ``memory://`` URI.
+
+    Keys legally contain ``/``, ``:``, and other characters the URI
+    grammar treats as structural (authority / path / query delimiters),
+    so a naive ``f"memory://{key}"`` produces an ambiguous URI that
+    clients can't parse back to the original key. Quote everything
+    except ASCII alphanumerics and the unreserved-char set; the result
+    round-trips losslessly via ``_decode_memory_key``.
+    """
+    # `safe=""` forces `/` + `:` to be encoded; alphanumerics and
+    # unreserved chars (`-_.~`) pass through unchanged.
+    return quote(key, safe="")
+
+
+def _decode_memory_key(encoded: str) -> str:
+    """Inverse of ``_encode_memory_key``."""
+    return unquote(encoded)
+
+
 def _resource_auth() -> tuple[HiveStorage, str]:
     """Resolve ``(storage, client_id)`` for an MCP Resource read.
 
     Resources don't receive a ``Context`` object the way tools do, so
     the token is pulled via ``get_access_token()`` — the
     ``RemoteAuthProvider`` on the ``FastMCP`` instance has already
-    validated it by the time the handler runs. Raises ``ValueError``
-    on missing token / insufficient scope; the MCP framework surfaces
-    that as an error response to the client.
+    validated it by the time the handler runs.
+
+    Applies the same per-client rate-limit the tool-side ``_auth()``
+    uses: even though resource reads are cheap individually, the
+    ``memory://index`` handler scans DynamoDB and a misbehaving client
+    could run the account's rate-limit budget without it.
+
+    Raises ``ValueError`` on missing token / insufficient scope / rate
+    limit; the MCP framework surfaces that as an error response.
     """
     token = get_access_token()
     if token is None:
@@ -1524,7 +1551,12 @@ def _resource_auth() -> tuple[HiveStorage, str]:
     scopes = set(token.scopes or [])
     if _MEMORIES_READ_SCOPE not in scopes:
         raise ValueError(f"Insufficient scope: '{_MEMORIES_READ_SCOPE}' required")
-    return HiveStorage(), token.client_id
+    storage = HiveStorage()
+    try:
+        check_rate_limit(token.client_id, storage)
+    except RateLimitExceeded as exc:
+        raise ValueError(f"Rate limit exceeded. Retry after {exc.retry_after}s.") from exc
+    return storage, token.client_id
 
 
 @mcp.resource(
@@ -1533,7 +1565,8 @@ def _resource_auth() -> tuple[HiveStorage, str]:
     description=(
         "Newline-separated list of `memory://` URIs owned by the authenticated "
         "client. Read this first to discover what's available, then read "
-        "individual memories via `memory://{key}`."
+        "individual memories via `memory://{key}`. Keys containing `/` or `:` "
+        "are percent-encoded so each URI round-trips losslessly."
     ),
     mime_type="text/plain",
 )
@@ -1542,7 +1575,14 @@ def list_memory_resources() -> str:
     memories, next_cursor = storage.list_all_memories(
         client_id=client_id, limit=_MEMORY_RESOURCE_LIST_LIMIT
     )
-    uris = sorted(f"memory://{m.key}" for m in memories if not m.is_redacted)
+    # Skip both redacted and expired entries — otherwise the index can
+    # advertise keys that `read_memory_resource` will later 404 on
+    # (`get_memory_by_id` filters expired, `list_all_memories` doesn't).
+    uris = sorted(
+        f"memory://{_encode_memory_key(m.key)}"
+        for m in memories
+        if not m.is_redacted and not m.is_expired
+    )
     body = "\n".join(uris)
     if next_cursor:
         # Flag truncation so the agent knows to fall back to
@@ -1559,20 +1599,25 @@ def list_memory_resources() -> str:
     "memory://{key}",
     name="Memory content",
     description=(
-        "Read the value of a single memory by its key. Scoped to the authenticated OAuth client."
+        "Read the value of a single memory by its key. Scoped to the authenticated "
+        "OAuth client. The `{key}` portion may be percent-encoded — keys with "
+        "`/` or `:` work as long as they're quoted."
     ),
     mime_type="text/plain",
 )
 def read_memory_resource(key: str) -> str:
     storage, client_id = _resource_auth()
-    memory = storage.get_memory_by_key(key)
+    # FastMCP passes the URI template parameter as the encoded substring;
+    # decode back to the original key before hitting storage.
+    decoded_key = _decode_memory_key(key)
+    memory = storage.get_memory_by_key(decoded_key)
     # Tenant isolation: `get_memory_by_key` doesn't filter by owner, so
     # a client asking for another tenant's key would otherwise succeed.
     # Treat cross-tenant lookups as 404 to avoid leaking existence.
     if memory is None or memory.owner_client_id != client_id:
-        raise ValueError(f"Memory not found: {key}")
+        raise ValueError(f"Memory not found: {decoded_key}")
     if memory.is_redacted:
-        raise ValueError(f"Memory has been redacted: {key}")
+        raise ValueError(f"Memory has been redacted: {decoded_key}")
     return memory.value
 
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1495,10 +1495,14 @@ def forget_older_than_prompt(
 # Exposes the caller's memories as read-only MCP Resources in addition
 # to the existing tool surface. Supported URIs:
 #
-#   memory://index        — newline-separated list of memory:// URIs the
+#   memory://_index       — newline-separated list of memory:// URIs the
 #                           authenticated client owns
 #   memory://{key}        — the value of a single memory, addressable by
 #                           key
+#
+# The leading underscore on `_index` puts it in a reserved namespace so
+# a user can still store and read a memory whose key is literally
+# `index` — otherwise the concrete URI would shadow the template.
 #
 # All reads are scoped to the authenticated OAuth client (client_id) and
 # require the `memories:read` scope. Resources are intentionally read-
@@ -1560,13 +1564,15 @@ def _resource_auth() -> tuple[HiveStorage, str]:
 
 
 @mcp.resource(
-    "memory://index",
+    "memory://_index",
     name="Memory index",
     description=(
         "Newline-separated list of `memory://` URIs owned by the authenticated "
         "client. Read this first to discover what's available, then read "
         "individual memories via `memory://{key}`. Keys containing `/` or `:` "
-        "are percent-encoded so each URI round-trips losslessly."
+        "are percent-encoded so each URI round-trips losslessly. The "
+        "underscore-prefixed path is reserved so a memory with the literal "
+        "key `index` can still be read via `memory://index`."
     ),
     mime_type="text/plain",
 )

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -28,7 +28,7 @@ from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.auth import AccessToken as FastMCPAccessToken
 from fastmcp.server.auth import RemoteAuthProvider, TokenVerifier
-from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.dependencies import get_access_token, get_http_request
 from fastmcp.tools.tool import ToolResult
 from pydantic import AnyHttpUrl
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -1485,6 +1485,95 @@ def forget_older_than_prompt(
         "only call `forget` when I reply yes. Do not batch-delete without "
         "confirmation."
     )
+
+
+# ---------------------------------------------------------------------------
+# MCP Resources (#446)
+# ---------------------------------------------------------------------------
+#
+# Exposes the caller's memories as read-only MCP Resources in addition
+# to the existing tool surface. Supported URIs:
+#
+#   memory://index        — newline-separated list of memory:// URIs the
+#                           authenticated client owns
+#   memory://{key}        — the value of a single memory, addressable by
+#                           key
+#
+# All reads are scoped to the authenticated OAuth client (client_id) and
+# require the `memories:read` scope. Resources are intentionally read-
+# only — writes still go through the `remember` tool so the quota + TTL
+# + version machinery stays in one place.
+
+
+_MEMORY_RESOURCE_LIST_LIMIT = 500
+
+
+def _resource_auth() -> tuple[HiveStorage, str]:
+    """Resolve ``(storage, client_id)`` for an MCP Resource read.
+
+    Resources don't receive a ``Context`` object the way tools do, so
+    the token is pulled via ``get_access_token()`` — the
+    ``RemoteAuthProvider`` on the ``FastMCP`` instance has already
+    validated it by the time the handler runs. Raises ``ValueError``
+    on missing token / insufficient scope; the MCP framework surfaces
+    that as an error response to the client.
+    """
+    token = get_access_token()
+    if token is None:
+        raise ValueError("Unauthorized: no valid access token")
+    scopes = set(token.scopes or [])
+    if _MEMORIES_READ_SCOPE not in scopes:
+        raise ValueError(f"Insufficient scope: '{_MEMORIES_READ_SCOPE}' required")
+    return HiveStorage(), token.client_id
+
+
+@mcp.resource(
+    "memory://index",
+    name="Memory index",
+    description=(
+        "Newline-separated list of `memory://` URIs owned by the authenticated "
+        "client. Read this first to discover what's available, then read "
+        "individual memories via `memory://{key}`."
+    ),
+    mime_type="text/plain",
+)
+def list_memory_resources() -> str:
+    storage, client_id = _resource_auth()
+    memories, next_cursor = storage.list_all_memories(
+        client_id=client_id, limit=_MEMORY_RESOURCE_LIST_LIMIT
+    )
+    uris = sorted(f"memory://{m.key}" for m in memories if not m.is_redacted)
+    body = "\n".join(uris)
+    if next_cursor:
+        # Flag truncation so the agent knows to fall back to
+        # `list_memories(tag=…)` for narrower retrieval rather than
+        # assume the index is exhaustive.
+        body += (
+            f"\n\n_(Truncated at {_MEMORY_RESOURCE_LIST_LIMIT} entries. "
+            "Use the `list_memories` tool with tags for targeted retrieval.)_"
+        )
+    return body
+
+
+@mcp.resource(
+    "memory://{key}",
+    name="Memory content",
+    description=(
+        "Read the value of a single memory by its key. Scoped to the authenticated OAuth client."
+    ),
+    mime_type="text/plain",
+)
+def read_memory_resource(key: str) -> str:
+    storage, client_id = _resource_auth()
+    memory = storage.get_memory_by_key(key)
+    # Tenant isolation: `get_memory_by_key` doesn't filter by owner, so
+    # a client asking for another tenant's key would otherwise succeed.
+    # Treat cross-tenant lookups as 404 to avoid leaking existence.
+    if memory is None or memory.owner_client_id != client_id:
+        raise ValueError(f"Memory not found: {key}")
+    if memory.is_redacted:
+        raise ValueError(f"Memory has been redacted: {key}")
+    return memory.value
 
 
 # ---------------------------------------------------------------------------

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1585,12 +1585,16 @@ def list_memory_resources() -> str:
     )
     body = "\n".join(uris)
     if next_cursor:
-        # Flag truncation so the agent knows to fall back to
-        # `list_memories(tag=…)` for narrower retrieval rather than
-        # assume the index is exhaustive.
+        # Flag that the index view is capped so the agent knows to
+        # fall back to `list_memories(tag=…)` for narrower retrieval.
+        # Redacted + expired items are filtered out of the body above,
+        # so the visible URI count is often less than the cap — avoid
+        # implying the body itself holds exactly _MEMORY_RESOURCE_LIST_LIMIT
+        # entries.
         body += (
-            f"\n\n_(Truncated at {_MEMORY_RESOURCE_LIST_LIMIT} entries. "
-            "Use the `list_memories` tool with tags for targeted retrieval.)_"
+            f"\n\n_(Index capped at {_MEMORY_RESOURCE_LIST_LIMIT} entries; "
+            "more results may exist. Use the `list_memories` tool with "
+            "tags for targeted retrieval.)_"
         )
     return body
 
@@ -1614,10 +1618,13 @@ def read_memory_resource(key: str) -> str:
     # Tenant isolation: `get_memory_by_key` doesn't filter by owner, so
     # a client asking for another tenant's key would otherwise succeed.
     # Treat cross-tenant lookups as 404 to avoid leaking existence.
+    # `!r` quotes the key in error messages so a client key containing
+    # newlines / control chars can't forge fake log lines or break the
+    # response envelope for clients that render the error verbatim.
     if memory is None or memory.owner_client_id != client_id:
-        raise ValueError(f"Memory not found: {decoded_key}")
+        raise ValueError(f"Memory not found: {decoded_key!r}")
     if memory.is_redacted:
-        raise ValueError(f"Memory has been redacted: {decoded_key}")
+        raise ValueError(f"Memory has been redacted: {decoded_key!r}")
     return memory.value
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2368,4 +2368,4 @@ class TestMcpResources:
             ):
                 body = list_memory_resources()
         # Truncation note mentions the actual limit, not a hard-coded 500.
-        assert "Truncated at 2" in body
+        assert "Index capped at 2" in body

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2103,3 +2103,208 @@ class TestMcpPrompts:
         msg = result.messages[0]
         assert msg.role == "user"
         assert "ops" in msg.content.text
+
+
+class TestMcpResources:
+    """#446 — MCP Resources exposing memories by URI.
+
+    Resources are auth-protected via ``get_access_token()``; tests mock
+    the dependency so handlers run in isolation without a full FastMCP
+    request context.
+    """
+
+    def _mock_token(self, client_id: str, scopes: list[str] | None = None):
+        """Build a stand-in ``AccessToken`` with the given scopes."""
+        from unittest.mock import MagicMock
+
+        tok = MagicMock()
+        tok.client_id = client_id
+        tok.scopes = scopes if scopes is not None else ["memories:read"]
+        return tok
+
+    @pytest.mark.asyncio
+    async def test_list_resources_advertises_index_and_template(self):
+        from hive.server import mcp
+
+        resources = await mcp.list_resources()
+        uris = {str(r.uri) for r in resources}
+        # Static index resource must be registered so clients see it in
+        # `resources/list` without needing to build a URI.
+        assert "memory://index" in uris
+
+        templates = await mcp.list_resource_templates()
+        template_uris = {str(t.uri_template) for t in templates}
+        assert "memory://{key}" in template_uris
+
+    def test_resource_auth_rejects_missing_token(self):
+        from unittest.mock import patch
+
+        from hive.server import _resource_auth
+
+        with (
+            patch("hive.server.get_access_token", return_value=None),
+            pytest.raises(ValueError, match="Unauthorized"),
+        ):
+            _resource_auth()
+
+    def test_resource_auth_rejects_missing_scope(self):
+        from unittest.mock import patch
+
+        from hive.server import _resource_auth
+
+        # Token exists but doesn't have memories:read — must refuse to
+        # surface memory content.
+        no_read = self._mock_token("c1", scopes=["memories:write"])
+        with (
+            patch("hive.server.get_access_token", return_value=no_read),
+            pytest.raises(ValueError, match="Insufficient scope"),
+        ):
+            _resource_auth()
+
+    def test_resource_auth_tolerates_none_scopes_list(self):
+        from unittest.mock import patch
+
+        from hive.server import _resource_auth
+
+        # Pydantic-style tokens may surface scopes as `None` rather than
+        # an empty list. Both shapes must route to "insufficient scope"
+        # rather than crashing on `None` set-construction.
+        tok = self._mock_token("c1", scopes=None)
+        tok.scopes = None
+        with (
+            patch("hive.server.get_access_token", return_value=tok),
+            pytest.raises(ValueError, match="Insufficient scope"),
+        ):
+            _resource_auth()
+
+    async def test_read_memory_resource_returns_value(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import read_memory_resource, remember
+
+        _, client_id, jwt = server_env
+        await remember("res-key", "res-value", [], ctx=_make_ctx(jwt))
+        with patch("hive.server.get_access_token", return_value=self._mock_token(client_id)):
+            value = read_memory_resource("res-key")
+        assert value == "res-value"
+
+    async def test_read_memory_resource_rejects_cross_tenant_lookup(self, server_env):
+        """Reading another client's memory key must 404, not leak content.
+
+        `storage.get_memory_by_key` doesn't filter by owner — the
+        resource handler is the scope boundary, so a client asking
+        for another tenant's key must get "not found" and not the
+        value. Verifies the tenant-isolation guard on the handler.
+        """
+        from unittest.mock import patch
+
+        from hive.server import read_memory_resource, remember
+
+        _, client_id, jwt = server_env
+        await remember("tenant-a-key", "secret", [], ctx=_make_ctx(jwt))
+        other_client_token = self._mock_token("some-other-client")
+        with (
+            patch("hive.server.get_access_token", return_value=other_client_token),
+            pytest.raises(ValueError, match="Memory not found"),
+        ):
+            read_memory_resource("tenant-a-key")
+
+    async def test_read_memory_resource_404s_for_missing_key(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import read_memory_resource
+
+        _, client_id, _ = server_env
+        with (
+            patch("hive.server.get_access_token", return_value=self._mock_token(client_id)),
+            pytest.raises(ValueError, match="Memory not found"),
+        ):
+            read_memory_resource("never-stored")
+
+    async def test_read_memory_resource_refuses_redacted(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import read_memory_resource, redact_memory, remember
+
+        _, client_id, jwt = server_env
+        await remember("tombstoned", "original", [], ctx=_make_ctx(jwt))
+        await redact_memory("tombstoned", ctx=_make_ctx(jwt))
+        with (
+            patch("hive.server.get_access_token", return_value=self._mock_token(client_id)),
+            pytest.raises(ValueError, match="redacted"),
+        ):
+            read_memory_resource("tombstoned")
+
+    async def test_list_memory_resources_returns_owned_keys(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import list_memory_resources, remember
+
+        _, client_id, jwt = server_env
+        await remember("a", "va", [], ctx=_make_ctx(jwt))
+        await remember("b", "vb", [], ctx=_make_ctx(jwt))
+        with patch("hive.server.get_access_token", return_value=self._mock_token(client_id)):
+            body = list_memory_resources()
+        lines = body.splitlines()
+        assert "memory://a" in lines
+        assert "memory://b" in lines
+        # Sorted alphabetically so output is stable between reads —
+        # clients can cache the index and diff.
+        assert lines == sorted(lines)
+
+    async def test_list_memory_resources_excludes_redacted(self, server_env):
+        from unittest.mock import patch
+
+        from hive.server import (
+            list_memory_resources,
+            redact_memory,
+            remember,
+        )
+
+        _, client_id, jwt = server_env
+        await remember("visible", "v", [], ctx=_make_ctx(jwt))
+        await remember("gone", "v", [], ctx=_make_ctx(jwt))
+        await redact_memory("gone", ctx=_make_ctx(jwt))
+        with patch("hive.server.get_access_token", return_value=self._mock_token(client_id)):
+            body = list_memory_resources()
+        assert "memory://visible" in body
+        assert "memory://gone" not in body
+
+    async def test_list_memory_resources_excludes_other_tenants(self, server_env):
+        """Tenant isolation on the list path — another client's memories
+        never appear in the authenticated client's index."""
+        from unittest.mock import patch
+
+        from hive.server import list_memory_resources, remember
+
+        _, client_id, jwt = server_env
+        await remember("mine", "v", [], ctx=_make_ctx(jwt))
+        with patch(
+            "hive.server.get_access_token",
+            return_value=self._mock_token("some-other-client"),
+        ):
+            body = list_memory_resources()
+        # The other client owns no memories, so the index is empty.
+        assert body == ""
+
+    async def test_list_memory_resources_flags_truncation(self, server_env):
+        """When the corpus exceeds the limit, the index surfaces the cap
+        so the agent knows to fall back to `list_memories(tag=…)`."""
+        from unittest.mock import patch
+
+        from hive.server import list_memory_resources, remember
+
+        _, client_id, jwt = server_env
+        # Monkey-patch the limit down so the test doesn't need to
+        # write 500 memories just to trip the truncation flag.
+        with patch("hive.server._MEMORY_RESOURCE_LIST_LIMIT", 2):
+            await remember("k1", "v", [], ctx=_make_ctx(jwt))
+            await remember("k2", "v", [], ctx=_make_ctx(jwt))
+            await remember("k3", "v", [], ctx=_make_ctx(jwt))
+            with patch(
+                "hive.server.get_access_token",
+                return_value=self._mock_token(client_id),
+            ):
+                body = list_memory_resources()
+        # Truncation note mentions the actual limit, not a hard-coded 500.
+        assert "Truncated at 2" in body

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2130,7 +2130,7 @@ class TestMcpResources:
         uris = {str(r.uri) for r in resources}
         # Static index resource must be registered so clients see it in
         # `resources/list` without needing to build a URI.
-        assert "memory://index" in uris
+        assert "memory://_index" in uris
 
         templates = await mcp.list_resource_templates()
         template_uris = {str(t.uri_template) for t in templates}
@@ -2208,6 +2208,36 @@ class TestMcpResources:
         with patch("hive.server.get_access_token", return_value=self._mock_token(client_id)):
             value = read_memory_resource("res-key")
         assert value == "res-value"
+
+    async def test_index_uri_does_not_shadow_key_named_index(self, server_env):
+        """Regression for iter-3 r3111826839.
+
+        The static `memory://_index` URI lives in an underscore-prefixed
+        reserved namespace so a user's memory with the literal key
+        `index` can still be read as `memory://index` via the template.
+        """
+        from unittest.mock import patch
+
+        from hive.server import (
+            list_memory_resources,
+            read_memory_resource,
+            remember,
+        )
+
+        _, client_id, jwt = server_env
+        # Store a memory with key literally "index".
+        await remember("index", "the real index value", [], ctx=_make_ctx(jwt))
+
+        with patch("hive.server.get_access_token", return_value=self._mock_token(client_id)):
+            # Template read resolves to the user's memory, not the
+            # index listing.
+            value = read_memory_resource("index")
+            assert value == "the real index value"
+
+            # The static index listing is still reachable at its
+            # reserved URI and contains the user's `index` key.
+            body = list_memory_resources()
+        assert "memory://index" in body.splitlines()
 
     async def test_resource_uri_round_trips_keys_with_slash_and_colon(self, server_env):
         """Keys legally contain `/` and `:` (see key-conventions docs).

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2177,6 +2177,27 @@ class TestMcpResources:
         ):
             _resource_auth()
 
+    def test_resource_auth_enforces_rate_limit(self):
+        from unittest.mock import patch
+
+        from hive.rate_limiter import RateLimitExceeded
+        from hive.server import _resource_auth
+
+        # Resources hit DynamoDB (memory://index can scan pages), so the
+        # same per-client rate limit the tool surface uses must apply —
+        # a misbehaving client can't burst the index endpoint without
+        # burning the account's budget.
+        tok = self._mock_token("c1")
+        with (
+            patch("hive.server.get_access_token", return_value=tok),
+            patch(
+                "hive.server.check_rate_limit",
+                side_effect=RateLimitExceeded(retry_after=30),
+            ),
+            pytest.raises(ValueError, match="Rate limit exceeded"),
+        ):
+            _resource_auth()
+
     async def test_read_memory_resource_returns_value(self, server_env):
         from unittest.mock import patch
 
@@ -2187,6 +2208,46 @@ class TestMcpResources:
         with patch("hive.server.get_access_token", return_value=self._mock_token(client_id)):
             value = read_memory_resource("res-key")
         assert value == "res-value"
+
+    async def test_resource_uri_round_trips_keys_with_slash_and_colon(self, server_env):
+        """Keys legally contain `/` and `:` (see key-conventions docs).
+
+        A raw `memory://project:task/42:summary` is an ambiguous URI
+        that clients can't parse back to the original key. The fix
+        percent-encodes on the index side; the read handler
+        percent-decodes, so the round-trip is lossless.
+        """
+        from unittest.mock import patch
+
+        from hive.server import (
+            _decode_memory_key,
+            _encode_memory_key,
+            list_memory_resources,
+            read_memory_resource,
+            remember,
+        )
+
+        _, client_id, jwt = server_env
+        raw_key = "project:task/42:summary"
+        await remember(raw_key, "round-trip value", [], ctx=_make_ctx(jwt))
+
+        # Index publishes the encoded form.
+        with patch("hive.server.get_access_token", return_value=self._mock_token(client_id)):
+            body = list_memory_resources()
+        encoded = _encode_memory_key(raw_key)
+        assert f"memory://{encoded}" in body.splitlines()
+        # Encoded form contains no structural characters that would
+        # confuse a URI parser.
+        assert "/" not in encoded and ":" not in encoded
+
+        # Read handler decodes the URI parameter back to the raw key
+        # and fetches correctly.
+        with patch("hive.server.get_access_token", return_value=self._mock_token(client_id)):
+            value = read_memory_resource(encoded)
+        assert value == "round-trip value"
+
+        # Round-trip identity as a hygiene check.
+        assert _decode_memory_key(encoded) == raw_key
 
     async def test_read_memory_resource_rejects_cross_tenant_lookup(self, server_env):
         """Reading another client's memory key must 404, not leak content.


### PR DESCRIPTION
Closes #446

## Summary

Registers two FastMCP `@mcp.resource` handlers so supported clients
(Claude Code, Cursor, Claude Desktop) can browse + read memories by
URI alongside the existing tool surface:

| URI | What it returns |
| --- | --- |
| `memory://index` | Newline-separated list of `memory://{key}` URIs the authenticated client owns |
| `memory://{key}` | The value of a specific memory |

Tools handle reads like `recall`/`list_memories` already — Resources
give clients a *declarative* alternative: they can pre-fetch or
cache content by URI without a tool round-trip, and agents can
reference `memory://release/cadence` directly in prompts.

## Approach

- **Read-only by design**. Writes stay on the `remember` / `forget` /
  `redact_memory` tool path so quota, TTL, version, and audit-log
  enforcement stay in one place.
- **Auth** runs through FastMCP's `RemoteAuthProvider` (already
  validated by `HiveTokenVerifier`). Resource handlers call
  `get_access_token()` — a dedicated `_resource_auth()` helper
  mirrors the tool-side `_auth()` but skips rate-limit and metric
  emission since resources are cheap. Enforces the `memories:read`
  scope.
- **Tenant isolation** is enforced at the handler level.
  `storage.get_memory_by_key` doesn't filter by owner, so
  `read_memory_resource` verifies `memory.owner_client_id ==
  token.client_id` and returns "Memory not found" on cross-tenant
  lookups (existence doesn't leak).
- **Redacted memories** are excluded from the index and
  `memory://{key}` surfaces an explicit "redacted" error so UIs can
  distinguish tombstoned from missing.
- **Truncation** — `memory://index` caps at 500 entries and appends
  a note directing the agent to `list_memories(tag=…)` for larger
  corpora.

## Non-scope (deferred)

The issue lists `resources/subscribe` + `notifications/resources/updated`
as desired — those depend on the memory change-feed work in #392 so
I've left them for a follow-up. Current scope ships `resources/list`,
`resources/read`, and `resources/templates/list` (which FastMCP
auto-handles for the `memory://{key}` template).

## Test plan

- [x] `tests/unit/test_server.py::TestMcpResources` — 12 tests:
  - `list_resources` exposes `memory://index` concretely and
    `memory://{key}` as a template
  - `_resource_auth` rejects missing token / missing scope / null
    scopes field
  - `read_memory_resource` happy path, cross-tenant 404, missing-key
    404, redacted memory explicit error
  - `list_memory_resources` returns owned keys sorted, excludes
    redacted, excludes other tenants, flags truncation with the
    actual limit
- [x] Docs: `docs-site/concepts/resources.md` + sidebar wire-up
- [x] `uv run inv pre-push` clean

Per §7.5, auto-merge is **not** armed at PR creation — step 7.5
arms it after the Copilot loop resolves.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb