### PR TITLE
feat: branded 404 + error boundary across SPA, plus docs-site 404

### DIFF
--- a/docs-site/404.md
+++ b/docs-site/404.md
@@ -1,0 +1,17 @@
+---
+title: Page not found
+description: The docs page you're looking for doesn't exist or has moved.
+---
+
+# Page not found
+
+The docs page you&rsquo;re looking for doesn&rsquo;t exist or has moved. Try one
+of these instead:
+
+- [Docs home](/docs/)
+- [Quick start](/docs/getting-started/quick-start)
+- [MCP tools reference](/docs/tools/overview)
+- [Marketing site home](/)
+
+Still stuck? Email [hello@warlordofmars.net](mailto:hello@warlordofmars.net)
+and we&rsquo;ll help.

--- a/docs-site/404.md
+++ b/docs-site/404.md
@@ -8,10 +8,10 @@ description: The docs page you're looking for doesn't exist or has moved.
 The docs page you&rsquo;re looking for doesn&rsquo;t exist or has moved. Try one
 of these instead:
 
-- [Docs home](/docs/)
-- [Quick start](/docs/getting-started/quick-start)
-- [MCP tools reference](/docs/tools/overview)
-- [Marketing site home](/)
+- [Docs home](/)
+- [Quick start](/getting-started/quick-start)
+- [MCP tools reference](/tools/overview)
+- [Marketing site home](https://hive.warlordofmars.net/)
 
 Still stuck? Email [hello@warlordofmars.net](mailto:hello@warlordofmars.net)
 and we&rsquo;ll help.

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -8,10 +8,12 @@ import ActivityLog from "./components/ActivityLog.jsx";
 import AuthCallback from "./components/AuthCallback.jsx";
 import ClientManager from "./components/ClientManager.jsx";
 import Dashboard from "./components/Dashboard.jsx";
+import ErrorBoundary from "./components/ErrorBoundary.jsx";
 import LogViewer from "./components/LogViewer.jsx";
 import ChangelogPage from "./components/ChangelogPage.jsx";
 import FaqPage from "./components/FaqPage.jsx";
 import HomePage from "./components/HomePage.jsx";
+import NotFoundPage from "./components/NotFoundPage.jsx";
 import PrivacyPage from "./components/PrivacyPage.jsx";
 import SubprocessorsPage from "./components/SubprocessorsPage.jsx";
 import TermsPage from "./components/TermsPage.jsx";
@@ -246,24 +248,32 @@ function RouteTracker() {
 
 export default function App() {
   useTheme(); // apply data-theme to <html> for all routes
+  // ErrorBoundary wraps the entire route tree so a thrown render
+  // exception in any page lands on the friendly fallback instead of
+  // a blank tab. Catch-all `*` route renders the branded 404 page —
+  // CloudFront already serves index.html for unknown paths (with a
+  // 200 so the SPA can route), so hitting `*` is the React Router
+  // signal that no route matched.
   return (
-    <BrowserRouter>
-      <RouteTracker />
-      <Routes>
-        <Route path="/" element={<HomeRoute />} />
-        <Route path="/pricing" element={<PricingPage />} />
-        <Route path="/faq" element={<FaqPage />} />
-        <Route path="/use-cases" element={<UseCasesPage />} />
-        <Route path="/clients" element={<McpClientsPage />} />
-        <Route path="/changelog" element={<ChangelogPage />} />
-        <Route path="/status" element={<StatusPage />} />
-        <Route path="/terms" element={<TermsPage />} />
-        <Route path="/privacy" element={<PrivacyPage />} />
-        <Route path="/subprocessors" element={<SubprocessorsPage />} />
-        <Route path="/app" element={<AppShell />} />
-        <Route path="/oauth/callback" element={<AuthCallback />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <RouteTracker />
+        <Routes>
+          <Route path="/" element={<HomeRoute />} />
+          <Route path="/pricing" element={<PricingPage />} />
+          <Route path="/faq" element={<FaqPage />} />
+          <Route path="/use-cases" element={<UseCasesPage />} />
+          <Route path="/clients" element={<McpClientsPage />} />
+          <Route path="/changelog" element={<ChangelogPage />} />
+          <Route path="/status" element={<StatusPage />} />
+          <Route path="/terms" element={<TermsPage />} />
+          <Route path="/privacy" element={<PrivacyPage />} />
+          <Route path="/subprocessors" element={<SubprocessorsPage />} />
+          <Route path="/app" element={<AppShell />} />
+          <Route path="/oauth/callback" element={<AuthCallback />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </BrowserRouter>
+    </ErrorBoundary>
   );
 }

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -106,10 +106,14 @@ describe("App routing", () => {
     window.history.pushState({}, "", "/");
   });
 
-  it("redirects unknown routes to /", async () => {
+  it("renders the branded NotFoundPage on unknown routes", async () => {
+    // Catch-all `*` route now lands on a real 404 instead of
+    // silently redirecting home — gives the user a path forward
+    // (Home / Docs / Contact) instead of a confusing reset.
     window.history.pushState({}, "", "/unknown-path");
     await act(async () => render(<App />));
-    expect(screen.getByTestId("home-page")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Page not found" })).toBeTruthy();
+    expect(screen.queryByTestId("home-page")).toBeNull();
     window.history.pushState({}, "", "/");
   });
 });

--- a/ui/src/components/ErrorBoundary.jsx
+++ b/ui/src/components/ErrorBoundary.jsx
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+
+// React's error-boundary contract still requires a class component
+// — there is no hook equivalent for `componentDidCatch` /
+// `getDerivedStateFromError`. Wrap the entire route tree so a thrown
+// exception in any rendered component falls into a friendly
+// "Something went wrong" page with a reload button instead of
+// blanking the whole tab.
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, message: "" };
+    this.handleReload = this.handleReload.bind(this);
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, message: error?.message ?? "" };
+  }
+
+  componentDidCatch(error, info) {
+    // Best-effort: log to the browser console so a developer
+    // inspecting the page can find the trace. A real backend
+    // ingest endpoint can be wired here later.
+    if (globalThis.console) {
+      // eslint-disable-next-line no-console
+      globalThis.console.error("ErrorBoundary caught:", error, info);
+    }
+  }
+
+  handleReload() {
+    if (globalThis.location) globalThis.location.reload();
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <div
+        role="alert"
+        data-testid="error-boundary"
+        className="min-h-screen flex flex-col items-center justify-center text-center px-4"
+      >
+        <p
+          className="font-bold tracking-[2px] text-[var(--text-muted)] uppercase text-sm mb-3"
+          aria-hidden="true"
+        >
+          Error
+        </p>
+        <h1 className="text-3xl md:text-4xl font-bold mb-4">Something went wrong</h1>
+        <p className="text-[var(--text-muted)] mb-8 max-w-[480px]">
+          The page failed to load. Try reloading; if the problem
+          persists, please get in touch.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 items-center">
+          <button
+            type="button"
+            onClick={this.handleReload}
+            className="px-4 py-2 rounded bg-[var(--accent)] text-white border-0 cursor-pointer text-sm"
+          >
+            Reload page
+          </button>
+          <a
+            href="mailto:hello@warlordofmars.net"
+            className="text-[var(--accent)] no-underline hover:underline text-sm"
+          >
+            Contact support
+          </a>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ui/src/components/ErrorBoundary.test.jsx
+++ b/ui/src/components/ErrorBoundary.test.jsx
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ErrorBoundary from "./ErrorBoundary.jsx";
+
+function Boom() {
+  throw new Error("boom");
+}
+
+describe("ErrorBoundary", () => {
+  let consoleError;
+
+  beforeEach(() => {
+    // React logs the caught error to console.error; silence it so the
+    // test output stays readable.
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("renders children when no error is thrown", async () => {
+    await act(async () =>
+      render(
+        <ErrorBoundary>
+          <p>healthy</p>
+        </ErrorBoundary>,
+      ),
+    );
+    expect(screen.getByText("healthy")).toBeTruthy();
+    expect(screen.queryByTestId("error-boundary")).toBeNull();
+  });
+
+  it("catches a thrown render error and shows the friendly fallback", async () => {
+    await act(async () =>
+      render(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>,
+      ),
+    );
+    const fallback = screen.getByTestId("error-boundary");
+    expect(fallback).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Something went wrong" })).toBeTruthy();
+    // Reload + Contact support paths must both be visible.
+    expect(screen.getByRole("button", { name: "Reload page" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Contact support" })).toBeTruthy();
+    // componentDidCatch logged the error.
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it("calls window.location.reload when the Reload button is clicked", async () => {
+    const reload = vi.fn();
+    vi.stubGlobal("location", { reload });
+
+    await act(async () =>
+      render(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>,
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Reload page" }));
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("treats undefined error.message as empty without crashing", async () => {
+    // Defensive — covers the `error?.message ?? ""` branch in
+    // getDerivedStateFromError.
+    function ThrowsUndefined() {
+      // eslint-disable-next-line no-throw-literal
+      throw undefined;
+    }
+    await act(async () =>
+      render(
+        <ErrorBoundary>
+          <ThrowsUndefined />
+        </ErrorBoundary>,
+      ),
+    );
+    expect(screen.getByTestId("error-boundary")).toBeTruthy();
+  });
+});

--- a/ui/src/components/ErrorBoundary.test.jsx
+++ b/ui/src/components/ErrorBoundary.test.jsx
@@ -46,8 +46,16 @@ describe("ErrorBoundary", () => {
     // Reload + Contact support paths must both be visible.
     expect(screen.getByRole("button", { name: "Reload page" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "Contact support" })).toBeTruthy();
-    // componentDidCatch logged the error.
-    expect(consoleError).toHaveBeenCalled();
+    // componentDidCatch logged the error with our specific prefix.
+    // React itself also logs caught errors to console.error, so we
+    // can't just assert the spy was called — distinguish on the
+    // "ErrorBoundary caught:" prefix to confirm our handler ran.
+    expect(
+      consoleError.mock.calls.some(
+        ([firstArg]) =>
+          typeof firstArg === "string" && firstArg.includes("ErrorBoundary caught:"),
+      ),
+    ).toBe(true);
   });
 
   it("calls window.location.reload when the Reload button is clicked", async () => {

--- a/ui/src/components/NotFoundPage.jsx
+++ b/ui/src/components/NotFoundPage.jsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import { Link } from "react-router-dom";
+import PageLayout from "@/components/PageLayout";
+
+export default function NotFoundPage() {
+  return (
+    <PageLayout>
+      <section className="max-w-[640px] mx-auto px-4 md:px-8 py-20 md:py-28 text-center">
+        <p
+          className="font-bold tracking-[2px] text-[var(--text-muted)] uppercase text-sm mb-3"
+          aria-hidden="true"
+        >
+          404
+        </p>
+        <h1 className="text-3xl md:text-4xl font-bold mb-4">Page not found</h1>
+        <p className="text-[var(--text-muted)] mb-10">
+          The page you&apos;re looking for doesn&apos;t exist or has moved. Try
+          one of these instead:
+        </p>
+        <ul className="flex flex-col sm:flex-row sm:justify-center gap-4 sm:gap-8 list-none p-0 m-0">
+          <li>
+            <Link
+              to="/"
+              className="text-[var(--accent)] no-underline hover:underline"
+            >
+              Home
+            </Link>
+          </li>
+          <li>
+            <a
+              href="/docs/"
+              className="text-[var(--accent)] no-underline hover:underline"
+            >
+              Docs
+            </a>
+          </li>
+          <li>
+            <a
+              href="mailto:hello@warlordofmars.net"
+              className="text-[var(--accent)] no-underline hover:underline"
+            >
+              Contact support
+            </a>
+          </li>
+        </ul>
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/NotFoundPage.test.jsx
+++ b/ui/src/components/NotFoundPage.test.jsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import NotFoundPage from "./NotFoundPage.jsx";
+
+function renderInRouter() {
+  return render(
+    <MemoryRouter>
+      <NotFoundPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("NotFoundPage", () => {
+  it("renders the 404 banner and 'Page not found' heading", async () => {
+    await act(async () => renderInRouter());
+    expect(screen.getByText("404")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Page not found" })).toBeTruthy();
+  });
+
+  it("offers Home / Docs / Contact support links so the user has a path forward", async () => {
+    await act(async () => renderInRouter());
+    // Scope to the body section so we don't pick up the navbar/footer
+    // Docs links from PageLayout (PageLayout adds three Docs links of
+    // its own — nav, mobile-drawer-not-rendered, footer).
+    const heading = screen.getByRole("heading", { name: "Page not found" });
+    const section = heading.closest("section");
+    const links = section.querySelectorAll("a");
+    const byLabel = {};
+    for (const link of links) byLabel[link.textContent.trim()] = link;
+
+    expect(byLabel["Home"].getAttribute("href")).toBe("/");
+    // Marketing-site Docs link points at the VitePress mount, not a
+    // React Router route, so it stays a plain `<a href>` (consistent
+    // with the navbar / footer link).
+    expect(byLabel["Docs"].getAttribute("href")).toBe("/docs/");
+    expect(byLabel["Contact support"].getAttribute("href")).toContain(
+      "mailto:hello@warlordofmars.net",
+    );
+  });
+
+  it("hides the literal '404' text from screen readers (decorative only)", async () => {
+    await act(async () => renderInRouter());
+    // The "404" badge above the heading is purely decorative — the
+    // heading itself carries the semantic meaning. Asserting the
+    // aria-hidden so an SR doesn't read out "four oh four — Page not
+    // found".
+    const badge = screen.getByText("404");
+    expect(badge.getAttribute("aria-hidden")).toBe("true");
+  });
+});


### PR DESCRIPTION
Closes #417

## Summary

Three on-brand error surfaces, replacing what was there:

- **`NotFoundPage.jsx`** — catch-all React route, rendered via `PageLayout` so the navbar / footer / consent banner stay consistent. Offers Home / Docs / Contact-support so the user has a path forward instead of being bounced silently to `/`.
- **`ErrorBoundary.jsx`** — class-based boundary at the App root (no hook equivalent for `componentDidCatch`). Friendly "Something went wrong" fallback with a Reload button + Contact-support link. Logs the caught error via `console.error` for developer inspection; a backend ingest endpoint can be wired here later.
- **`docs-site/404.md`** — VitePress auto-generates a generic 404; a custom markdown overrides it so the docs 404 matches the rest of the site (links to docs home, quick start, tools reference, marketing home, plus the same support email).

CloudFront-level errors are already wired — `hive_stack.py:842` routes 403/404 to `/index.html` with a 200 so React Router can render the SPA&#39;s `NotFoundPage`. No infra changes needed.

## Approach

- Catch-all route was previously `<Navigate to="/" replace />`; replaced with `<Route path="*" element={<NotFoundPage />} />`. The redirect was hostile UX — it told users nothing about where they ended up.
- ErrorBoundary wraps the entire `<BrowserRouter>` tree (not individual routes) so it catches anything, including AppShell mount errors. Loading the boundary at app root costs nothing when there&#39;s no error — the class&#39;s render is just `props.children`.
- Local e2e not run — local stack isn&#39;t up in this session. The dev pipeline e2e covers UI flows on push to `development`.

## Test plan

- [x] `NotFoundPage.test.jsx` — heading, link targets (Home → `/`, Docs → `/docs/`, Contact → `mailto:`), `aria-hidden` on the decorative "404" badge.
- [x] `ErrorBoundary.test.jsx` — passthrough on healthy children, fallback render on thrown error, Reload button calls `window.location.reload`, defensive branch when `error.message` is undefined.
- [x] `App.test.jsx` — `redirects unknown routes to /` test rewritten to assert `NotFoundPage` renders (and `home-page` doesn&#39;t).
- [x] `uv run inv pre-push` clean (774 frontend tests, +8 new; 100% coverage maintained).

Per §7.5, auto-merge will arm after the Copilot loop resolves.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb