### PR TITLE
feat: transparent text-large recall and full-text vector embedding

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -470,7 +470,11 @@ async def remember(
         event_type = EventType.memory_updated
         action = "Updated"
         try:
-            _vector_store().upsert_memory(existing)
+            _vector_store().upsert_memory(
+                existing.model_copy(update={"value": value})
+                if existing.value_type == "text-large"
+                else existing
+            )
         except Exception:
             logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
     else:
@@ -491,7 +495,11 @@ async def remember(
         event_type = EventType.memory_created
         action = "Stored"
         try:
-            _vector_store().upsert_memory(memory)
+            _vector_store().upsert_memory(
+                memory.model_copy(update={"value": value})
+                if memory.value_type == "text-large"
+                else memory
+            )
         except Exception:
             logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
 
@@ -599,7 +607,11 @@ async def remember_if_absent(
         await emit_metric("ToolErrors", operation="remember_if_absent")
         raise ToolError(str(exc)) from exc
     try:
-        _vector_store().upsert_memory(memory)
+        _vector_store().upsert_memory(
+            memory.model_copy(update={"value": value})
+            if memory.value_type == "text-large"
+            else memory
+        )
     except Exception:
         logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
 
@@ -698,7 +710,19 @@ async def recall(
     await emit_metric(
         "StorageLatencyMs", value=float(duration_ms), unit="Milliseconds", operation="recall"
     )
-    return _tool_result(memory.value, storage, client_id, memory=memory)
+    if memory.value_type == "text-large":
+        try:
+            recalled_value = storage.fetch_blob_value(memory)
+        except Exception:
+            logger.warning(
+                "blob_fetch_failed for recall key='%s'",
+                key,
+                exc_info=True,
+            )
+            recalled_value = f"[memory content unavailable — blob fetch failed for key '{key}']"
+    else:
+        recalled_value = memory.value or ""
+    return _tool_result(recalled_value, storage, client_id, memory=memory)
 
 
 @mcp.tool(
@@ -1231,9 +1255,10 @@ async def search_memories(
     now = datetime.now(timezone.utc)
     scored: list[tuple[Memory, float, float, float, float]] = []
     for m, sem in hydrated:
-        # Large-memory entries keep an empty-string inline placeholder
-        # until #498 lands the S3 fetch. Fall back to "" here so
-        # keyword_score always receives a str.
+        # For text-large memories, keyword scoring uses the empty inline
+        # placeholder — fetching S3 blobs per candidate would be too
+        # expensive. Semantic relevance from the vector index covers the
+        # large-document recall path.
         kw = keyword_score(query_tokens, m.value or "")
         rec = recency_score(m, now=now)
         blended = blend_score(
@@ -1328,11 +1353,20 @@ async def relate_memories(
     if memory is None:
         raise ToolError(f"No memory found for key '{key}'.")
 
+    query_value = memory.value or ""
+    if memory.value_type == "text-large":
+        try:
+            query_value = storage.fetch_blob_value(memory)
+        except Exception:
+            logger.warning(
+                "blob_fetch_failed for relate_memories key='%s'",
+                key,
+                exc_info=True,
+            )
+
     try:
         # Fetch top_k+1 so that dropping the source still leaves up to top_k.
-        # `memory.value or ""` guards the #497 large-memory path where
-        # the inline value is empty until #498 wires the S3 fetch.
-        pairs = _vector_store().search(memory.value or "", client_id, top_k=top_k + 1)
+        pairs = _vector_store().search(query_value, client_id, top_k=top_k + 1)
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
     except Exception:
@@ -1899,8 +1933,16 @@ def read_memory_resource(key: str) -> str:
         raise ValueError(f"Memory not found: {decoded_key!r}")
     if memory.is_redacted:
         raise ValueError(f"Memory has been redacted: {decoded_key!r}")
-    # `memory.value or ""` guards the #497 large-memory path — #498
-    # swaps this for a transparent S3 fetch on text-large items.
+    if memory.value_type == "text-large":
+        try:
+            return storage.fetch_blob_value(memory)
+        except Exception:
+            logger.warning(
+                "blob_fetch_failed for resource key='%s'",
+                decoded_key,
+                exc_info=True,
+            )
+            return f"[memory content unavailable — blob fetch failed for key {decoded_key!r}]"
     return memory.value or ""
 
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -235,19 +235,26 @@ class HiveStorage:
     def _route_large_value(self, memory: Memory) -> None:
         """Offload oversized text to S3, leaving a pointer in DynamoDB.
 
-        Only runs on "text"-typed memories. Non-text types (image /
-        blob, arriving via #499) are expected to already carry an
-        ``s3_uri`` when they reach ``put_memory`` — this router only
-        handles the transparent-text-large path where a caller hands
-        us an oversized string and expects us to pick the right
-        backend.
+        Handles both initial writes and updates for text and text-large
+        memories. Binary types (image/blob, arriving via #499) are expected
+        to already carry an ``s3_uri`` — this router only handles the
+        transparent-text path where a caller hands us a string and expects
+        the right backend to be chosen automatically.
         """
         from hive.blob_store import INLINE_TEXT_THRESHOLD_BYTES, MAX_BLOB_SIZE_BYTES
 
-        # Non-text paths have their own upload lifecycle (#499) —
-        # don't touch them here.
-        if memory.value_type != "text":
+        # Binary paths (image, blob) have their own upload lifecycle (#499).
+        if memory.value_type not in ("text", "text-large"):
             return
+
+        # A text-large memory fetched from DynamoDB has value="" (blob already
+        # in S3). Re-route only when the caller has provided a new value (the
+        # remember-update path). An empty value means the existing S3 object
+        # is unchanged.
+        if memory.value_type == "text-large":
+            if not memory.value:
+                return
+            memory.value_type = "text"
 
         if memory.value is None:
             return
@@ -1138,6 +1145,16 @@ class HiveStorage:
                 memory.s3_uri,
                 exc_info=True,
             )
+
+    def fetch_blob_value(self, memory: Memory) -> str:
+        """Fetch the full text content from S3 for a ``text-large`` memory.
+
+        Raises whatever the underlying blob store raises so the caller can
+        decide whether to propagate or surface a user-facing fallback.
+        """
+        owner = memory.owner_user_id or memory.owner_client_id or ""
+        data = self.blob_store.get(owner=owner, memory_id=memory.memory_id)
+        return data.decode("utf-8")
 
     def _get_memory_meta(self, memory_id: str) -> dict[str, Any] | None:
         resp = self.table.get_item(Key={"PK": f"MEMORY#{memory_id}", "SK": "META"})

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1446,6 +1446,208 @@ class TestRelateMemories:
 
 
 # ---------------------------------------------------------------------------
+# Text-large transparent routing (#498)
+# ---------------------------------------------------------------------------
+
+
+class TestTextLargeRouting:
+    """#498 — recall, relate_memories, read_memory_resource, and vector upsert
+    work transparently for text-large memories stored in S3."""
+
+    _BIG = "z" * (150 * 1024)  # 150 KB — above 100 KB inline threshold
+
+    def _setup_blob_bucket(self, monkeypatch):
+        """Create a moto S3 bucket and point HIVE_BLOBS_BUCKET at it."""
+        bucket = "test-text-large-498"
+        monkeypatch.setenv("HIVE_BLOBS_BUCKET", bucket)
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=bucket)
+        return bucket
+
+    async def test_recall_text_large_returns_full_value(self, server_env, monkeypatch):
+        """recall() transparently fetches the blob and returns the full text."""
+        self._setup_blob_bucket(monkeypatch)
+        storage, _, jwt = server_env
+        from hive.server import recall, remember
+
+        await remember("tl-recall", self._BIG, [], ctx=_make_ctx(jwt))
+        stored = storage.get_memory_by_key("tl-recall")
+        assert stored.value_type == "text-large"
+
+        result = await recall("tl-recall", ctx=_make_ctx(jwt))
+        assert _text(result) == self._BIG
+
+    async def test_recall_text_large_s3_error_returns_unavailable(self, server_env, monkeypatch):
+        """S3 fetch failure surfaces as 'unavailable' rather than crashing."""
+        from hive.models import Memory
+        from hive.server import recall
+
+        storage, client_id, jwt = server_env
+        # Insert a text-large memory directly without putting a blob in S3.
+        # No HIVE_BLOBS_BUCKET set → BlobStore() raises, which our except catches.
+        monkeypatch.delenv("HIVE_BLOBS_BUCKET", raising=False)
+        m = Memory(
+            key="tl-error",
+            value="",
+            value_type="text-large",
+            s3_uri="s3://missing/key",
+            owner_client_id=client_id,
+        )
+        storage.put_memory(m)
+
+        result = await recall("tl-error", ctx=_make_ctx(jwt))
+        assert "unavailable" in _text(result)
+
+    async def test_remember_text_large_embeds_full_value_new_memory(self, server_env, monkeypatch):
+        """remember() passes full text to VectorStore.upsert_memory for new text-large."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import remember
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await remember("tl-embed-new", self._BIG, [], ctx=_make_ctx(jwt))
+
+        mock_vs.upsert_memory.assert_called_once()
+        embedded_memory = mock_vs.upsert_memory.call_args[0][0]
+        assert embedded_memory.value == self._BIG
+
+    async def test_remember_text_large_embeds_full_value_on_update(self, server_env, monkeypatch):
+        """remember() passes full text to VectorStore.upsert_memory on update."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import remember
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            # first write → creates
+            await remember("tl-embed-upd", self._BIG, [], ctx=_make_ctx(jwt))
+            # second write → updates
+            updated_big = "a" * (150 * 1024)
+            await remember("tl-embed-upd", updated_big, [], ctx=_make_ctx(jwt))
+
+        assert mock_vs.upsert_memory.call_count == 2
+        embedded_on_update = mock_vs.upsert_memory.call_args_list[1][0][0]
+        assert embedded_on_update.value == updated_big
+
+    async def test_remember_if_absent_text_large_embeds_full_value(self, server_env, monkeypatch):
+        """remember_if_absent() passes full text to upsert_memory for text-large."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import remember_if_absent
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        mock_vs = MagicMock()
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await remember_if_absent("tl-absent", self._BIG, [], ctx=_make_ctx(jwt))
+
+        mock_vs.upsert_memory.assert_called_once()
+        embedded_memory = mock_vs.upsert_memory.call_args[0][0]
+        assert embedded_memory.value == self._BIG
+
+    async def test_relate_memories_text_large_uses_full_value(self, server_env, monkeypatch):
+        """relate_memories() fetches blob for source memory and uses it as query."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import relate_memories, remember
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+
+        await remember("tl-relate-src", self._BIG, [], ctx=_make_ctx(jwt))
+        mock_vs = MagicMock()
+        mock_vs.search.return_value = []
+        mock_vs.upsert_memory.return_value = None
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await relate_memories("tl-relate-src", ctx=_make_ctx(jwt))
+
+        mock_vs.search.assert_called_once()
+        query_arg = mock_vs.search.call_args[0][0]
+        assert query_arg == self._BIG
+
+    async def test_relate_memories_text_large_s3_error_falls_back_to_empty(
+        self, server_env, monkeypatch
+    ):
+        """relate_memories() falls back to empty query string on S3 error."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.models import Memory
+        from hive.server import relate_memories
+
+        storage, client_id, jwt = server_env
+        monkeypatch.delenv("HIVE_BLOBS_BUCKET", raising=False)
+        m = Memory(
+            key="tl-relate-err",
+            value="",
+            value_type="text-large",
+            s3_uri="s3://missing/key",
+            owner_client_id=client_id,
+        )
+        storage.put_memory(m)
+
+        mock_vs = MagicMock()
+        mock_vs.search.return_value = []
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            await relate_memories("tl-relate-err", ctx=_make_ctx(jwt))
+
+        query_arg = mock_vs.search.call_args[0][0]
+        assert query_arg == ""
+
+    async def test_read_memory_resource_text_large_fetches_blob(self, server_env, monkeypatch):
+        """read_memory_resource() returns the full blob content for text-large."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.server import read_memory_resource, remember
+
+        self._setup_blob_bucket(monkeypatch)
+        _, client_id, jwt = server_env
+        await remember("tl-resource", self._BIG, [], ctx=_make_ctx(jwt))
+
+        tok = MagicMock()
+        tok.client_id = client_id
+        tok.scopes = ["memories:read"]
+        with patch("hive.server.get_access_token", return_value=tok):
+            value = read_memory_resource("tl-resource")
+        assert value == self._BIG
+
+    async def test_read_memory_resource_text_large_s3_error_returns_unavailable(
+        self, server_env, monkeypatch
+    ):
+        """read_memory_resource() returns unavailable message on S3 error."""
+        from unittest.mock import MagicMock, patch
+
+        from hive.models import Memory
+        from hive.server import read_memory_resource
+
+        storage, client_id, jwt = server_env
+        monkeypatch.delenv("HIVE_BLOBS_BUCKET", raising=False)
+        m = Memory(
+            key="tl-res-err",
+            value="",
+            value_type="text-large",
+            s3_uri="s3://missing/key",
+            owner_client_id=client_id,
+        )
+        storage.put_memory(m)
+
+        tok = MagicMock()
+        tok.client_id = client_id
+        tok.scopes = ["memories:read"]
+        with patch("hive.server.get_access_token", return_value=tok):
+            value = read_memory_resource("tl-res-err")
+        assert "unavailable" in value
+
+
+# ---------------------------------------------------------------------------
 # forget_all
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -606,6 +606,69 @@ class TestLargeMemoryRouting:
         storage.delete_memories_by_tag("bulk")
         assert ("u1", m.memory_id) not in fake.objects
 
+    def test_update_text_large_memory_re_uploads_new_value(self, storage_with_blob_store):
+        # Updating a text-large memory's value re-uploads to S3, overwriting
+        # the old blob at the same key.
+        storage, fake = storage_with_blob_store
+        big_value = "x" * (200 * 1024)
+        m = Memory(key="re-upload", value=big_value, owner_user_id="u1", owner_client_id="c1")
+        storage.put_memory(m)
+        assert ("u1", m.memory_id) in fake.objects
+        assert fake.objects[("u1", m.memory_id)] == big_value.encode()
+
+        updated_big = "y" * (200 * 1024)
+        m.value = updated_big
+        storage.put_memory(m)
+        assert fake.objects[("u1", m.memory_id)] == updated_big.encode()
+
+    def test_update_text_large_empty_value_skips_routing(self, storage_with_blob_store):
+        # A text-large memory fetched from DynamoDB (value="") goes through
+        # put_memory for metadata-only updates (e.g. tag changes). The router
+        # must leave it untouched — the blob is already in S3.
+        storage, fake = storage_with_blob_store
+        big_value = "z" * (200 * 1024)
+        m = Memory(
+            key="skip-reupload",
+            value=big_value,
+            tags=["old"],
+            owner_user_id="u1",
+            owner_client_id="c1",
+        )
+        storage.put_memory(m)
+        initial_calls = dict(fake.objects)
+
+        # Simulate a tag-only update: fetch the memory (value="" in DynamoDB),
+        # change tags, then put again. The router must not re-upload the blob.
+        fetched = storage.get_memory_by_key("skip-reupload")
+        assert fetched.value == ""  # inline value is empty for text-large
+        fetched.tags = ["new"]
+        storage.put_memory(fetched)
+        # The S3 object is unchanged — the router skipped the empty-value memory
+        assert fake.objects == initial_calls
+
+    def test_fetch_blob_value_returns_full_text(self, storage_with_blob_store):
+        storage, fake = storage_with_blob_store
+        big_value = "hello blob " * 10_000
+        m = Memory(key="fetch-test", value=big_value, owner_user_id="u1", owner_client_id="c1")
+        storage.put_memory(m)
+        assert m.value_type == "text-large"
+
+        fetched = storage.fetch_blob_value(m)
+        assert fetched == big_value
+
+    def test_fetch_blob_value_propagates_s3_error(self, storage_with_blob_store):
+        storage, fake = storage_with_blob_store
+        big_value = "x" * (200 * 1024)
+        m = Memory(key="fetch-fail", value=big_value, owner_user_id="u1", owner_client_id="c1")
+        storage.put_memory(m)
+
+        def _raise(owner, memory_id):
+            raise RuntimeError("S3 unavailable")
+
+        fake.get = _raise
+        with pytest.raises(RuntimeError, match="S3 unavailable"):
+            storage.fetch_blob_value(m)
+
 
 class TestMemoryVersionStorage:
     def test_list_versions_newest_first(self, storage):


### PR DESCRIPTION
Closes #498

## Summary

- `recall()` transparently fetches the S3 blob for `text-large` memories and returns the full content verbatim; S3/BlobStore failures surface as a clear "memory content unavailable" message rather than crashing the tool call
- `remember()` and `remember_if_absent()` pass the original value string to `VectorStore.upsert_memory()` so Bedrock Titan embeds the full text, not the empty placeholder that lives in DynamoDB after large-text promotion
- `_route_large_value()` in `storage.py` is extended to handle the update path: a `text-large` memory given a new non-empty value re-routes through the S3 upload, overwriting the old blob at the same key
- `read_memory_resource()` and `relate_memories()` receive the same S3-fetch treatment, so MCP Resources and `relate_memories` queries over large memories work transparently
- Adds `HiveStorage.fetch_blob_value()` as the shared helper for S3 text retrieval

## Approach

**Embedding:** The `Memory` object is mutated by `put_memory()` (inline value cleared when promoted to S3). Rather than a second S3 round-trip for embedding, `model_copy(update={"value": value})` is used to pass the original tool parameter to `upsert_memory()` with zero extra I/O.

**Search-time keyword scoring:** `search_memories()` still scores `m.value or ""` for text-large candidates — fetching S3 for every search result would be prohibitively expensive. Semantic recall via the vector index covers the large-document path.

**Update path fix:** `_route_large_value()` previously skipped any memory with `value_type != "text"`. Updating a text-large memory's value would have stored a 150 KB string directly in DynamoDB (bypassing S3), silently violating the 400 KB item limit in production. The fix detects a non-empty value on a `text-large` memory and re-routes it through the standard text-upload path.

Local e2e not run — CI will cover this on the development branch deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y56sF9QXGtvyZ9cajArMdV)_