### PR TITLE
Large-memory routing: offload text >100KB to S3 (#497)

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -260,10 +260,39 @@ class HiveStack(cdk.Stack):
             vector_bucket_name=vectors_bucket_name,
         )
 
+        # Memory blobs bucket — stores text values over 100 KB and
+        # (post-#499) binary memory content. SSE-S3 is sufficient
+        # given the bucket is tenant-partitioned by the object-key
+        # prefix (``{owner}/{memory_id}``); the IAM policy on each
+        # Lambda role is what keeps cross-tenant access off the
+        # table. Block-public-access is on. Versioning is off —
+        # Hive's own version-history (VERSION items in DynamoDB)
+        # already covers that need, and S3 versioning would double
+        # the storage bill. In non-prod we set RemovalPolicy=DESTROY
+        # + auto-delete so ephemeral dev stacks tear down cleanly;
+        # prod gets RETAIN to prevent accidental data loss.
+        blobs_bucket_name = (
+            "hive-memory-blobs" if is_prod else f"hive-memory-blobs-{env_name}"
+        )
+        blobs_bucket = s3.Bucket(
+            self,
+            "MemoryBlobsBucket",
+            bucket_name=blobs_bucket_name,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            versioned=False,
+            enforce_ssl=True,
+            removal_policy=(
+                cdk.RemovalPolicy.RETAIN if is_prod else cdk.RemovalPolicy.DESTROY
+            ),
+            auto_delete_objects=not is_prod,
+        )
+
         app_version = os.environ.get("APP_VERSION", "dev")
         common_env = {
             "HIVE_TABLE_NAME": table.table_name,
             "HIVE_VECTORS_BUCKET": vectors_bucket_name,
+            "HIVE_BLOBS_BUCKET": blobs_bucket_name,
             # Custom domain is the canonical issuer URL for all environments.
             "HIVE_ISSUER": f"https://{custom_domain}",
             # Tell both Lambdas which SSM parameter holds the JWT secret.
@@ -307,6 +336,11 @@ class HiveStack(cdk.Stack):
         google_client_secret_param.grant_read(mcp_role)
         allowed_emails_param.grant_read(mcp_role)
         origin_verify_param.grant_read(mcp_role)
+        # Memory blobs — MCP Lambda reads, writes, and (post-#502)
+        # deletes objects on forget. Scoped to the bucket via CDK's
+        # grant; no cross-bucket access is possible from this role.
+        blobs_bucket.grant_read_write(mcp_role)
+        blobs_bucket.grant_delete(mcp_role)
         # S3 Vectors + Bedrock Titan Embeddings V2 for MCP Lambda
         mcp_role.add_to_policy(
             iam.PolicyStatement(
@@ -382,6 +416,10 @@ class HiveStack(cdk.Stack):
         google_client_secret_param.grant_read(api_role)
         allowed_emails_param.grant_read(api_role)
         origin_verify_param.grant_read(api_role)
+        # Memory blobs — API Lambda needs read/write for the
+        # management UI's memory CRUD + delete on forget (#502).
+        blobs_bucket.grant_read_write(api_role)
+        blobs_bucket.grant_delete(api_role)
         api_role.add_to_policy(
             iam.PolicyStatement(
                 actions=["cloudwatch:GetMetricData", "cloudwatch:DescribeAlarms"],

--- a/src/hive/blob_store.py
+++ b/src/hive/blob_store.py
@@ -54,7 +54,13 @@ class BlobStore:
         _s3_client: Any = None,
     ) -> None:
         # Read env at call time so tests can override after import.
-        self._bucket = bucket_name or os.environ.get("HIVE_BLOBS_BUCKET", "")
+        resolved = bucket_name or os.environ.get("HIVE_BLOBS_BUCKET", "")
+        if not resolved.strip():
+            raise ValueError(
+                "BlobStore requires a non-empty bucket name; pass `bucket_name` "
+                "or set the HIVE_BLOBS_BUCKET environment variable."
+            )
+        self._bucket = resolved
         region = region or os.environ.get("AWS_REGION", "us-east-1")
         self._s3: S3Client = _s3_client or boto3.client("s3", region_name=region)
 

--- a/src/hive/blob_store.py
+++ b/src/hive/blob_store.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Blob store for Hive — S3-backed storage for memories that exceed the
+DynamoDB 400 KB item limit (or are non-text by construction).
+
+DynamoDB is the authoritative index — every memory has a META item.
+When the inline value would overflow DynamoDB, or the caller passes a
+non-text ``value_type``, the content is stored in S3 under
+``s3://{bucket}/{owner}/{memory_id}`` and a pointer is kept in the
+META item as ``s3_uri``.
+
+The 100 KB inline/S3 threshold sits well under DynamoDB's 400 KB
+per-item cap so the headers, tag list, timestamps etc. never tip the
+item over.
+
+All operations are best-effort at the protocol level — they raise on
+hard failures so the caller can surface a meaningful error rather
+than silently losing data.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import boto3
+
+from hive.logging_config import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mypy_boto3_s3 import S3Client
+
+logger = get_logger("hive.blob_store")
+
+# Above this size, text values get promoted from inline `value` to
+# S3-backed `text-large`. Chosen well under DynamoDB's 400 KB item
+# cap so the rest of the META item (key, tags, timestamps, GSI keys)
+# never tips the total over.
+INLINE_TEXT_THRESHOLD_BYTES = 100 * 1024
+
+# Hard cap enforced by the ``remember_blob`` tool at upload time. 10
+# MB matches Lambda's binary-invoke payload ceiling with headroom for
+# MCP-protocol framing.
+MAX_BLOB_SIZE_BYTES = 10 * 1024 * 1024
+
+
+class BlobStore:
+    """S3 wrapper for large-memory storage."""
+
+    def __init__(
+        self,
+        bucket_name: str | None = None,
+        region: str | None = None,
+        _s3_client: Any = None,
+    ) -> None:
+        # Read env at call time so tests can override after import.
+        self._bucket = bucket_name or os.environ.get("HIVE_BLOBS_BUCKET", "")
+        region = region or os.environ.get("AWS_REGION", "us-east-1")
+        self._s3: S3Client = _s3_client or boto3.client("s3", region_name=region)
+
+    @property
+    def bucket(self) -> str:
+        return self._bucket
+
+    def _key(self, owner: str, memory_id: str) -> str:
+        """Object key layout: ``{owner}/{memory_id}``.
+
+        ``owner`` is the workspace id once #482 lands; until then
+        callers pass the user id (falling back to client id for
+        pre-user-migration memories).
+        """
+        return f"{owner}/{memory_id}"
+
+    def put(
+        self,
+        owner: str,
+        memory_id: str,
+        body: bytes,
+        content_type: str = "text/plain; charset=utf-8",
+    ) -> str:
+        """Upload ``body`` and return the ``s3://`` URI."""
+        key = self._key(owner, memory_id)
+        self._s3.put_object(
+            Bucket=self._bucket,
+            Key=key,
+            Body=body,
+            ContentType=content_type,
+        )
+        return f"s3://{self._bucket}/{key}"
+
+    def get(self, owner: str, memory_id: str) -> bytes:
+        """Fetch the body at ``{owner}/{memory_id}`` as bytes."""
+        key = self._key(owner, memory_id)
+        resp = self._s3.get_object(Bucket=self._bucket, Key=key)
+        return resp["Body"].read()
+
+    def delete(self, owner: str, memory_id: str) -> None:
+        """Delete the object at ``{owner}/{memory_id}``.
+
+        Missing objects don't raise — S3 ``delete_object`` is
+        idempotent and we already log the action for audit.
+        """
+        key = self._key(owner, memory_id)
+        self._s3.delete_object(Bucket=self._bucket, Key=key)
+        logger.info(
+            "blob_delete",
+            extra={"bucket": self._bucket, "key": key},
+        )

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_serializer
 
@@ -67,7 +67,7 @@ class Memory(BaseModel):
     # oversized text to S3 with ``value`` cleared and ``s3_uri`` set.
     # "image" / "blob" are reserved for the binary remember_blob
     # path that lands in #499.
-    value_type: str = "text"
+    value_type: Literal["text", "text-large", "image", "blob"] = "text"
     s3_uri: str | None = None
     content_type: str | None = None
     size_bytes: int | None = None

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -52,7 +52,7 @@ class Memory(BaseModel):
 
     memory_id: str = Field(default_factory=_new_id)
     key: str
-    value: str
+    value: str | None = ""
     tags: list[str] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=_now_utc)
     updated_at: datetime = Field(default_factory=_now_utc)
@@ -62,6 +62,15 @@ class Memory(BaseModel):
     recall_count: int = 0  # incremented on every successful recall
     last_accessed_at: datetime | None = None  # set on every successful recall
     redacted_at: datetime | None = None  # when redact_memory tombstoned the value (#400)
+    # Large-memory foundation (#497). "text" remains the default and
+    # keeps the inline-value path unchanged. "text-large" offloads
+    # oversized text to S3 with ``value`` cleared and ``s3_uri`` set.
+    # "image" / "blob" are reserved for the binary remember_blob
+    # path that lands in #499.
+    value_type: str = "text"
+    s3_uri: str | None = None
+    content_type: str | None = None
+    size_bytes: int | None = None
 
     # ------------------------------------------------------------------
     # DynamoDB serialisation
@@ -74,7 +83,12 @@ class Memory(BaseModel):
             "SK": "META",
             "memory_id": self.memory_id,
             "key": self.key,
-            "value": self.value,
+            # Inline ``value`` stores text up to the 100 KB threshold.
+            # For "text-large"/"image"/"blob" the body lives in S3 and
+            # we persist an empty string so legacy readers that expect
+            # a str keep working. Authoritative content pointer is
+            # ``s3_uri``.
+            "value": self.value if self.value is not None else "",
             "tags": self.tags,
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
@@ -93,6 +107,16 @@ class Memory(BaseModel):
             item["last_accessed_at"] = self.last_accessed_at.isoformat()
         if self.redacted_at is not None:
             item["redacted_at"] = self.redacted_at.isoformat()
+        # Only serialise non-default large-memory fields so legacy
+        # items (all "text", all inline) round-trip byte-identical.
+        if self.value_type != "text":
+            item["value_type"] = self.value_type
+        if self.s3_uri is not None:
+            item["s3_uri"] = self.s3_uri
+        if self.content_type is not None:
+            item["content_type"] = self.content_type
+        if self.size_bytes is not None:
+            item["size_bytes"] = self.size_bytes
         return item
 
     def to_dynamo_tag_items(self) -> list[dict[str, Any]]:
@@ -124,6 +148,8 @@ class Memory(BaseModel):
         redacted_at = None
         if ra := item.get("redacted_at"):
             redacted_at = datetime.fromisoformat(ra)
+        # Legacy items predate #497 — default value_type to "text"
+        # so the unchanged inline-value path keeps working.
         return cls(
             memory_id=item["memory_id"],
             key=item["key"],
@@ -137,6 +163,10 @@ class Memory(BaseModel):
             recall_count=int(item.get("recall_count", 0) or 0),
             last_accessed_at=last_accessed_at,
             redacted_at=redacted_at,
+            value_type=item.get("value_type", "text"),
+            s3_uri=item.get("s3_uri"),
+            content_type=item.get("content_type"),
+            size_bytes=int(item["size_bytes"]) if item.get("size_bytes") is not None else None,
         )
 
     @property

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -65,7 +65,7 @@ logger = get_logger("hive.server")
 
 _MEMORIES_READ_SCOPE = "memories:read"
 
-DEFAULT_MAX_VALUE_BYTES = 10 * 1024
+DEFAULT_MAX_VALUE_BYTES = 10 * 1024 * 1024
 
 
 def _max_value_bytes() -> int:
@@ -1231,9 +1231,9 @@ async def search_memories(
     now = datetime.now(timezone.utc)
     scored: list[tuple[Memory, float, float, float, float]] = []
     for m, sem in hydrated:
-        # value is None for the large-memory foundation (#497);
-        # #498 lands the S3 fetch. Until then, fall back to empty
-        # string so keyword_score stays typed as str.
+        # Large-memory entries keep an empty-string inline placeholder
+        # until #498 lands the S3 fetch. Fall back to "" here so
+        # keyword_score always receives a str.
         kw = keyword_score(query_tokens, m.value or "")
         rec = recency_score(m, now=now)
         blended = blend_score(

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1231,7 +1231,10 @@ async def search_memories(
     now = datetime.now(timezone.utc)
     scored: list[tuple[Memory, float, float, float, float]] = []
     for m, sem in hydrated:
-        kw = keyword_score(query_tokens, m.value)
+        # value is None for the large-memory foundation (#497);
+        # #498 lands the S3 fetch. Until then, fall back to empty
+        # string so keyword_score stays typed as str.
+        kw = keyword_score(query_tokens, m.value or "")
         rec = recency_score(m, now=now)
         blended = blend_score(
             semantic=sem,
@@ -1327,7 +1330,9 @@ async def relate_memories(
 
     try:
         # Fetch top_k+1 so that dropping the source still leaves up to top_k.
-        pairs = _vector_store().search(memory.value, client_id, top_k=top_k + 1)
+        # `memory.value or ""` guards the #497 large-memory path where
+        # the inline value is empty until #498 wires the S3 fetch.
+        pairs = _vector_store().search(memory.value or "", client_id, top_k=top_k + 1)
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
     except Exception:
@@ -1569,7 +1574,7 @@ async def pack_context(
     for memory, sem in hydrated:
         if memory.is_redacted:
             continue
-        kw = keyword_score(query_tokens, memory.value)
+        kw = keyword_score(query_tokens, memory.value or "")
         rec = recency_score(memory, now=now)
         blended = blend_score(semantic=sem, keyword=kw, recency=rec)
         scored.append(
@@ -1894,7 +1899,9 @@ def read_memory_resource(key: str) -> str:
         raise ValueError(f"Memory not found: {decoded_key!r}")
     if memory.is_redacted:
         raise ValueError(f"Memory has been redacted: {decoded_key!r}")
-    return memory.value
+    # `memory.value or ""` guards the #497 large-memory path — #498
+    # swaps this for a transparent S3 fetch on text-large items.
+    return memory.value or ""
 
 
 # ---------------------------------------------------------------------------

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -118,7 +118,11 @@ class HiveStorage:
     """All DynamoDB read/write operations for Hive."""
 
     def __init__(
-        self, table_name: str | None = None, region: str | None = None, **kwargs: Any
+        self,
+        table_name: str | None = None,
+        region: str | None = None,
+        blob_store: Any = None,
+        **kwargs: Any,
     ) -> None:
         # Read env vars at call time so tests can override them after import
         table_name = table_name or os.environ.get("HIVE_TABLE_NAME", "hive")
@@ -127,6 +131,24 @@ class HiveStorage:
         kwargs.setdefault("endpoint_url", os.environ.get("DYNAMODB_ENDPOINT"))
         dynamodb = boto3.resource("dynamodb", region_name=region, **kwargs)
         self.table = dynamodb.Table(table_name)
+        # Lazily-instantiated BlobStore — we only need it on the
+        # text-large / binary path so tests that never exercise that
+        # branch can leave HIVE_BLOBS_BUCKET unset. Inject a mock via
+        # the ``blob_store`` kwarg in tests.
+        self._blob_store_override = blob_store
+        self._blob_store: Any = None
+
+    @property
+    def blob_store(self) -> Any:
+        """Lazy BlobStore handle — constructed on first use."""
+        if self._blob_store_override is not None:
+            return self._blob_store_override
+        # Import inline to avoid circular-import risk at module load.
+        if self._blob_store is None:
+            from hive.blob_store import BlobStore
+
+            self._blob_store = BlobStore()
+        return self._blob_store
 
     # ------------------------------------------------------------------
     # Memory CRUD
@@ -142,7 +164,14 @@ class HiveStorage:
         conditional expression requiring the stored ``updated_at`` to match
         — supporting optimistic locking (#391). Raises ``VersionConflict``
         if the stored version has moved on since the caller read it.
+
+        Large-memory routing (#497): text values over the inline
+        threshold are uploaded to S3 and the META item stores only
+        ``s3_uri`` + ``size_bytes``. The routing happens in-place on
+        the passed ``memory`` so callers always see the persisted
+        shape.
         """
+        self._route_large_value(memory)
         existing_raw = self._get_memory_meta(memory.memory_id)
         if expected_version is not None:
             if existing_raw is None:
@@ -199,6 +228,51 @@ class HiveStorage:
                     "Memory value is too large to store (DynamoDB 400 KB item limit exceeded)."
                 ) from exc
             raise
+
+    def _route_large_value(self, memory: Memory) -> None:
+        """Offload oversized text to S3, leaving a pointer in DynamoDB.
+
+        Only runs on "text"-typed memories. Non-text types (image /
+        blob, arriving via #499) are expected to already carry an
+        ``s3_uri`` when they reach ``put_memory`` — this router only
+        handles the transparent-text-large path where a caller hands
+        us an oversized string and expects us to pick the right
+        backend.
+        """
+        from hive.blob_store import INLINE_TEXT_THRESHOLD_BYTES
+
+        # Non-text paths have their own upload lifecycle (#499) —
+        # don't touch them here.
+        if memory.value_type != "text":
+            return
+
+        if memory.value is None:
+            return
+
+        encoded = memory.value.encode("utf-8")
+        if len(encoded) <= INLINE_TEXT_THRESHOLD_BYTES:
+            # Inline path: unchanged. Capture size_bytes for the
+            # forthcoming two-dimension quota (#500) even on the
+            # small path so rollups are consistent.
+            memory.size_bytes = len(encoded)
+            return
+
+        # Promote to text-large — write body to S3 under the
+        # workspace-equivalent prefix (user id today, workspace id
+        # post-#482).
+        owner = memory.owner_user_id or memory.owner_client_id
+        s3_uri = self.blob_store.put(
+            owner=owner,
+            memory_id=memory.memory_id,
+            body=encoded,
+            content_type="text/plain; charset=utf-8",
+        )
+        memory.value_type = "text-large"
+        memory.s3_uri = s3_uri
+        memory.size_bytes = len(encoded)
+        memory.content_type = "text/plain; charset=utf-8"
+        # Drop the inline value — DynamoDB only keeps the pointer.
+        memory.value = ""
 
     def get_memory_by_id(self, memory_id: str) -> Memory | None:
         item = self._get_memory_meta(memory_id)

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -239,7 +239,7 @@ class HiveStorage:
         us an oversized string and expects us to pick the right
         backend.
         """
-        from hive.blob_store import INLINE_TEXT_THRESHOLD_BYTES
+        from hive.blob_store import INLINE_TEXT_THRESHOLD_BYTES, MAX_BLOB_SIZE_BYTES
 
         # Non-text paths have their own upload lifecycle (#499) —
         # don't touch them here.
@@ -250,6 +250,11 @@ class HiveStorage:
             return
 
         encoded = memory.value.encode("utf-8")
+        if len(encoded) > MAX_BLOB_SIZE_BYTES:
+            raise ValueError(
+                f"Value size {len(encoded)} bytes exceeds the maximum of "
+                f"{MAX_BLOB_SIZE_BYTES} bytes."
+            )
         if len(encoded) <= INLINE_TEXT_THRESHOLD_BYTES:
             # Inline path: unchanged. Capture size_bytes for the
             # forthcoming two-dimension quota (#500) even on the

--- a/tests/unit/test_blob_store.py
+++ b/tests/unit/test_blob_store.py
@@ -88,3 +88,8 @@ class TestBlobStore:
         monkeypatch.setenv("HIVE_BLOBS_BUCKET", "env-bucket")
         store = BlobStore()
         assert store.bucket == "env-bucket"
+
+    def test_missing_bucket_raises_value_error(self, monkeypatch):
+        monkeypatch.delenv("HIVE_BLOBS_BUCKET", raising=False)
+        with pytest.raises(ValueError, match="HIVE_BLOBS_BUCKET"):
+            BlobStore()

--- a/tests/unit/test_blob_store.py
+++ b/tests/unit/test_blob_store.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for the S3-backed BlobStore (#497)."""
+
+from __future__ import annotations
+
+import os
+
+import boto3
+import pytest
+
+os.environ.setdefault("HIVE_BLOBS_BUCKET", "hive-blobs-test")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+
+from moto import mock_aws
+
+from hive.blob_store import (
+    INLINE_TEXT_THRESHOLD_BYTES,
+    MAX_BLOB_SIZE_BYTES,
+    BlobStore,
+)
+
+
+@pytest.fixture()
+def blob_store():
+    """BlobStore backed by a fresh moto-mocked S3 bucket."""
+    with mock_aws():
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="hive-blobs-test")
+        yield BlobStore(bucket_name="hive-blobs-test")
+
+
+class TestBlobStore:
+    def test_thresholds_are_sensible_defaults(self):
+        # 100 KB inline threshold sits well under DynamoDB's 400 KB
+        # item cap so the rest of the META item (tags, timestamps,
+        # GSI keys) can never tip the total over.
+        assert INLINE_TEXT_THRESHOLD_BYTES == 100 * 1024
+        # 10 MB cap matches Lambda's binary-invoke payload ceiling
+        # with headroom for MCP framing.
+        assert MAX_BLOB_SIZE_BYTES == 10 * 1024 * 1024
+
+    def test_put_uploads_and_returns_s3_uri(self, blob_store):
+        uri = blob_store.put(owner="user-1", memory_id="mem-1", body=b"hello world")
+        assert uri == "s3://hive-blobs-test/user-1/mem-1"
+
+    def test_get_returns_body_written_by_put(self, blob_store):
+        blob_store.put(owner="user-1", memory_id="mem-1", body=b"hello world")
+        assert blob_store.get("user-1", "mem-1") == b"hello world"
+
+    def test_put_stores_content_type_for_binary(self, blob_store):
+        blob_store.put(
+            owner="user-1",
+            memory_id="mem-png",
+            body=b"\x89PNG\r\n\x1a\n",
+            content_type="image/png",
+        )
+        # moto reports the stored content-type via HeadObject — we
+        # only check PUT succeeded (no raise) and bytes round-trip.
+        assert blob_store.get("user-1", "mem-png") == b"\x89PNG\r\n\x1a\n"
+
+    def test_delete_removes_the_object(self, blob_store):
+        from botocore.exceptions import ClientError
+
+        blob_store.put(owner="user-1", memory_id="mem-1", body=b"x")
+        blob_store.delete(owner="user-1", memory_id="mem-1")
+        # botocore raises ClientError (NoSuchKey) on GET of a
+        # missing object — the BlobStore doesn't swallow that.
+        with pytest.raises(ClientError):
+            blob_store.get("user-1", "mem-1")
+
+    def test_owner_prefix_keeps_tenants_isolated_by_key(self, blob_store):
+        # Same memory_id under two owners must land at different
+        # S3 keys so the IAM policy (which happens to be unscoped
+        # in this moto harness) can't cross-leak in production.
+        blob_store.put(owner="user-a", memory_id="same-id", body=b"A")
+        blob_store.put(owner="user-b", memory_id="same-id", body=b"B")
+        assert blob_store.get("user-a", "same-id") == b"A"
+        assert blob_store.get("user-b", "same-id") == b"B"
+
+    def test_bucket_property_exposes_configured_bucket(self, blob_store):
+        assert blob_store.bucket == "hive-blobs-test"
+
+    def test_default_bucket_comes_from_env(self, monkeypatch):
+        # Env-var override path — covers the `or os.environ.get`
+        # fallback in __init__.
+        monkeypatch.setenv("HIVE_BLOBS_BUCKET", "env-bucket")
+        store = BlobStore()
+        assert store.bucket == "env-bucket"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -53,6 +53,65 @@ class TestMemory:
         m = Memory(key="k", value="v", owner_client_id="c1")
         assert m.to_dynamo_tag_items() == []
 
+    def test_default_value_type_is_text(self):
+        # #497: existing memories stay "text" with no pointer
+        # fields, so legacy items round-trip byte-identical through
+        # to_dynamo_meta.
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        assert m.value_type == "text"
+        assert m.s3_uri is None
+        assert m.content_type is None
+        assert m.size_bytes is None
+        item = m.to_dynamo_meta()
+        # None of the large-memory fields appear on the wire for
+        # inline text — legacy readers see an unchanged item.
+        assert "value_type" not in item
+        assert "s3_uri" not in item
+        assert "content_type" not in item
+        assert "size_bytes" not in item
+
+    def test_large_memory_fields_round_trip_through_dynamo(self):
+        m = Memory(
+            key="big",
+            value="",
+            value_type="text-large",
+            s3_uri="s3://hive-memory-blobs/u-1/mem-1",
+            content_type="text/plain; charset=utf-8",
+            size_bytes=500_000,
+            owner_client_id="c1",
+        )
+        item = m.to_dynamo_meta()
+        assert item["value_type"] == "text-large"
+        assert item["s3_uri"] == "s3://hive-memory-blobs/u-1/mem-1"
+        assert item["content_type"] == "text/plain; charset=utf-8"
+        assert item["size_bytes"] == 500_000
+        # None-value is serialised as an empty string so readers
+        # that expect a str keep working.
+        assert item["value"] == ""
+
+        m2 = Memory.from_dynamo(item)
+        assert m2.value_type == "text-large"
+        assert m2.s3_uri == "s3://hive-memory-blobs/u-1/mem-1"
+        assert m2.content_type == "text/plain; charset=utf-8"
+        assert m2.size_bytes == 500_000
+
+    def test_legacy_dynamo_item_without_value_type_defaults_to_text(self):
+        # Pre-#497 META items have no value_type / s3_uri / etc —
+        # from_dynamo must default them so the read path stays
+        # backwards compatible.
+        item = {
+            "memory_id": "mem-1",
+            "key": "legacy",
+            "value": "legacy-value",
+            "created_at": "2026-04-20T00:00:00+00:00",
+            "updated_at": "2026-04-20T00:00:00+00:00",
+            "owner_client_id": "c1",
+        }
+        m = Memory.from_dynamo(item)
+        assert m.value_type == "text"
+        assert m.s3_uri is None
+        assert m.size_bytes is None
+
     def test_default_recall_fields(self):
         m = Memory(key="k", value="v", owner_client_id="c1")
         assert m.recall_count == 0

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -294,8 +294,16 @@ class TestRemember:
         ):
             await remember("big-key", "x" * 1000, [], ctx=_make_ctx(jwt))
 
-    async def test_value_at_limit_succeeds(self, server_env):
+    async def test_value_at_limit_succeeds(self, server_env, monkeypatch):
+        import boto3
+
         from hive.server import DEFAULT_MAX_VALUE_BYTES, remember
+
+        # With the new 10 MB default, a value at the limit exceeds the
+        # inline threshold and routes to S3. Create the bucket inside
+        # the existing mock_aws() context so the routing path succeeds.
+        monkeypatch.setenv("HIVE_BLOBS_BUCKET", "test-blobs-at-limit")
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="test-blobs-at-limit")
 
         storage, _, jwt = server_env
         value = "x" * DEFAULT_MAX_VALUE_BYTES

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -544,6 +544,17 @@ class TestLargeMemoryRouting:
         storage.put_memory(m)
         assert fake.objects == {}
 
+    def test_value_exceeding_max_blob_size_raises(self, storage_with_blob_store):
+        from hive.blob_store import INLINE_TEXT_THRESHOLD_BYTES, MAX_BLOB_SIZE_BYTES
+
+        storage, _ = storage_with_blob_store
+        big_value = "x" * (MAX_BLOB_SIZE_BYTES + 1)
+        m = Memory(key="too-big", value=big_value, owner_client_id="c1")
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            storage._route_large_value(m)
+        # Inline-threshold check must still pass before the size guard triggers.
+        assert len(big_value.encode("utf-8")) > INLINE_TEXT_THRESHOLD_BYTES
+
     def test_blob_store_property_lazy_instantiates_real_blob_store(self, storage, monkeypatch):
         # Covers the lazy-init path (lines 147-151) when no override
         # is injected — the real BlobStore is constructed on first

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -544,6 +544,17 @@ class TestLargeMemoryRouting:
         storage.put_memory(m)
         assert fake.objects == {}
 
+    def test_blob_store_property_lazy_instantiates_real_blob_store(self, storage, monkeypatch):
+        # Covers the lazy-init path (lines 147-151) when no override
+        # is injected — the real BlobStore is constructed on first
+        # access and cached for subsequent calls.
+        monkeypatch.setenv("HIVE_BLOBS_BUCKET", "lazy-init-bucket")
+        from hive.blob_store import BlobStore
+
+        first = storage.blob_store
+        assert isinstance(first, BlobStore)
+        assert storage.blob_store is first  # cached — not re-created
+
 
 class TestMemoryVersionStorage:
     def test_list_versions_newest_first(self, storage):

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -422,8 +422,127 @@ class TestMemoryStorage:
 
 
 # ---------------------------------------------------------------------------
-# Memory version tests
+# Large-memory routing tests (#497)
 # ---------------------------------------------------------------------------
+
+
+class _FakeBlobStore:
+    """In-memory stand-in for BlobStore — records put/get/delete."""
+
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+        self.content_types: dict[tuple[str, str], str] = {}
+
+    def put(self, owner, memory_id, body, content_type="text/plain; charset=utf-8"):
+        self.objects[(owner, memory_id)] = body
+        self.content_types[(owner, memory_id)] = content_type
+        return f"s3://fake-bucket/{owner}/{memory_id}"
+
+    def get(self, owner, memory_id):
+        return self.objects[(owner, memory_id)]
+
+    def delete(self, owner, memory_id):
+        self.objects.pop((owner, memory_id), None)
+
+
+@pytest.fixture()
+def storage_with_blob_store(storage):
+    """Storage fixture with a fake BlobStore wired in."""
+    fake = _FakeBlobStore()
+    storage._blob_store_override = fake
+    return storage, fake
+
+
+class TestLargeMemoryRouting:
+    """#497 — oversized text values get offloaded to the blob store."""
+
+    def test_small_text_memory_stays_inline(self, storage_with_blob_store):
+        storage, fake = storage_with_blob_store
+        m = Memory(key="small", value="hello", owner_client_id="c1")
+        storage.put_memory(m)
+
+        # No S3 object — stayed inline in DynamoDB.
+        assert fake.objects == {}
+
+        stored = storage.get_memory_by_key("small")
+        assert stored is not None
+        assert stored.value == "hello"
+        assert stored.value_type == "text"
+        assert stored.s3_uri is None
+        # size_bytes gets set for future quota rollups (#500) even
+        # on the inline path.
+        assert stored.size_bytes == 5
+
+    def test_large_text_memory_routes_to_s3(self, storage_with_blob_store):
+        storage, fake = storage_with_blob_store
+        # 500 KB > 100 KB threshold → gets promoted to text-large.
+        big_value = "x" * (500 * 1024)
+        m = Memory(
+            key="big-doc",
+            value=big_value,
+            owner_client_id="c1",
+            owner_user_id="u-1",
+        )
+        storage.put_memory(m)
+
+        # Exactly one S3 object stored under owner_user_id / memory_id.
+        assert list(fake.objects.keys()) == [("u-1", m.memory_id)]
+        assert fake.objects[("u-1", m.memory_id)] == big_value.encode("utf-8")
+
+        stored = storage.get_memory_by_key("big-doc")
+        assert stored is not None
+        assert stored.value_type == "text-large"
+        assert stored.s3_uri == f"s3://fake-bucket/u-1/{m.memory_id}"
+        assert stored.size_bytes == 500 * 1024
+        assert stored.content_type == "text/plain; charset=utf-8"
+        # Inline DynamoDB value is empty — authoritative bytes live in S3.
+        assert stored.value == ""
+
+    def test_owner_prefix_falls_back_to_client_when_user_missing(self, storage_with_blob_store):
+        # Pre-user-migration memories (#482 pending) don't carry
+        # owner_user_id. The routing uses owner_client_id so those
+        # memories still land in a tenant-scoped prefix.
+        storage, fake = storage_with_blob_store
+        big_value = "y" * (200 * 1024)
+        m = Memory(key="pre-user", value=big_value, owner_client_id="legacy-client")
+        storage.put_memory(m)
+        assert ("legacy-client", m.memory_id) in fake.objects
+
+    def test_non_text_value_type_skips_the_router(self, storage_with_blob_store):
+        # #499's remember_blob path supplies an image/blob with its
+        # own s3_uri already set — the transparent-text router must
+        # leave those alone.
+        storage, fake = storage_with_blob_store
+        m = Memory(
+            key="img",
+            value="",
+            value_type="image",
+            s3_uri="s3://some/other/path",
+            content_type="image/png",
+            size_bytes=1234,
+            owner_client_id="c1",
+        )
+        storage.put_memory(m)
+        # Router did not upload anything — binary upload is the
+        # caller's responsibility for non-text types.
+        assert fake.objects == {}
+
+        stored = storage.get_memory_by_key("img")
+        assert stored is not None
+        assert stored.value_type == "image"
+        assert stored.s3_uri == "s3://some/other/path"
+        assert stored.content_type == "image/png"
+        assert stored.size_bytes == 1234
+
+    def test_value_type_text_with_none_value_skips_upload(self, storage_with_blob_store):
+        # Defensive — Pydantic would coerce this to the default
+        # empty string, but an explicit None must not crash the
+        # router.
+        storage, fake = storage_with_blob_store
+        m = Memory(key="edge", owner_client_id="c1")
+        m.value = None  # bypass pydantic default
+        storage.put_memory(m)
+        assert fake.objects == {}
 
 
 class TestMemoryVersionStorage:


### PR DESCRIPTION
## Summary

Implements transparent routing of large text values to S3 storage, keeping DynamoDB items under the 400 KB limit. Text values exceeding 100 KB are automatically promoted to `text-large` type, uploaded to S3, and replaced with a pointer (`s3_uri`) in the DynamoDB META item. Smaller values remain inline unchanged, preserving backward compatibility with legacy items.

## Changes

- **New `BlobStore` class** (`src/hive/blob_store.py`): S3 wrapper for large-memory storage with `put()`, `get()`, and `delete()` operations. Defines `INLINE_TEXT_THRESHOLD_BYTES` (100 KB) and `MAX_BLOB_SIZE_BYTES` (10 MB) constants.

- **Storage routing** (`src/hive/storage.py`): 
  - Added `_route_large_value()` method that intercepts `put_memory()` calls and transparently offloads oversized text to S3
  - Lazy-initialized `blob_store` property to avoid requiring `HIVE_BLOBS_BUCKET` for tests that don't exercise the large-memory path
  - Preserves `size_bytes` on all text paths for future quota tracking (#500)

- **Memory model updates** (`src/hive/models.py`):
  - Added `value_type` (defaults to `"text"`), `s3_uri`, `content_type`, and `size_bytes` fields
  - Updated `to_dynamo_meta()` to only serialize non-default large-memory fields, ensuring legacy items round-trip byte-identical
  - Updated `from_dynamo()` to default `value_type` to `"text"` for pre-#497 items
  - Changed `value` field to allow `None` with empty-string default

- **Infrastructure** (`infra/stacks/hive_stack.py`):
  - Created `MemoryBlobsBucket` S3 bucket with SSE-S3 encryption, block-public-access, and tenant-scoped object keys
  - Granted MCP and API Lambda roles read/write/delete permissions on the blobs bucket
  - Added `HIVE_BLOBS_BUCKET` environment variable to Lambda functions

- **Server-side guards** (`src/hive/server.py`): Added `m.value or ""` fallbacks in `search_memories()` and `relate_memories()` to handle empty inline values until S3 fetch is wired in (#498)

## Test plan

- Added comprehensive unit tests in `tests/unit/test_blob_store.py` covering S3 operations, tenant isolation, and threshold constants
- Added integration tests in `tests/unit/test_storage.py` (`TestLargeMemoryRouting`) covering:
  - Small text staying inline with `size_bytes` captured
  - Large text (500 KB) routing to S3 with `text-large` type and empty inline value
  - Owner prefix fallback from `owner_user_id` to `owner_client_id` for pre-user-migration memories
  - Non-text types (image/blob) bypassing the router
  - Edge case of `None` value skipping upload
- Added model serialization tests in `tests/unit/test_models.py` verifying large-memory fields round-trip through DynamoDB and legacy items default correctly

All tests pass with 100% coverage maintained.

https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb