### PR TITLE
feat: public /roadmap page — client-fetched from GitHub issues

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -21,6 +21,7 @@ import LoginPage from "./components/LoginPage.jsx";
 import McpClientsPage from "./components/McpClientsPage.jsx";
 import OnboardingTour from "./components/OnboardingTour.jsx";
 import PricingPage from "./components/PricingPage.jsx";
+import RoadmapPage from "./components/RoadmapPage.jsx";
 import StatusPage from "./components/StatusPage.jsx";
 import UseCasesPage from "./components/UseCasesPage.jsx";
 import ApiKeysPanel from "./components/ApiKeysPanel.jsx";
@@ -277,6 +278,7 @@ export default function App() {
           <Route path="/use-cases" element={<UseCasesPage />} />
           <Route path="/clients" element={<McpClientsPage />} />
           <Route path="/changelog" element={<ChangelogPage />} />
+          <Route path="/roadmap" element={<RoadmapPage />} />
           <Route path="/status" element={<StatusPage />} />
           <Route path="/terms" element={<TermsPage />} />
           <Route path="/privacy" element={<PrivacyPage />} />

--- a/ui/src/components/PageLayout.jsx
+++ b/ui/src/components/PageLayout.jsx
@@ -154,6 +154,7 @@ export default function PageLayout({ children }) {
               <a href="/pricing" className="no-underline hover:text-[var(--text)] transition-colors">Pricing</a>
               <a href="/faq" className="no-underline hover:text-[var(--text)] transition-colors">FAQ</a>
               <a href="/docs/" className="no-underline hover:text-[var(--text)] transition-colors">Docs</a>
+              <a href="/roadmap" className="no-underline hover:text-[var(--text)] transition-colors">Roadmap</a>
               <a href="/changelog" className="no-underline hover:text-[var(--text)] transition-colors">Changelog</a>
               <a href="/status" className="no-underline hover:text-[var(--text)] transition-colors">Status</a>
               <a href="/terms" className="no-underline hover:text-[var(--text)] transition-colors">Terms</a>

--- a/ui/src/components/RoadmapPage.jsx
+++ b/ui/src/components/RoadmapPage.jsx
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React, { useEffect, useMemo, useState } from "react";
+import PageLayout from "@/components/PageLayout";
+
+// Public GitHub REST API — unauth, limited to 60/hr per IP. The
+// marketing site is cacheable behind CloudFront, so in practice we
+// hit this endpoint far less than the limit.
+const ISSUES_URL =
+  "https://api.github.com/repos/warlordofmars/hive/issues?" +
+  "labels=public-roadmap&state=all&per_page=100";
+
+// Columns map to `status:<col>` labels on each issue. Shipped = closed
+// regardless of status label so recently-merged work shows up
+// automatically without a manual label flip.
+const COLUMNS = [
+  { id: "now", title: "Now", blurb: "In progress — landing soon." },
+  { id: "next", title: "Next", blurb: "Planned for the next release or two." },
+  { id: "later", title: "Later", blurb: "On the backlog — we'll get to it." },
+  { id: "shipped", title: "Shipped", blurb: "Already live — recent highlights." },
+];
+
+// Exported for unit testing in isolation. Takes the raw GitHub
+// issues payload and returns a `{columnId: [issue, ...]}` map.
+export function _bucketByColumn(issues) {
+  const buckets = { now: [], next: [], later: [], shipped: [] };
+  for (const issue of issues) {
+    if (issue.state === "closed") {
+      buckets.shipped.push(issue);
+      continue;
+    }
+    const labels = (issue.labels ?? []).map((l) =>
+      typeof l === "string" ? l : l.name,
+    );
+    if (labels.includes("status:now")) buckets.now.push(issue);
+    else if (labels.includes("status:next")) buckets.next.push(issue);
+    else if (labels.includes("status:later")) buckets.later.push(issue);
+    // Items with `public-roadmap` but no status label are
+    // intentionally omitted — the roadmap is curated, not a dump
+    // of every tagged issue.
+  }
+  // Shipped column is time-ordered desc (most-recent first), capped
+  // to the last 8 so the marketing page doesn't scroll forever.
+  buckets.shipped.sort((a, b) =>
+    (b.closed_at ?? "").localeCompare(a.closed_at ?? ""),
+  );
+  buckets.shipped = buckets.shipped.slice(0, 8);
+  return buckets;
+}
+
+// Area label → short tag rendered on each card. Derived per issue so
+// cards group visually at a glance.
+function _pickArea(issue) {
+  const known = [
+    "ui",
+    "ux",
+    "a11y",
+    "api",
+    "mcp",
+    "auth",
+    "infra",
+    "docs",
+    "security",
+    "performance",
+    "observability",
+    "growth",
+  ];
+  const labels = (issue.labels ?? []).map((l) =>
+    typeof l === "string" ? l : l.name,
+  );
+  return labels.find((l) => known.includes(l)) ?? null;
+}
+
+function RoadmapCard({ issue }) {
+  const area = _pickArea(issue);
+  const reactions = issue.reactions?.total_count ?? 0;
+  return (
+    <li className="border border-[var(--border)] rounded p-3 bg-[var(--surface)] flex flex-col gap-2">
+      <a
+        href={issue.html_url}
+        target="_blank"
+        rel="noreferrer"
+        className="text-[var(--text)] no-underline hover:text-[var(--accent)]"
+      >
+        <h3 className="text-[15px] font-semibold leading-snug m-0">
+          {issue.title}
+        </h3>
+      </a>
+      <div className="flex items-center justify-between gap-2 text-[12px] text-[var(--text-muted)]">
+        {area ? <span>{area}</span> : <span aria-hidden="true" />}
+        {reactions > 0 && (
+          <span aria-label={`${reactions} upvotes on GitHub`}>
+            +{reactions}
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export default function RoadmapPage() {
+  const [state, setState] = useState({ status: "loading", issues: [] });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(ISSUES_URL, { headers: { Accept: "application/vnd.github+json" } })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((issues) => {
+        if (!cancelled) setState({ status: "ok", issues });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: "error", issues: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const buckets = useMemo(() => _bucketByColumn(state.issues), [state.issues]);
+
+  return (
+    <PageLayout>
+      <section className="max-w-[1100px] mx-auto px-4 md:px-8 py-12 md:py-16">
+        <h1 className="text-3xl md:text-4xl font-bold mb-3">Roadmap</h1>
+        <p className="text-[var(--text-muted)] max-w-[640px] mb-10">
+          What we&rsquo;re working on, what&rsquo;s next, and what&rsquo;s
+          recently shipped. Click any item to read or upvote the GitHub
+          issue — reactions on the issue feed directly into prioritisation.
+        </p>
+
+        {state.status === "loading" && (
+          <p className="text-[var(--text-muted)]" role="status">
+            Loading roadmap…
+          </p>
+        )}
+
+        {state.status === "error" && (
+          <p className="text-[var(--danger)]" role="alert">
+            Couldn&rsquo;t reach GitHub. You can still view the roadmap
+            directly on{" "}
+            <a
+              href="https://github.com/warlordofmars/hive/issues?q=is%3Aissue%20label%3Apublic-roadmap"
+              target="_blank"
+              rel="noreferrer"
+              className="text-[var(--accent)] underline"
+            >
+              our GitHub repo
+            </a>
+            .
+          </p>
+        )}
+
+        {state.status === "ok" && (
+          <div
+            data-testid="roadmap-columns"
+            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6"
+          >
+            {COLUMNS.map((col) => (
+              <div key={col.id} data-testid={`roadmap-col-${col.id}`}>
+                <h2 className="text-lg font-bold mb-1">{col.title}</h2>
+                <p className="text-[12px] text-[var(--text-muted)] mb-3">
+                  {col.blurb}
+                </p>
+                {buckets[col.id].length === 0 ? (
+                  <p className="text-[13px] text-[var(--text-muted)] italic">
+                    Nothing here yet.
+                  </p>
+                ) : (
+                  <ul className="flex flex-col gap-2 list-none m-0 p-0">
+                    {buckets[col.id].map((issue) => (
+                      <RoadmapCard key={issue.id} issue={issue} />
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </PageLayout>
+  );
+}

--- a/ui/src/components/RoadmapPage.jsx
+++ b/ui/src/components/RoadmapPage.jsx
@@ -2,16 +2,22 @@
 import React, { useEffect, useMemo, useState } from "react";
 import PageLayout from "@/components/PageLayout";
 
-// Public GitHub REST API — unauth, limited to 60/hr per IP. The
-// marketing site is cacheable behind CloudFront, so in practice we
-// hit this endpoint far less than the limit.
+// Public GitHub REST API — unauth, rate-limited per caller (the
+// visitor's IP, not our CloudFront edge, because the browser calls
+// api.github.com directly). 60 req/hour in the unauth quota is
+// plenty for a marketing page; browser HTTP caching + GitHub's
+// ETag revalidation further reduce real traffic.
 const ISSUES_URL =
   "https://api.github.com/repos/warlordofmars/hive/issues?" +
   "labels=public-roadmap&state=all&per_page=100";
 
-// Columns map to `status:<col>` labels on each issue. Shipped = closed
-// regardless of status label so recently-merged work shows up
-// automatically without a manual label flip.
+// Columns map to `roadmap:<col>` labels on each issue. We deliberately
+// use a dedicated `roadmap:*` namespace rather than reusing the
+// existing `status:*` labels (which `label-check.yml` already treats
+// as the required backlog-workflow status — `status:ready`,
+// `status:blocked`, `status:needs-info`, `status:design-needed`).
+// Shipped column is closed-state regardless of label so recently-
+// merged work shows up automatically without a manual label flip.
 const COLUMNS = [
   { id: "now", title: "Now", blurb: "In progress — landing soon." },
   { id: "next", title: "Next", blurb: "Planned for the next release or two." },
@@ -19,22 +25,40 @@ const COLUMNS = [
   { id: "shipped", title: "Shipped", blurb: "Already live — recent highlights." },
 ];
 
+// Known area labels — kept in sync with the taxonomy in CLAUDE.md
+// (§Backlog labels and milestones → Area).
+const AREA_LABELS = [
+  "ui", "ux", "a11y", "api", "mcp", "auth", "infra", "ci", "dx", "sdk",
+  "security", "compliance", "docs", "design", "performance",
+  "observability", "marketing", "seo", "growth", "ops", "reliability",
+];
+
+// GitHub labels can come as either `{name: "foo"}` objects or bare
+// strings depending on the payload shape. Normalise here so callers
+// can always treat them as strings.
+function _labelNames(issue) {
+  const raw = issue.labels ?? [];
+  return raw.map((l) => (typeof l === "string" ? l : l.name));
+}
+
 // Exported for unit testing in isolation. Takes the raw GitHub
 // issues payload and returns a `{columnId: [issue, ...]}` map.
 export function _bucketByColumn(issues) {
   const buckets = { now: [], next: [], later: [], shipped: [] };
   for (const issue of issues) {
+    // GitHub's /issues endpoint returns PRs too (they share an id
+    // space) — skip anything with a `pull_request` field so the
+    // roadmap doesn't accidentally surface code-review work.
+    if (issue.pull_request) continue;
     if (issue.state === "closed") {
       buckets.shipped.push(issue);
       continue;
     }
-    const labels = (issue.labels ?? []).map((l) =>
-      typeof l === "string" ? l : l.name,
-    );
-    if (labels.includes("status:now")) buckets.now.push(issue);
-    else if (labels.includes("status:next")) buckets.next.push(issue);
-    else if (labels.includes("status:later")) buckets.later.push(issue);
-    // Items with `public-roadmap` but no status label are
+    const labels = _labelNames(issue);
+    if (labels.includes("roadmap:now")) buckets.now.push(issue);
+    else if (labels.includes("roadmap:next")) buckets.next.push(issue);
+    else if (labels.includes("roadmap:later")) buckets.later.push(issue);
+    // Items with `public-roadmap` but no roadmap:* label are
     // intentionally omitted — the roadmap is curated, not a dump
     // of every tagged issue.
   }
@@ -50,24 +74,8 @@ export function _bucketByColumn(issues) {
 // Area label → short tag rendered on each card. Derived per issue so
 // cards group visually at a glance.
 function _pickArea(issue) {
-  const known = [
-    "ui",
-    "ux",
-    "a11y",
-    "api",
-    "mcp",
-    "auth",
-    "infra",
-    "docs",
-    "security",
-    "performance",
-    "observability",
-    "growth",
-  ];
-  const labels = (issue.labels ?? []).map((l) =>
-    typeof l === "string" ? l : l.name,
-  );
-  return labels.find((l) => known.includes(l)) ?? null;
+  const labels = _labelNames(issue);
+  return labels.find((l) => AREA_LABELS.includes(l)) ?? null;
 }
 
 function RoadmapCard({ issue }) {

--- a/ui/src/components/RoadmapPage.test.jsx
+++ b/ui/src/components/RoadmapPage.test.jsx
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import RoadmapPage, { _bucketByColumn } from "./RoadmapPage.jsx";
+
+function mockFetchOk(payload) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(payload),
+    }),
+  );
+}
+
+function issue(partial) {
+  return {
+    id: partial.id ?? Math.random(),
+    number: partial.number ?? 1,
+    title: partial.title ?? "Untitled",
+    state: partial.state ?? "open",
+    html_url: partial.html_url ?? "https://github.com/warlordofmars/hive/issues/1",
+    labels: (partial.labels ?? []).map((name) => ({ name })),
+    reactions: partial.reactions ?? { total_count: 0 },
+    closed_at: partial.closed_at ?? null,
+  };
+}
+
+function renderInRouter() {
+  return render(
+    <MemoryRouter>
+      <RoadmapPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("RoadmapPage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the heading and intro copy", async () => {
+    mockFetchOk([]);
+    await act(async () => renderInRouter());
+    expect(screen.getByRole("heading", { name: "Roadmap" })).toBeTruthy();
+    expect(screen.getByText(/reactions on the issue feed directly/i)).toBeTruthy();
+  });
+
+  it("shows a loading indicator while the fetch is in flight", () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    renderInRouter();
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText("Loading roadmap…")).toBeTruthy();
+  });
+
+  it("shows an error message with a GitHub fallback link when the fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+    const link = screen.getByRole("link", { name: /our GitHub repo/i });
+    expect(link.getAttribute("href")).toContain("label%3Apublic-roadmap");
+  });
+
+  it("falls back to the error branch when fetch itself rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+  });
+
+  it("renders Now / Next / Later / Shipped columns with their issues", async () => {
+    mockFetchOk([
+      issue({ id: 1, title: "Alpha now", labels: ["public-roadmap", "status:now"] }),
+      issue({ id: 2, title: "Beta next", labels: ["public-roadmap", "status:next"] }),
+      issue({ id: 3, title: "Gamma later", labels: ["public-roadmap", "status:later"] }),
+      issue({
+        id: 4,
+        title: "Delta shipped",
+        state: "closed",
+        labels: ["public-roadmap"],
+        closed_at: "2026-04-20T00:00:00Z",
+      }),
+    ]);
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByTestId("roadmap-columns")).toBeTruthy());
+
+    const now = within(screen.getByTestId("roadmap-col-now"));
+    expect(now.getByText("Alpha now")).toBeTruthy();
+    const next = within(screen.getByTestId("roadmap-col-next"));
+    expect(next.getByText("Beta next")).toBeTruthy();
+    const later = within(screen.getByTestId("roadmap-col-later"));
+    expect(later.getByText("Gamma later")).toBeTruthy();
+    const shipped = within(screen.getByTestId("roadmap-col-shipped"));
+    expect(shipped.getByText("Delta shipped")).toBeTruthy();
+  });
+
+  it("renders empty columns with a 'Nothing here yet' placeholder", async () => {
+    mockFetchOk([]);
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByTestId("roadmap-columns")).toBeTruthy());
+    const placeholders = screen.getAllByText("Nothing here yet.");
+    expect(placeholders).toHaveLength(4);
+  });
+
+  it("card links open the GitHub issue in a new tab", async () => {
+    mockFetchOk([
+      issue({
+        id: 1,
+        title: "Item with link",
+        labels: ["public-roadmap", "status:now"],
+        html_url: "https://github.com/warlordofmars/hive/issues/42",
+      }),
+    ]);
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByTestId("roadmap-columns")).toBeTruthy());
+    const link = screen.getByRole("link", { name: "Item with link" });
+    expect(link.getAttribute("href")).toBe("https://github.com/warlordofmars/hive/issues/42");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noreferrer");
+  });
+
+  it("shows reaction count on cards that have upvotes", async () => {
+    mockFetchOk([
+      issue({
+        id: 1,
+        title: "Popular item",
+        labels: ["public-roadmap", "status:now"],
+        reactions: { total_count: 17 },
+      }),
+      issue({
+        id: 2,
+        title: "Lonely item",
+        labels: ["public-roadmap", "status:now"],
+        reactions: { total_count: 0 },
+      }),
+    ]);
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByTestId("roadmap-columns")).toBeTruthy());
+    expect(screen.getByText("+17")).toBeTruthy();
+    // Zero-reaction item shouldn't render a +0 badge.
+    expect(screen.queryByText("+0")).toBeNull();
+  });
+
+  it("shows the area tag when an issue has a known area label", async () => {
+    mockFetchOk([
+      issue({
+        id: 1,
+        title: "UI item",
+        labels: ["public-roadmap", "status:now", "ui"],
+      }),
+      issue({
+        id: 2,
+        title: "Obscure area item",
+        labels: ["public-roadmap", "status:now", "random-label"],
+      }),
+    ]);
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByTestId("roadmap-columns")).toBeTruthy());
+    expect(screen.getByText("ui")).toBeTruthy();
+    // Unknown area labels don't render.
+    expect(screen.queryByText("random-label")).toBeNull();
+  });
+
+  describe("_bucketByColumn", () => {
+    it("drops open issues without a status label", () => {
+      const buckets = _bucketByColumn([issue({ labels: ["public-roadmap"] })]);
+      expect(buckets.now).toHaveLength(0);
+      expect(buckets.next).toHaveLength(0);
+      expect(buckets.later).toHaveLength(0);
+      expect(buckets.shipped).toHaveLength(0);
+    });
+
+    it("caps the shipped column at 8 items, most-recent first", () => {
+      const twelve = Array.from({ length: 12 }, (_, i) =>
+        issue({
+          id: 100 + i,
+          state: "closed",
+          closed_at: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+          labels: ["public-roadmap"],
+        }),
+      );
+      const { shipped } = _bucketByColumn(twelve);
+      expect(shipped).toHaveLength(8);
+      // Most recent is the item closed 2026-04-12 (index 11).
+      expect(shipped[0].id).toBe(111);
+    });
+
+    it("handles labels provided as plain strings (not {name} objects)", () => {
+      const buckets = _bucketByColumn([
+        {
+          id: 1,
+          state: "open",
+          labels: ["public-roadmap", "status:now"],
+        },
+      ]);
+      expect(buckets.now).toHaveLength(1);
+    });
+
+    it("handles missing labels array defensively", () => {
+      const buckets = _bucketByColumn([
+        { id: 1, state: "open" },
+        { id: 2, state: "closed", closed_at: "2026-04-01T00:00:00Z" },
+      ]);
+      expect(buckets.now).toHaveLength(0);
+      // Closed issues flow into Shipped regardless of labels.
+      expect(buckets.shipped).toHaveLength(1);
+    });
+  });
+});

--- a/ui/src/components/RoadmapPage.test.jsx
+++ b/ui/src/components/RoadmapPage.test.jsx
@@ -72,9 +72,9 @@ describe("RoadmapPage", () => {
 
   it("renders Now / Next / Later / Shipped columns with their issues", async () => {
     mockFetchOk([
-      issue({ id: 1, title: "Alpha now", labels: ["public-roadmap", "status:now"] }),
-      issue({ id: 2, title: "Beta next", labels: ["public-roadmap", "status:next"] }),
-      issue({ id: 3, title: "Gamma later", labels: ["public-roadmap", "status:later"] }),
+      issue({ id: 1, title: "Alpha now", labels: ["public-roadmap", "roadmap:now"] }),
+      issue({ id: 2, title: "Beta next", labels: ["public-roadmap", "roadmap:next"] }),
+      issue({ id: 3, title: "Gamma later", labels: ["public-roadmap", "roadmap:later"] }),
       issue({
         id: 4,
         title: "Delta shipped",
@@ -109,7 +109,7 @@ describe("RoadmapPage", () => {
       issue({
         id: 1,
         title: "Item with link",
-        labels: ["public-roadmap", "status:now"],
+        labels: ["public-roadmap", "roadmap:now"],
         html_url: "https://github.com/warlordofmars/hive/issues/42",
       }),
     ]);
@@ -121,18 +121,38 @@ describe("RoadmapPage", () => {
     expect(link.getAttribute("rel")).toBe("noreferrer");
   });
 
+  it("handles a missing reactions field on the card", async () => {
+    // Covers the `issue.reactions?.total_count ?? 0` fallback when
+    // GitHub omits the reactions object entirely (older API
+    // responses, cached CDN payload, etc.). The +N badge must not
+    // render and the card must not crash.
+    mockFetchOk([
+      {
+        ...issue({
+          id: 1,
+          title: "Reactionless item",
+          labels: ["public-roadmap", "roadmap:now"],
+        }),
+        reactions: undefined,
+      },
+    ]);
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByTestId("roadmap-columns")).toBeTruthy());
+    expect(screen.getByText("Reactionless item")).toBeTruthy();
+  });
+
   it("shows reaction count on cards that have upvotes", async () => {
     mockFetchOk([
       issue({
         id: 1,
         title: "Popular item",
-        labels: ["public-roadmap", "status:now"],
+        labels: ["public-roadmap", "roadmap:now"],
         reactions: { total_count: 17 },
       }),
       issue({
         id: 2,
         title: "Lonely item",
-        labels: ["public-roadmap", "status:now"],
+        labels: ["public-roadmap", "roadmap:now"],
         reactions: { total_count: 0 },
       }),
     ]);
@@ -148,12 +168,12 @@ describe("RoadmapPage", () => {
       issue({
         id: 1,
         title: "UI item",
-        labels: ["public-roadmap", "status:now", "ui"],
+        labels: ["public-roadmap", "roadmap:now", "ui"],
       }),
       issue({
         id: 2,
         title: "Obscure area item",
-        labels: ["public-roadmap", "status:now", "random-label"],
+        labels: ["public-roadmap", "roadmap:now", "random-label"],
       }),
     ]);
     await act(async () => renderInRouter());
@@ -192,7 +212,7 @@ describe("RoadmapPage", () => {
         {
           id: 1,
           state: "open",
-          labels: ["public-roadmap", "status:now"],
+          labels: ["public-roadmap", "roadmap:now"],
         },
       ]);
       expect(buckets.now).toHaveLength(1);
@@ -207,5 +227,83 @@ describe("RoadmapPage", () => {
       // Closed issues flow into Shipped regardless of labels.
       expect(buckets.shipped).toHaveLength(1);
     });
+
+    it("tolerates a missing closed_at on the shipped sort key", () => {
+      // Defensive — GitHub sometimes returns closed issues without
+      // a closed_at timestamp (edge case). Cover both sides of the
+      // `?? ""` fallback: a pair where only one side is dated, and
+      // a pair where neither side is dated.
+      const partial = _bucketByColumn([
+        { id: 1, state: "closed", closed_at: "2026-04-20T00:00:00Z", labels: [] },
+        { id: 2, state: "closed", labels: [] }, // no closed_at
+      ]);
+      expect(partial.shipped).toHaveLength(2);
+      // The dated one sorts before the undated one (empty-string
+      // comparator puts undated last).
+      expect(partial.shipped[0].id).toBe(1);
+
+      // Both-undated: the sort still runs but doesn't reorder.
+      const both = _bucketByColumn([
+        { id: 10, state: "closed", labels: [] },
+        { id: 11, state: "closed", labels: [] },
+      ]);
+      expect(both.shipped).toHaveLength(2);
+    });
+
+    it("filters out pull requests from the /issues payload", () => {
+      // GitHub's /issues endpoint returns PRs too (shared id space).
+      // Anything with a `pull_request` field is a PR and must be
+      // dropped regardless of state or labels so code-review work
+      // never leaks onto the public marketing roadmap.
+      const buckets = _bucketByColumn([
+        issue({
+          id: 1,
+          title: "Real issue",
+          state: "closed",
+          closed_at: "2026-04-21T00:00:00Z",
+          labels: ["public-roadmap"],
+        }),
+        {
+          ...issue({
+            id: 2,
+            title: "PR in disguise",
+            state: "closed",
+            closed_at: "2026-04-21T01:00:00Z",
+            labels: ["public-roadmap", "roadmap:now"],
+          }),
+          pull_request: { url: "https://api.github.com/..." },
+        },
+      ]);
+      expect(buckets.shipped).toHaveLength(1);
+      expect(buckets.shipped[0].title).toBe("Real issue");
+      expect(buckets.now).toHaveLength(0);
+    });
+  });
+
+  it("renders an area tag for every known area in the taxonomy", async () => {
+    // Regression for the Copilot-flagged drift between the roadmap
+    // allowlist and CLAUDE.md's taxonomy. Render one issue per
+    // known area label and verify each tag surfaces — catches the
+    // case where someone adds a new area to CLAUDE.md but forgets
+    // to update the component constant.
+    const ALL_AREAS = [
+      "ui", "ux", "a11y", "api", "mcp", "auth", "infra", "ci", "dx", "sdk",
+      "security", "compliance", "docs", "design", "performance",
+      "observability", "marketing", "seo", "growth", "ops", "reliability",
+    ];
+    mockFetchOk(
+      ALL_AREAS.map((area, i) =>
+        issue({
+          id: i + 1,
+          title: `Issue-${area}`,
+          labels: ["public-roadmap", "roadmap:now", area],
+        }),
+      ),
+    );
+    await act(async () => renderInRouter());
+    await waitFor(() => expect(screen.getByTestId("roadmap-columns")).toBeTruthy());
+    for (const area of ALL_AREAS) {
+      expect(screen.getByText(area)).toBeTruthy();
+    }
   });
 });


### PR DESCRIPTION
Closes #430

## Summary

Ships a public `/roadmap` page — Option B of the three the issue laid out. Custom on-brand React page that fetches open + recently-closed issues with the `public-roadmap` label from GitHub&#39;s public REST API at render time and buckets them into **Now / Next / Later / Shipped** columns based on `status:*` labels.

Each card links to the underlying GitHub issue so reactions (`+1` emoji) feed directly into prioritisation. Footer link wired into `PageLayout.jsx` so the page is discoverable from every marketing surface.

## Approach

- **Client-side fetch** over build-time generation: GitHub&#39;s unauth REST endpoint is rate-limited to 60/hr per IP, which is plenty for a marketing page — and users get freshness without waiting on a site rebuild.
- **Curated, not a dump**: issues with `public-roadmap` but no `status:*` label are intentionally omitted. The roadmap is what we&#39;re choosing to communicate, not every tagged issue.
- **Shipped column is time-bounded**: sorted by `closed_at` desc and capped to the 8 most-recent items so the page doesn&#39;t scroll forever.
- **Area tags** (`ui`, `api`, `auth`, etc.) surface on each card so related work groups visually. Unknown labels are hidden.
- **Error state** points users at the raw GitHub search URL as a fallback when the fetch fails.
- Label conventions (`public-roadmap` + `status:now/next/later` + area labels) follow the existing CLAUDE.md taxonomy. Actually labelling issues for the roadmap is a follow-up the human owner can do incrementally — the page renders an empty state until there&#39;s content to show.
- Local e2e not run — local stack not up in this session. CI e2e covers on push.

## Test plan

- [x] `RoadmapPage.test.jsx` — 13 tests: heading, loading state, error state (both `!ok` response and rejected promise), four-column render with items in each, empty-column placeholder, GitHub-issue links open in new tab, reaction-count badges (present + absent), area tag render (known + unknown), plus four `_bucketByColumn` unit tests covering no-status-label drop, 8-item shipped cap, string-labels-vs-object-labels shape, and missing labels array.
- [x] `PageLayout.test.jsx` — extended footer test inherits the new Roadmap link (21 passing).
- [x] `uv run inv pre-push` clean (808 frontend tests, +14 new; 100% coverage maintained).

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb