### PR TITLE
feat: semantic search playground — Top-K slider + visible scores

### DIFF
--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -181,6 +181,9 @@ export default function MemoryBrowser() {
   const [tagFilter, setTagFilter] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchMode, setIsSearchMode] = useState(false);
+  // Top-K slider for the semantic search playground (#384). Default
+  // matches the API default (50); clamped 1–100.
+  const [searchTopK, setSearchTopK] = useState(50);
   const [editing, setEditing] = useState(null); // memory object or null
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState({ key: "", value: "", tags: "", ttl: "" });
@@ -250,12 +253,12 @@ export default function MemoryBrowser() {
     }
   }, [tagFilter]);
 
-  const runSearch = useCallback(async (query) => {
+  const runSearch = useCallback(async (query, topK) => {
     setLoading(true);
     setError("");
     setNextCursor(null);
     try {
-      const data = await api.searchMemories(query);
+      const data = await api.searchMemories(query, { limit: topK });
       setMemories(data.items);
     } catch (e) {
       setError(e.message);
@@ -269,15 +272,16 @@ export default function MemoryBrowser() {
     if (!isSearchMode) load();
   }, [load, isSearchMode]);
 
-  // Debounce search input
+  // Debounce search input. Re-runs when topK changes too so the
+  // playground reacts to slider tweaks without a page reload.
   useEffect(() => {
     if (!searchQuery) return;
     clearTimeout(searchDebounceRef.current);
     searchDebounceRef.current = setTimeout(() => {
-      runSearch(searchQuery);
+      runSearch(searchQuery, searchTopK);
     }, 400);
     return () => clearTimeout(searchDebounceRef.current);
-  }, [searchQuery, runSearch]);
+  }, [searchQuery, searchTopK, runSearch]);
 
   // #537 — Stats charts click-through: the Stats tab dispatches a
   // `hive:memory-browser` CustomEvent with `{ tag }` or `{ search }` to
@@ -546,6 +550,38 @@ export default function MemoryBrowser() {
           <TagPicker knownTags={knownTags} value={tagFilter} onSelect={handleTagSelect} />
           <Button onClick={openCreate}>+ New</Button>
         </div>
+        {isSearchMode && (
+          <div
+            data-testid="search-topk-control"
+            className="flex items-center gap-3 mb-4 text-[13px] text-[var(--text-muted)]"
+          >
+            <Label htmlFor="search-topk" className="whitespace-nowrap">
+              Top K
+            </Label>
+            <input
+              id="search-topk"
+              type="range"
+              min={1}
+              max={100}
+              value={searchTopK}
+              onChange={(e) => setSearchTopK(Number(e.target.value))}
+              className="flex-1 max-w-[200px] cursor-pointer"
+              aria-valuemin={1}
+              aria-valuemax={100}
+              aria-valuenow={searchTopK}
+              aria-label="Maximum number of search results"
+            />
+            <span
+              className="font-semibold text-[var(--text)] min-w-[2ch] text-right"
+              aria-live="polite"
+            >
+              {searchTopK}
+            </span>
+            <span className="text-[11px] text-[var(--text-muted)] hidden sm:inline">
+              results
+            </span>
+          </div>
+        )}
 
         {quotaError && (
           <div

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -1149,9 +1149,58 @@ describe("MemoryBrowser", () => {
     await act(async () =>
       fireEvent.change(searchInput, { target: { value: "semantic" } }),
     );
-    await waitFor(() => expect(api.searchMemories).toHaveBeenCalledWith("semantic"), {
-      timeout: 1000,
-    });
+    await waitFor(
+      () =>
+        expect(api.searchMemories).toHaveBeenCalledWith("semantic", { limit: 50 }),
+      { timeout: 1000 },
+    );
+  });
+
+  it("exposes a Top-K slider only when search mode is active", async () => {
+    api.searchMemories.mockResolvedValue({ items: [], count: 0 });
+
+    await act(async () => render(<MemoryBrowser />));
+    // No search query typed yet → slider hidden.
+    expect(screen.queryByTestId("search-topk-control")).toBeNull();
+
+    const searchInput = screen.getByPlaceholderText("Search by meaning…");
+    await act(async () => fireEvent.change(searchInput, { target: { value: "q" } }));
+
+    expect(screen.getByTestId("search-topk-control")).toBeTruthy();
+    expect(screen.getByLabelText("Maximum number of search results")).toBeTruthy();
+  });
+
+  it("updating the Top-K slider re-runs search with the new limit", async () => {
+    api.searchMemories.mockResolvedValue({ items: [], count: 0 });
+    await act(async () => render(<MemoryBrowser />));
+    const searchInput = screen.getByPlaceholderText("Search by meaning…");
+    await act(async () => fireEvent.change(searchInput, { target: { value: "q" } }));
+    await waitFor(() =>
+      expect(api.searchMemories).toHaveBeenCalledWith("q", { limit: 50 }),
+    );
+
+    const slider = screen.getByLabelText("Maximum number of search results");
+    await act(async () => fireEvent.change(slider, { target: { value: "20" } }));
+
+    await waitFor(
+      () => expect(api.searchMemories).toHaveBeenCalledWith("q", { limit: 20 }),
+      { timeout: 1000 },
+    );
+  });
+
+  it("slider clamp: value displayed matches the current Top-K", async () => {
+    api.searchMemories.mockResolvedValue({ items: [], count: 0 });
+    await act(async () => render(<MemoryBrowser />));
+    const searchInput = screen.getByPlaceholderText("Search by meaning…");
+    await act(async () => fireEvent.change(searchInput, { target: { value: "q" } }));
+
+    // Default K=50 rendered in the live region.
+    const control = screen.getByTestId("search-topk-control");
+    expect(within(control).getByText("50")).toBeTruthy();
+
+    const slider = screen.getByLabelText("Maximum number of search results");
+    await act(async () => fireEvent.change(slider, { target: { value: "7" } }));
+    expect(within(control).getByText("7")).toBeTruthy();
   });
 
   it("renders score badge on search results", async () => {


### PR DESCRIPTION
Closes #384

## Summary

#384&#39;s acceptance criteria were mostly met already (search input wired to `api.searchMemories`, relevance-score badge on each card — `{Math.round(m.score * 100)}% match`). This ships the missing **Top-K slider** that appears only in search mode and lets users exercise the retrieval quality directly from the UI.

## Approach

- **Range slider (1–100, default 50)** — narrow enough to fit next to the search input, wide enough to actually tune top_k. `aria-label` + `aria-live` on the count span so the value is announced on change.
- **Re-runs on slider change** — the debounce `useEffect` dep array now includes `searchTopK` alongside `searchQuery`, so a slider tweak kicks a fresh query after the same 400ms debounce.
- **Only visible in search mode** — there&#39;s nothing to apply Top-K to when the tag filter or default list is active, so the control is hidden unless `isSearchMode` is true.
- `api.searchMemories` is called with `{ limit: searchTopK }` instead of the default. `min_score` threshold (also mentioned in the issue as a follow-up) stays out of scope until #378 lands.
- Local e2e not run — local stack not up in this session. CI e2e covers on push.

## Test plan

- [x] `MemoryBrowser.test.jsx` — 3 new tests: slider hidden when not in search mode; slider updates re-run search with the new `limit`; slider value renders in the live region. Existing "calls searchMemories after debounce" updated to assert the `{limit: 50}` default.
- [x] `uv run inv pre-push` clean (815 frontend tests, +3 new; 100% coverage maintained).

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb