### PR TITLE
feat: quota-limit UI — callouts at 80%/100% + 429 banner with Setup link

### DIFF
--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -29,7 +29,13 @@ async function request(method, path, body) {
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: res.statusText }));
-    throw new Error(err.detail ?? "Request failed");
+    // Attach the HTTP status so callers can branch on 429 (quota / rate
+    // limit) without scraping the message — generic JS Error has no
+    // status field of its own.
+    const message = err.detail ?? "Request failed";
+    const wrapped = new Error(message);
+    wrapped.status = res.status;
+    throw wrapped;
   }
 
   if (res.status === 204) return null;

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -75,6 +75,17 @@ describe("api", () => {
     await expect(api.listMemories()).rejects.toThrow("Something bad");
   });
 
+  it("attaches the HTTP status to the thrown error so callers can branch on 429", async () => {
+    mockErr("Memory quota exceeded.", 429);
+    try {
+      await api.createMemory({ key: "k", value: "v", tags: [] });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err.message).toBe("Memory quota exceeded.");
+      expect(err.status).toBe(429);
+    }
+  });
+
   it("falls back to statusText when error json has no detail", async () => {
     mockErr(undefined);
     await expect(api.listMemories()).rejects.toThrow("Request failed");

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -501,8 +501,13 @@ export default function MemoryBrowser() {
             <button
               type="button"
               onClick={goToUsage}
-              className="underline cursor-pointer"
-              style={{ color: "var(--danger)", background: "transparent", border: 0 }}
+              className="underline cursor-pointer p-0 m-0 font-inherit text-inherit leading-inherit"
+              style={{
+                color: "var(--danger)",
+                background: "transparent",
+                border: 0,
+                font: "inherit",
+              }}
             >
               Open Setup
             </button>

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -206,13 +206,17 @@ export default function MemoryBrowser() {
 
   // Quota / rate-limit hits get a richer banner that points back to
   // the Setup tab's Usage section, instead of the bare server detail
-  // string. Generic errors still go through `setError`.
+  // string. Generic errors still go through `setError`. Each branch
+  // clears the other state slot so the banner and the inline error
+  // can never render together.
   function handleMutationError(err) {
     if (err && err.status === 429) {
       setQuotaError(err.message || "Quota or rate limit reached.");
+      setError("");
       return;
     }
     setError(err.message);
+    setQuotaError(null);
   }
 
   function goToUsage() {
@@ -483,7 +487,7 @@ export default function MemoryBrowser() {
             className="mb-3 rounded border p-3 text-[13px]"
             style={{ borderColor: "var(--danger)", color: "var(--danger)" }}
           >
-            <strong>Memory quota reached.</strong>{" "}
+            <strong>Quota or rate limit reached.</strong>{" "}
             <span className="text-[var(--text-muted)]">
               {quotaError} Free up space or request more capacity from the Setup
               tab&apos;s Usage section.

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -222,6 +222,12 @@ export default function MemoryBrowser() {
   function goToUsage() {
     setQuotaError(null);
     globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "setup" }));
+    // Setup tab mounts asynchronously after the switch — defer the
+    // scroll so the #usage anchor exists by the time we look it up.
+    globalThis.setTimeout(function scrollToUsage() {
+      const target = globalThis.document?.getElementById("usage");
+      if (target) target.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 0);
   }
 
   const load = useCallback(async () => {
@@ -489,8 +495,8 @@ export default function MemoryBrowser() {
           >
             <strong>Quota or rate limit reached.</strong>{" "}
             <span className="text-[var(--text-muted)]">
-              {quotaError} Free up space or request more capacity from the Setup
-              tab&apos;s Usage section.
+              {quotaError} Try again later, or open Setup to review your
+              current usage and request more capacity.
             </span>{" "}
             <button
               type="button"

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -176,6 +176,7 @@ export default function MemoryBrowser() {
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState("");
+  const [quotaError, setQuotaError] = useState(null);
   const [tagFilter, setTagFilter] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchMode, setIsSearchMode] = useState(false);
@@ -202,6 +203,22 @@ export default function MemoryBrowser() {
   }, []);
   const searchDebounceRef = useRef(null);
   const listRef = useRef(null);
+
+  // Quota / rate-limit hits get a richer banner that points back to
+  // the Setup tab's Usage section, instead of the bare server detail
+  // string. Generic errors still go through `setError`.
+  function handleMutationError(err) {
+    if (err && err.status === 429) {
+      setQuotaError(err.message || "Quota or rate limit reached.");
+      return;
+    }
+    setError(err.message);
+  }
+
+  function goToUsage() {
+    setQuotaError(null);
+    globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "setup" }));
+  }
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -324,7 +341,7 @@ export default function MemoryBrowser() {
       setForm({ key: "", value: "", tags: "", ttl: "" });
       load();
     } catch (err) {
-      setError(err.message);
+      handleMutationError(err);
     }
   }
 
@@ -459,6 +476,28 @@ export default function MemoryBrowser() {
           <Button onClick={openCreate}>+ New</Button>
         </div>
 
+        {quotaError && (
+          <div
+            role="alert"
+            data-testid="quota-banner"
+            className="mb-3 rounded border p-3 text-[13px]"
+            style={{ borderColor: "var(--danger)", color: "var(--danger)" }}
+          >
+            <strong>Memory quota reached.</strong>{" "}
+            <span className="text-[var(--text-muted)]">
+              {quotaError} Free up space or request more capacity from the Setup
+              tab&apos;s Usage section.
+            </span>{" "}
+            <button
+              type="button"
+              onClick={goToUsage}
+              className="underline cursor-pointer"
+              style={{ color: "var(--danger)", background: "transparent", border: 0 }}
+            >
+              Open Setup
+            </button>
+          </div>
+        )}
         {error && <p className="text-[var(--danger)] mb-3">{error}</p>}
         {loading && <p className="text-[var(--text-muted)]">Loading…</p>}
 

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -471,7 +471,7 @@ describe("MemoryBrowser", () => {
     );
 
     const banner = await screen.findByTestId("quota-banner");
-    expect(banner.textContent).toContain("Memory quota reached");
+    expect(banner.textContent).toContain("Quota or rate limit reached");
     expect(banner.textContent).toContain("Memory quota of 500 reached.");
     // Generic error text MUST NOT also surface — banner replaces it.
     expect(screen.queryByText("Memory quota of 500 reached.", { selector: "p" })).toBeNull();
@@ -487,6 +487,61 @@ describe("MemoryBrowser", () => {
     expect(switchEvents.at(-1).detail).toBe("setup");
     expect(screen.queryByTestId("quota-banner")).toBeNull();
     dispatchSpy.mockRestore();
+  });
+
+  it("clears stale generic error when a follow-up 429 fires", async () => {
+    // Sequence: first create fails generically, then a retry hits the
+    // quota wall. The banner must take over and the inline error
+    // paragraph must clear so the two never render together.
+    const genericErr = new Error("Server hiccup");
+    const quotaErr = new Error("Memory quota of 500 reached.");
+    quotaErr.status = 429;
+    api.createMemory.mockRejectedValueOnce(genericErr).mockRejectedValueOnce(quotaErr);
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+    await waitFor(() => expect(screen.getByText("Server hiccup")).toBeTruthy());
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    await screen.findByTestId("quota-banner");
+    expect(screen.queryByText("Server hiccup")).toBeNull();
+  });
+
+  it("clears stale quota banner when a follow-up generic error fires", async () => {
+    const quotaErr = new Error("Memory quota of 500 reached.");
+    quotaErr.status = 429;
+    const genericErr = new Error("Server hiccup");
+    api.createMemory.mockRejectedValueOnce(quotaErr).mockRejectedValueOnce(genericErr);
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+    await screen.findByTestId("quota-banner");
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    await waitFor(() => expect(screen.getByText("Server hiccup")).toBeTruthy());
+    expect(screen.queryByTestId("quota-banner")).toBeNull();
   });
 
   it("falls back to a generic message on 429 with no detail body", async () => {

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -452,6 +452,64 @@ describe("MemoryBrowser", () => {
     await waitFor(() => expect(screen.getByText("Create error")).toBeTruthy());
   });
 
+  it("surfaces a quota banner with a Setup link when createMemory returns 429", async () => {
+    const quotaErr = new Error("Memory quota of 500 reached.");
+    quotaErr.status = 429;
+    api.createMemory.mockRejectedValue(quotaErr);
+    const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    const banner = await screen.findByTestId("quota-banner");
+    expect(banner.textContent).toContain("Memory quota reached");
+    expect(banner.textContent).toContain("Memory quota of 500 reached.");
+    // Generic error text MUST NOT also surface — banner replaces it.
+    expect(screen.queryByText("Memory quota of 500 reached.", { selector: "p" })).toBeNull();
+
+    // Clicking "Open Setup" dispatches the tab-switch event the App
+    // shell listens for; banner should clear so it doesn't stick on
+    // the new tab.
+    fireEvent.click(screen.getByText("Open Setup"));
+    const switchEvents = dispatchSpy.mock.calls
+      .map((call) => call[0])
+      .filter((evt) => evt && evt.type === "hive:switch-tab");
+    expect(switchEvents.length).toBeGreaterThan(0);
+    expect(switchEvents.at(-1).detail).toBe("setup");
+    expect(screen.queryByTestId("quota-banner")).toBeNull();
+    dispatchSpy.mockRestore();
+  });
+
+  it("falls back to a generic message on 429 with no detail body", async () => {
+    const quotaErr = new Error("");
+    quotaErr.status = 429;
+    api.createMemory.mockRejectedValue(quotaErr);
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    const banner = await screen.findByTestId("quota-banner");
+    expect(banner.textContent).toContain("Quota or rate limit reached.");
+  });
+
   // ---------------------------------------------------------------------------
   // Edit / Update
   // ---------------------------------------------------------------------------

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -473,6 +473,7 @@ describe("MemoryBrowser", () => {
     const banner = await screen.findByTestId("quota-banner");
     expect(banner.textContent).toContain("Quota or rate limit reached");
     expect(banner.textContent).toContain("Memory quota of 500 reached.");
+    expect(banner.textContent).toContain("Try again later");
     // Generic error text MUST NOT also surface — banner replaces it.
     expect(screen.queryByText("Memory quota of 500 reached.", { selector: "p" })).toBeNull();
 
@@ -487,6 +488,82 @@ describe("MemoryBrowser", () => {
     expect(switchEvents.at(-1).detail).toBe("setup");
     expect(screen.queryByTestId("quota-banner")).toBeNull();
     dispatchSpy.mockRestore();
+  });
+
+  it("scrolls the #usage anchor into view after switching to Setup", async () => {
+    // Banner copy points users at "open Setup to review your current
+    // usage" — verify the click actually deep-links to the anchor,
+    // not just the tab. Use a real timeout (setTimeout delay of 0)
+    // instead of fake timers because fake timers + initial React
+    // effects don't mix (see §UI conventions in CLAUDE.md).
+    const quotaErr = new Error("Memory quota of 500 reached.");
+    quotaErr.status = 429;
+    api.createMemory.mockRejectedValue(quotaErr);
+
+    const scrollIntoView = vi.fn();
+    const realGetElementById = document.getElementById.bind(document);
+    const getByIdSpy = vi
+      .spyOn(document, "getElementById")
+      .mockImplementation((id) => {
+        if (id === "usage") return { scrollIntoView };
+        return realGetElementById(id);
+      });
+
+    try {
+      await act(async () => render(<MemoryBrowser />));
+      fireEvent.click(screen.getByText("+ New"));
+      fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+        target: { value: "k" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+        target: { value: "v" },
+      });
+      await act(async () => {
+        fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form"));
+      });
+      await screen.findByTestId("quota-banner");
+
+      fireEvent.click(screen.getByText("Open Setup"));
+      // Real setTimeout(0) — flush the macrotask queue.
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "start",
+      });
+    } finally {
+      getByIdSpy.mockRestore();
+    }
+  });
+
+  it("no-ops scroll when the #usage anchor isn't present", async () => {
+    // Defensive — covers the `if (target)` guard so the timer
+    // callback can't NPE when SetupPanel hasn't mounted. The test
+    // DOM has no #usage element (SetupPanel isn't mounted), so the
+    // deferred scrollIntoView must short-circuit cleanly.
+    const quotaErr = new Error("Memory quota of 500 reached.");
+    quotaErr.status = 429;
+    api.createMemory.mockRejectedValue(quotaErr);
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () => {
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form"));
+    });
+    await screen.findByTestId("quota-banner");
+    fireEvent.click(screen.getByText("Open Setup"));
+    // Flush the macrotask queue — the deferred `if (target)` branch
+    // must no-op without throwing when #usage doesn't exist.
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+    // Banner cleared on tab-switch click, confirming the click
+    // handler still ran even without a scroll target.
+    expect(screen.queryByTestId("quota-banner")).toBeNull();
   });
 
   it("clears stale generic error when a follow-up 429 fires", async () => {

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -266,12 +266,13 @@ export default function SetupPanel() {
       </section>
 
       {quota && (
-        <section className="mt-12 border-t border-[var(--border)] pt-8">
+        <section id="usage" className="mt-12 border-t border-[var(--border)] pt-8">
           <h3 className="mb-4">Usage</h3>
           <div className="flex flex-col gap-3.5">
             <QuotaBar label="Memories" used={quota.total_memories} limit={quota.memory_limit} />
             <QuotaBar label="Clients" used={quota.total_clients} limit={quota.client_limit} />
           </div>
+          <QuotaCallout quota={quota} />
         </section>
       )}
 
@@ -420,6 +421,58 @@ function DesktopOrChatgptInstructions({
         </button>
       )}
     </>
+  );
+}
+
+// Highest fill ratio across the user's quotas. Drives the callout
+// severity — one resource at 100% is enough to block writes, so the
+// callout reflects the worst-case bucket rather than a per-bar
+// average.
+function _quotaSeverity(quota) {
+  const ratios = [];
+  if (quota.memory_limit) ratios.push(quota.total_memories / quota.memory_limit);
+  if (quota.client_limit) ratios.push(quota.total_clients / quota.client_limit);
+  if (ratios.length === 0) return "ok";
+  const worst = Math.max(...ratios);
+  if (worst >= 1) return "at";
+  if (worst >= 0.8) return "near";
+  return "ok";
+}
+
+export function QuotaCallout({ quota }) {
+  const severity = _quotaSeverity(quota);
+  if (severity === "ok") return null;
+
+  const isAt = severity === "at";
+  const tone = isAt ? "var(--danger)" : "var(--amber)";
+  const headline = isAt
+    ? "You've reached your free tier limit."
+    : "You're approaching your free tier limit.";
+  const detail = isAt
+    ? "New memories cannot be saved until you free up space or request more capacity."
+    : "Free up space soon, or get in touch to request more capacity.";
+
+  return (
+    <div
+      role="status"
+      data-testid="quota-callout"
+      data-severity={severity}
+      className="mt-4 rounded border p-3 text-[13px]"
+      style={{ borderColor: tone, color: tone }}
+    >
+      <strong>{headline}</strong>{" "}
+      <span className="text-[var(--text-muted)]">{detail}</span>{" "}
+      <a
+        href="mailto:hello@warlordofmars.net?subject=Hive%20capacity%20request"
+        className="underline"
+        style={{ color: tone }}
+      >
+        Contact us
+      </a>{" "}
+      <span className="text-[var(--text-muted)]">
+        to request an increase.
+      </span>
+    </div>
   );
 }
 

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -424,25 +424,56 @@ function DesktopOrChatgptInstructions({
   );
 }
 
-// Highest fill ratio across the user's quotas. Drives the callout
-// severity — one resource at 100% is enough to block writes, so the
-// callout reflects the worst-case bucket rather than a per-bar
-// average. Limits ≤ 0 are treated as "unconfigured" rather than
-// "infinitely full" so a misconfigured env var never lights the
-// callout up red.
+// Per-bucket fill ratio. Limits ≤ 0 are treated as "unconfigured"
+// (returns null) so a misconfigured env var never registers as
+// "infinitely full" and a 0-limit `QuotaBar` doesn't divide by zero.
+function _quotaRatio(used, limit) {
+  if (limit == null || limit <= 0) return null;
+  return used / limit;
+}
+
+// Worst-case bucket drives the callout severity — one resource at
+// 100% is enough to block writes, so the callout reflects the
+// per-bucket worst case rather than a flat average.
 function _quotaSeverity(quota) {
-  const ratios = [];
-  if (quota.memory_limit != null && quota.memory_limit > 0) {
-    ratios.push(quota.total_memories / quota.memory_limit);
-  }
-  if (quota.client_limit != null && quota.client_limit > 0) {
-    ratios.push(quota.total_clients / quota.client_limit);
-  }
+  const ratios = [
+    _quotaRatio(quota.total_memories, quota.memory_limit),
+    _quotaRatio(quota.total_clients, quota.client_limit),
+  ].filter((r) => r != null);
   if (ratios.length === 0) return "ok";
   const worst = Math.max(...ratios);
   if (worst >= 1) return "at";
   if (worst >= 0.8) return "near";
   return "ok";
+}
+
+// Which buckets are tripping the callout. Used to tailor the body
+// copy: "New memories cannot be saved" only applies when the memory
+// quota is the offender, not when it's the client quota that's full.
+function _affectedBuckets(quota, threshold) {
+  const memRatio = _quotaRatio(quota.total_memories, quota.memory_limit);
+  const cliRatio = _quotaRatio(quota.total_clients, quota.client_limit);
+  return {
+    memory: memRatio != null && memRatio >= threshold,
+    clients: cliRatio != null && cliRatio >= threshold,
+  };
+}
+
+function _detailCopy(severity, affected) {
+  const isAt = severity === "at";
+  const verbAt = "cannot be saved until you free up space or request more capacity";
+  const verbNear = "are running low — free up space soon, or get in touch to request more capacity";
+  const verb = isAt ? verbAt : verbNear;
+  if (affected.memory && affected.clients) {
+    return `New memories and OAuth clients ${verb}.`;
+  }
+  if (affected.clients) {
+    const clientVerb = isAt
+      ? "cannot be created until you delete an existing one or request more capacity"
+      : "are running low — delete an unused one, or get in touch to request more capacity";
+    return `New OAuth clients ${clientVerb}.`;
+  }
+  return `New memories ${verb}.`;
 }
 
 export function QuotaCallout({ quota }) {
@@ -454,9 +485,8 @@ export function QuotaCallout({ quota }) {
   const headline = isAt
     ? "You've reached your free tier limit."
     : "You're approaching your free tier limit.";
-  const detail = isAt
-    ? "New memories cannot be saved until you free up space or request more capacity."
-    : "Free up space soon, or get in touch to request more capacity.";
+  const affected = _affectedBuckets(quota, isAt ? 1 : 0.8);
+  const detail = _detailCopy(severity, affected);
 
   return (
     <div
@@ -483,6 +513,10 @@ export function QuotaCallout({ quota }) {
 }
 
 function QuotaBar({ label, used, limit }) {
+  // Match `_quotaSeverity` semantics: a missing or non-positive
+  // limit is "unconfigured", not "infinitely full" — skip the bar
+  // entirely rather than dividing by zero into a 100% red sliver.
+  if (limit == null || limit <= 0) return null;
   const pct = Math.min((used / limit) * 100, 100);
   const nearLimit = pct >= 80;
   const atLimit = pct >= 100;

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -265,7 +265,7 @@ export default function SetupPanel() {
         </p>
       </section>
 
-      {quota && (
+      {quota && _hasAnyConfiguredLimit(quota) && (
         <section id="usage" className="mt-12 border-t border-[var(--border)] pt-8">
           <h3 className="mb-4">Usage</h3>
           <div className="flex flex-col gap-3.5">
@@ -422,6 +422,16 @@ function DesktopOrChatgptInstructions({
       )}
     </>
   );
+}
+
+// True iff at least one bucket has a configured (positive) limit.
+// Used to hide the Usage section header when both limits are
+// missing or non-positive — without this guard the section would
+// render an empty block (no bars, no callout) and look broken.
+function _hasAnyConfiguredLimit(quota) {
+  const memOk = quota.memory_limit != null && quota.memory_limit > 0;
+  const cliOk = quota.client_limit != null && quota.client_limit > 0;
+  return memOk || cliOk;
 }
 
 // Per-bucket fill ratio. Limits ≤ 0 are treated as "unconfigured"

--- a/ui/src/components/SetupPanel.jsx
+++ b/ui/src/components/SetupPanel.jsx
@@ -427,11 +427,17 @@ function DesktopOrChatgptInstructions({
 // Highest fill ratio across the user's quotas. Drives the callout
 // severity — one resource at 100% is enough to block writes, so the
 // callout reflects the worst-case bucket rather than a per-bar
-// average.
+// average. Limits ≤ 0 are treated as "unconfigured" rather than
+// "infinitely full" so a misconfigured env var never lights the
+// callout up red.
 function _quotaSeverity(quota) {
   const ratios = [];
-  if (quota.memory_limit) ratios.push(quota.total_memories / quota.memory_limit);
-  if (quota.client_limit) ratios.push(quota.total_clients / quota.client_limit);
+  if (quota.memory_limit != null && quota.memory_limit > 0) {
+    ratios.push(quota.total_memories / quota.memory_limit);
+  }
+  if (quota.client_limit != null && quota.client_limit > 0) {
+    ratios.push(quota.total_clients / quota.client_limit);
+  }
   if (ratios.length === 0) return "ok";
   const worst = Math.max(...ratios);
   if (worst >= 1) return "at";

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -373,6 +373,104 @@ describe("SetupPanel", () => {
     expect(bars.length).toBeGreaterThan(0);
   });
 
+  describe("QuotaCallout", () => {
+    it("does not render under 80% utilisation", async () => {
+      api.getStats.mockResolvedValue({
+        total_memories: 100,
+        total_clients: 1,
+        memory_limit: 500,
+        client_limit: 10,
+      });
+      await act(async () => render(<SetupPanel />));
+      await waitFor(() => expect(screen.getByText("100 / 500")).toBeTruthy());
+      expect(screen.queryByTestId("quota-callout")).toBeNull();
+    });
+
+    it("renders amber 'approaching limit' callout between 80% and 99%", async () => {
+      api.getStats.mockResolvedValue({
+        total_memories: 420,
+        total_clients: 1,
+        memory_limit: 500,
+        client_limit: 10,
+      });
+      await act(async () => render(<SetupPanel />));
+      const callout = await screen.findByTestId("quota-callout");
+      expect(callout.dataset.severity).toBe("near");
+      expect(callout.textContent).toContain("approaching your free tier limit");
+      const link = callout.querySelector("a");
+      expect(link.getAttribute("href")).toContain("mailto:hello@warlordofmars.net");
+    });
+
+    it("renders red 'reached limit' callout at 100%", async () => {
+      api.getStats.mockResolvedValue({
+        total_memories: 500,
+        total_clients: 1,
+        memory_limit: 500,
+        client_limit: 10,
+      });
+      await act(async () => render(<SetupPanel />));
+      const callout = await screen.findByTestId("quota-callout");
+      expect(callout.dataset.severity).toBe("at");
+      expect(callout.textContent).toContain("reached your free tier limit");
+      expect(callout.textContent).toContain("New memories cannot be saved");
+    });
+
+    it("escalates to 'at' severity when only the client quota is full", async () => {
+      // The worst-case bucket drives severity — one resource at 100%
+      // is enough to block writes even if the other is well under.
+      api.getStats.mockResolvedValue({
+        total_memories: 0,
+        total_clients: 10,
+        memory_limit: 500,
+        client_limit: 10,
+      });
+      await act(async () => render(<SetupPanel />));
+      const callout = await screen.findByTestId("quota-callout");
+      expect(callout.dataset.severity).toBe("at");
+    });
+
+    it("renders nothing when both limits are absent", async () => {
+      api.getStats.mockResolvedValue({
+        total_memories: 0,
+        total_clients: 0,
+        memory_limit: null,
+        client_limit: null,
+      });
+      await act(async () => render(<SetupPanel />));
+      // Usage section is hidden entirely when memory_limit is null,
+      // so the callout never gets a chance to render.
+      expect(screen.queryByTestId("quota-callout")).toBeNull();
+    });
+
+    it("returns null directly when called with all-ok quota", async () => {
+      const { QuotaCallout } = await import("./SetupPanel.jsx");
+      const { container } = render(
+        <QuotaCallout
+          quota={{
+            total_memories: 1,
+            total_clients: 1,
+            memory_limit: 500,
+            client_limit: 10,
+          }}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("returns 'ok' from severity helper when no limits are present", async () => {
+      // Defensive branch — covered separately because the Usage
+      // section is hidden in that state, so the callout never
+      // renders via the panel.
+      const { QuotaCallout } = await import("./SetupPanel.jsx");
+      const { container } = render(
+        <QuotaCallout
+          quota={{ total_memories: 1, total_clients: 1 }}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
   it("renders key naming convention tip with example and docs link", async () => {
     await act(async () => render(<SetupPanel />));
     expect(screen.getByText(/Tip — naming your memories/)).toBeTruthy();

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -415,9 +415,12 @@ describe("SetupPanel", () => {
       expect(callout.textContent).toContain("New memories cannot be saved");
     });
 
-    it("escalates to 'at' severity when only the client quota is full", async () => {
+    it("tailors the body copy to clients when only the client quota is full", async () => {
       // The worst-case bucket drives severity — one resource at 100%
       // is enough to block writes even if the other is well under.
+      // Backend only blocks new clients on client_limit, not memories,
+      // so the body copy switches to "OAuth clients … cannot be
+      // created" rather than the default memory phrasing.
       api.getStats.mockResolvedValue({
         total_memories: 0,
         total_clients: 10,
@@ -427,6 +430,34 @@ describe("SetupPanel", () => {
       await act(async () => render(<SetupPanel />));
       const callout = await screen.findByTestId("quota-callout");
       expect(callout.dataset.severity).toBe("at");
+      expect(callout.textContent).toContain("New OAuth clients cannot be created");
+      expect(callout.textContent).not.toContain("New memories");
+    });
+
+    it("uses combined memories+clients copy when both buckets are at limit", async () => {
+      api.getStats.mockResolvedValue({
+        total_memories: 500,
+        total_clients: 10,
+        memory_limit: 500,
+        client_limit: 10,
+      });
+      await act(async () => render(<SetupPanel />));
+      const callout = await screen.findByTestId("quota-callout");
+      expect(callout.textContent).toContain("New memories and OAuth clients");
+    });
+
+    it("uses 'running low' wording for client-only near-limit case", async () => {
+      api.getStats.mockResolvedValue({
+        total_memories: 0,
+        total_clients: 9,
+        memory_limit: 500,
+        client_limit: 10,
+      });
+      await act(async () => render(<SetupPanel />));
+      const callout = await screen.findByTestId("quota-callout");
+      expect(callout.dataset.severity).toBe("near");
+      expect(callout.textContent).toContain("New OAuth clients are running low");
+      expect(callout.textContent).toContain("delete an unused one");
     });
 
     it("renders nothing when both limits are absent", async () => {
@@ -468,6 +499,21 @@ describe("SetupPanel", () => {
         />,
       );
       expect(container.firstChild).toBeNull();
+    });
+
+    it("hides individual QuotaBar when its limit is missing or non-positive", async () => {
+      // Even when one limit is set, a missing client_limit should
+      // skip its bar rather than rendering "3 / null" or a div-by-0
+      // 100% sliver.
+      api.getStats.mockResolvedValue({
+        total_memories: 10,
+        total_clients: 3,
+        memory_limit: 500,
+        client_limit: 0,
+      });
+      await act(async () => render(<SetupPanel />));
+      await waitFor(() => expect(screen.getByText("10 / 500")).toBeTruthy());
+      expect(screen.queryByText("Clients")).toBeNull();
     });
 
     it("treats limit=0 as unconfigured rather than infinitely full", async () => {

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -469,6 +469,24 @@ describe("SetupPanel", () => {
       );
       expect(container.firstChild).toBeNull();
     });
+
+    it("treats limit=0 as unconfigured rather than infinitely full", async () => {
+      // A misconfigured limit (env var typo, 0-coerced int) used to
+      // light the callout up red because `0 / 0` was Infinity. The
+      // helper now skips non-positive limits.
+      const { QuotaCallout } = await import("./SetupPanel.jsx");
+      const { container } = render(
+        <QuotaCallout
+          quota={{
+            total_memories: 5,
+            total_clients: 0,
+            memory_limit: 0,
+            client_limit: 0,
+          }}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
   });
 
   it("renders key naming convention tip with example and docs link", async () => {

--- a/ui/src/components/SetupPanel.test.jsx
+++ b/ui/src/components/SetupPanel.test.jsx
@@ -516,6 +516,34 @@ describe("SetupPanel", () => {
       expect(screen.queryByText("Clients")).toBeNull();
     });
 
+    it("hides the Usage section header when both limits are missing or 0", async () => {
+      // Iter-3: don't render an empty Usage block (header with no
+      // bars and no callout) when the configuration says no limits
+      // are tracked. The whole section disappears.
+      api.getStats.mockResolvedValue({
+        total_memories: 5,
+        total_clients: 2,
+        memory_limit: 500,
+        client_limit: 0,
+      });
+      // First render with one limit set — Usage shows.
+      const { unmount } = render(<SetupPanel />);
+      await waitFor(() => expect(screen.getByText("Usage")).toBeTruthy());
+      unmount();
+
+      // Re-render with both limits unconfigured — Usage hides.
+      api.getStats.mockResolvedValue({
+        total_memories: 5,
+        total_clients: 2,
+        memory_limit: 0,
+        client_limit: 0,
+      });
+      await act(async () => render(<SetupPanel />));
+      // Wait long enough for the getStats useEffect to settle.
+      await waitFor(() => expect(api.getStats).toHaveBeenCalledTimes(2));
+      expect(screen.queryByText("Usage")).toBeNull();
+    });
+
     it("treats limit=0 as unconfigured rather than infinitely full", async () => {
       // A misconfigured limit (env var typo, 0-coerced int) used to
       // light the callout up red because `0 / 0` was Infinity. The


### PR DESCRIPTION
Closes #359

## Summary

- **SetupPanel** now renders a `QuotaCallout` below the existing QuotaBar rows when memory or client utilisation hits ≥80% (amber) or 100% (red). The callout explains what the limit means and links to `mailto:hello@warlordofmars.net` for capacity requests.
- **MemoryBrowser** detects 429 responses on `createMemory` and surfaces a richer banner that explains the quota situation and offers an `Open Setup` button. Clicking it dispatches the existing `hive:switch-tab` event so the app shell deep-links to the Setup tab; the banner clears on the way out so it doesn&#39;t stick.
- **api.js** now attaches the HTTP status code to thrown errors so callers can branch on 429 without scraping the message string. Generic JS `Error` has no `status` field of its own.

## Approach

- **Severity is the worst-case bucket** — one resource at 100% is enough to block writes, so the callout reflects that even if the other bar is well under. Helper `_quotaSeverity()` extracted so the dispatch is unit-testable.
- **No `include_redacted`-style escape hatch** — the banner can&#39;t be permanently dismissed; clearing it is tied to the `Open Setup` action so the user sees the path forward.
- Mailto contact uses `hello@warlordofmars.net` to match the convention already in `TermsPage.jsx`.
- Local e2e not run — the local stack isn&#39;t up in this session. The dev pipeline e2e covers UI flows on push to `development`.

## Test plan

- [x] `api.test.js` — new test pins `err.status === 429` propagation.
- [x] `SetupPanel.test.jsx::QuotaCallout` — 7 tests covering all four severity branches (off / near / at + client-only-at), the all-limits-absent branch, the helper&#39;s defensive `ok` return, and the mailto link target.
- [x] `MemoryBrowser.test.jsx` — 2 new tests: 429 with detail surfaces the rich banner, button dispatches `hive:switch-tab`; 429 without detail falls back to a generic message.
- [x] `uv run inv pre-push` clean (758 frontend tests, 100% coverage maintained).

Per §7.5, auto-merge will arm after the Copilot loop resolves.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb