### PR TITLE
feat: remember_blob tool + binary MCP content types

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -32,6 +32,7 @@ from fastmcp.server.auth import AccessToken as FastMCPAccessToken
 from fastmcp.server.auth import RemoteAuthProvider, TokenVerifier
 from fastmcp.server.dependencies import get_access_token, get_http_request
 from fastmcp.tools.tool import ToolResult
+from mcp.types import ImageContent
 from pydantic import AnyHttpUrl
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
@@ -657,6 +658,146 @@ async def remember_if_absent(
     return _tool_result(f"Stored memory '{key}'.", storage, client_id)
 
 
+_BLOB_MAX_BYTES = 10 * 1024 * 1024  # 10 MB hard cap, matches Lambda payload ceiling
+
+
+@mcp.tool(
+    title="Remember blob",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def remember_blob(
+    key: Annotated[str, "Unique key to store the binary memory under"],
+    data: Annotated[str, "Base64-encoded binary content"],
+    content_type: Annotated[str, "MIME type of the content (e.g. image/png, application/pdf)"],
+    tags: Annotated[list[str] | None, "Optional tags for categorisation"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Store a binary memory (image, PDF, or other binary file) identified by key.
+
+    ``data`` must be standard Base64-encoded bytes. ``content_type`` must be a
+    valid MIME type — memories whose type begins with ``image/`` are stored as
+    ``value_type="image"``; all others use ``value_type="blob"``. The encoded
+    payload may not exceed 10 MB.
+
+    Calling ``remember_blob`` with the same key again replaces the existing
+    blob (upsert semantics).  Use ``recall(key)`` to retrieve the blob as an
+    MCP ``ImageContent`` block.
+    """
+    import base64
+
+    t0 = time.monotonic()
+    storage, client_id = await _auth(ctx, required_scope="memories:write")
+
+    content_type = content_type.strip()
+    if not content_type:
+        await emit_metric("ToolErrors", operation="remember_blob")
+        raise ToolError("content_type must be a non-empty MIME type string.")
+
+    try:
+        raw = base64.b64decode(data, validate=True)
+    except Exception as exc:
+        await emit_metric("ToolErrors", operation="remember_blob")
+        raise ToolError(f"data is not valid Base64: {exc}") from exc
+
+    if len(raw) > _BLOB_MAX_BYTES:
+        await emit_metric("ToolErrors", operation="remember_blob")
+        raise ToolError(f"Binary payload exceeds the 10 MB limit ({len(raw)} bytes provided).")
+
+    value_type: str = "image" if content_type.startswith("image/") else "blob"
+    tags = tags or []
+
+    existing = storage.get_memory_by_key(key)
+    if existing:
+        owner = existing.owner_user_id or existing.owner_client_id
+        s3_uri = storage.blob_store.put(
+            owner=owner,
+            memory_id=existing.memory_id,
+            body=raw,
+            content_type=content_type,
+        )
+        existing.value = ""
+        existing.value_type = value_type  # type: ignore[assignment]
+        existing.content_type = content_type
+        existing.s3_uri = s3_uri
+        existing.size_bytes = len(raw)
+        existing.tags = tags
+        existing.updated_at = datetime.now(timezone.utc)
+        try:
+            storage.put_memory(existing)
+        except ValueError as exc:
+            await emit_metric("ToolErrors", operation="remember_blob")
+            raise ToolError(str(exc)) from exc
+        event_type = EventType.memory_updated
+        action = "Updated"
+    else:
+        client = storage.get_client(client_id)
+        if client is None:
+            raise ToolError("Unable to load client record for authenticated caller.")
+        owner_user_id = client.owner_user_id
+        try:
+            check_memory_quota(owner_user_id, storage)
+        except QuotaExceeded as exc:
+            raise ToolError(exc.detail) from exc
+        memory = Memory(
+            key=key,
+            value="",
+            tags=tags,
+            owner_client_id=client_id,
+            owner_user_id=owner_user_id,
+            value_type=value_type,  # type: ignore[arg-type]
+            content_type=content_type,
+            size_bytes=len(raw),
+        )
+        owner = owner_user_id or client_id
+        s3_uri = storage.blob_store.put(
+            owner=owner,
+            memory_id=memory.memory_id,
+            body=raw,
+            content_type=content_type,
+        )
+        memory.s3_uri = s3_uri
+        try:
+            storage.put_memory(memory)
+        except ValueError as exc:
+            await emit_metric("ToolErrors", operation="remember_blob")
+            raise ToolError(str(exc)) from exc
+        event_type = EventType.memory_created
+        action = "Stored"
+
+    _log(
+        storage,
+        ActivityEvent(
+            event_type=event_type,
+            client_id=client_id,
+            metadata={"key": key, "tags": tags, "content_type": content_type},
+        ),
+    )
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    logger.info(
+        "%s blob memory '%s'",
+        action,
+        key,
+        extra={
+            "tool": "remember_blob",
+            "duration_ms": duration_ms,
+            "status": "success",
+        },
+    )
+    await emit_metric("ToolInvocations", operation="remember_blob")
+    await emit_metric(
+        "StorageLatencyMs",
+        value=float(duration_ms),
+        unit="Milliseconds",
+        operation="remember_blob",
+    )
+    return _tool_result(f"{action} blob memory '{key}'.", storage, client_id)
+
+
 @mcp.tool(
     title="Recall",
     annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
@@ -734,8 +875,31 @@ async def recall(
                 exc_info=True,
             )
             recalled_value = f"[memory content unavailable — blob fetch failed for key '{key}']"
-    else:
-        recalled_value = memory.value or ""
+        return _tool_result(recalled_value, storage, client_id, memory=memory)
+    if memory.value_type in ("image", "blob"):
+        import base64
+
+        try:
+            raw = storage.fetch_blob_bytes(memory)
+            b64 = base64.b64encode(raw).decode("ascii")
+            mime = memory.content_type or "application/octet-stream"
+            meta = _quota_meta(storage, client_id)
+            meta["hive"]["memory"] = {"key": memory.key, "version": memory.version}
+            return ToolResult(
+                content=[ImageContent(type="image", data=b64, mimeType=mime)],
+                meta=meta,
+            )
+        except Exception:
+            logger.warning(
+                "blob_fetch_failed for recall key='%s'",
+                key,
+                exc_info=True,
+            )
+            recalled_value = (
+                f"[binary memory content unavailable — blob fetch failed for key '{key}']"
+            )
+            return _tool_result(recalled_value, storage, client_id, memory=memory)
+    recalled_value = memory.value or ""
     return _tool_result(recalled_value, storage, client_id, memory=memory)
 
 
@@ -1081,7 +1245,10 @@ async def list_memories(
         "items": [
             {
                 "key": m.key,
-                "value": m.value,
+                "value": m.value if m.value_type not in ("image", "blob") else None,
+                "value_type": m.value_type,
+                "content_type": m.content_type,
+                "size_bytes": m.size_bytes,
                 "tags": m.tags,
                 "owner_client_id": m.owner_client_id,
                 "recall_count": m.recall_count,

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1160,6 +1160,15 @@ class HiveStorage:
         data = self.blob_store.get(owner=owner, memory_id=memory.memory_id)
         return data.decode("utf-8")
 
+    def fetch_blob_bytes(self, memory: Memory) -> bytes:
+        """Fetch raw binary content from S3 for an ``image`` or ``blob`` memory.
+
+        Raises whatever the underlying blob store raises so the caller can
+        decide whether to propagate or surface a user-facing fallback.
+        """
+        owner = memory.owner_user_id or memory.owner_client_id or ""
+        return self.blob_store.get(owner=owner, memory_id=memory.memory_id)
+
     def _get_memory_meta(self, memory_id: str) -> dict[str, Any] | None:
         resp = self.table.get_item(Key={"PK": f"MEMORY#{memory_id}", "SK": "META"})
         item: dict[str, Any] | None = resp.get("Item")  # type: ignore[assignment]

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1867,6 +1867,333 @@ class TestTextLargeRouting:
 
 
 # ---------------------------------------------------------------------------
+# remember_blob / recall binary
+# ---------------------------------------------------------------------------
+
+
+class TestRememberBlob:
+    """#499 — remember_blob stores binary content in S3; recall returns ImageContent."""
+
+    _PNG_1PX = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9Q"
+        "DwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )  # 1×1 transparent PNG, base64-encoded
+
+    def _setup_blob_bucket(self, monkeypatch):
+        bucket = "test-blob-499"
+        monkeypatch.setenv("HIVE_BLOBS_BUCKET", bucket)
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=bucket)
+        return bucket
+
+    async def test_store_new_image_blob(self, server_env, monkeypatch):
+        """remember_blob stores an image memory and returns a success message."""
+        self._setup_blob_bucket(monkeypatch)
+        storage, _, jwt = server_env
+        from hive.server import remember_blob
+
+        result = await remember_blob(
+            "blob-img", self._PNG_1PX, "image/png", ["img"], ctx=_make_ctx(jwt)
+        )
+        assert "Stored blob memory 'blob-img'" in _text(result)
+
+        m = storage.get_memory_by_key("blob-img")
+        assert m is not None
+        assert m.value_type == "image"
+        assert m.content_type == "image/png"
+        assert m.s3_uri is not None
+        assert m.size_bytes is not None
+        assert m.size_bytes > 0
+        assert m.value == ""
+
+    async def test_store_non_image_blob(self, server_env, monkeypatch):
+        """remember_blob with non-image MIME uses value_type='blob'."""
+        import base64
+
+        self._setup_blob_bucket(monkeypatch)
+        storage, _, jwt = server_env
+        from hive.server import remember_blob
+
+        pdf_data = base64.b64encode(b"%PDF-1.4 fake").decode()
+        result = await remember_blob("blob-pdf", pdf_data, "application/pdf", ctx=_make_ctx(jwt))
+        assert "Stored blob memory 'blob-pdf'" in _text(result)
+
+        m = storage.get_memory_by_key("blob-pdf")
+        assert m.value_type == "blob"
+        assert m.content_type == "application/pdf"
+
+    async def test_update_existing_blob(self, server_env, monkeypatch):
+        """remember_blob with an existing key replaces the blob (upsert)."""
+        import base64
+
+        self._setup_blob_bucket(monkeypatch)
+        storage, _, jwt = server_env
+        from hive.server import remember_blob
+
+        await remember_blob("blob-upd", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+        first = storage.get_memory_by_key("blob-upd")
+
+        new_data = base64.b64encode(b"updated binary").decode()
+        result = await remember_blob(
+            "blob-upd", new_data, "image/jpeg", ["new-tag"], ctx=_make_ctx(jwt)
+        )
+        assert "Updated blob memory 'blob-upd'" in _text(result)
+
+        updated = storage.get_memory_by_key("blob-upd")
+        assert updated.memory_id == first.memory_id
+        assert updated.content_type == "image/jpeg"
+        assert updated.tags == ["new-tag"]
+
+    async def test_invalid_base64_raises_tool_error(self, server_env):
+        """Non-base64 data raises ToolError with a useful message."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_blob
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="not valid Base64"):
+            await remember_blob("blob-bad", "!!!not base64!!!", "image/png", ctx=_make_ctx(jwt))
+
+    async def test_empty_content_type_raises_tool_error(self, server_env):
+        """Empty content_type raises ToolError."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_blob
+
+        _, _, jwt = server_env
+        with pytest.raises(ToolError, match="non-empty MIME type"):
+            await remember_blob("blob-ct", self._PNG_1PX, "   ", ctx=_make_ctx(jwt))
+
+    async def test_oversized_blob_raises_tool_error(self, server_env):
+        """Payload > 10 MB raises ToolError."""
+        import base64
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_blob
+
+        _, _, jwt = server_env
+        big = base64.b64encode(b"x" * (10 * 1024 * 1024 + 1)).decode()
+        with pytest.raises(ToolError, match="10 MB limit"):
+            await remember_blob("blob-big", big, "application/octet-stream", ctx=_make_ctx(jwt))
+
+    async def test_missing_auth_raises_tool_error(self, server_env):
+        """Missing Bearer token raises ToolError."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_blob
+
+        ctx = MagicMock()
+        ctx.request_context.meta = {}
+        with pytest.raises(ToolError, match="Unauthorized"):
+            await remember_blob("blob-auth", self._PNG_1PX, "image/png", ctx=ctx)
+
+    async def test_missing_client_record_raises_tool_error(self, server_env, monkeypatch):
+        """remember_blob fails closed when client record is missing."""
+        self._setup_blob_bucket(monkeypatch)
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import remember_blob
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Blob Client", owner_user_id="ghost-blob-user")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await remember_blob("blob-ghost", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+
+    async def test_quota_exceeded_raises_tool_error(self, server_env, monkeypatch):
+        """Quota exceeded on new blob raises ToolError."""
+        self._setup_blob_bucket(monkeypatch)
+        from unittest.mock import patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.quota import QuotaExceeded
+        from hive.server import remember_blob
+
+        _, _, jwt = server_env
+        with (
+            patch("hive.server.check_memory_quota", side_effect=QuotaExceeded("quota hit")),
+            pytest.raises(ToolError, match="quota hit"),
+        ):
+            await remember_blob("blob-quota", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+
+    async def test_storage_error_on_new_becomes_tool_error(self, server_env, monkeypatch):
+        """put_memory ValueError on new blob surfaces as ToolError."""
+        self._setup_blob_bucket(monkeypatch)
+        from unittest.mock import patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_blob
+
+        _, _, jwt = server_env
+        with (
+            patch("hive.storage.HiveStorage.put_memory", side_effect=ValueError("ddb error")),
+            pytest.raises(ToolError, match="ddb error"),
+        ):
+            await remember_blob("blob-err", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+
+    async def test_storage_error_on_update_becomes_tool_error(self, server_env, monkeypatch):
+        """put_memory ValueError on update blob surfaces as ToolError."""
+        self._setup_blob_bucket(monkeypatch)
+        from unittest.mock import patch
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_blob
+
+        _, _, jwt = server_env
+        # Store first so we hit the update path
+        await remember_blob("blob-upd-err", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+        with (
+            patch("hive.storage.HiveStorage.put_memory", side_effect=ValueError("ddb error")),
+            pytest.raises(ToolError, match="ddb error"),
+        ):
+            await remember_blob("blob-upd-err", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+
+
+class TestRecallBinary:
+    """#499 — recall returns ImageContent for image/blob memories."""
+
+    _PNG_1PX = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9Q"
+        "DwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+
+    def _setup_blob_bucket(self, monkeypatch):
+        bucket = "test-recall-blob-499"
+        monkeypatch.setenv("HIVE_BLOBS_BUCKET", bucket)
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=bucket)
+
+    async def test_recall_image_returns_image_content(self, server_env, monkeypatch):
+        """recall() returns ImageContent with base64 data for image/* blobs."""
+        from mcp.types import ImageContent
+
+        from hive.server import recall, remember_blob
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        await remember_blob("img-recall", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+
+        result = await recall("img-recall", ctx=_make_ctx(jwt))
+        assert len(result.content) == 1
+        block = result.content[0]
+        assert isinstance(block, ImageContent)
+        assert block.mimeType == "image/png"
+        assert block.data == self._PNG_1PX
+
+    async def test_recall_non_image_blob_returns_image_content(self, server_env, monkeypatch):
+        """recall() returns ImageContent for non-image binary blobs."""
+        import base64
+
+        from mcp.types import ImageContent
+
+        from hive.server import recall, remember_blob
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        raw = b"%PDF-1.4 fake pdf"
+        pdf_b64 = base64.b64encode(raw).decode()
+        await remember_blob("pdf-recall", pdf_b64, "application/pdf", ctx=_make_ctx(jwt))
+
+        result = await recall("pdf-recall", ctx=_make_ctx(jwt))
+        assert len(result.content) == 1
+        block = result.content[0]
+        assert isinstance(block, ImageContent)
+        assert block.mimeType == "application/pdf"
+        assert block.data == pdf_b64
+
+    async def test_recall_blob_s3_error_returns_unavailable_text(self, server_env, monkeypatch):
+        """recall() returns unavailable message when S3 fetch fails for blob."""
+        from hive.models import Memory
+        from hive.server import recall
+
+        storage, client_id, jwt = server_env
+        monkeypatch.delenv("HIVE_BLOBS_BUCKET", raising=False)
+        m = Memory(
+            key="blob-err-recall",
+            value="",
+            value_type="image",
+            content_type="image/png",
+            s3_uri="s3://missing/key",
+            owner_client_id=client_id,
+        )
+        storage.put_memory(m)
+
+        result = await recall("blob-err-recall", ctx=_make_ctx(jwt))
+        assert "unavailable" in _text(result)
+
+    async def test_recall_blob_result_carries_meta(self, server_env, monkeypatch):
+        """Successful binary recall carries quota meta like text recall."""
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        from hive.server import recall, remember_blob
+
+        await remember_blob("img-meta", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+        result = await recall("img-meta", ctx=_make_ctx(jwt))
+        meta = _hive_meta(result)
+        assert "memory_quota" in meta
+        assert "rate_limit" in meta
+
+
+class TestListMemoriesBinaryFields:
+    """#499 — list_memories includes value_type/content_type/size_bytes; omits value for binary."""
+
+    _PNG_1PX = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9Q"
+        "DwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+
+    def _setup_blob_bucket(self, monkeypatch):
+        bucket = "test-list-blob-499"
+        monkeypatch.setenv("HIVE_BLOBS_BUCKET", bucket)
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=bucket)
+
+    async def test_text_memory_has_value_type_text(self, server_env):
+        """Text memories carry value_type='text' in list output."""
+        _, _, jwt = server_env
+        from hive.server import list_memories, remember
+
+        await remember("txt-list-type", "hello", ["list-type-tag"], ctx=_make_ctx(jwt))
+        result = await list_memories("list-type-tag", ctx=_make_ctx(jwt))
+        items = _body(result)["items"]
+        assert len(items) == 1
+        assert items[0]["value_type"] == "text"
+        assert items[0]["value"] == "hello"
+
+    async def test_image_memory_omits_value_in_list(self, server_env, monkeypatch):
+        """Binary memories have value=None and carry content_type/size_bytes in list."""
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        from hive.server import list_memories, remember_blob
+
+        await remember_blob(
+            "img-list-499", self._PNG_1PX, "image/png", ["img-list-tag-499"], ctx=_make_ctx(jwt)
+        )
+        result = await list_memories("img-list-tag-499", ctx=_make_ctx(jwt))
+        items = _body(result)["items"]
+        assert len(items) == 1
+        item = items[0]
+        assert item["value"] is None
+        assert item["value_type"] == "image"
+        assert item["content_type"] == "image/png"
+        assert item["size_bytes"] is not None
+
+
+# ---------------------------------------------------------------------------
 # forget_all
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #499

## Summary

- New `remember_blob(key, data, content_type, tags)` MCP tool: accepts Base64-encoded binary, validates size (≤ 10 MB), stores in S3 with `value_type="image"` for `image/*` MIME types or `"blob"` for all others
- `recall(key)` now returns `ImageContent` (MCP native binary content block) for binary memories, falling back to an unavailable message on S3 errors
- `list_memories` now includes `value_type`, `content_type`, and `size_bytes` in each item; `value` is `null` for binary memories (content lives in S3)
- Added `fetch_blob_bytes()` to `HiveStorage` for raw binary retrieval from S3

## Approach

- Used `mcp.types.ImageContent` for all binary recall responses (both `image/*` and non-image blobs) since it's the standard MCP tool result type for binary data — carries `mimeType` so clients can distinguish content types
- Reused the existing `BlobStore.put()`/`get()` infrastructure from #497 (text-large routing) — binary path bypasses the `_route_large_value` router (which only handles text) and uploads to S3 directly in `remember_blob`
- `put_memory()` is still called after the S3 upload so DynamoDB remains the authoritative index
- 17 new unit tests covering all paths: new/update/error/quota/auth for `remember_blob`; ImageContent round-trip, S3 failure fallback, and meta propagation for binary `recall`; value_type fields in `list_memories`
- 100% coverage maintained

https://claude.ai/code/session_01Y56sF9QXGtvyZ9cajArMdV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y56sF9QXGtvyZ9cajArMdV)_