### PR TITLE
feat: MemoryBrowser rendering for large text, images, and blobs

### DIFF
--- a/docs-site/public/openapi.json
+++ b/docs-site/public/openapi.json
@@ -333,6 +333,17 @@
       },
       "MemoryResponse": {
         "properties": {
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -375,6 +386,17 @@
             "title": "Recall Count",
             "type": "integer"
           },
+          "size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Bytes"
+          },
           "tags": {
             "items": {
               "type": "string"
@@ -389,6 +411,17 @@
           },
           "value": {
             "title": "Value",
+            "type": "string"
+          },
+          "value_type": {
+            "default": "text",
+            "enum": [
+              "text",
+              "text-large",
+              "image",
+              "blob"
+            ],
+            "title": "Value Type",
             "type": "string"
           }
         },
@@ -2121,6 +2154,61 @@
           }
         ],
         "summary": "Update a memory",
+        "tags": [
+          "memories"
+        ]
+      }
+    },
+    "/api/memories/{memory_id}/content": {
+      "get": {
+        "description": "Stream raw binary or large-text content from S3 for image, blob, and text-large memories. Non-admins can only access their own memories.",
+        "operationId": "get_memory_content_api_memories__memory_id__content_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "memory_id",
+            "required": true,
+            "schema": {
+              "title": "Memory Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Memory not found"
+          },
+          "409": {
+            "description": "Memory has no S3 content"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Download memory content from S3",
         "tags": [
           "memories"
         ]

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import os
 
 import aws_cdk as cdk
-from cdk_nag import NagPackSuppression, NagSuppressions
 from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_cloudfront as cloudfront
 from aws_cdk import aws_cloudfront_origins as origins
@@ -39,9 +38,9 @@ from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_s3_deployment as s3deploy
 from aws_cdk import aws_s3vectors as s3vectors
 from aws_cdk import aws_sns as sns
-from aws_cdk import aws_sns_subscriptions as sns_subs
 from aws_cdk import aws_ssm as ssm
 from aws_cdk import aws_wafv2 as wafv2
+from cdk_nag import NagPackSuppression, NagSuppressions
 from constructs import Construct
 
 GITHUB_REPO = "warlordofmars/hive"
@@ -254,7 +253,7 @@ class HiveStack(cdk.Stack):
 
         # S3 Vectors bucket — one vector index per OAuth client, lazy-created
         vectors_bucket_name = "hive-vectors" if is_prod else f"hive-vectors-{env_name}"
-        vectors_bucket = s3vectors.CfnVectorBucket(
+        s3vectors.CfnVectorBucket(
             self,
             "VectorsBucket",
             vector_bucket_name=vectors_bucket_name,
@@ -1229,8 +1228,8 @@ function handler(event) {
             )
             return _notify(alarm)
 
-        mcp_throttles_alarm = _throttle_alarm("McpThrottlesAlarm", mcp_fn, "MCP")
-        api_throttles_alarm = _throttle_alarm("ApiThrottlesAlarm", api_fn, "API")
+        _throttle_alarm("McpThrottlesAlarm", mcp_fn, "MCP")
+        _throttle_alarm("ApiThrottlesAlarm", api_fn, "API")
 
         # DynamoDB user errors — 4xx-class failures from the SDK (validation,
         # ConditionalCheckFailed, etc.). A small rate is normal (optimistic

--- a/scripts/check_copyright.py
+++ b/scripts/check_copyright.py
@@ -64,7 +64,8 @@ def _collect_files() -> list[Path]:
     files.extend(p for p in SINGLE_FILES if p.exists())
     # Exclude caches, generated dirs, and empty init files
     return [
-        f for f in files
+        f
+        for f in files
         if "__pycache__" not in f.parts
         and "node_modules" not in f.parts
         and ".venv" not in f.parts

--- a/scripts/check_copyright.py
+++ b/scripts/check_copyright.py
@@ -45,10 +45,7 @@ def _has_copyright(path: Path) -> bool:
         lines = path.read_text(encoding="utf-8").splitlines()
     except UnicodeDecodeError:
         return True  # skip binary files
-    for line in lines[:5]:
-        if COPYRIGHT_RE.search(line):
-            return True
-    return False
+    return any(COPYRIGHT_RE.search(line) for line in lines[:5])
 
 
 def _add_copyright(path: Path) -> None:

--- a/scripts/sonar_to_sarif.py
+++ b/scripts/sonar_to_sarif.py
@@ -14,8 +14,7 @@ import json
 import sys
 
 _SARIF_SCHEMA = (
-    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/"
-    "Schemata/sarif-schema-2.1.0.json"
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
 )
 
 _SEVERITY_MAP: dict[str, str] = {
@@ -43,7 +42,7 @@ def convert(issues_data: dict[str, object], project_key: str) -> dict[str, objec
         component: str = str(issue.get("component", ""))
         prefix = f"{project_key}:"
         if component.startswith(prefix):
-            component = component[len(prefix):]
+            component = component[len(prefix) :]
 
         line: int = int(issue.get("line", 1) or 1)
 

--- a/sdk/python/src/hive_client/client.py
+++ b/sdk/python/src/hive_client/client.py
@@ -72,7 +72,11 @@ class HiveClient:
             except Exception:
                 body = {}
             if not resp.is_success:
-                detail = body.get("detail", resp.reason_phrase) if isinstance(body, dict) else resp.reason_phrase
+                detail = (
+                    body.get("detail", resp.reason_phrase)
+                    if isinstance(body, dict)
+                    else resp.reason_phrase
+                )
                 raise HiveError(resp.status_code, detail)
             return body
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -22,6 +22,7 @@ def client():
 # remember                                                             #
 # ------------------------------------------------------------------ #
 
+
 class TestRemember:
     async def test_remember_sends_post(self, client: HiveClient, httpx_mock: HTTPXMock):
         httpx_mock.add_response(
@@ -44,6 +45,7 @@ class TestRemember:
         assert memory.tags == ["t1"]
         request = httpx_mock.get_request()
         import json
+
         body = json.loads(request.content)
         assert body["ttl_seconds"] == 3600
         assert body["tags"] == ["t1"]
@@ -64,6 +66,7 @@ class TestRemember:
 # ------------------------------------------------------------------ #
 # get_memory                                                           #
 # ------------------------------------------------------------------ #
+
 
 class TestGetMemory:
     async def test_get_memory_sends_get(self, client: HiveClient, httpx_mock: HTTPXMock):
@@ -91,6 +94,7 @@ class TestGetMemory:
 # forget                                                               #
 # ------------------------------------------------------------------ #
 
+
 class TestForget:
     async def test_forget_sends_delete(self, client: HiveClient, httpx_mock: HTTPXMock):
         httpx_mock.add_response(
@@ -105,6 +109,7 @@ class TestForget:
 # ------------------------------------------------------------------ #
 # list_memories                                                        #
 # ------------------------------------------------------------------ #
+
 
 class TestListMemories:
     async def test_list_returns_items(self, client: HiveClient, httpx_mock: HTTPXMock):
@@ -133,17 +138,21 @@ class TestListMemories:
 # search_memories                                                      #
 # ------------------------------------------------------------------ #
 
+
 class TestSearchMemories:
     async def test_search_sends_search_param(self, client: HiveClient, httpx_mock: HTTPXMock):
         httpx_mock.add_response(method="GET", json={"items": [], "count": 0})
         await client.search_memories("hello world")
         request = httpx_mock.get_request()
-        assert "search=hello+world" in str(request.url) or "search=hello%20world" in str(request.url)
+        assert "search=hello+world" in str(request.url) or "search=hello%20world" in str(
+            request.url
+        )
 
 
 # ------------------------------------------------------------------ #
 # recall                                                               #
 # ------------------------------------------------------------------ #
+
 
 class TestRecall:
     async def test_recall_finds_matching_key(self, client: HiveClient, httpx_mock: HTTPXMock):
@@ -160,7 +169,9 @@ class TestRecall:
         assert memory is not None
         assert memory.value == "found"
 
-    async def test_recall_returns_none_when_not_found(self, client: HiveClient, httpx_mock: HTTPXMock):
+    async def test_recall_returns_none_when_not_found(
+        self, client: HiveClient, httpx_mock: HTTPXMock
+    ):
         httpx_mock.add_response(method="GET", json={"items": []})
         memory = await client.recall("missing")
         assert memory is None
@@ -169,6 +180,7 @@ class TestRecall:
 # ------------------------------------------------------------------ #
 # Authorization header                                                 #
 # ------------------------------------------------------------------ #
+
 
 class TestAuth:
     async def test_sends_bearer_token(self, client: HiveClient, httpx_mock: HTTPXMock):
@@ -181,6 +193,7 @@ class TestAuth:
 # ------------------------------------------------------------------ #
 # Error handling — no detail field                                     #
 # ------------------------------------------------------------------ #
+
 
 class TestErrorHandling:
     async def test_error_without_detail_uses_reason_phrase(
@@ -209,6 +222,7 @@ class TestErrorHandling:
 # ------------------------------------------------------------------ #
 # Sync wrappers                                                        #
 # ------------------------------------------------------------------ #
+
 
 class TestSyncWrappers:
     def test_sync_remember(self, client: HiveClient, httpx_mock: HTTPXMock):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 
 import pytest
 import pytest_asyncio  # noqa: F401 — registers asyncio mode
-from pytest_httpx import HTTPXMock
-
 from hive_client import HiveClient
 from hive_client.client import HiveError
-
+from pytest_httpx import HTTPXMock
 
 BASE_URL = "https://app.hive-memory.com"
 API_KEY = "hive_sk_test"

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -282,6 +282,43 @@ async def import_memories(
 
 
 @router.get(
+    "/memories/{memory_id}/content",
+    summary="Download memory content from S3",
+    description="Stream raw binary or large-text content from S3 for image, blob, and text-large memories. Non-admins can only access their own memories.",
+    responses={
+        401: {"description": "Unauthorized"},
+        404: {"description": _MEMORY_NOT_FOUND},
+        409: {"description": "Memory has no S3 content"},
+    },
+)
+async def get_memory_content(
+    memory_id: str,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> StreamingResponse:
+    from hive.blob_store import BlobStore
+
+    memory = storage.get_memory_by_id(memory_id)
+    if memory is None:
+        raise HTTPException(status_code=404, detail=_MEMORY_NOT_FOUND)
+    owner_user_id = _user_filter(claims)
+    if owner_user_id and memory.owner_user_id != owner_user_id:
+        raise HTTPException(status_code=404, detail=_MEMORY_NOT_FOUND)
+    if memory.s3_uri is None:
+        raise HTTPException(status_code=409, detail="Memory has no S3 content")
+
+    owner = memory.owner_user_id or memory.owner_client_id
+    blob_store = BlobStore()
+    body = blob_store.get(owner, memory_id)
+    content_type = memory.content_type or "application/octet-stream"
+    return StreamingResponse(
+        iter([body]),
+        media_type=content_type,
+        headers={"Content-Disposition": f'inline; filename="{memory.key}"'},
+    )
+
+
+@router.get(
     "/memories/{memory_id}",
     summary="Get a memory by ID",
     description="Retrieve a single memory by its unique ID. Non-admins can only access their own memories.",

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -614,6 +614,9 @@ class MemoryResponse(BaseModel):
     memory_id: str
     key: str
     value: str
+    value_type: Literal["text", "text-large", "image", "blob"] = "text"
+    content_type: str | None = None
+    size_bytes: int | None = None
     tags: list[str]
     created_at: datetime
     updated_at: datetime
@@ -626,7 +629,10 @@ class MemoryResponse(BaseModel):
         return cls(
             memory_id=m.memory_id,
             key=m.key,
-            value=m.value,
+            value=m.value or "",
+            value_type=m.value_type,
+            content_type=m.content_type,
+            size_bytes=m.size_bytes,
             tags=m.tags,
             created_at=m.created_at,
             updated_at=m.updated_at,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -21,6 +21,7 @@ os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
 os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
 os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
 os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+os.environ.setdefault("HIVE_VECTORS_BUCKET", "hive-unit-vectors")
 # Ensure unit tests never try to hit a real DynamoDB endpoint
 os.environ.pop("DYNAMODB_ENDPOINT", None)
 
@@ -102,7 +103,13 @@ def _setup_app_overrides(app, storage, claims):
     def _override_storage():
         return storage
 
+    from unittest.mock import MagicMock
+
+    mock_vs = MagicMock()
+    mock_vs.search.return_value = []
+
     app.dependency_overrides[auth_mod.require_mgmt_user] = _override_mgmt_user
+    app.dependency_overrides[memories_mod._vector_store] = lambda: mock_vs
     for mod in (memories_mod, clients_mod, stats_mod, users_mod, versions_mod):
         app.dependency_overrides[mod._storage] = _override_storage
 
@@ -490,6 +497,121 @@ class TestMemoryTTL:
         resp = tc.patch(f"/api/memories/{mid}", json={"ttl_seconds": 0})
         assert resp.status_code == 200
         assert resp.json()["expires_at"] is None
+
+    def test_response_includes_value_type_fields(self, client):
+        tc, *_ = client
+        resp = tc.post("/api/memories", json={"key": "vt-k", "value": "v"})
+        data = resp.json()
+        assert data["value_type"] == "text"
+        assert data["content_type"] is None
+        assert data["size_bytes"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Memory content endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryContentEndpoint:
+    def test_inline_memory_returns_409(self, client):
+        tc, *_ = client
+        mid = tc.post("/api/memories", json={"key": "inline-k", "value": "hi"}).json()["memory_id"]
+        resp = tc.get(f"/api/memories/{mid}/content")
+        assert resp.status_code == 409
+
+    def test_nonexistent_memory_returns_404(self, client):
+        tc, *_ = client
+        resp = tc.get("/api/memories/no-such-id/content")
+        assert resp.status_code == 404
+
+    def test_non_admin_cannot_access_other_users_content(self, client):
+        from hive.models import Memory
+
+        tc, storage, _ = client
+        other = Memory(
+            key="other-bin",
+            value_type="blob",
+            owner_client_id="x",
+            owner_user_id="other-user",
+            s3_uri="s3://bucket/other-user/mem-id",
+        )
+        storage.put_memory(other)
+        resp = tc.get(f"/api/memories/{other.memory_id}/content")
+        assert resp.status_code == 404
+
+    def test_streams_image_content_with_correct_type(self, client):
+        from unittest.mock import MagicMock, patch
+
+        from hive.models import Memory
+
+        tc, storage, user_id = client
+        mem = Memory(
+            key="img.png",
+            value_type="image",
+            owner_client_id=user_id,
+            owner_user_id=user_id,
+            s3_uri=f"s3://bucket/{user_id}/img-id",
+            content_type="image/png",
+        )
+        storage.put_memory(mem)
+
+        mock_bs = MagicMock()
+        mock_bs.get.return_value = b"\x89PNG\r\n"
+        with patch("hive.blob_store.BlobStore", return_value=mock_bs):
+            resp = tc.get(f"/api/memories/{mem.memory_id}/content")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("image/png")
+        assert resp.content == b"\x89PNG\r\n"
+        mock_bs.get.assert_called_once_with(user_id, mem.memory_id)
+
+    def test_admin_can_access_other_users_content(self, admin_client):
+        from unittest.mock import MagicMock, patch
+
+        from hive.models import Memory
+
+        tc, storage, _ = admin_client
+        mem = Memory(
+            key="other-pdf",
+            value_type="blob",
+            owner_client_id="x",
+            owner_user_id="other-user",
+            s3_uri="s3://bucket/other-user/pdf-id",
+            content_type="application/pdf",
+        )
+        storage.put_memory(mem)
+
+        mock_bs = MagicMock()
+        mock_bs.get.return_value = b"%PDF-1.4"
+        with patch("hive.blob_store.BlobStore", return_value=mock_bs):
+            resp = tc.get(f"/api/memories/{mem.memory_id}/content")
+
+        assert resp.status_code == 200
+        assert resp.content == b"%PDF-1.4"
+
+    def test_missing_content_type_defaults_to_octet_stream(self, client):
+        from unittest.mock import MagicMock, patch
+
+        from hive.models import Memory
+
+        tc, storage, user_id = client
+        mem = Memory(
+            key="unknown-blob",
+            value_type="blob",
+            owner_client_id=user_id,
+            owner_user_id=user_id,
+            s3_uri=f"s3://bucket/{user_id}/unknown-id",
+        )
+        storage.put_memory(mem)
+
+        mock_bs = MagicMock()
+        mock_bs.get.return_value = b"raw bytes"
+        with patch("hive.blob_store.BlobStore", return_value=mock_bs):
+            resp = tc.get(f"/api/memories/{mem.memory_id}/content")
+
+        assert resp.status_code == 200
+        assert "application/octet-stream" in resp.headers["content-type"]
+        assert resp.content == b"raw bytes"
 
 
 # ---------------------------------------------------------------------------

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -62,6 +62,22 @@ export const api = {
   listMemoryVersions: (id) => request("GET", `/api/memories/${id}/versions`),
   restoreMemoryVersion: (id, versionTimestamp) =>
     request("POST", `/api/memories/${id}/restore?version_timestamp=${encodeURIComponent(versionTimestamp)}`),
+  getMemoryContent: async (id) => {
+    const token = getToken();
+    const headers = {};
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const res = await fetch(`${BASE}/api/memories/${id}/content`, { headers });
+    if (res.status === 401) {
+      localStorage.removeItem("hive_mgmt_token");
+      globalThis.location.replace("/");
+      return null;
+    }
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: res.statusText }));
+      throw new Error(err.detail ?? "Failed to fetch content");
+    }
+    return res.blob();
+  },
 
   // Clients
   listClients: ({ limit = 50, cursor } = {}) => {

--- a/ui/src/api.test.js
+++ b/ui/src/api.test.js
@@ -514,4 +514,72 @@ describe("api", () => {
     expect(storage["hive_mgmt_token"]).toBeUndefined();
     expect(replace).toHaveBeenCalledWith("/");
   });
+
+  // ---------------------------------------------------------------------------
+  // getMemoryContent
+  // ---------------------------------------------------------------------------
+
+  it("getMemoryContent fetches memory content and returns blob", async () => {
+    const blob = new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(blob),
+    });
+    const result = await api.getMemoryContent("mem-abc");
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/memories/mem-abc/content");
+    expect(result).toBe(blob);
+  });
+
+  it("getMemoryContent sends Authorization header when token present", async () => {
+    storage["hive_mgmt_token"] = "user-token";
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(new Blob()),
+    });
+    await api.getMemoryContent("mem-abc");
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe("Bearer user-token");
+  });
+
+  it("getMemoryContent throws on non-ok response with detail", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      json: () => Promise.resolve({ detail: "Memory has no S3 content" }),
+    });
+    await expect(api.getMemoryContent("mem-abc")).rejects.toThrow("Memory has no S3 content");
+  });
+
+  it("getMemoryContent throws fallback message when json has no detail field", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: () => Promise.resolve({}),
+    });
+    await expect(api.getMemoryContent("mem-abc")).rejects.toThrow("Failed to fetch content");
+  });
+
+  it("getMemoryContent throws generic message when json parse fails", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: () => Promise.reject(new Error("bad json")),
+    });
+    await expect(api.getMemoryContent("mem-abc")).rejects.toThrow("Server Error");
+  });
+
+  it("getMemoryContent clears token and redirects on 401", async () => {
+    storage["hive_mgmt_token"] = "old-token";
+    const replace = vi.fn();
+    vi.stubGlobal("location", { replace });
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+    const result = await api.getMemoryContent("mem-abc");
+    expect(result).toBeNull();
+    expect(storage["hive_mgmt_token"]).toBeUndefined();
+    expect(replace).toHaveBeenCalledWith("/");
+  });
 });

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { X } from "lucide-react";
+import { Download, X } from "lucide-react";
 import { api } from "../api.js";
 import EmptyState from "./EmptyState.jsx";
 import MemoryDiff from "./MemoryDiff.jsx";
@@ -169,6 +169,59 @@ TagPicker.propTypes = {
 };
 
 // ------------------------------------------------------------------
+// Helpers for binary memory types
+// ------------------------------------------------------------------
+
+const _TYPE_LABELS = { "text-large": "Large text", image: "Image", blob: "Blob" };
+export function typeBadgeLabel(vt) {
+  return _TYPE_LABELS[vt] ?? vt;
+}
+
+export function formatBytes(n) {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function MemoryImage({ memoryId, alt, className }) {
+  const [src, setSrc] = useState(null);
+  const [imgError, setImgError] = useState(false);
+
+  useEffect(
+    function fetchImage() {
+      let objectUrl = null;
+      api
+        .getMemoryContent(memoryId)
+        .then(function onBlob(blob) {
+          objectUrl = URL.createObjectURL(blob);
+          setSrc(objectUrl);
+        })
+        .catch(function onError() {
+          setImgError(true);
+        });
+      return function cleanup() {
+        if (objectUrl) URL.revokeObjectURL(objectUrl);
+      };
+    },
+    [memoryId],
+  );
+
+  if (imgError)
+    return (
+      <span className="text-[var(--text-muted)] text-[13px]">Preview unavailable</span>
+    );
+  if (!src)
+    return <span className="text-[var(--text-muted)] text-[13px]">Loading preview…</span>;
+  return <img src={src} alt={alt} className={className} />;
+}
+
+MemoryImage.propTypes = {
+  memoryId: PropTypes.string.isRequired,
+  alt: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+// ------------------------------------------------------------------
 // MemoryBrowser
 // ------------------------------------------------------------------
 
@@ -198,6 +251,7 @@ export default function MemoryBrowser() {
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [pendingDelete, setPendingDelete] = useState(null);
   const [clientNameById, setClientNameById] = useState({});
+  const [contentLoading, setContentLoading] = useState(false);
 
   useEffect(function loadClientNames() {
     api.listClients()
@@ -455,12 +509,41 @@ export default function MemoryBrowser() {
     }
   }
 
-  function openEdit(m) {
+  async function openEdit(m) {
     setEditing(m);
-    setForm({ key: m.key, value: m.value, tags: m.tags.join(", "), ttl: "" });
     setCreating(false);
     setViewingHistory(null);
     setVersions([]);
+
+    if (m.value_type === "text-large") {
+      setForm({ key: m.key, value: "", tags: m.tags.join(", "), ttl: "" });
+      setContentLoading(true);
+      try {
+        const blob = await api.getMemoryContent(m.memory_id);
+        const text = await blob.text();
+        setForm((prev) => ({ ...prev, value: text }));
+      } catch {
+        // Keep the empty value; user can still save tags or a replacement value
+      } finally {
+        setContentLoading(false);
+      }
+    } else {
+      setForm({ key: m.key, value: m.value ?? "", tags: m.tags.join(", "), ttl: "" });
+    }
+  }
+
+  async function handleBlobDownload() {
+    try {
+      const blob = await api.getMemoryContent(editing.memory_id);
+      const url = URL.createObjectURL(blob);
+      const a = globalThis.document.createElement("a");
+      a.href = url;
+      a.download = editing.key;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err.message);
+    }
   }
 
   function openCreate() {
@@ -665,6 +748,14 @@ export default function MemoryBrowser() {
                     {m.score !== undefined && (
                       <Badge>{Math.round(m.score * 100)}% match</Badge>
                     )}
+                    {m.value_type && m.value_type !== "text" && (
+                      <Badge
+                        data-testid="type-badge"
+                        style={{ background: "var(--accent)", color: "var(--accent-fg)" }}
+                      >
+                        {typeBadgeLabel(m.value_type)}
+                      </Badge>
+                    )}
                     {m.expires_at && (
                       <Badge className="border-[var(--amber)] text-[var(--amber)]">Expires {new Date(m.expires_at).toLocaleDateString()}</Badge>
                     )}
@@ -674,9 +765,28 @@ export default function MemoryBrowser() {
                       </Badge>
                     )}
                   </div>
-                  <p className="mt-1 text-[var(--text-muted)] text-[13px] whitespace-pre-wrap">
-                    {m.value.length > 160 ? m.value.slice(0, 160) + "…" : m.value}
-                  </p>
+                  {m.value_type === "image" ? (
+                    <MemoryImage
+                      memoryId={m.memory_id}
+                      alt={m.key}
+                      className="mt-1 max-h-16 object-cover rounded"
+                    />
+                  ) : m.value_type === "blob" ? (
+                    <p className="mt-1 text-[var(--text-muted)] text-[13px]">
+                      {m.content_type ?? "Binary file"}
+                      {m.size_bytes ? ` · ${formatBytes(m.size_bytes)}` : ""}
+                    </p>
+                  ) : m.value_type === "text-large" ? (
+                    <p className="mt-1 text-[var(--text-muted)] text-[13px] italic">
+                      Large text{m.size_bytes ? ` · ${formatBytes(m.size_bytes)}` : ""}
+                    </p>
+                  ) : (
+                    <p className="mt-1 text-[var(--text-muted)] text-[13px] whitespace-pre-wrap">
+                      {(m.value ?? "").length > 160
+                        ? m.value.slice(0, 160) + "…"
+                        : (m.value ?? "")}
+                    </p>
+                  )}
                   <div className="mt-1.5 flex flex-wrap gap-1">
                     {m.tags.map((t) => (
                       <Badge key={t}>{t}</Badge>
@@ -716,63 +826,122 @@ export default function MemoryBrowser() {
       {/* Side form */}
       {(creating || editing) && (
         <div className="w-full md:w-[360px]">
-          <Card>
-            <h3 className="mb-4 text-base font-semibold">
-              {creating ? "New Memory" : `Edit: ${editing.key}`}
-            </h3>
-            <form onSubmit={creating ? handleCreate : handleUpdate}>
-              {creating && (
-                <div className="mb-3">
-                  <Label htmlFor="memory-key">Key</Label>
-                  <Input
-                    id="memory-key"
-                    required
-                    value={form.key}
-                    onChange={(e) => setForm({ ...form, key: e.target.value })}
-                    placeholder="unique-key"
-                  />
+          {editing?.value_type === "image" ? (
+            <Card>
+              <h3 className="mb-4 text-base font-semibold">Image: {editing.key}</h3>
+              <MemoryImage
+                memoryId={editing.memory_id}
+                alt={editing.key}
+                className="max-w-full rounded mb-3"
+              />
+              {(editing.content_type || editing.size_bytes) && (
+                <p className="text-[13px] text-[var(--text-muted)] mb-2">
+                  {editing.content_type}
+                  {editing.size_bytes ? ` · ${formatBytes(editing.size_bytes)}` : ""}
+                </p>
+              )}
+              {editing.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1 mb-3">
+                  {editing.tags.map((t) => (
+                    <Badge key={t}>{t}</Badge>
+                  ))}
                 </div>
               )}
-              <div className="mb-3">
-                <Label htmlFor="memory-value">Value</Label>
-                <Textarea
-                  id="memory-value"
-                  required
-                  rows={6}
-                  value={form.value}
-                  onChange={(e) => setForm({ ...form, value: e.target.value })}
-                  placeholder="Memory content…"
-                />
-              </div>
-              <div className="mb-3">
-                <Label htmlFor="memory-tags">Tags (comma-separated)</Label>
-                <Input
-                  id="memory-tags"
-                  value={form.tags}
-                  onChange={(e) => setForm({ ...form, tags: e.target.value })}
-                  placeholder="tag1, tag2"
-                />
-              </div>
-              <div className="mb-4">
-                <Label htmlFor="memory-ttl">Expires in</Label>
-                <Select
-                  id="memory-ttl"
-                  value={form.ttl}
-                  onChange={(e) => setForm({ ...form, ttl: e.target.value })}
-                >
-                  {TTL_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+              <Button variant="secondary" onClick={closePanel}>
+                Close
+              </Button>
+            </Card>
+          ) : editing?.value_type === "blob" ? (
+            <Card>
+              <h3 className="mb-4 text-base font-semibold">Blob: {editing.key}</h3>
+              <p className="text-[13px] mb-1">
+                {editing.content_type ?? "Binary file"}
+              </p>
+              {editing.size_bytes && (
+                <p className="text-[13px] text-[var(--text-muted)] mb-3">
+                  {formatBytes(editing.size_bytes)}
+                </p>
+              )}
+              {editing.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1 mb-3">
+                  {editing.tags.map((t) => (
+                    <Badge key={t}>{t}</Badge>
                   ))}
-                </Select>
-              </div>
+                </div>
+              )}
               <div className="flex gap-2">
-                <Button type="submit">Save</Button>
-                <Button variant="secondary" type="button" onClick={closePanel}>
-                  Cancel
+                <Button onClick={handleBlobDownload}>
+                  <Download size={14} className="mr-1" />
+                  Download
+                </Button>
+                <Button variant="secondary" onClick={closePanel}>
+                  Close
                 </Button>
               </div>
-            </form>
-          </Card>
+            </Card>
+          ) : (
+            <Card>
+              <h3 className="mb-4 text-base font-semibold">
+                {creating ? "New Memory" : `Edit: ${editing.key}`}
+              </h3>
+              <form onSubmit={creating ? handleCreate : handleUpdate}>
+                {creating && (
+                  <div className="mb-3">
+                    <Label htmlFor="memory-key">Key</Label>
+                    <Input
+                      id="memory-key"
+                      required
+                      value={form.key}
+                      onChange={(e) => setForm({ ...form, key: e.target.value })}
+                      placeholder="unique-key"
+                    />
+                  </div>
+                )}
+                <div className="mb-3">
+                  <Label htmlFor="memory-value">Value</Label>
+                  {contentLoading ? (
+                    <p className="text-[var(--text-muted)] text-[13px]">Loading content…</p>
+                  ) : (
+                    <Textarea
+                      id="memory-value"
+                      required
+                      rows={6}
+                      value={form.value}
+                      onChange={(e) => setForm({ ...form, value: e.target.value })}
+                      placeholder="Memory content…"
+                    />
+                  )}
+                </div>
+                <div className="mb-3">
+                  <Label htmlFor="memory-tags">Tags (comma-separated)</Label>
+                  <Input
+                    id="memory-tags"
+                    value={form.tags}
+                    onChange={(e) => setForm({ ...form, tags: e.target.value })}
+                    placeholder="tag1, tag2"
+                  />
+                </div>
+                <div className="mb-4">
+                  <Label htmlFor="memory-ttl">Expires in</Label>
+                  <Select
+                    id="memory-ttl"
+                    value={form.ttl}
+                    onChange={(e) => setForm({ ...form, ttl: e.target.value })}
+                  >
+                    {TTL_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </Select>
+                </div>
+                <div className="flex gap-2">
+                  <Button type="submit">Save</Button>
+                  <Button variant="secondary" type="button" onClick={closePanel}>
+                    Cancel
+                  </Button>
+                </div>
+              </form>
+            </Card>
+          )}
         </div>
       )}
 

--- a/ui/src/components/MemoryBrowser.test.jsx
+++ b/ui/src/components/MemoryBrowser.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import MemoryBrowser, { TagPicker } from "./MemoryBrowser.jsx";
+import MemoryBrowser, { MemoryImage, TagPicker, formatBytes, typeBadgeLabel } from "./MemoryBrowser.jsx";
 
 vi.mock("../api.js", () => ({
   api: {
@@ -13,6 +13,7 @@ vi.mock("../api.js", () => ({
     listMemoryVersions: vi.fn(),
     restoreMemoryVersion: vi.fn(),
     listClients: vi.fn(),
+    getMemoryContent: vi.fn(),
   },
 }));
 
@@ -1689,5 +1690,430 @@ describe("MemoryBrowser", () => {
     });
     const input = await screen.findByPlaceholderText(/search by meaning/i);
     expect(input.value).toBe("my-key");
+  });
+});
+
+// ------------------------------------------------------------------
+// typeBadgeLabel helper
+// ------------------------------------------------------------------
+
+describe("typeBadgeLabel", () => {
+  it("returns 'Large text' for text-large", () => {
+    expect(typeBadgeLabel("text-large")).toBe("Large text");
+  });
+
+  it("returns 'Image' for image", () => {
+    expect(typeBadgeLabel("image")).toBe("Image");
+  });
+
+  it("returns 'Blob' for blob", () => {
+    expect(typeBadgeLabel("blob")).toBe("Blob");
+  });
+
+  it("returns the raw type for unknown values", () => {
+    expect(typeBadgeLabel("video")).toBe("video");
+  });
+});
+
+// ------------------------------------------------------------------
+// formatBytes helper
+// ------------------------------------------------------------------
+
+describe("formatBytes", () => {
+  it("shows bytes below 1 KB", () => {
+    expect(formatBytes(512)).toBe("512 B");
+  });
+
+  it("shows KB between 1024 and 1 MB", () => {
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("shows MB for 1 MB and above", () => {
+    expect(formatBytes(2 * 1024 * 1024)).toBe("2.0 MB");
+  });
+});
+
+// ------------------------------------------------------------------
+// MemoryImage component
+// ------------------------------------------------------------------
+
+describe("MemoryImage", () => {
+  beforeEach(() => {
+    URL.createObjectURL.mockReturnValue("blob:fake-url");
+    URL.revokeObjectURL.mockClear();
+  });
+
+  afterEach(() => {
+    URL.createObjectURL.mockReset();
+    URL.revokeObjectURL.mockReset();
+    URL.createObjectURL.mockReturnValue("blob:test-url");
+  });
+
+  it("shows loading state while fetch is pending", async () => {
+    api.getMemoryContent.mockReturnValue(new Promise(() => {}));
+    await act(async () =>
+      render(<MemoryImage memoryId="m1" alt="img" className="rounded" />),
+    );
+    expect(screen.getByText("Loading preview…")).toBeTruthy();
+  });
+
+  it("renders img element after successful fetch", async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    api.getMemoryContent.mockResolvedValue(blob);
+    await act(async () =>
+      render(<MemoryImage memoryId="m1" alt="my image" className="rounded" />),
+    );
+    await waitFor(() => expect(screen.getByRole("img")).toBeTruthy());
+    expect(screen.getByRole("img").getAttribute("src")).toBe("blob:fake-url");
+    expect(screen.getByRole("img").getAttribute("alt")).toBe("my image");
+  });
+
+  it("shows error state when fetch fails", async () => {
+    api.getMemoryContent.mockRejectedValue(new Error("S3 error"));
+    await act(async () =>
+      render(<MemoryImage memoryId="m1" alt="img" />),
+    );
+    await waitFor(() => expect(screen.getByText("Preview unavailable")).toBeTruthy());
+  });
+
+  it("revokes object URL on unmount", async () => {
+    const blob = new Blob([], { type: "image/png" });
+    api.getMemoryContent.mockResolvedValue(blob);
+    const { unmount } = await act(async () =>
+      render(<MemoryImage memoryId="m1" alt="img" />),
+    );
+    await waitFor(() => screen.getByRole("img"));
+    unmount();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake-url");
+  });
+});
+
+// ------------------------------------------------------------------
+// Binary memory type rendering in list view
+// ------------------------------------------------------------------
+
+describe("Binary memory list view", () => {
+  beforeEach(() => {
+    api.listClients.mockResolvedValue({ items: [] });
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:fake-url"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows type badge for image memory", async () => {
+    const img = makeMemory({ value_type: "image", value: "", content_type: "image/png", size_bytes: 2048 });
+    api.listMemories.mockResolvedValue({ items: [img], next_cursor: null });
+    api.getMemoryContent.mockReturnValue(new Promise(() => {}));
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("type-badge"));
+    expect(screen.getByTestId("type-badge").textContent).toBe("Image");
+  });
+
+  it("shows type badge for blob memory", async () => {
+    const blob = makeMemory({ value_type: "blob", value: "", content_type: "application/pdf", size_bytes: 4096 });
+    api.listMemories.mockResolvedValue({ items: [blob], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("type-badge"));
+    expect(screen.getByTestId("type-badge").textContent).toBe("Blob");
+  });
+
+  it("shows type badge for text-large memory", async () => {
+    const large = makeMemory({ value_type: "text-large", value: "", size_bytes: 150000 });
+    api.listMemories.mockResolvedValue({ items: [large], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("type-badge"));
+    expect(screen.getByTestId("type-badge").textContent).toBe("Large text");
+  });
+
+  it("shows no type badge for regular text memory", async () => {
+    const text = makeMemory({ value_type: "text", value: "hello" });
+    api.listMemories.mockResolvedValue({ items: [text], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("hello"));
+    expect(screen.queryByTestId("type-badge")).toBeNull();
+  });
+
+  it("shows no type badge when value_type is absent (legacy memory)", async () => {
+    const text = makeMemory({ value: "legacy" });
+    api.listMemories.mockResolvedValue({ items: [text], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("legacy"));
+    expect(screen.queryByTestId("type-badge")).toBeNull();
+  });
+
+  it("truncates text value longer than 160 chars in list view", async () => {
+    const longValue = "a".repeat(200);
+    const text = makeMemory({ value_type: "text", value: longValue });
+    api.listMemories.mockResolvedValue({ items: [text], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText(/a{160}…/));
+    expect(screen.queryByText(longValue)).toBeNull();
+  });
+
+  it("shows empty string for text memory with null value in list view", async () => {
+    const text = makeMemory({ value_type: "text", value: null });
+    api.listMemories.mockResolvedValue({ items: [text], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    // No crash; the memory card renders with an empty value paragraph
+    await waitFor(() => screen.getByTestId("memory-card"));
+    expect(screen.queryByTestId("type-badge")).toBeNull();
+  });
+
+  it("shows blob content type and formatted size for blob memory", async () => {
+    const blob = makeMemory({ value_type: "blob", value: "", content_type: "application/pdf", size_bytes: 4096 });
+    api.listMemories.mockResolvedValue({ items: [blob], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText(/application\/pdf/));
+    expect(screen.getByText(/4\.0 KB/)).toBeTruthy();
+  });
+
+  it("shows 'Binary file' when blob has no content_type", async () => {
+    const blob = makeMemory({ value_type: "blob", value: "", size_bytes: null });
+    api.listMemories.mockResolvedValue({ items: [blob], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("Binary file"));
+  });
+
+  it("shows large text placeholder with size for text-large memory", async () => {
+    const large = makeMemory({ value_type: "text-large", value: "", size_bytes: 150000 });
+    api.listMemories.mockResolvedValue({ items: [large], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    // "Large text" appears in both the type badge and the placeholder; wait for the unique size text
+    await waitFor(() => screen.getByText(/146\.5 KB/));
+    expect(screen.getByText(/146\.5 KB/)).toBeTruthy();
+  });
+
+  it("shows large text without size when size_bytes is null", async () => {
+    const large = makeMemory({ value_type: "text-large", value: "", size_bytes: null });
+    api.listMemories.mockResolvedValue({ items: [large], next_cursor: null });
+    await act(async () => render(<MemoryBrowser />));
+    // "Large text" appears in both the type badge and the placeholder — assert no size is shown
+    await waitFor(() => screen.getByTestId("type-badge"));
+    expect(screen.queryByText(/KB/)).toBeNull();
+  });
+
+  it("shows MemoryImage loading state for image memory", async () => {
+    const img = makeMemory({ value_type: "image", value: "", content_type: "image/png" });
+    api.listMemories.mockResolvedValue({ items: [img], next_cursor: null });
+    api.getMemoryContent.mockReturnValue(new Promise(() => {}));
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByText("Loading preview…"));
+  });
+});
+
+// ------------------------------------------------------------------
+// Binary memory edit panel
+// ------------------------------------------------------------------
+
+describe("Binary memory edit panel", () => {
+  beforeEach(() => {
+    api.listClients.mockResolvedValue({ items: [] });
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:fake-url"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("clicking image memory shows image detail panel", async () => {
+    const img = makeMemory({
+      value_type: "image",
+      value: "",
+      content_type: "image/png",
+      size_bytes: 2048,
+      tags: ["photo"],
+    });
+    api.listMemories.mockResolvedValue({ items: [img], next_cursor: null });
+    api.getMemoryContent.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+
+    await waitFor(() => screen.getByText(/Image: test-key/));
+    expect(screen.getByText("image/png · 2.0 KB")).toBeTruthy();
+    // "photo" tag appears in both list card and detail panel — just assert it's present
+    expect(screen.getAllByText("photo").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
+  });
+
+  it("image panel with no content_type or size_bytes shows only the image", async () => {
+    const img = makeMemory({ value_type: "image", value: "", tags: [] });
+    api.listMemories.mockResolvedValue({ items: [img], next_cursor: null });
+    api.getMemoryContent.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+
+    await waitFor(() => screen.getByText(/Image: test-key/));
+    // No metadata line, no tags
+    expect(screen.queryByText(/KB/)).toBeNull();
+  });
+
+  it("clicking blob memory shows blob detail panel with download button", async () => {
+    const blob = makeMemory({
+      value_type: "blob",
+      value: "",
+      content_type: "application/pdf",
+      size_bytes: 8192,
+      tags: ["docs"],
+    });
+    api.listMemories.mockResolvedValue({ items: [blob], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+
+    await waitFor(() => screen.getByText(/Blob: test-key/));
+    expect(screen.getByText("application/pdf")).toBeTruthy();
+    expect(screen.getByText("8.0 KB")).toBeTruthy();
+    // "docs" tag appears in both list card and detail panel — just assert it's present
+    expect(screen.getAllByText("docs").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Download/ })).toBeTruthy();
+  });
+
+  it("blob panel without size_bytes omits the size line", async () => {
+    const blob = makeMemory({ value_type: "blob", value: "", tags: [] });
+    api.listMemories.mockResolvedValue({ items: [blob], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+
+    // "Binary file" appears in both list and detail panel; wait for the panel heading instead
+    await waitFor(() => screen.getByText(/Blob: test-key/));
+    expect(screen.queryByText(/KB/)).toBeNull();
+  });
+
+  it("blob download triggers file download via anchor click", async () => {
+    const blob = makeMemory({
+      value_type: "blob",
+      value: "",
+      content_type: "application/pdf",
+      tags: [],
+    });
+    api.listMemories.mockResolvedValue({ items: [blob], next_cursor: null });
+    const fakeBlob = new Blob(["pdf"], { type: "application/pdf" });
+    api.getMemoryContent.mockResolvedValue(fakeBlob);
+
+    // Render first so React's own createElement calls are not intercepted by our spy
+    await act(async () => render(<MemoryBrowser />));
+
+    const fakeAnchor = { href: "", download: "", click: vi.fn() };
+    const origCreateElement = document.createElement.bind(document);
+    const createElementSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tag, ...args) =>
+        tag === "a" ? fakeAnchor : origCreateElement(tag, ...args),
+      );
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+    await waitFor(() => screen.getByRole("button", { name: /Download/ }));
+    await act(async () =>
+      fireEvent.click(screen.getByRole("button", { name: /Download/ })),
+    );
+
+    await waitFor(() => expect(fakeAnchor.click).toHaveBeenCalled());
+    expect(fakeAnchor.download).toBe("test-key");
+    expect(fakeAnchor.href).toBe("blob:fake-url");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake-url");
+    createElementSpy.mockRestore();
+  });
+
+  it("blob download error shows error message", async () => {
+    const blob = makeMemory({ value_type: "blob", value: "", tags: [] });
+    api.listMemories.mockResolvedValue({ items: [blob], next_cursor: null });
+    api.getMemoryContent.mockRejectedValue(new Error("S3 failure"));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+    await waitFor(() => screen.getByRole("button", { name: /Download/ }));
+    await act(async () =>
+      fireEvent.click(screen.getByRole("button", { name: /Download/ })),
+    );
+
+    await waitFor(() => screen.getByText("S3 failure"));
+  });
+
+  it("clicking text-large memory shows loading then populated textarea", async () => {
+    const large = makeMemory({ value_type: "text-large", value: "", size_bytes: 200000 });
+    api.listMemories.mockResolvedValue({ items: [large], next_cursor: null });
+
+    let resolveBlob;
+    const blobPromise = new Promise((res) => { resolveBlob = res; });
+    api.getMemoryContent.mockReturnValue(blobPromise);
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    act(() => { fireEvent.click(screen.getByTestId("memory-card")); });
+
+    await waitFor(() => screen.getByText("Loading content…"));
+
+    const fakeBlob = { text: () => Promise.resolve("the full text content") };
+    await act(async () => { resolveBlob(fakeBlob); });
+
+    await waitFor(() => {
+      const ta = screen.getByRole("textbox", { name: /Value/ });
+      expect(ta.value).toBe("the full text content");
+    });
+  });
+
+  it("text-large content fetch error still shows editable textarea", async () => {
+    const large = makeMemory({ value_type: "text-large", value: "" });
+    api.listMemories.mockResolvedValue({ items: [large], next_cursor: null });
+    api.getMemoryContent.mockRejectedValue(new Error("S3 error"));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+
+    await waitFor(() => {
+      const ta = screen.queryByRole("textbox", { name: /Value/ });
+      expect(ta).toBeTruthy();
+    });
+  });
+
+  it("opening a text memory with null value populates form with empty string", async () => {
+    const mem = makeMemory({ value: null, value_type: "text" });
+    api.listMemories.mockResolvedValue({ items: [mem], next_cursor: null });
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+
+    await waitFor(() => {
+      const ta = screen.getByRole("textbox", { name: /Value/ });
+      expect(ta.value).toBe("");
+    });
+  });
+
+  it("image panel with content_type but no size_bytes shows type without size", async () => {
+    const img = makeMemory({
+      value_type: "image",
+      value: "",
+      content_type: "image/png",
+      size_bytes: null,
+      tags: [],
+    });
+    api.listMemories.mockResolvedValue({ items: [img], next_cursor: null });
+    api.getMemoryContent.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => render(<MemoryBrowser />));
+    await waitFor(() => screen.getByTestId("memory-card"));
+    await act(async () => fireEvent.click(screen.getByTestId("memory-card")));
+
+    await waitFor(() => screen.getByText(/Image: test-key/));
+    expect(screen.getByText("image/png")).toBeTruthy();
+    expect(screen.queryByText(/KB/)).toBeNull();
   });
 });

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -1,6 +1,12 @@
 // Copyright (c) 2026 John Carter. All rights reserved.
 import "@testing-library/jest-dom";
 
+// URL.createObjectURL and URL.revokeObjectURL are not implemented in jsdom.
+// Stub them as vi.fn() so components that call them don't throw.
+// Individual tests can call .mockReturnValue(...) to control the return.
+globalThis.URL.createObjectURL = vi.fn(() => "blob:test-url");
+globalThis.URL.revokeObjectURL = vi.fn();
+
 // jsdom does not implement scrollIntoView; stub it so components that call it
 // do not throw and coverage branches are reachable.
 globalThis.HTMLElement.prototype.scrollIntoView = function () {};


### PR DESCRIPTION
Closes #501

## Summary

- **`MemoryResponse` model** gains `value_type`, `content_type`, and `size_bytes` fields, propagated from the `Memory` model via `from_memory()`
- **New `/api/memories/{id}/content` endpoint** streams S3-backed binary content (image, blob, text-large) with the correct `Content-Type` header; returns 409 for inline memories, 404 for missing/unauthorized
- **`getMemoryContent(id)`** added to the management API client — auth-gated fetch that returns a `Blob` (used for both blob download and image preview)
- **`MemoryBrowser` list view** shows type badges for non-text memories and renders content-appropriate previews: `MemoryImage` (auth-gated blob URL) for images, content-type + size for blobs, italic placeholder for text-large
- **`MemoryBrowser` side panel** has three new branches: image detail card (read-only with preview), blob detail card (download button triggers anchor-click download), text-large editing (fetches full content via API on open)
- Exported helpers (`formatBytes`, `typeBadgeLabel`, `MemoryImage`) for direct unit testing
- Stubbed `URL.createObjectURL`/`URL.revokeObjectURL` globally in `setupTests.js` — jsdom doesn't implement these

## Approach

- Auth-gated fetch for image preview: browsers can't send `Authorization` headers on `<img src>` directly, so `MemoryImage` fetches the blob in a `useEffect`, creates an object URL, and cleans it up on unmount
- The `/content` route is registered *before* `GET /memories/{id}` in the router so FastAPI doesn't accidentally match `content` as a memory ID
- `document.createElement("a")` in the download handler is intercepted in tests using a discriminating `vi.spyOn` implementation that only returns the fake anchor for `"a"` tags, leaving React's own DOM creation intact
- 100% branch coverage maintained: simplified `m.value.slice(0, 160)` (instead of `(m.value ?? "").slice(0, 160)`) since null value can never have length > 160

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y56sF9QXGtvyZ9cajArMdV)_