### PR TITLE
docs: pack_context + overview Copilot iter-1 follow-ups

### DIFF
--- a/docs-site/tools/overview.md
+++ b/docs-site/tools/overview.md
@@ -16,7 +16,7 @@ Hive exposes MCP tools that your AI agent can call during a conversation. You do
 
 ## Scopes
 
-Each OAuth token has one or both of the following scopes:
+OAuth tokens may carry `memories:read` and/or `memories:write`. Each scope grants the tools listed below; `ping` is the one tool that needs only a valid Bearer token.
 
 | Scope | Grants access to |
 | --- | --- |

--- a/docs-site/tools/overview.md
+++ b/docs-site/tools/overview.md
@@ -1,6 +1,6 @@
 # MCP tools overview
 
-Hive exposes seven tools that your AI agent can call during a conversation. You don't invoke these directly — your agent decides when to use them based on your instructions.
+Hive exposes MCP tools that your AI agent can call during a conversation. You don't invoke these directly — your agent decides when to use them based on your instructions.
 
 ## Tool summary
 
@@ -20,8 +20,8 @@ Each OAuth token has one or both of the following scopes:
 
 | Scope | Grants access to |
 | --- | --- |
-| `memories:read` | `recall`, `list_memories`, `search_memories`, `summarize_context`, `pack_context` |
-| `memories:write` | `remember`, `forget` |
+| `memories:read` | `recall`, `list_memories`, `list_tags`, `memory_history`, `relate_memories`, `search_memories`, `summarize_context`, `pack_context` |
+| `memories:write` | `remember`, `remember_if_absent`, `forget`, `forget_all`, `redact_memory`, `restore_memory` |
 
 Tokens issued through the standard OAuth flow get both scopes by default.
 

--- a/docs-site/tools/overview.md
+++ b/docs-site/tools/overview.md
@@ -22,6 +22,7 @@ Each OAuth token has one or both of the following scopes:
 | --- | --- |
 | `memories:read` | `recall`, `list_memories`, `list_tags`, `memory_history`, `relate_memories`, `search_memories`, `summarize_context`, `pack_context` |
 | `memories:write` | `remember`, `remember_if_absent`, `forget`, `forget_all`, `redact_memory`, `restore_memory` |
+| _(none required)_ | `ping` — health check, requires only a valid Bearer token |
 
 Tokens issued through the standard OAuth flow get both scopes by default.
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1529,7 +1529,8 @@ async def pack_context(
     ordering: Annotated[
         str,
         "How to rank candidates before packing: 'relevance' (pure semantic), "
-        "'recency' (pure last-accessed decay), or 'relevance+recency' (blend, default).",
+        "'recency' (last-accessed decay, falling back to updated-at decay), or "
+        "'relevance+recency' (blend, default).",
     ] = "relevance+recency",
     ctx: Context | None = None,
 ) -> str:


### PR DESCRIPTION
Follow-up to #608. Carries the Copilot iter-1 clarity fixes that
were pushed after #608 auto-merged to `development`, so they didn't
land with the original feature.

## Summary

- `pack_context` `ordering='recency'` annotation now reads
  `"last-accessed decay, falling back to updated-at decay"` —
  matches what `recency_score()` actually does (the bare
  `last-accessed decay` wording was misleading, since the score
  falls back to `updated_at` when there's no access record yet).
- `docs-site/tools/overview.md`:
  - Opening sentence drops the literal count (`"seven tools"`)
    since Hive exposes 15 MCP tools now; the summary table stays
    scoped to the 7 most commonly used surfaces.
  - Scope grant table expanded to cover the full surface:
    `memories:read` adds `list_tags`, `memory_history`,
    `relate_memories`; `memories:write` adds `remember_if_absent`,
    `forget_all`, `redact_memory`, `restore_memory`. Scope docs now
    match `_auth(required_scope=...)` in `server.py` 1:1.

No behaviour change — docstring + doc text only.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb