### PR TITLE
fix: OAuth auth-code redemption is atomic (closes RFC 6749 §10.5 TOCTOU)

### DIFF
--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -32,7 +32,7 @@ from hive.models import (
     EventType,
     TokenResponse,
 )
-from hive.storage import HiveStorage
+from hive.storage import AuthCodeAlreadyUsed, HiveStorage
 
 # When set (non-prod environments only), /oauth/authorize issues auth codes
 # directly without redirecting to Google.  This keeps e2e tests functional
@@ -340,6 +340,9 @@ async def token(  # NOSONAR — complexity inherent in OAuth grant type dispatch
             )
 
         auth_code = storage.get_auth_code(code)
+        # Missing / pre-observed-used codes still fail fast without
+        # hitting the conditional write — the atomic path below is the
+        # fix for the concurrent-redemption TOCTOU only.
         if auth_code is None or auth_code.used:
             raise HTTPException(status_code=400, detail="Invalid or already-used code")
         if auth_code.client_id != client_id:
@@ -351,7 +354,15 @@ async def token(  # NOSONAR — complexity inherent in OAuth grant type dispatch
         if not _verify_pkce(code_verifier, auth_code.code_challenge):
             raise HTTPException(status_code=400, detail="PKCE verification failed")
 
-        storage.mark_auth_code_used(code)
+        # `mark_auth_code_used` is the commit point. If a concurrent
+        # redemption of the same code raced ahead of us, the
+        # conditional write fails with `AuthCodeAlreadyUsed` and we
+        # return the same 400 as the pre-check — RFC 6749 §10.5
+        # requires the losing redeemer gets no token pair.
+        try:
+            storage.mark_auth_code_used(code)
+        except AuthCodeAlreadyUsed as exc:
+            raise HTTPException(status_code=400, detail="Invalid or already-used code") from exc
         access, refresh = storage.create_token_pair(client_id, auth_code.scope)
 
     elif grant_type == "refresh_token":

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -78,6 +78,17 @@ class VersionConflict(Exception):
         super().__init__(f"Memory was updated since version {attempted_version!r}")
 
 
+class AuthCodeAlreadyUsed(Exception):
+    """Raised by ``mark_auth_code_used`` when another redemption got there first.
+
+    OAuth 2.1 authorization codes are single-use (RFC 6749 §10.5).
+    ``mark_auth_code_used`` now enforces that with a conditional
+    ``UpdateItem``; two concurrent redemptions can't both succeed.
+    The caller (token endpoint) maps this to the same 400 response
+    as an unknown / expired code.
+    """
+
+
 def _now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -537,12 +548,35 @@ class HiveStorage:
         return AuthorizationCode.from_dynamo(item) if item else None
 
     def mark_auth_code_used(self, code: str) -> None:
-        self.table.update_item(
-            Key={"PK": f"AUTHCODE#{code}", "SK": "META"},
-            UpdateExpression="SET #u = :t",
-            ExpressionAttributeNames={"#u": "used"},
-            ExpressionAttributeValues={":t": True},
-        )
+        """Atomically mark an OAuth authorization code as redeemed.
+
+        RFC 6749 §10.5 requires authorization codes to be single-use.
+        Two concurrent `POST /oauth/token` requests with the same `code`
+        used to both pass the `auth_code.used` pre-check in
+        ``oauth.py`` before either could write back — the classic
+        read-check-write TOCTOU. This now enforces single-use at the
+        DynamoDB layer via a conditional write on ``used = false``;
+        exactly one concurrent redeemer succeeds, the other raises
+        :class:`AuthCodeAlreadyUsed`.
+
+        The caller should have already validated the code's existence,
+        client binding, redirect URI, expiry, and PKCE; this call is
+        the commit point of the redemption pipeline.
+        """
+        try:
+            self.table.update_item(
+                Key={"PK": f"AUTHCODE#{code}", "SK": "META"},
+                UpdateExpression="SET #u = :t",
+                ConditionExpression="attribute_exists(PK) AND #u = :f",
+                ExpressionAttributeNames={"#u": "used"},
+                ExpressionAttributeValues={":t": True, ":f": False},
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                raise AuthCodeAlreadyUsed(
+                    "Authorization code has already been redeemed or does not exist"
+                ) from exc
+            raise
 
     # ------------------------------------------------------------------
     # Pending auth (PKCE state stored while user authenticates with Google)

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -79,13 +79,21 @@ class VersionConflict(Exception):
 
 
 class AuthCodeAlreadyUsed(Exception):
-    """Raised by ``mark_auth_code_used`` when another redemption got there first.
+    """Raised by ``mark_auth_code_used`` when the conditional write is rejected.
 
-    OAuth 2.1 authorization codes are single-use (RFC 6749 §10.5).
-    ``mark_auth_code_used`` now enforces that with a conditional
-    ``UpdateItem``; two concurrent redemptions can't both succeed.
-    The caller (token endpoint) maps this to the same 400 response
-    as an unknown / expired code.
+    Two conditions trip the conditional ``UpdateItem``:
+
+    1. Another redemption raced ahead and flipped ``used`` to ``true``
+       (the RFC 6749 §10.5 single-use case this fix exists for).
+    2. No AUTHCODE item exists under the supplied key — the
+       ``attribute_exists(PK)`` guard rejects forged / never-issued
+       codes so callers can't mint tokens from arbitrary strings.
+
+    Both are indistinguishable from the client's perspective: the
+    token endpoint maps either to ``400 "Invalid or already-used
+    code"``. The name stays narrow because concurrent redemption is
+    the motivating case; the forged-code path is a defensive
+    side-effect of the same condition.
     """
 
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -623,6 +623,41 @@ class TestOAuthToken:
         resp = tc.post("/oauth/token", data=data)  # second use — rejected
         assert resp.status_code == 400
 
+    def test_concurrent_redemption_loser_gets_400(self, oauth_client):
+        """#584 regression — simulates the race where two requests both
+        pass the `auth_code.used` pre-check and the storage-level
+        conditional write picks one winner.
+
+        We can't reliably trigger the race in-process against moto, so
+        patch `mark_auth_code_used` to raise `AuthCodeAlreadyUsed` on
+        the only call and assert the endpoint surfaces a clean 400
+        instead of a 500. This verifies the `try/except` in
+        `oauth.py`, which is the half of the fix the storage-level
+        concurrency test in `test_storage.py` doesn't reach.
+        """
+        from unittest.mock import patch
+
+        from hive.storage import AuthCodeAlreadyUsed
+
+        tc, storage, client = oauth_client
+        code, verifier = self._get_auth_code(tc, storage, client)
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "https://app.example.com/cb",
+            "client_id": client.client_id,
+            "code_verifier": verifier,
+        }
+        with patch(
+            "hive.storage.HiveStorage.mark_auth_code_used",
+            side_effect=AuthCodeAlreadyUsed("raced"),
+        ):
+            resp = tc.post("/oauth/token", data=data)
+        assert resp.status_code == 400
+        # Losing redeemer gets the same error body as a pre-observed
+        # "already-used" code — no token pair, no stack trace leaked.
+        assert "already-used" in resp.json()["detail"]
+
 
 class TestOAuthAuthorizeEdgeCases:
     def test_wrong_challenge_method_returns_400(self, oauth_client):

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -583,42 +583,40 @@ class TestAuthCodeAtomicRedemption:
         with pytest.raises(AuthCodeAlreadyUsed):
             storage.mark_auth_code_used("never-issued-code")
 
-    def test_concurrent_redemption_exactly_one_winner(self, storage):
-        """The TOCTOU regression — both callers read `used=False`, race
-        to write. The conditional UpdateItem serialises them and
-        exactly one wins.
-        """
-        import threading
+    def test_update_uses_conditional_write_on_unused_state(self, storage):
+        """The TOCTOU fix hinges on the conditional write — two
+        redemptions that both read `used=False` can't both commit.
 
-        from hive.storage import AuthCodeAlreadyUsed
+        Rather than spawning threads (moto's mock backend isn't a
+        reliable concurrency harness), assert the wire-level contract:
+        `mark_auth_code_used` issues an `UpdateItem` whose
+        `ConditionExpression` requires `used = false` AND the item
+        exists. DynamoDB's server-side serialisation of conditional
+        writes is what actually enforces single-use; this test pins
+        the condition so a future refactor can't silently drop it.
+        """
+        from unittest.mock import MagicMock
 
         code = self._create_code(storage)
+        captured: dict[str, object] = {}
 
-        results: list[str] = []
-        barrier = threading.Barrier(2)
+        original = storage.table.update_item
 
-        def redeem() -> None:
-            barrier.wait()  # align both threads on the write
-            try:
-                storage.mark_auth_code_used(code)
-                results.append("ok")
-            except AuthCodeAlreadyUsed:
-                results.append("rejected")
+        def _spy(**kwargs: object) -> object:
+            captured.update(kwargs)
+            return original(**kwargs)
 
-        t1 = threading.Thread(target=redeem)
-        t2 = threading.Thread(target=redeem)
-        t1.start()
-        t2.start()
-        t1.join()
-        t2.join()
+        storage.table = MagicMock(wraps=storage.table)
+        storage.table.update_item.side_effect = _spy
 
-        # Exactly one redemption succeeds, the other is rejected — no
-        # "both succeed" outcome survives the conditional write.
-        assert sorted(results) == ["ok", "rejected"]
+        storage.mark_auth_code_used(code)
 
-        fetched = storage.get_auth_code(code)
-        assert fetched is not None
-        assert fetched.used is True
+        assert "ConditionExpression" in captured
+        cond = captured["ConditionExpression"]
+        assert "attribute_exists(PK)" in cond
+        assert "#u = :f" in cond
+        assert captured["ExpressionAttributeNames"] == {"#u": "used"}
+        assert captured["ExpressionAttributeValues"] == {":t": True, ":f": False}
 
     def test_unexpected_client_error_reraises(self, storage):
         """Only ConditionalCheckFailedException is translated to

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -542,6 +542,104 @@ class TestTokenStorage:
         assert fetched.revoked
 
 
+class TestAuthCodeAtomicRedemption:
+    """#584 — OAuth authorization codes are single-use (RFC 6749 §10.5).
+
+    `mark_auth_code_used` is the commit point of the redemption
+    pipeline; it uses a conditional UpdateItem so concurrent
+    redemptions of the same code can't both succeed.
+    """
+
+    def _create_code(self, storage) -> str:
+        auth_code = storage.create_auth_code(
+            client_id="c1",
+            redirect_uri="https://app.example.com/cb",
+            scope="memories:read",
+            code_challenge="challenge",
+        )
+        return auth_code.code
+
+    def test_first_redemption_flips_used(self, storage):
+        from hive.storage import AuthCodeAlreadyUsed
+
+        code = self._create_code(storage)
+        storage.mark_auth_code_used(code)
+
+        fetched = storage.get_auth_code(code)
+        assert fetched is not None
+        assert fetched.used is True
+
+        # Sequential second call raises — the conditional write rejects
+        # because `used = true` no longer matches the expected `false`.
+        with pytest.raises(AuthCodeAlreadyUsed):
+            storage.mark_auth_code_used(code)
+
+    def test_missing_code_raises_already_used(self, storage):
+        from hive.storage import AuthCodeAlreadyUsed
+
+        # `attribute_exists(PK)` in the ConditionExpression guards
+        # against forged codes — a caller cannot spin up new tokens
+        # by passing a code that was never issued.
+        with pytest.raises(AuthCodeAlreadyUsed):
+            storage.mark_auth_code_used("never-issued-code")
+
+    def test_concurrent_redemption_exactly_one_winner(self, storage):
+        """The TOCTOU regression — both callers read `used=False`, race
+        to write. The conditional UpdateItem serialises them and
+        exactly one wins.
+        """
+        import threading
+
+        from hive.storage import AuthCodeAlreadyUsed
+
+        code = self._create_code(storage)
+
+        results: list[str] = []
+        barrier = threading.Barrier(2)
+
+        def redeem() -> None:
+            barrier.wait()  # align both threads on the write
+            try:
+                storage.mark_auth_code_used(code)
+                results.append("ok")
+            except AuthCodeAlreadyUsed:
+                results.append("rejected")
+
+        t1 = threading.Thread(target=redeem)
+        t2 = threading.Thread(target=redeem)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # Exactly one redemption succeeds, the other is rejected — no
+        # "both succeed" outcome survives the conditional write.
+        assert sorted(results) == ["ok", "rejected"]
+
+        fetched = storage.get_auth_code(code)
+        assert fetched is not None
+        assert fetched.used is True
+
+    def test_unexpected_client_error_reraises(self, storage):
+        """Only ConditionalCheckFailedException is translated to
+        AuthCodeAlreadyUsed — every other ClientError bubbles up
+        verbatim so accidental swallowing can't mask genuine AWS
+        failures."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        throttled = ClientError(
+            error_response={"Error": {"Code": "ProvisionedThroughputExceededException"}},
+            operation_name="UpdateItem",
+        )
+        with (
+            patch.object(storage.table, "update_item", side_effect=throttled),
+            pytest.raises(ClientError),
+        ):
+            storage.mark_auth_code_used("any-code")
+
+
 # ---------------------------------------------------------------------------
 # Activity log tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #584

## Summary

`HiveStorage.mark_auth_code_used` was a non-atomic read-check-write:
two concurrent `POST /oauth/token` requests with the same `code`
could both pass the `auth_code.used` pre-check in `oauth.py` and
both issue a token pair — violating **RFC 6749 §10.5** (single-use
authorization codes).

Fix: replace the unconditional `UpdateItem` with a conditional one
guarded by `attribute_exists(PK) AND used = false`. The loser of the
race gets a `ConditionalCheckFailedException`, translated to a new
`AuthCodeAlreadyUsed` exception. Token endpoint catches it and
returns the same **400 "Invalid or already-used code"** the
pre-check produced — no token pair, no stack trace leaked.

## Approach

Same optimistic-lock pattern as `HiveStorage.put_memory` /
`VersionConflict` — storage enforces the invariant atomically, the
caller maps the domain exception to a user-facing response.

- Storage: `mark_auth_code_used` wraps `UpdateItem` in
  try/except, raises `AuthCodeAlreadyUsed` on
  `ConditionalCheckFailedException`. The `attribute_exists(PK)`
  guard means forged / never-issued codes also raise — a caller
  can&#39;t spin up tokens by passing arbitrary strings.
- Endpoint: the original `if auth_code.used: raise` stays in place
  so already-observed-used codes fail fast without a conditional
  write. The `try/except AuthCodeAlreadyUsed` catches only the
  actual race case.

## Test plan

- [x] Storage tests (`TestAuthCodeAtomicRedemption`, 4 tests):
  - First redemption flips `used=True`; sequential second raises
    `AuthCodeAlreadyUsed`. This is the same code path a concurrent
    loser would hit — serialisation between the two writes is done
    by DynamoDB itself, so a sequential re-call proves the same
    invariant the race would.
  - Forged / never-issued code raises via `attribute_exists` guard
  - **Wire-level spy** (`test_update_uses_conditional_write_on_unused_state`)
    asserts the `UpdateItem` carries
    `ConditionExpression = attribute_exists(PK) AND #u = :f` with
    `{:f = False}` — pins the fix so a future refactor can&#39;t
    silently drop the condition. (An earlier iteration used a
    `threading.Barrier` to race two redemptions in-process, but
    moto&#39;s mock backend isn&#39;t a reliable concurrency harness —
    replaced with this deterministic spy.)
  - Non-`ConditionalCheckFailedException` ClientError re-raises
    verbatim so accidental swallowing can&#39;t mask AWS throttles.
- [x] Endpoint test (`test_concurrent_redemption_loser_gets_400`):
  patches `mark_auth_code_used` to raise `AuthCodeAlreadyUsed` and
  asserts the endpoint returns a clean 400 — covers the half of the
  fix that storage-layer tests can&#39;t reach.
- [x] Existing `test_already_used_code_rejected` still passes (the
  sequential pre-check path is unchanged).
- [x] `uv run inv pre-push` clean (frontend + full Python suite).

Per §7.5, auto-merge is **not** armed at PR creation. `agent-safe`
label was not applied to this issue (it touches the auth / token-
issuance path) so Copilot review is not required, but per your
request the 3-cycle Copilot loop will run here and you&#39;ll be the
final gate before merge.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb