### PR TITLE
security: scope list_memories and summarize_context to the requesting user

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -479,7 +479,9 @@ async def remember(
             logger.warning("Vector upsert failed (non-fatal)", exc_info=True)
     else:
         client = storage.get_client(client_id)
-        owner_user_id = client.owner_user_id if client else None
+        if client is None:
+            raise ToolError("Unable to load client record for authenticated caller.")
+        owner_user_id = client.owner_user_id
         try:
             check_memory_quota(owner_user_id, storage)
         except QuotaExceeded as exc:
@@ -597,7 +599,9 @@ async def remember_if_absent(
         return _tool_result(f"Memory '{key}' already exists — not overwritten.", storage, client_id)
 
     client = storage.get_client(client_id)
-    owner_user_id = client.owner_user_id if client else None
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    owner_user_id = client.owner_user_id
     try:
         check_memory_quota(owner_user_id, storage)
     except QuotaExceeded as exc:
@@ -1036,7 +1040,13 @@ async def list_memories(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     client = storage.get_client(client_id)
-    owner_user_id = client.owner_user_id if client else None
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    if client.owner_user_id is None:
+        raise ToolError(
+            "Client is not associated with a user account; per-user memory scoping is required."
+        )
+    owner_user_id = client.owner_user_id
 
     limit = max(1, min(limit, 500))
     memories, next_cursor = storage.list_memories_by_tag(
@@ -1137,7 +1147,13 @@ async def summarize_context(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
     client = storage.get_client(client_id)
-    owner_user_id = client.owner_user_id if client else None
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    if client.owner_user_id is None:
+        raise ToolError(
+            "Client is not associated with a user account; per-user memory scoping is required."
+        )
+    owner_user_id = client.owner_user_id
 
     await _report_progress(ctx, 0, 2, f"Retrieving memories for '{topic}'...")
     memories, _ = storage.list_memories_by_tag(topic, limit=500, owner_user_id=owner_user_id)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -485,7 +485,12 @@ async def remember(
         except QuotaExceeded as exc:
             raise ToolError(exc.detail) from exc
         memory = Memory(
-            key=key, value=value, tags=tags, owner_client_id=client_id, expires_at=expires_at
+            key=key,
+            value=value,
+            tags=tags,
+            owner_client_id=client_id,
+            owner_user_id=owner_user_id,
+            expires_at=expires_at,
         )
         try:
             storage.put_memory(memory)
@@ -599,7 +604,12 @@ async def remember_if_absent(
         raise ToolError(exc.detail) from exc
 
     memory = Memory(
-        key=key, value=value, tags=tags, owner_client_id=client_id, expires_at=expires_at
+        key=key,
+        value=value,
+        tags=tags,
+        owner_client_id=client_id,
+        owner_user_id=owner_user_id,
+        expires_at=expires_at,
     )
     try:
         storage.put_memory(memory)
@@ -1025,9 +1035,13 @@ async def list_memories(
     """List memories that have a specific tag, with optional pagination."""
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    client = storage.get_client(client_id)
+    owner_user_id = client.owner_user_id if client else None
 
     limit = max(1, min(limit, 500))
-    memories, next_cursor = storage.list_memories_by_tag(tag, limit=limit, cursor=cursor)
+    memories, next_cursor = storage.list_memories_by_tag(
+        tag, limit=limit, cursor=cursor, owner_user_id=owner_user_id
+    )
     if not include_redacted:
         memories = [m for m in memories if not m.is_redacted]
     _log(
@@ -1122,9 +1136,11 @@ async def summarize_context(
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
+    client = storage.get_client(client_id)
+    owner_user_id = client.owner_user_id if client else None
 
     await _report_progress(ctx, 0, 2, f"Retrieving memories for '{topic}'...")
-    memories, _ = storage.list_memories_by_tag(topic, limit=500)
+    memories, _ = storage.list_memories_by_tag(topic, limit=500, owner_user_id=owner_user_id)
     await _report_progress(
         ctx, 1, 2, f"Retrieved {len(memories)} memories; synthesising summary..."
     )

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -436,8 +436,13 @@ class HiveStorage:
         tag: str,
         limit: int = 100,
         cursor: str | None = None,
+        owner_user_id: str | None = None,
     ) -> tuple[list[Memory], str | None]:
         """Query TagIndex GSI to find memories with a given tag.
+
+        When owner_user_id is provided, only memories belonging to that user
+        are returned (within-user cross-client sharing is intentional product
+        behaviour; cross-user isolation is enforced here).
 
         Returns (memories, next_cursor). next_cursor is None when exhausted.
         """
@@ -453,7 +458,7 @@ class HiveStorage:
         memories: list[Memory] = []
         for item in resp.get("Items", []):
             m = self.get_memory_by_id(item["memory_id"])
-            if m is not None:
+            if m is not None and (owner_user_id is None or m.owner_user_id == owner_user_id):
                 memories.append(m)
 
         lek = resp.get("LastEvaluatedKey")
@@ -523,10 +528,10 @@ class HiveStorage:
         deleted = 0
         cursor: str | None = None
         while True:
-            items, cursor = self.list_memories_by_tag(tag, limit=100, cursor=cursor)
+            items, cursor = self.list_memories_by_tag(
+                tag, limit=100, cursor=cursor, owner_user_id=owner_user_id
+            )
             for memory in items:
-                if owner_user_id and memory.owner_user_id != owner_user_id:
-                    continue
                 self._delete_tag_items(memory)
                 self.table.delete_item(Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"})
                 self._delete_blob_if_needed(memory)
@@ -549,11 +554,10 @@ class HiveStorage:
         if tag:
             cursor: str | None = None
             while True:
-                items, cursor = self.list_memories_by_tag(tag, limit=100, cursor=cursor)
-                for memory in items:
-                    if owner_user_id and memory.owner_user_id != owner_user_id:
-                        continue
-                    yield memory
+                items, cursor = self.list_memories_by_tag(
+                    tag, limit=100, cursor=cursor, owner_user_id=owner_user_id
+                )
+                yield from items
                 if cursor is None:
                     break
         else:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -105,7 +105,7 @@ def setup():
         aws_secret_access_key="local",
     )
 
-    oauth_client = OAuthClient(client_name="MCP Test Client")
+    oauth_client = OAuthClient(client_name="MCP Test Client", owner_user_id="integration-test-user")
     storage.put_client(oauth_client)
 
     now = datetime.now(timezone.utc)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -172,3 +172,136 @@ class TestMCPTools:
         text = _text(result)
         assert "summary" in text.lower()
         assert "s1" in text or "s2" in text
+
+
+def _make_user_token(storage, owner_user_id: str) -> str:
+    """Create an OAuth client + token for ``owner_user_id`` and return a JWT."""
+    from datetime import datetime, timedelta, timezone
+
+    from hive.auth.tokens import issue_jwt
+    from hive.models import OAuthClient, Token
+
+    client = OAuthClient(
+        client_name=f"Integration User {owner_user_id}", owner_user_id=owner_user_id
+    )
+    storage.put_client(client)
+    now = datetime.now(timezone.utc)
+    token = Token(
+        client_id=client.client_id,
+        scope="memories:read memories:write",
+        issued_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    storage.put_token(token)
+    return issue_jwt(token)
+
+
+@pytest.fixture(scope="module")
+def two_user_setup():
+    """Set up DynamoDB Local table + two users for cross-user isolation tests."""
+    import contextlib
+
+    import boto3
+
+    table_name = "hive-mcp-cross-user"
+    ddb = boto3.client(
+        "dynamodb",
+        endpoint_url=DYNAMO_ENDPOINT,
+        region_name="us-east-1",
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+    )
+    with contextlib.suppress(Exception):
+        ddb.delete_table(TableName=table_name)
+
+    ddb.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    os.environ["HIVE_TABLE_NAME"] = table_name
+    from hive.storage import HiveStorage
+
+    storage = HiveStorage(
+        table_name=table_name,
+        region="us-east-1",
+        endpoint_url=DYNAMO_ENDPOINT,
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+    )
+
+    jwt_a = _make_user_token(storage, "integration-user-a")
+    jwt_b = _make_user_token(storage, "integration-user-b")
+    return jwt_a, jwt_b
+
+
+@pytest.mark.asyncio
+class TestCrossUserIsolation:
+    """Regression tests for the cross-user memory leak fixed in #587."""
+
+    async def test_list_memories_cross_user_isolation(self, two_user_setup):
+        """list_memories must not expose User A's memories to User B."""
+        from hive.server import list_memories, remember
+
+        jwt_a, jwt_b = two_user_setup
+        ctx_a = _make_context(jwt_a)
+        ctx_b = _make_context(jwt_b)
+
+        await remember(key="leak-a", value="sensitive-a", tags=["cross-user-tag"], ctx=ctx_a)
+        await remember(key="leak-b", value="sensitive-b", tags=["cross-user-tag"], ctx=ctx_b)
+
+        result_a = await list_memories(tag="cross-user-tag", ctx=ctx_a)
+        keys_a = [m["key"] for m in _body(result_a)["items"]]
+        assert "leak-a" in keys_a
+        assert "leak-b" not in keys_a, "User B's memory must not appear in User A's list"
+
+        result_b = await list_memories(tag="cross-user-tag", ctx=ctx_b)
+        keys_b = [m["key"] for m in _body(result_b)["items"]]
+        assert "leak-b" in keys_b
+        assert "leak-a" not in keys_b, "User A's memory must not appear in User B's list"
+
+    async def test_summarize_context_cross_user_isolation(self, two_user_setup):
+        """summarize_context must not include memories from a different user."""
+        from hive.server import remember, summarize_context
+
+        jwt_a, jwt_b = two_user_setup
+        ctx_a = _make_context(jwt_a)
+        ctx_b = _make_context(jwt_b)
+
+        await remember(key="sum-a", value="user-a-private", tags=["cross-sum-tag"], ctx=ctx_a)
+        await remember(key="sum-b", value="user-b-private", tags=["cross-sum-tag"], ctx=ctx_b)
+
+        result_a = await summarize_context(topic="cross-sum-tag", ctx=ctx_a)
+        text_a = _text(result_a)
+        assert "user-a-private" in text_a
+        assert "user-b-private" not in text_a, "User B's value must not appear in User A's summary"

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -249,20 +249,27 @@ def two_user_setup():
         BillingMode="PAY_PER_REQUEST",
     )
 
+    previous_table_name = os.environ.get("HIVE_TABLE_NAME")
     os.environ["HIVE_TABLE_NAME"] = table_name
-    from hive.storage import HiveStorage
+    try:
+        from hive.storage import HiveStorage
 
-    storage = HiveStorage(
-        table_name=table_name,
-        region="us-east-1",
-        endpoint_url=DYNAMO_ENDPOINT,
-        aws_access_key_id="local",
-        aws_secret_access_key="local",
-    )
+        storage = HiveStorage(
+            table_name=table_name,
+            region="us-east-1",
+            endpoint_url=DYNAMO_ENDPOINT,
+            aws_access_key_id="local",
+            aws_secret_access_key="local",
+        )
 
-    jwt_a = _make_user_token(storage, "integration-user-a")
-    jwt_b = _make_user_token(storage, "integration-user-b")
-    return jwt_a, jwt_b
+        jwt_a = _make_user_token(storage, "integration-user-a")
+        jwt_b = _make_user_token(storage, "integration-user-b")
+        yield jwt_a, jwt_b
+    finally:
+        if previous_table_name is None:
+            os.environ.pop("HIVE_TABLE_NAME", None)
+        else:
+            os.environ["HIVE_TABLE_NAME"] = previous_table_name
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -601,6 +601,85 @@ class TestListMemories:
         assert body["has_more"] is False
 
 
+def _make_user_jwt(storage, owner_user_id: str) -> str:
+    """Issue a full-scope JWT for a new client belonging to ``owner_user_id``."""
+    from hive.auth.tokens import issue_jwt
+    from hive.models import OAuthClient, Token
+
+    client = OAuthClient(client_name=f"User {owner_user_id}", owner_user_id=owner_user_id)
+    storage.put_client(client)
+    now = datetime.now(timezone.utc)
+    token = Token(
+        client_id=client.client_id,
+        scope="memories:read memories:write",
+        issued_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    storage.put_token(token)
+    return issue_jwt(token)
+
+
+class TestListMemoriesUserScoping:
+    """Cross-user isolation for the list_memories MCP tool."""
+
+    async def test_cross_user_isolation(self, server_env):
+        """User B cannot see User A's memories even if they share a tag."""
+        storage, _, _ = server_env
+        from hive.server import list_memories, remember
+
+        jwt_a = _make_user_jwt(storage, "user-alice")
+        jwt_b = _make_user_jwt(storage, "user-bob")
+
+        await remember("secret-alice", "alice-value", ["shared-tag"], ctx=_make_ctx(jwt_a))
+        await remember("secret-bob", "bob-value", ["shared-tag"], ctx=_make_ctx(jwt_b))
+
+        result_a = await list_memories("shared-tag", ctx=_make_ctx(jwt_a))
+        keys_a = [m["key"] for m in _body(result_a)["items"]]
+        assert "secret-alice" in keys_a
+        assert "secret-bob" not in keys_a
+
+        result_b = await list_memories("shared-tag", ctx=_make_ctx(jwt_b))
+        keys_b = [m["key"] for m in _body(result_b)["items"]]
+        assert "secret-bob" in keys_b
+        assert "secret-alice" not in keys_b
+
+    async def test_within_user_cross_client_sharing(self, server_env):
+        """Two clients owned by the same user can see each other's tagged memories."""
+        storage, _, _ = server_env
+        from hive.server import list_memories, remember
+
+        jwt_c1 = _make_user_jwt(storage, "user-charlie")
+        jwt_c2 = _make_user_jwt(storage, "user-charlie")
+
+        await remember("from-client1", "v1", ["proj"], ctx=_make_ctx(jwt_c1))
+        await remember("from-client2", "v2", ["proj"], ctx=_make_ctx(jwt_c2))
+
+        result = await list_memories("proj", ctx=_make_ctx(jwt_c2))
+        keys = [m["key"] for m in _body(result)["items"]]
+        assert "from-client1" in keys
+        assert "from-client2" in keys
+
+
+class TestSummarizeContextUserScoping:
+    """Cross-user isolation for the summarize_context MCP tool."""
+
+    async def test_cross_user_isolation(self, server_env):
+        """summarize_context must not include memories from a different user."""
+        storage, _, _ = server_env
+        from hive.server import remember, summarize_context
+
+        jwt_a = _make_user_jwt(storage, "user-diana")
+        jwt_b = _make_user_jwt(storage, "user-eve")
+
+        await remember("diana-note", "diana-private", ["project-x"], ctx=_make_ctx(jwt_a))
+        await remember("eve-note", "eve-private", ["project-x"], ctx=_make_ctx(jwt_b))
+
+        result = await summarize_context("project-x", ctx=_make_ctx(jwt_a))
+        text = _text(result)
+        assert "diana-private" in text
+        assert "eve-private" not in text
+
+
 # ---------------------------------------------------------------------------
 # list_tags
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -744,6 +744,81 @@ class TestUnscopedClientRejected:
         with pytest.raises(ToolError, match="Unable to load client record"):
             await remember("key", "value", ctx=_make_ctx(jwt))
 
+    async def test_remember_if_absent_rejects_missing_client_record(self, server_env):
+        """remember_if_absent fails closed when the authenticated client record has been deleted."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import remember_if_absent
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Client IA", owner_user_id="ghost-user-ia")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await remember_if_absent("key", "value", ctx=_make_ctx(jwt))
+
+    async def test_list_memories_rejects_missing_client_record(self, server_env):
+        """list_memories fails closed when the authenticated client record has been deleted."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import list_memories
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Client LM", owner_user_id="ghost-user-lm")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await list_memories("any-tag", ctx=_make_ctx(jwt))
+
+    async def test_summarize_context_rejects_missing_client_record(self, server_env):
+        """summarize_context fails closed when the authenticated client record has been deleted."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import summarize_context
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Client SC", owner_user_id="ghost-user-sc")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await summarize_context("any-topic", ctx=_make_ctx(jwt))
+
 
 # ---------------------------------------------------------------------------
 # list_tags

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -122,7 +122,7 @@ def server_env():
             from hive.storage import HiveStorage
 
             storage = HiveStorage(table_name="hive-unit-server", region="us-east-1")
-            client = OAuthClient(client_name="MCP Test Client")
+            client = OAuthClient(client_name="MCP Test Client", owner_user_id="test-user")
             storage.put_client(client)
 
             now = datetime.now(timezone.utc)
@@ -678,6 +678,71 @@ class TestSummarizeContextUserScoping:
         text = _text(result)
         assert "diana-private" in text
         assert "eve-private" not in text
+
+
+class TestUnscopedClientRejected:
+    """list_memories and summarize_context must fail closed when owner_user_id is missing."""
+
+    def _make_unscoped_jwt(self, storage) -> str:
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+
+        client = OAuthClient(client_name="Unscoped Client")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        return issue_jwt(token)
+
+    async def test_list_memories_rejects_unscoped_client(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import list_memories
+
+        storage, _, _ = server_env
+        jwt = self._make_unscoped_jwt(storage)
+        with pytest.raises(ToolError, match="per-user memory scoping is required"):
+            await list_memories("any-tag", ctx=_make_ctx(jwt))
+
+    async def test_summarize_context_rejects_unscoped_client(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import summarize_context
+
+        storage, _, _ = server_env
+        jwt = self._make_unscoped_jwt(storage)
+        with pytest.raises(ToolError, match="per-user memory scoping is required"):
+            await summarize_context("any-topic", ctx=_make_ctx(jwt))
+
+    async def test_remember_rejects_missing_client_record(self, server_env):
+        """remember fails closed when the authenticated client record has been deleted."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import remember
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Client", owner_user_id="ghost-user")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await remember("key", "value", ctx=_make_ctx(jwt))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1105,6 +1105,89 @@ class TestPagination:
         assert len(page2) == 2
         assert cursor2 is None
 
+    def test_list_memories_by_tag_owner_user_id_filters_cross_user(self, storage):
+        """Cross-user memories sharing a tag must not be returned when owner_user_id is set."""
+        from hive.models import OAuthClient
+
+        client_a = OAuthClient(client_name="User-A Client", owner_user_id="user-a")
+        client_b = OAuthClient(client_name="User-B Client", owner_user_id="user-b")
+        storage.put_client(client_a)
+        storage.put_client(client_b)
+
+        storage.put_memory(
+            Memory(
+                key="a-mem",
+                value="user-a value",
+                tags=["shared"],
+                owner_client_id=client_a.client_id,
+                owner_user_id="user-a",
+            )
+        )
+        storage.put_memory(
+            Memory(
+                key="b-mem",
+                value="user-b value",
+                tags=["shared"],
+                owner_client_id=client_b.client_id,
+                owner_user_id="user-b",
+            )
+        )
+
+        # User A only sees their own memory
+        mems_a, _ = storage.list_memories_by_tag("shared", owner_user_id="user-a")
+        assert [m.key for m in mems_a] == ["a-mem"]
+
+        # User B only sees their own memory
+        mems_b, _ = storage.list_memories_by_tag("shared", owner_user_id="user-b")
+        assert [m.key for m in mems_b] == ["b-mem"]
+
+    def test_list_memories_by_tag_owner_user_id_cross_client_within_user(self, storage):
+        """Within-user cross-client sharing: both clients of the same user see all memories."""
+        from hive.models import OAuthClient
+
+        client_1 = OAuthClient(client_name="User-A Client-1", owner_user_id="user-a")
+        client_2 = OAuthClient(client_name="User-A Client-2", owner_user_id="user-a")
+        storage.put_client(client_1)
+        storage.put_client(client_2)
+
+        storage.put_memory(
+            Memory(
+                key="from-c1",
+                value="v1",
+                tags=["work"],
+                owner_client_id=client_1.client_id,
+                owner_user_id="user-a",
+            )
+        )
+        storage.put_memory(
+            Memory(
+                key="from-c2",
+                value="v2",
+                tags=["work"],
+                owner_client_id=client_2.client_id,
+                owner_user_id="user-a",
+            )
+        )
+
+        mems, _ = storage.list_memories_by_tag("work", owner_user_id="user-a")
+        assert {m.key for m in mems} == {"from-c1", "from-c2"}
+
+    def test_list_memories_by_tag_no_owner_filter_returns_all(self, storage):
+        """When owner_user_id is None, all memories matching the tag are returned."""
+        storage.put_memory(
+            Memory(
+                key="xa", value="v", tags=["open"], owner_client_id="c-x", owner_user_id="user-x"
+            )
+        )
+        storage.put_memory(
+            Memory(
+                key="ya", value="v", tags=["open"], owner_client_id="c-y", owner_user_id="user-y"
+            )
+        )
+
+        mems, _ = storage.list_memories_by_tag("open")
+        assert {m.key for m in mems} == {"xa", "ya"}
+
     def test_invalid_cursor_raises(self, storage):
         with pytest.raises(ValueError, match="Invalid pagination cursor"):
             storage.list_all_memories(cursor="not-valid-base64!!!")


### PR DESCRIPTION
Closes #587

## Summary

- `list_memories` and `summarize_context` MCP tools were querying the `TagIndex` GSI without an owner filter, returning memories from **all** users who had stored anything under a matching tag — a cross-tenant data leak.
- `remember` and `remember_if_absent` were not propagating `owner_user_id` from the OAuth client onto the stored `Memory` object, so memories were silently stored with `owner_user_id=None` and could not be filtered on retrieval.

## Approach

The `TagIndex` GSI tag items (`SK=TAG#{tag}`) do not store `owner_user_id`, so a DynamoDB-level `FilterExpression` cannot be applied directly. The fix post-filters after hydrating each tag item via `get_memory_by_id`, which returns the full `Memory` object (including `owner_user_id`).

Within-user cross-client sharing is intentional product behaviour and is preserved — the filter scopes to `owner_user_id`, not `owner_client_id`, so all clients owned by the same user continue to share a memory namespace.

Changes:
- `storage.list_memories_by_tag` — new optional `owner_user_id` parameter; post-filters hydrated results
- `server.list_memories` + `server.summarize_context` — look up caller's `owner_user_id` via `get_client` and pass it through
- `server.remember` + `server.remember_if_absent` — propagate `owner_user_id` onto the new `Memory` object at creation time
- `storage.iter_all_memories` + `storage.delete_memories_by_tag` — delegate filtering to `list_memories_by_tag` (removes redundant post-filter)
- Unit tests: storage-level cross-user isolation, within-user cross-client sharing, no-filter passthrough; server-level cross-user isolation and within-user sharing for both tools
- Integration regression tests (two-user fixture against DynamoDB Local) for `list_memories` and `summarize_context`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y56sF9QXGtvyZ9cajArMdV)_