### PR TITLE
docs(claude): document public-roadmap label convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1086,6 +1086,39 @@ queue trustworthy.
   this label, the agent still runs Copilot review (everyone benefits
   from a second opinion) but then stops for human merge.
 
+### Public roadmap labels
+
+Orthogonal to the backlog-workflow `status:*` labels — an issue can
+carry one of each without conflict. These control what surfaces on
+the public-facing `/roadmap` page (rendered by `RoadmapPage.jsx`,
+fetching from GitHub's public REST API at render time):
+
+- `public-roadmap` — gate label. Without it, the issue never appears
+  on the roadmap regardless of other labels.
+- `roadmap:now` — **Now** column — in-progress, landing soon
+- `roadmap:next` — **Next** column — planned for the next release or two
+- `roadmap:later` — **Later** column — accepted, no committed date
+
+Issues with `public-roadmap` but no `roadmap:*` label are
+intentionally omitted — the roadmap is curated, not a dump.
+
+The **Shipped** column auto-populates from closed `public-roadmap`
+issues (time-ordered, capped to the 8 most-recent) — no label flip
+needed when work lands.
+
+Deliberately a separate namespace from `status:*` because
+`label-check.yml` already treats `status:*` as the required
+backlog-workflow status (`status:ready` / `blocked` /
+`design-needed` / `needs-info`). Using `roadmap:*` avoids cross-purpose
+confusion.
+
+Principle: the roadmap communicates to users what we've chosen to
+tell them — not every tagged issue. Prefer fewer, clearer cards over
+exhaustive coverage. Skip bugs, infra/CI chores, internal security
+fixes, design spikes that don't read as user-visible capability, and
+anything that would confuse or worry users (e.g. cross-tenant leak
+investigations).
+
 ### Issue creation rules
 
 When filing a new issue:


### PR DESCRIPTION
## Summary

Adds a `### Public roadmap labels` subsection under `## Backlog labels and milestones` documenting the convention introduced by #430 / PR #620 (public `/roadmap` page).

## Convention documented

- **`public-roadmap`** — gate label
- **`roadmap:now`** / **`roadmap:next`** / **`roadmap:later`** — column placement
- **Shipped** column auto-populates from closed `public-roadmap` issues

## Why worth documenting

`RoadmapPage.jsx` carries an inline comment explaining why `roadmap:*` is a separate namespace from `status:*`:

> We deliberately use a dedicated `roadmap:*` namespace rather than reusing the existing `status:*` labels (which `label-check.yml` already treats as the required backlog-workflow status — `status:ready`, `status:blocked`, `status:needs-info`, `status:design-needed`).

But that rationale only lives in code comments — nothing in CLAUDE.md tells an operator (or a future agent triaging new issues) that:

- `roadmap:*` and `status:*` are orthogonal
- An issue can carry one of each
- `public-roadmap` gates visibility; `roadmap:*` places the column

This PR closes that gap.

## Also captures

- The "curated, not a dump" principle — the roadmap is what we *choose* to tell users
- Skip-guidance (bugs, infra/CI chores, internal security fixes, anything that would confuse or worry users)

## Why not auto-merge

Governance-adjacent CLAUDE.md edit — same rule as #461 / #464 / #483 / #514 / #612. Please review manually.

## Test plan

- [x] Docs-only change; lint + typecheck + tests unaffected
- [ ] Reviewer confirms the rationale for `roadmap:*` vs `status:*` separation is accurately captured
- [x] Pairs with the initial `public-roadmap` + `roadmap:*` label application across 13 issues done in the same session; the `/roadmap` page will show curated content on next deploy

https://claude.ai/code/session_01CHZukppdQyVuVfG3cJb2xV