### PR TITLE
feat: onboarding tour + richer empty state + first-memory celebration

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -19,6 +19,7 @@ import SubprocessorsPage from "./components/SubprocessorsPage.jsx";
 import TermsPage from "./components/TermsPage.jsx";
 import LoginPage from "./components/LoginPage.jsx";
 import McpClientsPage from "./components/McpClientsPage.jsx";
+import OnboardingTour from "./components/OnboardingTour.jsx";
 import PricingPage from "./components/PricingPage.jsx";
 import StatusPage from "./components/StatusPage.jsx";
 import UseCasesPage from "./components/UseCasesPage.jsx";
@@ -122,11 +123,14 @@ function AppShell() {
           <span className="font-bold text-xl tracking-wide">Hive</span>
         </button>
 
-        {/* Desktop tab nav — hidden on mobile */}
+        {/* Desktop tab nav — hidden on mobile. Each button carries
+            data-tab-id so the OnboardingTour can spotlight it
+            without prop-drilling refs through. */}
         <nav className="hidden md:flex gap-1 flex-1">
           {tabs.map((t) => (
             <Button
               key={t.id}
+              data-tab-id={t.id}
               variant="ghost"
               size="sm"
               onClick={() => switchTab(t.id)}
@@ -226,6 +230,7 @@ function AppShell() {
       )}
 
       <Toaster />
+      <OnboardingTour isAdmin={isAdmin} />
     </div>
   );
 }

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -191,6 +191,7 @@ function AppShell() {
             {tabs.map((t) => (
               <button
                 key={t.id}
+                data-tab-id={t.id}
                 type="button"
                 className={`w-full text-left px-6 py-3 text-sm text-white bg-transparent cursor-pointer font-[inherit] min-h-[44px] hover:bg-white/5 border-l-2 ${
                   tab === t.id

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -92,7 +92,13 @@ function AppShell() {
     if (!authenticated) return;
     api.listClients()
       .then((data) => {
-        if (data?.items.length === 0) setTab("setup");
+        // Skip the auto-switch when the OnboardingTour is still
+        // active — otherwise step 1 spotlights "Memories" while
+        // the underlying content silently jumps to Setup, leaving
+        // the spotlight pointing at a tab that's no longer the
+        // active panel.
+        const tourActive = !localStorage.getItem("hive_tour_dismissed");
+        if (data?.items.length === 0 && !tourActive) setTab("setup");
       })
       .catch(() => {});
   }, [authenticated]);

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -173,11 +173,26 @@ describe("AppShell", () => {
     expect(screen.queryByTestId("setup-panel")).toBeNull();
   });
 
-  it("defaults to Setup tab on first load when no clients registered", async () => {
+  it("defaults to Setup tab on first load when no clients registered (tour dismissed)", async () => {
+    // The auto-switch only fires once the OnboardingTour has been
+    // dismissed — otherwise step 1's "Memories" spotlight would
+    // point at a tab that's no longer the active panel.
+    _storage["hive_tour_dismissed"] = "1";
     vi.stubGlobal("fetch", makeFetch({ clients: [] }));
     await act(async () => render(<App />));
     await waitFor(() => expect(screen.getByTestId("setup-panel")).toBeTruthy());
     expect(screen.queryByTestId("memory-browser")).toBeNull();
+  });
+
+  it("suppresses auto-switch to Setup while the OnboardingTour is still active", async () => {
+    // Tour dismissed flag is NOT set — the empty-clients
+    // auto-switch must hold so the spotlight on step 1 ("Memories")
+    // matches the active tab.
+    vi.stubGlobal("fetch", makeFetch({ clients: [] }));
+    await act(async () => render(<App />));
+    // Settle the listClients promise.
+    await waitFor(() => expect(screen.getByTestId("memory-browser")).toBeTruthy());
+    expect(screen.queryByTestId("setup-panel")).toBeNull();
   });
 
   it("does not switch to Setup when listClients returns null", async () => {

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -393,7 +393,7 @@ export default function MemoryBrowser() {
             localStorage.setItem("hive_first_memory_skipped", "1");
           }
           if (!tagFilter && !isSearchMode) {
-            setMemories(fresh.items);
+            setMemories(fresh.items ?? []);
             setNextCursor(fresh.next_cursor ?? null);
             // load() normally clears `error` via setError("") on
             // its happy path. We're skipping load() here, so do the

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -395,6 +395,12 @@ export default function MemoryBrowser() {
           if (!tagFilter && !isSearchMode) {
             setMemories(fresh.items);
             setNextCursor(fresh.next_cursor ?? null);
+            // load() normally clears `error` via setError("") on
+            // its happy path. We're skipping load() here, so do the
+            // clear explicitly — otherwise a stale error from an
+            // earlier failed mutation can stay visible after a
+            // successful create.
+            setError("");
             return;
           }
           // Filtered view — fall through to load() so we re-fetch

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -362,21 +362,34 @@ export default function MemoryBrowser() {
       //      exactly this one item (so an existing user with
       //      memories from another browser / agent doesn't get a
       //      misleading "first memory" toast).
+      // Wrapped in try/catch so a transient list failure doesn't
+      // make a successful create look like it failed — the caller
+      // still falls through to the normal refresh path. We also
+      // only reuse the unfiltered fetch as the visible list when
+      // the user isn't currently filtered (search / tag) — otherwise
+      // we'd silently jump them out of their current view.
       if (!localStorage.getItem("hive_first_memory")) {
-        const fresh = await api.listMemories(undefined);
-        const isFirstInStore =
-          (fresh.items?.length ?? 0) === 1 && (fresh.next_cursor ?? null) === null;
-        if (isFirstInStore) {
-          localStorage.setItem("hive_first_memory", "1");
-          toast.success("First memory saved", {
-            description: "Your agent can now recall it across sessions.",
-          });
+        try {
+          const fresh = await api.listMemories(undefined);
+          const isFirstInStore =
+            (fresh.items?.length ?? 0) === 1 && (fresh.next_cursor ?? null) === null;
+          if (isFirstInStore) {
+            localStorage.setItem("hive_first_memory", "1");
+            toast.success("First memory saved", {
+              description: "Your agent can now recall it across sessions.",
+            });
+          }
+          if (!tagFilter && !isSearchMode) {
+            setMemories(fresh.items);
+            setNextCursor(fresh.next_cursor ?? null);
+            return;
+          }
+          // Filtered view — fall through to load() so we re-fetch
+          // the user's current slice instead of clobbering it.
+        } catch {
+          // Transient list failure shouldn't surface as a create
+          // error since the create itself succeeded.
         }
-        // We refreshed the list above; reuse it instead of calling
-        // load() (which would re-fetch immediately).
-        setMemories(fresh.items);
-        setNextCursor(fresh.next_cursor ?? null);
-        return;
       }
       load();
     } catch (err) {

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -354,13 +354,29 @@ export default function MemoryBrowser() {
       await api.createMemory(body);
       setCreating(false);
       setForm({ key: "", value: "", tags: "", ttl: "" });
-      // First-memory celebration. Fire once per user (localStorage
-      // flag) so subsequent creates don't spam the toast.
+      // First-memory celebration. Two gates so the toast only fires
+      // for the genuine first-ever memory in the workspace:
+      //   1. Per-browser localStorage flag (don't repeat on later
+      //      creates from this browser).
+      //   2. Server-side check that the unfiltered store now has
+      //      exactly this one item (so an existing user with
+      //      memories from another browser / agent doesn't get a
+      //      misleading "first memory" toast).
       if (!localStorage.getItem("hive_first_memory")) {
-        localStorage.setItem("hive_first_memory", "1");
-        toast.success("First memory saved", {
-          description: "Your agent can now recall it across sessions.",
-        });
+        const fresh = await api.listMemories(undefined);
+        const isFirstInStore =
+          (fresh.items?.length ?? 0) === 1 && (fresh.next_cursor ?? null) === null;
+        if (isFirstInStore) {
+          localStorage.setItem("hive_first_memory", "1");
+          toast.success("First memory saved", {
+            description: "Your agent can now recall it across sessions.",
+          });
+        }
+        // We refreshed the list above; reuse it instead of calling
+        // load() (which would re-fetch immediately).
+        setMemories(fresh.items);
+        setNextCursor(fresh.next_cursor ?? null);
+        return;
       }
       load();
     } catch (err) {

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { X } from "lucide-react";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
+import { toast } from "sonner";
 import { AlertDialog } from "./ui/alert-dialog.jsx";
 import { Badge } from "./ui/badge.jsx";
 import { Button } from "./ui/button.jsx";
@@ -219,9 +220,13 @@ export default function MemoryBrowser() {
     setQuotaError(null);
   }
 
-  function goToUsage() {
+  function openSetup() {
     setQuotaError(null);
     globalThis.dispatchEvent(new CustomEvent("hive:switch-tab", { detail: "setup" }));
+  }
+
+  function goToUsage() {
+    openSetup();
     // Setup tab mounts asynchronously after the switch — defer the
     // scroll so the #usage anchor exists by the time we look it up.
     globalThis.setTimeout(function scrollToUsage() {
@@ -349,6 +354,14 @@ export default function MemoryBrowser() {
       await api.createMemory(body);
       setCreating(false);
       setForm({ key: "", value: "", tags: "", ttl: "" });
+      // First-memory celebration. Fire once per user (localStorage
+      // flag) so subsequent creates don't spam the toast.
+      if (!localStorage.getItem("hive_first_memory")) {
+        localStorage.setItem("hive_first_memory", "1");
+        toast.success("First memory saved", {
+          description: "Your agent can now recall it across sessions.",
+        });
+      }
       load();
     } catch (err) {
       handleMutationError(err);
@@ -521,8 +534,19 @@ export default function MemoryBrowser() {
             <EmptyState
               variant="memories"
               title="No memories yet"
-              description="Use the remember tool in your MCP client to store your first memory."
-              action={<Button onClick={openCreate}>+ New Memory</Button>}
+              description="Connect an MCP client from the Setup tab — once your agent calls the remember tool, memories show up here. You can also create one by hand below."
+              action={
+                <div className="flex flex-col sm:flex-row gap-3 items-center">
+                  <Button onClick={openCreate}>+ New Memory</Button>
+                  <button
+                    type="button"
+                    onClick={openSetup}
+                    className="text-[var(--accent)] underline cursor-pointer bg-transparent border-0 p-0 text-sm font-inherit"
+                  >
+                    Open Setup
+                  </button>
+                </div>
+              }
             />
           </Card>
         )}

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -368,7 +368,16 @@ export default function MemoryBrowser() {
       // only reuse the unfiltered fetch as the visible list when
       // the user isn't currently filtered (search / tag) — otherwise
       // we'd silently jump them out of their current view.
-      if (!localStorage.getItem("hive_first_memory")) {
+      // Two flags so we don't pay for the probe on every create:
+      //   hive_first_memory=1 — we already celebrated; skip.
+      //   hive_first_memory_skipped=1 — the workspace already had
+      //     other memories the first time we checked, so a "first
+      //     memory in store" can't happen here without a wipe;
+      //     skip until the user clears it.
+      if (
+        !localStorage.getItem("hive_first_memory") &&
+        !localStorage.getItem("hive_first_memory_skipped")
+      ) {
         try {
           const fresh = await api.listMemories(undefined);
           const isFirstInStore =
@@ -378,6 +387,10 @@ export default function MemoryBrowser() {
             toast.success("First memory saved", {
               description: "Your agent can now recall it across sessions.",
             });
+          } else {
+            // Cache the negative result so we don't re-probe on
+            // every subsequent create.
+            localStorage.setItem("hive_first_memory_skipped", "1");
           }
           if (!tagFilter && !isSearchMode) {
             setMemories(fresh.items);

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -641,6 +641,37 @@ describe("MemoryBrowser", () => {
     expect(lastListCall[0]).toBe("alpha");
   });
 
+  it("handles a probe response with missing items/next_cursor via the nullish fallbacks", async () => {
+    // Defensive — covers the `?? 0` / `?? null` branches on line 384
+    // when the server returns a sparse payload (older API version,
+    // or a proxy that strips fields).
+    const sonner = await import("sonner");
+    const toastSuccess = vi.spyOn(sonner.toast, "success").mockImplementation(() => {});
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+    api.listMemories
+      .mockResolvedValueOnce({ items: [], next_cursor: null })
+      .mockResolvedValueOnce({}); // no items, no next_cursor
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    // items undefined → items?.length === undefined → ?? 0 →
+    // 0 === 1 is false, so isFirstInStore is false and the toast
+    // does NOT fire.
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(localStorage.getItem("hive_first_memory_skipped")).toBe("1");
+    toastSuccess.mockRestore();
+  });
+
   it("subsequent creates don't re-fire the celebration toast once the flag is set", async () => {
     const sonner = await import("sonner");
     const toastSuccess = vi.spyOn(sonner.toast, "success").mockImplementation(() => {});

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -520,6 +520,92 @@ describe("MemoryBrowser", () => {
     toastSuccess.mockRestore();
   });
 
+  it("does not surface a create error when the post-create first-memory check fails", async () => {
+    // Iter-2 fix: the post-create listMemories was throwing as a
+    // create failure — wrap the first-memory probe in its own
+    // try/catch and fall back to the normal refresh path.
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+    // First listMemories (mount) succeeds with empty page; second
+    // call (the first-memory probe) blows up; load() is then called
+    // and we let it succeed.
+    api.listMemories
+      .mockResolvedValueOnce({ items: [], next_cursor: null })
+      .mockRejectedValueOnce(new Error("transient list failure"))
+      .mockResolvedValueOnce({ items: [makeMemory()], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    // No "transient list failure" surfaced as an error — the create
+    // succeeded and the form closed.
+    expect(screen.queryByText("transient list failure")).toBeNull();
+    await waitFor(() => expect(screen.queryByText("New Memory")).toBeNull());
+  });
+
+  it("first-memory probe doesn't clobber the user's filtered view", async () => {
+    // Iter-2 fix: when a tag filter is active, the post-create
+    // probe must not call setMemories(fresh.items) — that would
+    // jump the user out of their filter back to the unfiltered
+    // first page. Instead the path falls through to load() which
+    // re-fetches the current slice.
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+    // mount: filter "alpha" returns one memory.
+    // probe: unfiltered fetch returns 5 memories (some from other tags).
+    // post-create load: filter "alpha" returns the new + one existing.
+    api.listMemories
+      .mockResolvedValueOnce({ items: [makeMemory({ tags: ["alpha"] })], next_cursor: null })
+      .mockResolvedValueOnce({
+        items: [
+          makeMemory({ tags: ["alpha"] }),
+          makeMemory({ tags: ["beta"] }),
+          makeMemory({ tags: ["beta"] }),
+          makeMemory({ tags: ["beta"] }),
+          makeMemory({ tags: ["beta"] }),
+        ],
+        next_cursor: null,
+      })
+      .mockResolvedValueOnce({
+        items: [makeMemory({ tags: ["alpha"] }), makeMemory({ tags: ["alpha"] })],
+        next_cursor: null,
+      });
+
+    await act(async () => render(<MemoryBrowser />));
+    // Apply the alpha tag filter via the existing TagPicker — but
+    // we can also simulate it by dispatching the hive:memory-browser
+    // event the component listens for in production. For test
+    // simplicity, mount with a known tag filter via the event.
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new CustomEvent("hive:memory-browser", { detail: { tag: "alpha" } }),
+      );
+    });
+
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    // The third call (load() with filter) was made — listMemories
+    // received the "alpha" tag, not undefined.
+    const lastListCall = api.listMemories.mock.calls.at(-1);
+    expect(lastListCall[0]).toBe("alpha");
+  });
+
   it("subsequent creates don't re-fire the celebration toast once the flag is set", async () => {
     const sonner = await import("sonner");
     const toastSuccess = vi.spyOn(sonner.toast, "success").mockImplementation(() => {});

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -252,6 +252,7 @@ describe("MemoryBrowser", () => {
     // expects it (otherwise a previous test's create leaves the
     // flag set and the toast suppresses).
     localStorage.removeItem("hive_first_memory");
+    localStorage.removeItem("hive_first_memory_skipped");
     localStorage.removeItem("hive_tour_dismissed");
     api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
     api.searchMemories.mockResolvedValue({ items: [], count: 0 });
@@ -262,6 +263,7 @@ describe("MemoryBrowser", () => {
   afterEach(() => {
     vi.clearAllMocks();
     localStorage.removeItem("hive_first_memory");
+    localStorage.removeItem("hive_first_memory_skipped");
     localStorage.removeItem("hive_tour_dismissed");
   });
 
@@ -514,9 +516,42 @@ describe("MemoryBrowser", () => {
     );
 
     expect(toastSuccess).not.toHaveBeenCalled();
-    // Flag must NOT flip — otherwise a real future first-memory in
-    // a freshly-purged workspace would never celebrate.
+    // Celebration flag must NOT flip — that would suppress a real
+    // future first-memory celebration if the workspace ever drops
+    // back to a single item.
     expect(localStorage.getItem("hive_first_memory")).toBeNull();
+    // But the "skipped" flag MUST flip so subsequent creates don't
+    // re-probe the unfiltered list on every save.
+    expect(localStorage.getItem("hive_first_memory_skipped")).toBe("1");
+    toastSuccess.mockRestore();
+  });
+
+  it("respects the cached 'skipped' flag and doesn't re-probe on later creates", async () => {
+    // Iter-3 fix: existing-workspace users used to pay for an
+    // unfiltered listMemories on every create. The skipped flag
+    // suppresses the probe entirely until they clear it.
+    const sonner = await import("sonner");
+    const toastSuccess = vi.spyOn(sonner.toast, "success").mockImplementation(() => {});
+    localStorage.setItem("hive_first_memory_skipped", "1");
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+    api.listMemories.mockResolvedValue({ items: [makeMemory()], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    api.listMemories.mockClear(); // ignore the initial mount fetch
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    // Only the load() refresh should fire — no probe call.
+    expect(api.listMemories).toHaveBeenCalledTimes(1);
     toastSuccess.mockRestore();
   });
 

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -460,7 +460,11 @@ describe("MemoryBrowser", () => {
     const sonner = await import("sonner");
     const toastSuccess = vi.spyOn(sonner.toast, "success").mockImplementation(() => {});
     api.createMemory.mockResolvedValue({ memory_id: "new" });
-    api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
+    // Post-create reload returns the single new memory — that's the
+    // server-side "first in store" signal the toast gates on.
+    api.listMemories
+      .mockResolvedValueOnce({ items: [], next_cursor: null })
+      .mockResolvedValueOnce({ items: [makeMemory()], next_cursor: null });
 
     await act(async () => render(<MemoryBrowser />));
     fireEvent.click(screen.getByText("+ New"));
@@ -479,6 +483,40 @@ describe("MemoryBrowser", () => {
       expect.objectContaining({ description: expect.any(String) }),
     );
     expect(localStorage.getItem("hive_first_memory")).toBe("1");
+    toastSuccess.mockRestore();
+  });
+
+  it("does not fire the celebration toast when the store already has other memories", async () => {
+    // Existing user / multi-browser case: localStorage flag isn't
+    // set yet (this browser is fresh), but the workspace already
+    // has more than one memory. The toast must stay silent — and
+    // the flag should still flip so we don't keep re-checking.
+    const sonner = await import("sonner");
+    const toastSuccess = vi.spyOn(sonner.toast, "success").mockImplementation(() => {});
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+    api.listMemories
+      .mockResolvedValueOnce({ items: [makeMemory(), makeMemory()], next_cursor: null })
+      .mockResolvedValueOnce({
+        items: [makeMemory(), makeMemory(), makeMemory()],
+        next_cursor: null,
+      });
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    // Flag must NOT flip — otherwise a real future first-memory in
+    // a freshly-purged workspace would never celebrate.
+    expect(localStorage.getItem("hive_first_memory")).toBeNull();
     toastSuccess.mockRestore();
   });
 

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MemoryBrowser, { TagPicker } from "./MemoryBrowser.jsx";
 
@@ -247,6 +247,12 @@ describe("TagPicker", () => {
 describe("MemoryBrowser", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Clear localStorage flags between tests so the
+    // first-memory celebration toast fires for the test that
+    // expects it (otherwise a previous test's create leaves the
+    // flag set and the toast suppresses).
+    localStorage.removeItem("hive_first_memory");
+    localStorage.removeItem("hive_tour_dismissed");
     api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
     api.searchMemories.mockResolvedValue({ items: [], count: 0 });
     // Default to a shape without `items` so the `?? []` fallback is exercised.
@@ -255,6 +261,8 @@ describe("MemoryBrowser", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    localStorage.removeItem("hive_first_memory");
+    localStorage.removeItem("hive_tour_dismissed");
   });
 
   // Helpers
@@ -284,6 +292,18 @@ describe("MemoryBrowser", () => {
   it("renders empty state after load", async () => {
     await act(async () => render(<MemoryBrowser />));
     await waitFor(() => expect(screen.getByText("No memories yet")).toBeTruthy());
+  });
+
+  it("empty-state Open Setup CTA dispatches the tab-switch event", async () => {
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => expect(screen.getByText("No memories yet")).toBeTruthy());
+    const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+    fireEvent.click(screen.getByRole("button", { name: "Open Setup" }));
+    const switchEvents = dispatchSpy.mock.calls
+      .map((call) => call[0])
+      .filter((evt) => evt && evt.type === "hive:switch-tab");
+    expect(switchEvents.at(-1).detail).toBe("setup");
+    dispatchSpy.mockRestore();
   });
 
   it("renders loaded memories", async () => {
@@ -436,6 +456,56 @@ describe("MemoryBrowser", () => {
     await waitFor(() => expect(screen.queryByText("New Memory")).toBeNull());
   });
 
+  it("first successful create fires the celebration toast and sets the localStorage flag", async () => {
+    const sonner = await import("sonner");
+    const toastSuccess = vi.spyOn(sonner.toast, "success").mockImplementation(() => {});
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+    api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "First memory saved",
+      expect.objectContaining({ description: expect.any(String) }),
+    );
+    expect(localStorage.getItem("hive_first_memory")).toBe("1");
+    toastSuccess.mockRestore();
+  });
+
+  it("subsequent creates don't re-fire the celebration toast once the flag is set", async () => {
+    const sonner = await import("sonner");
+    const toastSuccess = vi.spyOn(sonner.toast, "success").mockImplementation(() => {});
+    localStorage.setItem("hive_first_memory", "1");
+    api.createMemory.mockResolvedValue({ memory_id: "new" });
+    api.listMemories.mockResolvedValue({ items: [], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    fireEvent.click(screen.getByText("+ New"));
+    fireEvent.change(screen.getByPlaceholderText("unique-key"), {
+      target: { value: "k" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Memory content…"), {
+      target: { value: "v" },
+    });
+    await act(async () =>
+      fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form")),
+    );
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    toastSuccess.mockRestore();
+    localStorage.removeItem("hive_first_memory");
+  });
+
   it("shows error when createMemory fails", async () => {
     api.createMemory.mockRejectedValue(new Error("Create error"));
     await act(async () => render(<MemoryBrowser />));
@@ -479,8 +549,9 @@ describe("MemoryBrowser", () => {
 
     // Clicking "Open Setup" dispatches the tab-switch event the App
     // shell listens for; banner should clear so it doesn't stick on
-    // the new tab.
-    fireEvent.click(screen.getByText("Open Setup"));
+    // the new tab. Scope to the banner because the empty-state CTA
+    // also has an "Open Setup" link when no memories exist.
+    fireEvent.click(within(banner).getByText("Open Setup"));
     const switchEvents = dispatchSpy.mock.calls
       .map((call) => call[0])
       .filter((evt) => evt && evt.type === "hive:switch-tab");
@@ -521,9 +592,9 @@ describe("MemoryBrowser", () => {
       await act(async () => {
         fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form"));
       });
-      await screen.findByTestId("quota-banner");
+      const banner = await screen.findByTestId("quota-banner");
 
-      fireEvent.click(screen.getByText("Open Setup"));
+      fireEvent.click(within(banner).getByText("Open Setup"));
       // Real setTimeout(0) — flush the macrotask queue.
       await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
 
@@ -556,8 +627,8 @@ describe("MemoryBrowser", () => {
     await act(async () => {
       fireEvent.submit(screen.getByPlaceholderText("unique-key").closest("form"));
     });
-    await screen.findByTestId("quota-banner");
-    fireEvent.click(screen.getByText("Open Setup"));
+    const banner = await screen.findByTestId("quota-banner");
+    fireEvent.click(within(banner).getByText("Open Setup"));
     // Flush the macrotask queue — the deferred `if (target)` branch
     // must no-op without throwing when #usage doesn't exist.
     await new Promise((resolve) => globalThis.setTimeout(resolve, 0));

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -59,10 +59,21 @@ export default function OnboardingTour({ isAdmin = false }) {
     return () => globalThis.removeEventListener("resize", onResize);
   }, [dismissed]);
 
-  if (dismissed) return null;
-
   const steps = isAdmin ? [...BASE_STEPS, ADMIN_STEP] : BASE_STEPS;
   const step = steps[stepIndex];
+
+  // Switch the underlying tab so the page content matches what the
+  // current step describes — otherwise the user reads "Connect your
+  // first agent" while still staring at the empty Memories list.
+  // Fires on every stepIndex change including initial mount.
+  useEffect(() => {
+    if (dismissed || !step) return;
+    globalThis.dispatchEvent(
+      new CustomEvent("hive:switch-tab", { detail: step.tabId }),
+    );
+  }, [dismissed, step]);
+
+  if (dismissed) return null;
   // `tick` is read here to keep the dependency array honest — the
   // resize listener bumps it to force a re-measure.
   void tick;
@@ -100,12 +111,19 @@ export default function OnboardingTour({ isAdmin = false }) {
       data-testid="onboarding-tour"
       className="fixed inset-0 z-[60] pointer-events-none"
     >
-      {/* Backdrop — click anywhere outside the tooltip to dismiss. */}
+      {/* Backdrop — click anywhere outside the tooltip to dismiss.
+          Transparent when the spotlight is rendering its own dimming
+          via box-shadow (avoids stacking two dim layers and
+          double-darkening the page). When `rect` is missing the
+          backdrop carries the dim itself so the user still sees a
+          tour overlay. */}
       <button
         type="button"
         aria-label="Dismiss onboarding tour"
         onClick={dismiss}
-        className="absolute inset-0 bg-black/40 pointer-events-auto cursor-pointer border-0 p-0"
+        className={`absolute inset-0 pointer-events-auto cursor-pointer border-0 p-0 ${
+          rect ? "bg-transparent" : "bg-black/40"
+        }`}
       />
       {/* Spotlight outline around the highlighted tab. */}
       {rect && (

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -65,6 +65,34 @@ export default function OnboardingTour({ isAdmin = false }) {
     return () => globalThis.removeEventListener("resize", onResize);
   }, [dismissed]);
 
+  // Escape-to-dismiss for keyboard users — matches the convention
+  // used by shadcn/ui's AlertDialog primitive without pulling in
+  // Radix for a 2-button overlay.
+  useEffect(() => {
+    if (dismissed) return undefined;
+    function onKey(e) {
+      if (e.key === "Escape") {
+        _markDismissed();
+        setDismissed(true);
+      }
+    }
+    globalThis.addEventListener("keydown", onKey);
+    return () => globalThis.removeEventListener("keydown", onKey);
+  }, [dismissed]);
+
+  // Focus the primary action when the tour mounts so keyboard
+  // users land inside the dialog without having to tab into it.
+  // Re-runs when the step changes so each step's primary control
+  // gets focus.
+  const cardRef = useRef(null);
+  useEffect(() => {
+    if (dismissed) return;
+    const primary = cardRef.current?.querySelector(
+      '[data-tour-primary="true"]',
+    );
+    if (primary && typeof primary.focus === "function") primary.focus();
+  }, [dismissed, stepIndex]);
+
   const steps = isAdmin ? [...BASE_STEPS, ADMIN_STEP] : BASE_STEPS;
   const step = steps[stepIndex];
 
@@ -158,7 +186,9 @@ export default function OnboardingTour({ isAdmin = false }) {
       )}
       {/* Tooltip card. */}
       <div
+        ref={cardRef}
         role="dialog"
+        aria-modal="true"
         aria-labelledby="onboarding-tour-title"
         data-testid="onboarding-tour-card"
         className="absolute pointer-events-auto bg-[var(--surface)] border border-[var(--border)] rounded-md shadow-lg p-4 max-w-[320px]"
@@ -188,7 +218,7 @@ export default function OnboardingTour({ isAdmin = false }) {
                 Back
               </Button>
             )}
-            <Button size="sm" onClick={next}>
+            <Button size="sm" onClick={next} data-tour-primary="true">
               {stepIndex >= steps.length - 1 ? "Got it" : "Next"}
             </Button>
           </div>

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useEffect, useState } from "react";
+import { Button } from "./ui/button.jsx";
+
+const DISMISSED_KEY = "hive_tour_dismissed";
+
+// Each step pairs a tab id (matched against `data-tab-id` on the
+// nav buttons) with a short blurb. The component finds the tab's
+// bounding rect at render time so we don't have to forwardRef
+// through the tab nav.
+const BASE_STEPS = [
+  {
+    tabId: "memories",
+    title: "Your memory store",
+    body: "Every memory your agent remembers lives here. Browse, search, and edit anything in this tab.",
+  },
+  {
+    tabId: "setup",
+    title: "Connect your first agent",
+    body: "Setup walks you through wiring Hive into Claude Code, ChatGPT, or any MCP client — start here on day one.",
+  },
+  {
+    tabId: "activity",
+    title: "See your agents at work",
+    body: "Every tool call lands here, with the agent name and timestamp, so you can audit what your agents are doing.",
+  },
+  {
+    tabId: "clients",
+    title: "Manage OAuth clients",
+    body: "Each MCP client registers an OAuth client here. Revoke access at any time.",
+  },
+];
+
+const ADMIN_STEP = {
+  tabId: "dashboard",
+  title: "Admin dashboard",
+  body: "CloudWatch metrics, cost data, and system health — only admins see this tab.",
+};
+
+export function _isDismissed() {
+  return !!localStorage.getItem(DISMISSED_KEY);
+}
+
+export function _markDismissed() {
+  localStorage.setItem(DISMISSED_KEY, "1");
+}
+
+export default function OnboardingTour({ isAdmin = false }) {
+  const [dismissed, setDismissed] = useState(_isDismissed);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [tick, setTick] = useState(0);
+
+  // Re-measure the spotlight rect on resize so the tooltip stays
+  // anchored to its tab when the viewport changes.
+  useEffect(() => {
+    if (dismissed) return undefined;
+    function onResize() { setTick((t) => t + 1); }
+    globalThis.addEventListener("resize", onResize);
+    return () => globalThis.removeEventListener("resize", onResize);
+  }, [dismissed]);
+
+  if (dismissed) return null;
+
+  const steps = isAdmin ? [...BASE_STEPS, ADMIN_STEP] : BASE_STEPS;
+  const step = steps[stepIndex];
+  // `tick` is read here to keep the dependency array honest — the
+  // resize listener bumps it to force a re-measure.
+  void tick;
+  const target = globalThis.document?.querySelector(
+    `[data-tab-id="${step.tabId}"]`,
+  );
+  const rect = target?.getBoundingClientRect();
+
+  function dismiss() {
+    _markDismissed();
+    setDismissed(true);
+  }
+
+  function next() {
+    if (stepIndex >= steps.length - 1) {
+      dismiss();
+      return;
+    }
+    setStepIndex(stepIndex + 1);
+  }
+
+  function back() {
+    if (stepIndex > 0) setStepIndex(stepIndex - 1);
+  }
+
+  // Position the tooltip below the highlighted tab. Falls back to
+  // top-of-viewport when the tab can't be found (e.g. mobile drawer
+  // closed) so the user still sees the overlay.
+  const tooltipStyle = rect
+    ? { top: rect.bottom + 12, left: Math.max(12, rect.left) }
+    : { top: 80, left: 16 };
+
+  return (
+    <div
+      data-testid="onboarding-tour"
+      className="fixed inset-0 z-[60] pointer-events-none"
+    >
+      {/* Backdrop — click anywhere outside the tooltip to dismiss. */}
+      <button
+        type="button"
+        aria-label="Dismiss onboarding tour"
+        onClick={dismiss}
+        className="absolute inset-0 bg-black/40 pointer-events-auto cursor-pointer border-0 p-0"
+      />
+      {/* Spotlight outline around the highlighted tab. */}
+      {rect && (
+        <div
+          aria-hidden="true"
+          className="absolute pointer-events-none rounded"
+          style={{
+            top: rect.top - 4,
+            left: rect.left - 4,
+            width: rect.width + 8,
+            height: rect.height + 8,
+            boxShadow: "0 0 0 9999px rgba(0,0,0,0.4), 0 0 0 3px var(--accent)",
+          }}
+        />
+      )}
+      {/* Tooltip card. */}
+      <div
+        role="dialog"
+        aria-labelledby="onboarding-tour-title"
+        data-testid="onboarding-tour-card"
+        className="absolute pointer-events-auto bg-[var(--surface)] border border-[var(--border)] rounded-md shadow-lg p-4 max-w-[320px]"
+        style={tooltipStyle}
+      >
+        <p
+          className="text-[11px] font-semibold tracking-[1px] text-[var(--text-muted)] uppercase mb-1"
+          aria-hidden="true"
+        >
+          Step {stepIndex + 1} of {steps.length}
+        </p>
+        <h3 id="onboarding-tour-title" className="text-base font-bold mb-2">
+          {step.title}
+        </h3>
+        <p className="text-[13px] text-[var(--text-muted)] mb-4">{step.body}</p>
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={dismiss}
+            className="text-[12px] text-[var(--text-muted)] underline cursor-pointer bg-transparent border-0 p-0"
+          >
+            Skip
+          </button>
+          <div className="flex gap-2">
+            {stepIndex > 0 && (
+              <Button variant="outline" size="sm" onClick={back}>
+                Back
+              </Button>
+            )}
+            <Button size="sm" onClick={next}>
+              {stepIndex >= steps.length - 1 ? "Got it" : "Next"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -65,13 +65,15 @@ export default function OnboardingTour({ isAdmin = false }) {
   // Switch the underlying tab so the page content matches what the
   // current step describes — otherwise the user reads "Connect your
   // first agent" while still staring at the empty Memories list.
-  // Fires on every stepIndex change including initial mount.
+  // Skip the initial dispatch (stepIndex === 0): the default tab is
+  // already "memories", so we'd just be firing a redundant tab_view
+  // analytics event for a tab the user is already on.
   useEffect(() => {
-    if (dismissed || !step) return;
+    if (dismissed || !step || stepIndex === 0) return;
     globalThis.dispatchEvent(
       new CustomEvent("hive:switch-tab", { detail: step.tabId }),
     );
-  }, [dismissed, step]);
+  }, [dismissed, step, stepIndex]);
 
   if (dismissed) return null;
   // `tick` is read here to keep the dependency array honest — the

--- a/ui/src/components/OnboardingTour.jsx
+++ b/ui/src/components/OnboardingTour.jsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button } from "./ui/button.jsx";
 
 const DISMISSED_KEY = "hive_tour_dismissed";
@@ -49,6 +49,12 @@ export default function OnboardingTour({ isAdmin = false }) {
   const [dismissed, setDismissed] = useState(_isDismissed);
   const [stepIndex, setStepIndex] = useState(0);
   const [tick, setTick] = useState(0);
+  // Track whether the step-change effect has run at least once so
+  // we can skip the very first dispatch (default tab is already
+  // "memories") without also skipping Back → step 1, which would
+  // leave the underlying tab on Setup while the spotlight is on
+  // Memories.
+  const didMountRef = useRef(false);
 
   // Re-measure the spotlight rect on resize so the tooltip stays
   // anchored to its tab when the viewport changes.
@@ -65,15 +71,21 @@ export default function OnboardingTour({ isAdmin = false }) {
   // Switch the underlying tab so the page content matches what the
   // current step describes — otherwise the user reads "Connect your
   // first agent" while still staring at the empty Memories list.
-  // Skip the initial dispatch (stepIndex === 0): the default tab is
-  // already "memories", so we'd just be firing a redundant tab_view
-  // analytics event for a tab the user is already on.
+  // Skip the *initial* render (default tab is already "memories",
+  // dispatching there would just fire a redundant tab_view), but
+  // not subsequent renders where stepIndex happens to land on 0
+  // again (Back from step 2 → step 1 still needs to re-sync the
+  // active tab).
   useEffect(() => {
-    if (dismissed || !step || stepIndex === 0) return;
+    if (dismissed || !step) return;
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
     globalThis.dispatchEvent(
       new CustomEvent("hive:switch-tab", { detail: step.tabId }),
     );
-  }, [dismissed, step, stepIndex]);
+  }, [dismissed, step]);
 
   if (dismissed) return null;
   // `tick` is read here to keep the dependency array honest — the
@@ -94,11 +106,14 @@ export default function OnboardingTour({ isAdmin = false }) {
       dismiss();
       return;
     }
-    setStepIndex(stepIndex + 1);
+    // Functional setState so a fast double-click can't compute
+    // both updates from the same captured `stepIndex` and skip a
+    // step.
+    setStepIndex((i) => i + 1);
   }
 
   function back() {
-    if (stepIndex > 0) setStepIndex(stepIndex - 1);
+    if (stepIndex > 0) setStepIndex((i) => i - 1);
   }
 
   // Position the tooltip below the highlighted tab. Falls back to

--- a/ui/src/components/OnboardingTour.test.jsx
+++ b/ui/src/components/OnboardingTour.test.jsx
@@ -123,6 +123,16 @@ describe("OnboardingTour", () => {
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(dispatched.at(-1)).toBe("activity");
 
+    // Back from step 3 → step 2 must re-dispatch "setup", and
+    // Back from step 2 → step 1 must re-dispatch "memories" so
+    // the underlying tab matches the spotlight even when the user
+    // walks backwards. (Iter-3 fix: skip-on-mount ref instead of
+    // skip-on-stepIndex-zero.)
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(dispatched.at(-1)).toBe("setup");
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(dispatched.at(-1)).toBe("memories");
+
     vi.restoreAllMocks();
   });
 

--- a/ui/src/components/OnboardingTour.test.jsx
+++ b/ui/src/components/OnboardingTour.test.jsx
@@ -103,7 +103,10 @@ describe("OnboardingTour", () => {
     expect(card.style.left).toBe("16px");
   });
 
-  it("dispatches hive:switch-tab on each step so the underlying tab matches the spotlight", async () => {
+  it("dispatches hive:switch-tab on step changes (skipping initial mount)", async () => {
+    // Initial mount doesn't dispatch — the default tab is already
+    // "memories", so a programmatic switch would just fire a
+    // redundant tab_view analytics event.
     const dispatched = [];
     const realDispatch = globalThis.dispatchEvent.bind(globalThis);
     vi.spyOn(globalThis, "dispatchEvent").mockImplementation((evt) => {
@@ -112,7 +115,7 @@ describe("OnboardingTour", () => {
     });
 
     await act(async () => render(<OnboardingTour />));
-    expect(dispatched.at(-1)).toBe("memories");
+    expect(dispatched).toEqual([]); // no initial dispatch
 
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(dispatched.at(-1)).toBe("setup");

--- a/ui/src/components/OnboardingTour.test.jsx
+++ b/ui/src/components/OnboardingTour.test.jsx
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import OnboardingTour from "./OnboardingTour.jsx";
+
+function setupTabAnchors() {
+  // The tour spotlights real tab buttons via [data-tab-id]. Render
+  // a stand-in nav into the document body so getBoundingClientRect
+  // returns a real DOMRect instead of zeroes.
+  for (const id of ["memories", "setup", "activity", "clients", "dashboard"]) {
+    const btn = document.createElement("button");
+    btn.setAttribute("data-tab-id", id);
+    btn.textContent = id;
+    document.body.appendChild(btn);
+  }
+}
+
+function teardownTabAnchors() {
+  document.querySelectorAll("[data-tab-id]").forEach((el) => el.remove());
+}
+
+describe("OnboardingTour", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setupTabAnchors();
+  });
+
+  afterEach(() => {
+    teardownTabAnchors();
+    localStorage.clear();
+  });
+
+  it("renders the tour on first visit and walks Memories → Setup → Activity → Clients", async () => {
+    await act(async () => render(<OnboardingTour />));
+    expect(screen.getByTestId("onboarding-tour-card")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Your memory store" })).toBeTruthy();
+    expect(screen.getByText("Step 1 of 4")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByRole("heading", { name: "Connect your first agent" })).toBeTruthy();
+    expect(screen.getByText("Step 2 of 4")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByRole("heading", { name: "See your agents at work" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByRole("heading", { name: "Manage OAuth clients" })).toBeTruthy();
+    // Last step: button label flips to "Got it" and clicking
+    // dismisses the tour (no Step 5).
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+    expect(screen.queryByTestId("onboarding-tour-card")).toBeNull();
+    expect(localStorage.getItem("hive_tour_dismissed")).toBe("1");
+  });
+
+  it("appends the admin Dashboard step when isAdmin", async () => {
+    await act(async () => render(<OnboardingTour isAdmin />));
+    expect(screen.getByText("Step 1 of 5")).toBeTruthy();
+    // Skip ahead to the admin step.
+    for (let i = 0; i < 4; i++) {
+      fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    }
+    expect(screen.getByRole("heading", { name: "Admin dashboard" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Got it" })).toBeTruthy();
+  });
+
+  it("Back button returns to the previous step", async () => {
+    await act(async () => render(<OnboardingTour />));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByText("Step 1 of 4")).toBeTruthy();
+    // Step 1 has no Back button (there's nothing to go back to).
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+  });
+
+  it("Skip dismisses the tour and persists the choice across reloads", async () => {
+    const { unmount } = render(<OnboardingTour />);
+    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+    expect(screen.queryByTestId("onboarding-tour-card")).toBeNull();
+    unmount();
+
+    // Re-mount: dismissed flag in localStorage prevents the tour
+    // from re-appearing.
+    await act(async () => render(<OnboardingTour />));
+    expect(screen.queryByTestId("onboarding-tour-card")).toBeNull();
+  });
+
+  it("clicking the backdrop dismisses the tour", async () => {
+    await act(async () => render(<OnboardingTour />));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss onboarding tour" }));
+    expect(screen.queryByTestId("onboarding-tour-card")).toBeNull();
+  });
+
+  it("falls back to top-of-viewport tooltip when the tab anchor is missing", async () => {
+    teardownTabAnchors(); // simulate mobile drawer closed / no nav rendered
+    await act(async () => render(<OnboardingTour />));
+    const card = screen.getByTestId("onboarding-tour-card");
+    // Fallback positions the card at top:80, left:16 — pin it so a
+    // regression that changes the fallback origin breaks the test.
+    expect(card.style.top).toBe("80px");
+    expect(card.style.left).toBe("16px");
+  });
+
+  it("re-measures the spotlight rect on window resize", async () => {
+    await act(async () => render(<OnboardingTour />));
+    // Move the anchor: a resize event should re-read its rect via
+    // the effect's setTick(). We can't easily assert the new
+    // position from jsdom, but we can verify the listener is wired
+    // by triggering and confirming the card still renders without
+    // throwing.
+    await act(async () => {
+      globalThis.dispatchEvent(new Event("resize"));
+    });
+    expect(screen.getByTestId("onboarding-tour-card")).toBeTruthy();
+  });
+});

--- a/ui/src/components/OnboardingTour.test.jsx
+++ b/ui/src/components/OnboardingTour.test.jsx
@@ -4,9 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OnboardingTour from "./OnboardingTour.jsx";
 
 function setupTabAnchors() {
-  // The tour spotlights real tab buttons via [data-tab-id]. Render
-  // a stand-in nav into the document body so getBoundingClientRect
-  // returns a real DOMRect instead of zeroes.
+  // The tour spotlights tab buttons via [data-tab-id]. In jsdom,
+  // appending stand-in buttons ensures those anchors exist in the
+  // document for the component to find via querySelector. jsdom
+  // still returns a zero-rect from getBoundingClientRect, so the
+  // tooltip ends up positioned at top:8 left:-4 — fine for asserting
+  // logic; visual positioning is only meaningful in a real browser.
   for (const id of ["memories", "setup", "activity", "clients", "dashboard"]) {
     const btn = document.createElement("button");
     btn.setAttribute("data-tab-id", id);
@@ -98,6 +101,26 @@ describe("OnboardingTour", () => {
     // regression that changes the fallback origin breaks the test.
     expect(card.style.top).toBe("80px");
     expect(card.style.left).toBe("16px");
+  });
+
+  it("dispatches hive:switch-tab on each step so the underlying tab matches the spotlight", async () => {
+    const dispatched = [];
+    const realDispatch = globalThis.dispatchEvent.bind(globalThis);
+    vi.spyOn(globalThis, "dispatchEvent").mockImplementation((evt) => {
+      if (evt && evt.type === "hive:switch-tab") dispatched.push(evt.detail);
+      return realDispatch(evt);
+    });
+
+    await act(async () => render(<OnboardingTour />));
+    expect(dispatched.at(-1)).toBe("memories");
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(dispatched.at(-1)).toBe("setup");
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(dispatched.at(-1)).toBe("activity");
+
+    vi.restoreAllMocks();
   });
 
   it("re-measures the spotlight rect on window resize", async () => {

--- a/ui/src/components/OnboardingTour.test.jsx
+++ b/ui/src/components/OnboardingTour.test.jsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OnboardingTour from "./OnboardingTour.jsx";
 
@@ -134,6 +134,44 @@ describe("OnboardingTour", () => {
     expect(dispatched.at(-1)).toBe("memories");
 
     vi.restoreAllMocks();
+  });
+
+  it("Escape key dismisses the tour", async () => {
+    await act(async () => render(<OnboardingTour />));
+    await act(async () => {
+      globalThis.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(screen.queryByTestId("onboarding-tour-card")).toBeNull();
+    expect(localStorage.getItem("hive_tour_dismissed")).toBe("1");
+  });
+
+  it("ignores non-Escape keys", async () => {
+    // Defensive — covers the `if (e.key === 'Escape')` branch
+    // false path so a regression that broadens the dismiss key
+    // (e.g. any key) is caught.
+    await act(async () => render(<OnboardingTour />));
+    await act(async () => {
+      globalThis.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    });
+    expect(screen.getByTestId("onboarding-tour-card")).toBeTruthy();
+  });
+
+  it("focuses the primary action on mount and on each step change", async () => {
+    await act(async () => render(<OnboardingTour />));
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toBe("Next");
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toBe("Next");
+    });
+  });
+
+  it("renders the dialog with aria-modal so screen readers trap focus", async () => {
+    await act(async () => render(<OnboardingTour />));
+    const card = screen.getByTestId("onboarding-tour-card");
+    expect(card.getAttribute("role")).toBe("dialog");
+    expect(card.getAttribute("aria-modal")).toBe("true");
   });
 
   it("re-measures the spotlight rect on window resize", async () => {


### PR DESCRIPTION
Closes #429

## Summary

Three onboarding nudges replacing the cold landing experience:

- **`OnboardingTour.jsx`** — ~150-line in-house tour overlay that fires on first visit (dismissed flag persisted in `localStorage`). Walks the user through Memories → Setup → Activity Log → OAuth Clients, with an extra Dashboard step for admins. Each step spotlights the relevant tab via a `[data-tab-id]` selector + computed bounding rect so we don&#39;t have to forwardRef through the AppShell nav. Skip / Back / Next / Got it controls; backdrop click also dismisses.
- **MemoryBrowser empty state** — was a single line ("Use the remember tool in your MCP client"). Now points users at the Setup tab with an Open Setup button alongside the existing + New Memory action. Reuses the existing `hive:switch-tab` event the AppShell listens for.
- **First-memory celebration** — Sonner toast fires once per user when the first create succeeds (gated on a `localStorage` flag so subsequent creates don&#39;t spam). Sonner was already wired via the `Toaster` mount in App.jsx; this is the first place that calls `toast(...)`.

## Approach

- **In-house tour** rather than a dep — driver.js / shepherd.js would each pull ~30KB+ of code and theming for ~150 lines of behaviour we can write directly. Spotlight is a CSS box-shadow trick (`0 0 0 9999px rgba(0,0,0,0.4)`) so we don&#39;t have to clip-path or render a separate overlay per step.
- **Spotlight by data attribute** — `data-tab-id` on the nav buttons keeps the tour decoupled from the AppShell&#39;s tab-switching logic; the spotlight just queries the DOM at render time.
- **Skipped the issue&#39;s Phase 3 server-side onboarding state** — that needs a `User` model change + new API endpoints + scope decisions, which is a separate `size:m` on its own. `localStorage`-only is good enough for v1; we can promote to server-side later when we want to measure the activation funnel.
- Local e2e not run — the local stack isn&#39;t up in this session. The dev pipeline e2e covers UI flows on push to `development`.

## Test plan

- [x] `OnboardingTour.test.jsx` — 7 tests: full step walk, admin Dashboard step appears for admins, Back returns to previous step, Skip + backdrop both dismiss + persist, fallback positioning when tab anchor is missing, resize re-measures rect.
- [x] `MemoryBrowser.test.jsx` — new tests: empty-state Open Setup CTA dispatches `hive:switch-tab`; first create fires the celebration toast and sets the flag; subsequent creates don&#39;t re-fire. Existing 429-banner tests scoped to `within(banner)` because the empty-state CTA also has an "Open Setup" link now.
- [x] `uv run inv pre-push` clean (784 frontend tests, +10 new; 100% coverage maintained).

Per §7.5, auto-merge will arm after the Copilot loop resolves.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb