### PR TITLE
chore: delete S3 blob on forget + lifecycle safety-net rule (#502)

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -287,6 +287,16 @@ class HiveStack(cdk.Stack):
             ),
             auto_delete_objects=not is_prod,
         )
+        # Safety-net lifecycle rule: abort truly incomplete multipart
+        # uploads after 1 day so partial PutObject failures don't leave
+        # phantom in-progress uploads consuming storage quota.
+        # Full orphan detection (objects with no DynamoDB counterpart)
+        # requires a scheduled cross-check Lambda — tracked separately.
+        blobs_bucket.add_lifecycle_rule(
+            id="AbortIncompleteUploads",
+            abort_incomplete_multipart_upload_after=cdk.Duration.days(1),
+            enabled=True,
+        )
 
         app_version = os.environ.get("APP_VERSION", "dev")
         common_env = {

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -271,9 +271,7 @@ class HiveStack(cdk.Stack):
         # the storage bill. In non-prod we set RemovalPolicy=DESTROY
         # + auto-delete so ephemeral dev stacks tear down cleanly;
         # prod gets RETAIN to prevent accidental data loss.
-        blobs_bucket_name = (
-            "hive-memory-blobs" if is_prod else f"hive-memory-blobs-{env_name}"
-        )
+        blobs_bucket_name = "hive-memory-blobs" if is_prod else f"hive-memory-blobs-{env_name}"
         blobs_bucket = s3.Bucket(
             self,
             "MemoryBlobsBucket",
@@ -282,16 +280,14 @@ class HiveStack(cdk.Stack):
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             versioned=False,
             enforce_ssl=True,
-            removal_policy=(
-                cdk.RemovalPolicy.RETAIN if is_prod else cdk.RemovalPolicy.DESTROY
-            ),
+            removal_policy=(cdk.RemovalPolicy.RETAIN if is_prod else cdk.RemovalPolicy.DESTROY),
             auto_delete_objects=not is_prod,
         )
-        # Safety-net lifecycle rule: abort truly incomplete multipart
-        # uploads after 1 day so partial PutObject failures don't leave
-        # phantom in-progress uploads consuming storage quota.
-        # Full orphan detection (objects with no DynamoDB counterpart)
-        # requires a scheduled cross-check Lambda — tracked separately.
+        # Safety-net lifecycle rule: abort abandoned multipart upload
+        # sessions after 1 day so in-progress parts don't accumulate
+        # storage quota. Full orphan detection (complete objects with
+        # no DynamoDB counterpart) requires a scheduled cross-check
+        # Lambda — tracked separately.
         blobs_bucket.add_lifecycle_rule(
             id="AbortIncompleteUploads",
             abort_incomplete_multipart_upload_after=cdk.Duration.days(1),
@@ -659,9 +655,7 @@ class HiveStack(cdk.Stack):
                 resources=[f"{waf_log_group.log_group_arn}:*"],
                 conditions={
                     "StringEquals": {"aws:SourceAccount": self.account},
-                    "ArnLike": {
-                        "aws:SourceArn": f"arn:aws:logs:{self.region}:{self.account}:*"
-                    },
+                    "ArnLike": {"aws:SourceArn": f"arn:aws:logs:{self.region}:{self.account}:*"},
                 },
             )
         )
@@ -924,9 +918,7 @@ function handler(event) {
             )
 
         # Deploy built docs site assets — only if docs-site/.vitepress/dist exists
-        docs_dist_path = os.path.join(
-            os.path.dirname(__file__), "../../docs-site/.vitepress/dist"
-        )
+        docs_dist_path = os.path.join(os.path.dirname(__file__), "../../docs-site/.vitepress/dist")
         if os.path.exists(docs_dist_path):
             deploy_docs = s3deploy.BucketDeployment(
                 self,
@@ -1098,9 +1090,7 @@ function handler(event) {
         ) -> cw.Alarm:
             """Lambda error rate alarm: > 5% over two consecutive 5-min periods."""
             errors = fn.metric_errors(period=cdk.Duration.minutes(5), statistic="Sum")
-            invocations = fn.metric_invocations(
-                period=cdk.Duration.minutes(5), statistic="Sum"
-            )
+            invocations = fn.metric_invocations(period=cdk.Duration.minutes(5), statistic="Sum")
             error_rate = cw.MathExpression(
                 expression="100 * errors / MAX([errors, invocations])",
                 using_metrics={"errors": errors, "invocations": invocations},
@@ -1129,9 +1119,7 @@ function handler(event) {
             self,
             "McpP99DurationAlarm",
             alarm_name=f"Hive-{env_name}-McpP99Duration",
-            metric=mcp_fn.metric_duration(
-                period=cdk.Duration.minutes(5), statistic="p99"
-            ),
+            metric=mcp_fn.metric_duration(period=cdk.Duration.minutes(5), statistic="p99"),
             threshold=25_000,  # milliseconds
             evaluation_periods=2,
             datapoints_to_alarm=2,
@@ -1232,9 +1220,7 @@ function handler(event) {
                 self,
                 construct_id,
                 alarm_name=f"Hive-{env_name}-{construct_id.removesuffix('Alarm')}",
-                metric=fn.metric_throttles(
-                    period=cdk.Duration.minutes(5), statistic="Sum"
-                ),
+                metric=fn.metric_throttles(period=cdk.Duration.minutes(5), statistic="Sum"),
                 threshold=0,
                 evaluation_periods=1,
                 comparison_operator=cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -1306,9 +1292,7 @@ function handler(event) {
             window_minutes: int,
         ) -> cw.Alarm:
             """Burn rate alarm using error rate vs SLO error budget."""
-            errors = fn.metric_errors(
-                period=cdk.Duration.minutes(window_minutes), statistic="Sum"
-            )
+            errors = fn.metric_errors(period=cdk.Duration.minutes(window_minutes), statistic="Sum")
             invocations = fn.metric_invocations(
                 period=cdk.Duration.minutes(window_minutes), statistic="Sum"
             )
@@ -1355,9 +1339,7 @@ function handler(event) {
             self,
             "McpP95LatencyAlarm",
             alarm_name=f"Hive-{env_name}-McpP95Latency",
-            metric=mcp_fn.metric_duration(
-                period=cdk.Duration.minutes(60), statistic="p95"
-            ),
+            metric=mcp_fn.metric_duration(period=cdk.Duration.minutes(60), statistic="p95"),
             threshold=2000,
             evaluation_periods=1,
             datapoints_to_alarm=1,
@@ -1390,39 +1372,23 @@ function handler(event) {
                 cw.GraphWidget(
                     title="MCP Invocations & Errors",
                     left=[
-                        mcp_fn.metric_invocations(
-                            period=cdk.Duration.minutes(5), statistic="Sum"
-                        )
+                        mcp_fn.metric_invocations(period=cdk.Duration.minutes(5), statistic="Sum")
                     ],
-                    right=[
-                        mcp_fn.metric_errors(
-                            period=cdk.Duration.minutes(5), statistic="Sum"
-                        )
-                    ],
+                    right=[mcp_fn.metric_errors(period=cdk.Duration.minutes(5), statistic="Sum")],
                     width=8,
                 ),
                 cw.GraphWidget(
                     title="MCP Duration (ms)",
                     left=[
-                        mcp_fn.metric_duration(
-                            period=cdk.Duration.minutes(5), statistic="p50"
-                        ),
-                        mcp_fn.metric_duration(
-                            period=cdk.Duration.minutes(5), statistic="p95"
-                        ),
-                        mcp_fn.metric_duration(
-                            period=cdk.Duration.minutes(5), statistic="p99"
-                        ),
+                        mcp_fn.metric_duration(period=cdk.Duration.minutes(5), statistic="p50"),
+                        mcp_fn.metric_duration(period=cdk.Duration.minutes(5), statistic="p95"),
+                        mcp_fn.metric_duration(period=cdk.Duration.minutes(5), statistic="p99"),
                     ],
                     width=8,
                 ),
                 cw.GraphWidget(
                     title="MCP Throttles",
-                    left=[
-                        mcp_fn.metric_throttles(
-                            period=cdk.Duration.minutes(5), statistic="Sum"
-                        )
-                    ],
+                    left=[mcp_fn.metric_throttles(period=cdk.Duration.minutes(5), statistic="Sum")],
                     width=8,
                 ),
             ),
@@ -1434,39 +1400,23 @@ function handler(event) {
                 cw.GraphWidget(
                     title="API Invocations & Errors",
                     left=[
-                        api_fn.metric_invocations(
-                            period=cdk.Duration.minutes(5), statistic="Sum"
-                        )
+                        api_fn.metric_invocations(period=cdk.Duration.minutes(5), statistic="Sum")
                     ],
-                    right=[
-                        api_fn.metric_errors(
-                            period=cdk.Duration.minutes(5), statistic="Sum"
-                        )
-                    ],
+                    right=[api_fn.metric_errors(period=cdk.Duration.minutes(5), statistic="Sum")],
                     width=8,
                 ),
                 cw.GraphWidget(
                     title="API Duration (ms)",
                     left=[
-                        api_fn.metric_duration(
-                            period=cdk.Duration.minutes(5), statistic="p50"
-                        ),
-                        api_fn.metric_duration(
-                            period=cdk.Duration.minutes(5), statistic="p95"
-                        ),
-                        api_fn.metric_duration(
-                            period=cdk.Duration.minutes(5), statistic="p99"
-                        ),
+                        api_fn.metric_duration(period=cdk.Duration.minutes(5), statistic="p50"),
+                        api_fn.metric_duration(period=cdk.Duration.minutes(5), statistic="p95"),
+                        api_fn.metric_duration(period=cdk.Duration.minutes(5), statistic="p99"),
                     ],
                     width=8,
                 ),
                 cw.GraphWidget(
                     title="API Throttles",
-                    left=[
-                        api_fn.metric_throttles(
-                            period=cdk.Duration.minutes(5), statistic="Sum"
-                        )
-                    ],
+                    left=[api_fn.metric_throttles(period=cdk.Duration.minutes(5), statistic="Sum")],
                     width=8,
                 ),
             ),
@@ -1677,7 +1627,9 @@ function handler(event) {
                 cw.AlarmWidget(alarm=api_slow_burn_alarm, title="API Slow Burn (2×, 6h)", width=6),
             ),
             cw.Row(
-                cw.AlarmWidget(alarm=mcp_p95_latency_alarm, title="MCP p95 Latency SLO (1h)", width=8),
+                cw.AlarmWidget(
+                    alarm=mcp_p95_latency_alarm, title="MCP p95 Latency SLO (1h)", width=8
+                ),
                 cw.GraphWidget(
                     title="MCP Error Rate % (SLO threshold = 0.5%)",
                     left=[
@@ -1700,11 +1652,7 @@ function handler(event) {
                 ),
                 cw.GraphWidget(
                     title="MCP p95 Latency (SLO threshold = 2000 ms)",
-                    left=[
-                        mcp_fn.metric_duration(
-                            period=cdk.Duration.minutes(60), statistic="p95"
-                        )
-                    ],
+                    left=[mcp_fn.metric_duration(period=cdk.Duration.minutes(60), statistic="p95")],
                     left_y_axis=cw.YAxisProps(min=0),
                     width=8,
                 ),
@@ -1714,8 +1662,12 @@ function handler(event) {
         # ----------------------------------------------------------------
         # Outputs
         # ----------------------------------------------------------------
-        cdk.CfnOutput(self, "McpFunctionUrl", value=mcp_url.url, description="MCP Lambda URL (direct)")
-        cdk.CfnOutput(self, "ApiFunctionUrl", value=api_url.url, description="API Lambda URL (direct)")
+        cdk.CfnOutput(
+            self, "McpFunctionUrl", value=mcp_url.url, description="MCP Lambda URL (direct)"
+        )
+        cdk.CfnOutput(
+            self, "ApiFunctionUrl", value=api_url.url, description="API Lambda URL (direct)"
+        )
         cdk.CfnOutput(self, "TableName", value=table.table_name, description="DynamoDB table name")
         cdk.CfnOutput(
             self,

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1122,8 +1122,9 @@ class HiveStorage:
 
         Called after the DynamoDB item is already removed. Failures are
         logged as warnings and swallowed — the memory is already gone from
-        DynamoDB so it's inaccessible regardless; the S3 lifecycle rule
-        provides a backstop for any objects that slip through.
+        DynamoDB so it's inaccessible regardless. The configured S3
+        lifecycle rule only aborts incomplete multipart uploads; it does
+        not clean up orphaned objects left behind by failed deletes.
         """
         if memory.s3_uri is None:
             return
@@ -1132,8 +1133,9 @@ class HiveStorage:
             self.blob_store.delete(owner=owner, memory_id=memory.memory_id)
         except Exception:
             logger.warning(
-                "blob_delete_failed",
-                extra={"memory_id": memory.memory_id, "s3_uri": memory.s3_uri},
+                "blob_delete_failed memory_id=%s s3_uri=%s",
+                memory.memory_id,
+                memory.s3_uri,
                 exc_info=True,
             )
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -24,6 +24,7 @@ import boto3
 from boto3.dynamodb.conditions import Attr, Key
 from botocore.exceptions import ClientError
 
+from hive.logging_config import get_logger
 from hive.models import (
     ActivityEvent,
     ApiKey,
@@ -37,6 +38,8 @@ from hive.models import (
     TokenType,
     User,
 )
+
+logger = get_logger("hive.storage")
 
 TABLE_NAME = os.environ.get("HIVE_TABLE_NAME", "hive")
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
@@ -341,6 +344,7 @@ class HiveStorage:
         memory = Memory.from_dynamo(existing)
         self._delete_tag_items(memory)
         self.table.delete_item(Key={"PK": f"MEMORY#{memory_id}", "SK": "META"})
+        self._delete_blob_if_needed(memory)
         return True
 
     # ------------------------------------------------------------------
@@ -518,6 +522,7 @@ class HiveStorage:
                     continue
                 self._delete_tag_items(memory)
                 self.table.delete_item(Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"})
+                self._delete_blob_if_needed(memory)
                 deleted += 1
             if cursor is None:
                 break
@@ -1111,6 +1116,26 @@ class HiveStorage:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _delete_blob_if_needed(self, memory: Memory) -> None:
+        """Delete the S3 blob for a memory if one exists.
+
+        Called after the DynamoDB item is already removed. Failures are
+        logged as warnings and swallowed — the memory is already gone from
+        DynamoDB so it's inaccessible regardless; the S3 lifecycle rule
+        provides a backstop for any objects that slip through.
+        """
+        if memory.s3_uri is None:
+            return
+        owner = memory.owner_user_id or memory.owner_client_id or ""
+        try:
+            self.blob_store.delete(owner=owner, memory_id=memory.memory_id)
+        except Exception:
+            logger.warning(
+                "blob_delete_failed",
+                extra={"memory_id": memory.memory_id, "s3_uri": memory.s3_uri},
+                exc_info=True,
+            )
 
     def _get_memory_meta(self, memory_id: str) -> dict[str, Any] | None:
         resp = self.table.get_item(Key={"PK": f"MEMORY#{memory_id}", "SK": "META"})

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -566,6 +566,46 @@ class TestLargeMemoryRouting:
         assert isinstance(first, BlobStore)
         assert storage.blob_store is first  # cached — not re-created
 
+    def test_delete_memory_removes_s3_blob(self, storage_with_blob_store):
+        storage, fake = storage_with_blob_store
+        big_value = "x" * (200 * 1024)
+        m = Memory(key="big", value=big_value, owner_user_id="u1", owner_client_id="c1")
+        storage.put_memory(m)
+        assert ("u1", m.memory_id) in fake.objects
+
+        storage.delete_memory(m.memory_id)
+        assert ("u1", m.memory_id) not in fake.objects
+
+    def test_delete_memory_s3_failure_is_nonfatal(self, storage_with_blob_store):
+        storage, fake = storage_with_blob_store
+        big_value = "x" * (200 * 1024)
+        m = Memory(key="big2", value=big_value, owner_user_id="u1", owner_client_id="c1")
+        storage.put_memory(m)
+
+        def _raise(owner, memory_id):
+            raise RuntimeError("S3 unavailable")
+
+        fake.delete = _raise
+        # Should not raise — DynamoDB item is gone; S3 failure is logged
+        assert storage.delete_memory(m.memory_id)
+        assert storage.get_memory_by_key("big2") is None
+
+    def test_delete_memories_by_tag_removes_blobs(self, storage_with_blob_store):
+        storage, fake = storage_with_blob_store
+        big_value = "x" * (200 * 1024)
+        m = Memory(
+            key="bulk-big",
+            value=big_value,
+            tags=["bulk"],
+            owner_user_id="u1",
+            owner_client_id="c1",
+        )
+        storage.put_memory(m)
+        assert ("u1", m.memory_id) in fake.objects
+
+        storage.delete_memories_by_tag("bulk")
+        assert ("u1", m.memory_id) not in fake.objects
+
 
 class TestMemoryVersionStorage:
     def test_list_versions_newest_first(self, storage):


### PR DESCRIPTION
Closes #502

## Summary

- `delete_memory()` now calls `_delete_blob_if_needed()` after the DynamoDB item is removed, so `forget()` and `delete_user_data()` automatically purge S3 objects for text-large memories. S3 failures are logged as warnings and swallowed — the memory is already inaccessible from DynamoDB regardless.
- `delete_memories_by_tag()` receives the same blob cleanup so bulk-tag deletions also purge their S3 objects; `delete_user_data()` cascades naturally via `delete_memory()`.
- Added `AbortIncompleteMultipartUpload` (1-day) lifecycle rule to the `hive-memory-blobs` CDK bucket as the S3-native safety net for partial upload failures. Full orphan detection (objects with no DynamoDB counterpart) would require a scheduled cross-check Lambda, noted in a comment as future work.
- 100% coverage: three new unit tests cover the happy path, the S3-failure non-fatal path, and the bulk-tag delete path.

## Approach

The `_delete_blob_if_needed()` helper is intentionally placed at the storage-layer `delete_memory()` level rather than in the MCP tool (`forget()`), so all three deletion paths (single forget, bulk tag delete, full account delete) share the same S3 cleanup without duplication.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y56sF9QXGtvyZ9cajArMdV)_