### PR TITLE
feat: memory diff view in History panel

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "diff": "^9.0.0",
         "lucide-react": "^1.7.0",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
@@ -1606,9 +1607,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1623,9 +1621,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1640,9 +1635,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1657,9 +1649,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1674,9 +1663,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1691,9 +1677,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1708,9 +1691,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1725,9 +1705,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1742,9 +1719,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,9 +1733,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1776,9 +1747,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1793,9 +1761,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1810,9 +1775,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2055,9 +2017,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2075,9 +2034,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2095,9 +2051,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2115,9 +2068,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3587,6 +3537,15 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -5601,9 +5560,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5625,9 +5581,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5649,9 +5602,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5673,9 +5623,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "diff": "^9.0.0",
     "lucide-react": "^1.7.0",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { X } from "lucide-react";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
+import MemoryDiff from "./MemoryDiff.jsx";
 import { toast } from "sonner";
 import { AlertDialog } from "./ui/alert-dialog.jsx";
 import { Badge } from "./ui/badge.jsx";
@@ -187,6 +188,10 @@ export default function MemoryBrowser() {
   const [viewingHistory, setViewingHistory] = useState(null); // memory object or null
   const [versions, setVersions] = useState([]);
   const [versionsLoading, setVersionsLoading] = useState(false);
+  // Which previous version is currently expanded into the diff view.
+  // null = the list-only mode; a timestamp = that version diffed
+  // against the live current value.
+  const [expandedVersion, setExpandedVersion] = useState(null);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [pendingDelete, setPendingDelete] = useState(null);
   const [clientNameById, setClientNameById] = useState({});
@@ -471,6 +476,7 @@ export default function MemoryBrowser() {
     setViewingHistory(m);
     setEditing(null);
     setCreating(false);
+    setExpandedVersion(null);
     setVersionsLoading(true);
     try {
       const vs = await api.listMemoryVersions(m.memory_id);
@@ -485,6 +491,13 @@ export default function MemoryBrowser() {
   function closeHistory() {
     setViewingHistory(null);
     setVersions([]);
+    setExpandedVersion(null);
+  }
+
+  function toggleDiff(versionTimestamp) {
+    setExpandedVersion((prev) =>
+      prev === versionTimestamp ? null : versionTimestamp,
+    );
   }
 
   async function handleRestore(versionTimestamp) {
@@ -729,7 +742,7 @@ export default function MemoryBrowser() {
 
       {/* Version history panel */}
       {viewingHistory && (
-        <div className="w-full md:w-[360px]">
+        <div className="w-full md:w-[420px]">
           <Card>
             <h3 className="mb-4 text-base font-semibold">History: {viewingHistory.key}</h3>
             {versionsLoading && <p className="text-[var(--text-muted)]">Loading…</p>}
@@ -737,23 +750,58 @@ export default function MemoryBrowser() {
               <p className="text-[var(--text-muted)] text-sm">No previous versions.</p>
             )}
             <ul className="flex flex-col gap-3 list-none m-0 p-0">
-              {versions.map((v) => (
-                <li key={v.version_timestamp} className="border border-[var(--border)] rounded-[var(--radius)] p-3">
-                  <div className="text-[11px] text-[var(--text-muted)] mb-1">
-                    {new Date(v.recorded_at).toLocaleString()}
-                  </div>
-                  <p className="text-[13px] whitespace-pre-wrap mb-2">
-                    {v.value.length > 120 ? v.value.slice(0, 120) + "…" : v.value}
-                  </p>
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => handleRestore(v.version_timestamp)}
+              {versions.map((v) => {
+                const isOpen = expandedVersion === v.version_timestamp;
+                const truncated =
+                  v.value.length > 120 ? v.value.slice(0, 120) + "…" : v.value;
+                return (
+                  <li
+                    key={v.version_timestamp}
+                    className="border border-[var(--border)] rounded-[var(--radius)] p-3"
                   >
-                    Restore
-                  </Button>
-                </li>
-              ))}
+                    <div className="text-[11px] text-[var(--text-muted)] mb-1">
+                      {new Date(v.recorded_at).toLocaleString()}
+                    </div>
+                    {isOpen ? (
+                      <div className="mb-2">
+                        <p className="text-[11px] text-[var(--text-muted)] mb-1">
+                          Changes vs current
+                        </p>
+                        <MemoryDiff
+                          before={v.value}
+                          after={viewingHistory.value}
+                        />
+                      </div>
+                    ) : (
+                      <p className="text-[13px] whitespace-pre-wrap mb-2">
+                        {truncated}
+                      </p>
+                    )}
+                    <div className="flex gap-2 flex-wrap">
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => toggleDiff(v.version_timestamp)}
+                        aria-expanded={isOpen}
+                        aria-label={
+                          isOpen
+                            ? "Hide diff against current"
+                            : "Show diff against current"
+                        }
+                      >
+                        {isOpen ? "Hide diff" : "Show diff"}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => handleRestore(v.version_timestamp)}
+                      >
+                        Restore
+                      </Button>
+                    </div>
+                  </li>
+                );
+              })}
             </ul>
             <div className="mt-4">
               <Button variant="secondary" onClick={closeHistory}>Close</Button>

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -1390,6 +1390,78 @@ describe("MemoryBrowser", () => {
     expect(screen.getAllByText("Restore")).toHaveLength(2);
   });
 
+  it("toggles the diff view when 'Show diff' is clicked", async () => {
+    // #383: each history row gets a diff toggle that compares the
+    // version against the current live value. Toggle on → replaces
+    // the truncated value with a diff; toggle off → back to the
+    // truncated summary.
+    const version = {
+      version_timestamp: "20260412T120000000000",
+      value: "hello old world",
+      tags: [],
+      recorded_at: "2026-04-12T12:00:00.000Z",
+    };
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ value: "hello new world" })],
+      next_cursor: null,
+    });
+    api.listMemoryVersions.mockResolvedValue([version]);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+    await waitFor(() => screen.getByText("Show diff"));
+
+    // Initially truncated value is visible, diff testid is not.
+    expect(screen.getByText("hello old world")).toBeTruthy();
+    expect(screen.queryByTestId("memory-diff")).toBeNull();
+
+    fireEvent.click(screen.getByText("Show diff"));
+    expect(screen.getByTestId("memory-diff")).toBeTruthy();
+    // Toggle button flips label.
+    expect(screen.getByText("Hide diff")).toBeTruthy();
+
+    // Diff renders the before→after words via <ins>/<del>.
+    const diff = screen.getByTestId("memory-diff");
+    expect(diff.querySelector("ins").textContent).toContain("new");
+    expect(diff.querySelector("del").textContent).toContain("old");
+
+    fireEvent.click(screen.getByText("Hide diff"));
+    expect(screen.queryByTestId("memory-diff")).toBeNull();
+  });
+
+  it("closing history clears the expanded diff state", async () => {
+    // Defensive — expandedVersion must reset when the panel
+    // closes, otherwise reopening history would land in diff mode
+    // even though the user dismissed it.
+    const version = {
+      version_timestamp: "20260412T120000000000",
+      value: "hello old world",
+      tags: [],
+      recorded_at: "2026-04-12T12:00:00.000Z",
+    };
+    api.listMemories.mockResolvedValue({
+      items: [makeMemory({ value: "hello new world" })],
+      next_cursor: null,
+    });
+    api.listMemoryVersions.mockResolvedValue([version]);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("test-key"));
+    await act(async () => fireEvent.click(screen.getByText("History")));
+    await waitFor(() => screen.getByText("Show diff"));
+    fireEvent.click(screen.getByText("Show diff"));
+    expect(screen.getByTestId("memory-diff")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Close"));
+    await waitFor(() => expect(screen.queryByText("History: test-key")).toBeNull());
+    // Re-open: should land on the truncated list view, not stay in
+    // diff mode from the previous session.
+    await act(async () => fireEvent.click(screen.getByText("History")));
+    await waitFor(() => screen.getByText("Show diff"));
+    expect(screen.queryByTestId("memory-diff")).toBeNull();
+  });
+
   it("restores a version and closes history panel", async () => {
     const version = {
       version_timestamp: "20260412T120000000000",

--- a/ui/src/components/MemoryDiff.jsx
+++ b/ui/src/components/MemoryDiff.jsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import React from "react";
+import { diffWords } from "diff";
+
+// Inline word-level diff. We use word granularity (rather than chars
+// or lines) because memory values are typically short prose — word
+// diffs read clearly and still surface small edits. For very long
+// multi-line memories the same renderer works acceptably.
+//
+// Colour is driven by CSS variables so dark-mode and light-mode
+// both look clean without extra branching.
+export default function MemoryDiff({ before, after }) {
+  const parts = diffWords(before ?? "", after ?? "");
+  return (
+    <pre
+      data-testid="memory-diff"
+      className="m-0 p-2 rounded bg-[var(--surface)] border border-[var(--border)] text-[13px] whitespace-pre-wrap font-[inherit] leading-relaxed"
+    >
+      {parts.map((part, i) => {
+        if (part.added) {
+          return (
+            <ins
+              key={i}
+              className="no-underline bg-[var(--success-surface,rgba(16,185,129,0.15))]"
+              style={{ color: "var(--success)" }}
+            >
+              {part.value}
+            </ins>
+          );
+        }
+        if (part.removed) {
+          return (
+            <del
+              key={i}
+              className="bg-[var(--danger-surface,rgba(239,68,68,0.15))]"
+              style={{ color: "var(--danger)" }}
+            >
+              {part.value}
+            </del>
+          );
+        }
+        return (
+          <span key={i} className="text-[var(--text-muted)]">
+            {part.value}
+          </span>
+        );
+      })}
+    </pre>
+  );
+}

--- a/ui/src/components/MemoryDiff.test.jsx
+++ b/ui/src/components/MemoryDiff.test.jsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 John Carter. All rights reserved.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import MemoryDiff from "./MemoryDiff.jsx";
+
+describe("MemoryDiff", () => {
+  it("renders the diff container with the test id anchor", () => {
+    render(<MemoryDiff before="hello" after="hello" />);
+    expect(screen.getByTestId("memory-diff")).toBeTruthy();
+  });
+
+  it("renders additions in an <ins> element", () => {
+    const { container } = render(
+      <MemoryDiff before="hello world" after="hello beautiful world" />,
+    );
+    const ins = container.querySelector("ins");
+    expect(ins).not.toBeNull();
+    expect(ins.textContent).toContain("beautiful");
+  });
+
+  it("renders removals in a <del> element", () => {
+    const { container } = render(
+      <MemoryDiff before="hello old world" after="hello world" />,
+    );
+    const del = container.querySelector("del");
+    expect(del).not.toBeNull();
+    expect(del.textContent).toContain("old");
+  });
+
+  it("renders unchanged text without ins/del markup", () => {
+    const { container } = render(
+      <MemoryDiff before="shared text" after="shared text" />,
+    );
+    expect(container.querySelector("ins")).toBeNull();
+    expect(container.querySelector("del")).toBeNull();
+    expect(container.textContent).toContain("shared text");
+  });
+
+  it("falls back to empty-string when before is null/undefined", () => {
+    const { container } = render(<MemoryDiff before={null} after="new" />);
+    // Entire text is an addition — rendered inside <ins>.
+    expect(container.querySelector("ins")?.textContent).toContain("new");
+  });
+
+  it("falls back to empty-string when after is null/undefined", () => {
+    const { container } = render(<MemoryDiff before="old" after={undefined} />);
+    // Entire text is a removal — rendered inside <del>.
+    expect(container.querySelector("del")?.textContent).toContain("old");
+  });
+});


### PR DESCRIPTION
Closes #383

## Summary

Each version row in the History panel now has a **Show diff** toggle that expands an inline word-level diff between that version&#39;s value and the current live value. Clicking the button again (now labelled **Hide diff**) collapses back to the truncated summary. Restore button stays in place — this is read-only visual augmentation.

## Approach

- **New `MemoryDiff.jsx` component** wraps the `diff` npm package&#39;s `diffWords` (word-level granularity reads cleanly for typical prose + still surfaces small edits). Additions render inside `<ins>` with `var(--success)`, removals inside `<del>` with `var(--danger)`, unchanged text stays muted. Both colours come from CSS vars so dark/light mode both look clean.
- **Compared against the current live value** rather than pairs-of-versions — that&#39;s the question users actually ask ("what&#39;s changed since this version"). A future enhancement could add a two-version picker.
- **`expandedVersion` state** is scoped per-history-session — closing + reopening the panel clears it, so the user doesn&#39;t land in diff mode from a previous session.
- **Null-guarded**: `before`/`after` fall back to empty string so a freshly-created memory with no prior value doesn&#39;t crash.
- Local e2e not run — local stack not up in this session. CI e2e covers on push.

## Test plan

- [x] `MemoryDiff.test.jsx` — 6 tests: renders container; renders `<ins>` on additions; `<del>` on removals; no ins/del when unchanged; before-null fallback renders full addition; after-undefined fallback renders full removal.
- [x] `MemoryBrowser.test.jsx` — 2 new tests: Show/Hide diff toggle wires to MemoryDiff and flips label; closing + reopening History clears the expanded state.
- [x] `uv run inv pre-push` clean (803 frontend tests, +8 new; 100% coverage maintained).

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb