### PR TITLE
fix(e2e): pre-dismiss OnboardingTour in browser fixtures

### DIFF
--- a/tests/e2e/test_dashboard_e2e.py
+++ b/tests/e2e/test_dashboard_e2e.py
@@ -36,9 +36,7 @@ def admin_browser_page():
         context = browser.new_context()
         # #619: pre-dismiss the onboarding tour so its viewport-
         # covering backdrop doesn't intercept tab clicks.
-        context.add_init_script(
-            "localStorage.setItem('hive_tour_dismissed', '1');"
-        )
+        context.add_init_script("localStorage.setItem('hive_tour_dismissed', '1');")
         page = context.new_page()
 
         page.goto(

--- a/tests/e2e/test_dashboard_e2e.py
+++ b/tests/e2e/test_dashboard_e2e.py
@@ -33,7 +33,13 @@ def admin_browser_page():
 
     with sync_playwright() as p:
         browser = p.chromium.launch()
-        page = browser.new_page()
+        context = browser.new_context()
+        # #619: pre-dismiss the onboarding tour so its viewport-
+        # covering backdrop doesn't intercept tab clicks.
+        context.add_init_script(
+            "localStorage.setItem('hive_tour_dismissed', '1');"
+        )
+        page = context.new_page()
 
         page.goto(
             f"{UI_URL}/auth/login?test_email={ADMIN_EMAIL}",
@@ -43,6 +49,7 @@ def admin_browser_page():
         page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
 
         yield page
+        context.close()
         browser.close()
 
 

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -35,9 +35,7 @@ def browser_page():
         # nav-tab click until it's dismissed. An `add_init_script`
         # pre-sets the dismissed flag on every page that loads in
         # this context so e2e tests never see the overlay.
-        context.add_init_script(
-            "localStorage.setItem('hive_tour_dismissed', '1');"
-        )
+        context.add_init_script("localStorage.setItem('hive_tour_dismissed', '1');")
         page = context.new_page()
 
         # Navigate to the bypass login endpoint via CloudFront (same origin as

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -27,7 +27,18 @@ def browser_page():
 
     with sync_playwright() as p:
         browser = p.chromium.launch()
-        page = browser.new_page()
+        context = browser.new_context()
+
+        # #619 shipped an OnboardingTour that renders a full-viewport
+        # backdrop with pointer-events-auto on first visit — its
+        # "click outside to dismiss" behaviour intercepts every
+        # nav-tab click until it's dismissed. An `add_init_script`
+        # pre-sets the dismissed flag on every page that loads in
+        # this context so e2e tests never see the overlay.
+        context.add_init_script(
+            "localStorage.setItem('hive_tour_dismissed', '1');"
+        )
+        page = context.new_page()
 
         # Navigate to the bypass login endpoint via CloudFront (same origin as
         # the UI) so the mgmt JWT lands in the correct localStorage origin.
@@ -45,6 +56,7 @@ def browser_page():
         page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
 
         yield page
+        context.close()
         browser.close()
 
 


### PR DESCRIPTION
## Summary

e2e UI tests are failing post-#619 merge because the `OnboardingTour`'s viewport-covering backdrop (a `<button aria-label="Dismiss onboarding tour">` with `pointer-events-auto`) intercepts every nav-tab click. Fresh browser contexts never have `hive_tour_dismissed` set, so the tour mounts on every test run and blocks the tests that were written before it existed.

## Fix

Both sync-Playwright browser fixtures (`test_ui_e2e.browser_page` and `test_dashboard_e2e.admin_browser_page`) now use `browser.new_context()` + `context.add_init_script()` to pre-set `localStorage.hive_tour_dismissed = "1"` on every page load in the context. The init script runs before any user JS, so the tour never mounts and tests proceed against the real UI.

Marketing-nav test is unchanged — the tour only renders inside `AppShell` (`/app`), not on the marketing root.

## Why this over a product fix

Could also change the tour to let clicks fall through to the spotlighted tab (better real UX) but that's a bigger change with its own test coverage. The fixture fix is minimal and unblocks the dev pipeline immediately; a product follow-up can land later if we want the click-through behaviour.

## Test plan

- [x] Re-read the e2e failure trace — confirmed the backdrop is the only interceptor.
- [x] Verified `OnboardingTour` reads `localStorage.hive_tour_dismissed` at mount (`_isDismissed`) and returns `null` when set.
- [x] CI will re-run the full e2e suite on merge to `development` — that's the authoritative signal.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb