### PR TITLE
docs: large-memory — concepts, size limits, binary content

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -77,7 +77,7 @@ export default defineConfig({
         items: [
           { text: "Overview", link: "/tools/overview" },
           { text: "remember", link: "/tools/remember" },
-          { text: "remember_blob", link: "/tools/remember_blob" },
+          { text: "remember_blob", link: "/tools/remember-blob" },
           { text: "recall", link: "/tools/recall" },
           { text: "forget", link: "/tools/forget" },
           { text: "list_memories", link: "/tools/list-memories" },

--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -77,6 +77,7 @@ export default defineConfig({
         items: [
           { text: "Overview", link: "/tools/overview" },
           { text: "remember", link: "/tools/remember" },
+          { text: "remember_blob", link: "/tools/remember_blob" },
           { text: "recall", link: "/tools/recall" },
           { text: "forget", link: "/tools/forget" },
           { text: "list_memories", link: "/tools/list-memories" },
@@ -100,6 +101,7 @@ export default defineConfig({
           { text: "How memory scoping works", link: "/concepts/memory-scoping" },
           { text: "Tags and organisation", link: "/concepts/tags" },
           { text: "Key naming conventions", link: "/concepts/key-conventions" },
+          { text: "Large memory", link: "/concepts/large-memory" },
           { text: "Quotas and rate limits", link: "/concepts/quotas" },
           { text: "MCP Resources", link: "/concepts/resources" },
         ],

--- a/docs-site/concepts/large-memory.md
+++ b/docs-site/concepts/large-memory.md
@@ -7,11 +7,9 @@ Hive stores three kinds of non-standard memory alongside ordinary inline text. U
 | `value_type` | Stored where | How it arrives | Max size |
 | --- | --- | --- | --- |
 | `text` | DynamoDB (inline) | `remember` with a short value | ~100 KB |
-| `text-large` | S3 (auto-promoted) | `remember` with a long value | No hard limit\* |
+| `text-large` | S3 (auto-promoted) | `remember` with a long value | 10 MB |
 | `image` | S3 | `remember_blob` with an `image/*` MIME type | 10 MB |
 | `blob` | S3 | `remember_blob` with any other MIME type | 10 MB |
-
-\* Practical upper bound is the Lambda request payload size (~6 MB for synchronous invocations). Large documents should be split into sections.
 
 ## Inline threshold — when text spills to S3
 
@@ -27,7 +25,7 @@ The promotion to `text-large` is **transparent**: you call `remember` and `recal
 
 ## Binary memories — images and blobs
 
-Use [`remember_blob`](/tools/remember_blob) to store images, PDFs, audio, or any other binary content. Pass the bytes as standard Base64 and specify a MIME type.
+Use [`remember_blob`](/tools/remember-blob) to store images, PDFs, audio, or any other binary content. Pass the bytes as standard Base64 and specify a MIME type.
 
 Hive routes by MIME prefix:
 
@@ -43,23 +41,24 @@ Semantic search (via `search_memories`) operates on **text embeddings**:
 | `value_type` | Embedded? | Notes |
 | --- | --- | --- |
 | `text` | Yes | Full inline value is embedded |
-| `text-large` | No | S3 content is not embedded (no vectors for large text) |
+| `text-large` | Yes | Large text is embedded; full S3 value is not fetched for list/search previews |
 | `image` | No | Binary content is not embedded |
 | `blob` | No | Binary content is not embedded |
 
-`text-large` and binary memories are excluded from semantic search results. They are still reachable via `recall` (by key) and `list_memories` (by tag).
+`text-large` memories can appear in semantic search results. Binary memories (`image` and `blob`) are excluded from semantic search. For large text, `search_memories` and `list_memories` may omit the full value preview; use `recall` to fetch the complete content by key.
 
 ## Size limits summary
 
 | Limit | Value |
 | --- | --- |
 | Inline text threshold (auto S3 promotion) | 100 KB |
-| Maximum blob / `remember_blob` payload | 10 MB |
+| Maximum text value (`remember`, including S3-promoted) | 10 MB |
+| Maximum binary payload (`remember_blob`) | 10 MB |
 | DynamoDB item ceiling (hard) | 400 KB |
 
 ## Related pages
 
 - [`remember`](/tools/remember) — store text memories (handles text-large transparently)
-- [`remember_blob`](/tools/remember_blob) — store binary content
+- [`remember_blob`](/tools/remember-blob) — store binary content
 - [`recall`](/tools/recall) — retrieve any memory by key
 - [Memory Browser](/ui-guide/memory-browser) — view and download large memories in the UI

--- a/docs-site/concepts/large-memory.md
+++ b/docs-site/concepts/large-memory.md
@@ -15,7 +15,7 @@ Hive stores three kinds of non-standard memory alongside ordinary inline text. U
 
 When you call `remember` with a text value, Hive checks the encoded byte length against a 100 KB threshold:
 
-- **≤ 100 KB** — stored inline in DynamoDB as `value_type="text"`. Retrieval is a single `GetItem`.
+- **≤ 100 KB** — stored inline in DynamoDB as `value_type="text"`. `recall` stays DynamoDB-only and does not fetch from S3.
 - **> 100 KB** — stored in S3 as `value_type="text-large"`. The DynamoDB item holds metadata only; the value is fetched from S3 when you `recall` the key.
 
 The promotion to `text-large` is **transparent**: you call `remember` and `recall` exactly as before. The only observable differences are:

--- a/docs-site/concepts/large-memory.md
+++ b/docs-site/concepts/large-memory.md
@@ -20,7 +20,7 @@ When you call `remember` with a text value, Hive checks the encoded byte length 
 
 The promotion to `text-large` is **transparent**: you call `remember` and `recall` exactly as before. The only observable differences are:
 
-- `list_memories` omits the inline value for `text-large` memories (it shows metadata only).
+- `list_memories` returns an empty `value` string for `text-large` memories (the inline value is cleared on S3 promotion; use `recall` to fetch the full content).
 - Retrieval adds a small S3 latency (~50–200 ms) on top of the DynamoDB read.
 
 ## Binary memories — images and blobs
@@ -45,7 +45,7 @@ Semantic search (via `search_memories`) operates on **text embeddings**:
 | `image` | No | Binary content is not embedded |
 | `blob` | No | Binary content is not embedded |
 
-`text-large` memories can appear in semantic search results. Binary memories (`image` and `blob`) are excluded from semantic search. For large text, `search_memories` and `list_memories` may omit the full value preview; use `recall` to fetch the complete content by key.
+`text-large` memories can appear in semantic search results. Binary memories (`image` and `blob`) are excluded from semantic search. For large text, `search_memories` and `list_memories` return an empty `value` string; use `recall` to fetch the complete content by key.
 
 ## Size limits summary
 

--- a/docs-site/concepts/large-memory.md
+++ b/docs-site/concepts/large-memory.md
@@ -1,0 +1,65 @@
+# Large memory — text, images, and blobs
+
+Hive stores three kinds of non-standard memory alongside ordinary inline text. Understanding the distinction helps you choose the right tool and set accurate expectations for retrieval behaviour.
+
+## Memory value types
+
+| `value_type` | Stored where | How it arrives | Max size |
+| --- | --- | --- | --- |
+| `text` | DynamoDB (inline) | `remember` with a short value | ~100 KB |
+| `text-large` | S3 (auto-promoted) | `remember` with a long value | No hard limit\* |
+| `image` | S3 | `remember_blob` with an `image/*` MIME type | 10 MB |
+| `blob` | S3 | `remember_blob` with any other MIME type | 10 MB |
+
+\* Practical upper bound is the Lambda request payload size (~6 MB for synchronous invocations). Large documents should be split into sections.
+
+## Inline threshold — when text spills to S3
+
+When you call `remember` with a text value, Hive checks the encoded byte length against a 100 KB threshold:
+
+- **≤ 100 KB** — stored inline in DynamoDB as `value_type="text"`. Retrieval is a single `GetItem`.
+- **> 100 KB** — stored in S3 as `value_type="text-large"`. The DynamoDB item holds metadata only; the value is fetched from S3 when you `recall` the key.
+
+The promotion to `text-large` is **transparent**: you call `remember` and `recall` exactly as before. The only observable differences are:
+
+- `list_memories` omits the inline value for `text-large` memories (it shows metadata only).
+- Retrieval adds a small S3 latency (~50–200 ms) on top of the DynamoDB read.
+
+## Binary memories — images and blobs
+
+Use [`remember_blob`](/tools/remember_blob) to store images, PDFs, audio, or any other binary content. Pass the bytes as standard Base64 and specify a MIME type.
+
+Hive routes by MIME prefix:
+
+- `image/*` (e.g. `image/png`, `image/jpeg`) → `value_type="image"`
+- Everything else (e.g. `application/pdf`, `audio/mpeg`) → `value_type="blob"`
+
+Both subtypes are stored in S3. A binary memory has no inline `value` — the management UI and `recall` fetch the bytes directly from S3.
+
+## Semantic search
+
+Semantic search (via `search_memories`) operates on **text embeddings**:
+
+| `value_type` | Embedded? | Notes |
+| --- | --- | --- |
+| `text` | Yes | Full inline value is embedded |
+| `text-large` | No | S3 content is not embedded (no vectors for large text) |
+| `image` | No | Binary content is not embedded |
+| `blob` | No | Binary content is not embedded |
+
+`text-large` and binary memories are excluded from semantic search results. They are still reachable via `recall` (by key) and `list_memories` (by tag).
+
+## Size limits summary
+
+| Limit | Value |
+| --- | --- |
+| Inline text threshold (auto S3 promotion) | 100 KB |
+| Maximum blob / `remember_blob` payload | 10 MB |
+| DynamoDB item ceiling (hard) | 400 KB |
+
+## Related pages
+
+- [`remember`](/tools/remember) — store text memories (handles text-large transparently)
+- [`remember_blob`](/tools/remember_blob) — store binary content
+- [`recall`](/tools/recall) — retrieve any memory by key
+- [Memory Browser](/ui-guide/memory-browser) — view and download large memories in the UI

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -877,9 +877,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,9 +891,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -911,9 +905,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,9 +919,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -945,9 +933,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -962,9 +947,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -979,9 +961,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -996,9 +975,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1013,9 +989,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1030,9 +1003,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,9 +1017,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1064,9 +1031,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1081,9 +1045,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/docs-site/tools/remember-blob.md
+++ b/docs-site/tools/remember-blob.md
@@ -46,7 +46,7 @@ Save this architecture PDF as "project/myapp/architecture-doc" with tag "docs".
 
 Use [`recall`](/tools/recall) to retrieve a binary memory. For both `value_type="image"` and `value_type="blob"`, the tool returns an MCP `ImageContent` block whose `data` contains the Base64-encoded bytes and whose `mimeType` is set from the stored `content_type`. Non-image blobs (e.g. PDFs, audio) are still returned as `ImageContent` with `type="image"`; client implementations must use `mimeType` to determine the actual content type and must not assume the payload is an image.
 
-Binary memories are **not included** in semantic search (`search_memories`) results — retrieve them by key or tag only.
+Binary memories are not embedded, so they generally won't appear in semantic search (`search_memories`) results — retrieve them by key or tag only.
 
 ## Related tools
 

--- a/docs-site/tools/remember-blob.md
+++ b/docs-site/tools/remember-blob.md
@@ -39,12 +39,12 @@ Save this architecture PDF as "project/myapp/architecture-doc" with tag "docs".
 | Limit | Value |
 | --- | --- |
 | Maximum payload (decoded bytes) | 10 MB |
-| Supported MIME types | Any valid MIME string |
+| Supported MIME types | Any non-empty string (typically a MIME type such as `image/png`) |
 | Key length | Up to 512 characters |
 
 ## Retrieval
 
-Use [`recall`](/tools/recall) to retrieve a binary memory. For both `value_type="image"` and `value_type="blob"`, the tool returns an MCP `ImageContent` block whose `data` contains the Base64-encoded bytes and whose `mimeType` is set from the stored `content_type`.
+Use [`recall`](/tools/recall) to retrieve a binary memory. For both `value_type="image"` and `value_type="blob"`, the tool returns an MCP `ImageContent` block whose `data` contains the Base64-encoded bytes and whose `mimeType` is set from the stored `content_type`. Non-image blobs (e.g. PDFs, audio) are still returned as `ImageContent` with `type="image"`; client implementations must use `mimeType` to determine the actual content type and must not assume the payload is an image.
 
 Binary memories are **not included** in semantic search (`search_memories`) results — retrieve them by key or tag only.
 

--- a/docs-site/tools/remember-blob.md
+++ b/docs-site/tools/remember-blob.md
@@ -44,7 +44,7 @@ Save this architecture PDF as "project/myapp/architecture-doc" with tag "docs".
 
 ## Retrieval
 
-Use [`recall`](/tools/recall) to retrieve a binary memory. For `value_type="image"`, the tool returns an `ImageContent` MCP response (the bytes, ready for the client to render). For `value_type="blob"`, it returns the raw bytes with the correct `Content-Type` header.
+Use [`recall`](/tools/recall) to retrieve a binary memory. For both `value_type="image"` and `value_type="blob"`, the tool returns an MCP `ImageContent` block whose `data` contains the Base64-encoded bytes and whose `mimeType` is set from the stored `content_type`.
 
 Binary memories are **not included** in semantic search (`search_memories`) results — retrieve them by key or tag only.
 

--- a/docs-site/tools/remember.md
+++ b/docs-site/tools/remember.md
@@ -34,7 +34,7 @@ Update the memory at key "project/deadline" — the deadline has moved to April 
 
 ## Limits
 
-- **Value size**: up to ~100 KB stored inline; values above that are transparently promoted to S3-backed `text-large` storage with no practical upper limit (see [Large memory](/concepts/large-memory))
+- **Value size**: up to ~100 KB stored inline; values above that are transparently promoted to S3-backed `text-large` storage, up to a maximum of **10 MB** (see [Large memory](/concepts/large-memory))
 - **Tags per memory**: no hard limit, but keep it reasonable
 - **Key length**: up to 512 characters
 
@@ -42,4 +42,4 @@ Update the memory at key "project/deadline" — the deadline has moved to April 
 
 - [`recall`](/tools/recall) — retrieve a memory by key
 - [`forget`](/tools/forget) — delete a memory
-- [`remember_blob`](/tools/remember_blob) — store binary content (images, PDFs, etc.)
+- [`remember_blob`](/tools/remember-blob) — store binary content (images, PDFs, etc.)

--- a/docs-site/tools/remember.md
+++ b/docs-site/tools/remember.md
@@ -15,6 +15,7 @@ Store or update a memory.
 - If no memory with the given `key` exists, a new memory is created.
 - If a memory with that `key` already exists, it is **updated** in place (same `memory_id`, new `value` and `tags`).
 - If the value and tags are identical to the existing memory, no write occurs (idempotent).
+- Values larger than **100 KB** are automatically stored in S3 (`value_type="text-large"`). The promotion is transparent — you still call `remember` and `recall` as normal. See [Large memory](/concepts/large-memory) for details.
 
 ## Examples
 
@@ -33,7 +34,7 @@ Update the memory at key "project/deadline" — the deadline has moved to April 
 
 ## Limits
 
-- **Value size**: up to ~380 KB of text
+- **Value size**: up to ~100 KB stored inline; values above that are transparently promoted to S3-backed `text-large` storage with no practical upper limit (see [Large memory](/concepts/large-memory))
 - **Tags per memory**: no hard limit, but keep it reasonable
 - **Key length**: up to 512 characters
 
@@ -41,3 +42,4 @@ Update the memory at key "project/deadline" — the deadline has moved to April 
 
 - [`recall`](/tools/recall) — retrieve a memory by key
 - [`forget`](/tools/forget) — delete a memory
+- [`remember_blob`](/tools/remember_blob) — store binary content (images, PDFs, etc.)

--- a/docs-site/tools/remember_blob.md
+++ b/docs-site/tools/remember_blob.md
@@ -1,0 +1,55 @@
+# remember_blob
+
+Store a binary memory — an image, document, audio file, or any other non-text content.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `key` | string | Yes | Unique identifier for the memory. Same path-like convention as [`remember`](/tools/remember). |
+| `data` | string | Yes | Standard Base64-encoded bytes of the binary content. |
+| `content_type` | string | Yes | MIME type of the content, e.g. `image/png`, `application/pdf`. |
+| `tags` | list of strings | No | Tags for grouping and retrieval. |
+
+## Behaviour
+
+- Content is stored in S3; only metadata is written to DynamoDB.
+- If `content_type` starts with `image/` (e.g. `image/png`, `image/jpeg`, `image/webp`), the memory gets `value_type="image"`.
+- All other MIME types produce `value_type="blob"`.
+- Calling `remember_blob` with the same key again **replaces** the existing binary content (upsert semantics, same `memory_id`).
+- The `data` payload (after Base64 decoding) must not exceed **10 MB**.
+
+## Examples
+
+Store a PNG screenshot:
+
+```
+Store this screenshot as a memory with key "project/myapp/ui-screenshot".
+Tag it "project" and "screenshot".
+```
+
+Store a PDF document:
+
+```
+Save this architecture PDF as "project/myapp/architecture-doc" with tag "docs".
+```
+
+## Limits
+
+| Limit | Value |
+| --- | --- |
+| Maximum payload (decoded bytes) | 10 MB |
+| Supported MIME types | Any valid MIME string |
+| Key length | Up to 512 characters |
+
+## Retrieval
+
+Use [`recall`](/tools/recall) to retrieve a binary memory. For `value_type="image"`, the tool returns an `ImageContent` MCP response (the bytes, ready for the client to render). For `value_type="blob"`, it returns the raw bytes with the correct `Content-Type` header.
+
+Binary memories are **not included** in semantic search (`search_memories`) results — retrieve them by key or tag only.
+
+## Related tools
+
+- [`remember`](/tools/remember) — store text (handles large text transparently via S3)
+- [`recall`](/tools/recall) — retrieve any memory by key
+- [`list_memories`](/tools/list-memories) — list memories by tag (shows metadata for binary memories)

--- a/docs-site/ui-guide/memory-browser.md
+++ b/docs-site/ui-guide/memory-browser.md
@@ -10,8 +10,8 @@ Sign in at [hive.warlordofmars.net](https://hive.warlordofmars.net) and click th
 
 Your memories are listed in the main panel. Each card shows:
 - The memory **key**
-- A **type badge** for non-text memories (`Large text`, `Image`, or `Blob`)
-- A preview of the **value** (first 160 characters for text memories; a placeholder or thumbnail for large/binary memories)
+- A **type badge** for non-inline or binary memories (`Large text`, `Image`, or `Blob`)
+- A preview of the **value** (first 160 characters for inline text memories; a placeholder or thumbnail for large text or binary memories)
 - Any **tags** attached to the memory
 - A **by {client name}** badge attributing the memory to the OAuth client that created it (falls back to the client id when the name has been deleted)
 

--- a/docs-site/ui-guide/memory-browser.md
+++ b/docs-site/ui-guide/memory-browser.md
@@ -10,9 +10,22 @@ Sign in at [hive.warlordofmars.net](https://hive.warlordofmars.net) and click th
 
 Your memories are listed in the main panel. Each card shows:
 - The memory **key**
-- A preview of the **value** (first 160 characters)
+- A **type badge** for non-text memories (`Large text`, `Image`, or `Blob`)
+- A preview of the **value** (first 160 characters for text memories; a placeholder or thumbnail for large/binary memories)
 - Any **tags** attached to the memory
 - A **by {client name}** badge attributing the memory to the OAuth client that created it (falls back to the client id when the name has been deleted)
+
+### Large text memories
+
+When a text value exceeds 100 KB it is stored in S3 and shown with a **Large text** badge. Clicking the memory opens the full content in the edit panel (fetched from S3 on demand). You can edit and save large text memories the same way as ordinary ones.
+
+### Image memories
+
+Images stored via `remember_blob` show a thumbnail preview in both the list and the detail panel. Clicking a card opens a full-size preview. Images are read-only — to replace an image, use the MCP tool `remember_blob` with the same key.
+
+### Blob memories
+
+Non-image binary memories (PDFs, audio, etc.) show a **Blob** badge with the MIME type and file size. The detail panel has a **Download** button to save the file locally. Blobs are read-only in the UI.
 
 ## Searching memories
 


### PR DESCRIPTION
Closes #503

## Summary

- New `docs-site/concepts/large-memory.md` — explains text-large vs binary, the 100 KB inline threshold, S3 promotion, size limits (10 MB for blobs), and semantic search exclusions for non-text memories
- New `docs-site/tools/remember_blob.md` — full tool reference covering parameters, image/* vs blob routing, 10 MB limit, retrieval behaviour, and related tools
- Updated `docs-site/tools/remember.md` — notes the transparent text-large path and corrects the size limit from the old ~380 KB figure to the actual 100 KB inline threshold with S3 overflow
- Updated `docs-site/ui-guide/memory-browser.md` — documents the new type badges and rendering modes for large text (fetch-on-open edit), image (thumbnail preview), and blob (download button) memories
- Added `remember_blob` and `large-memory` entries to the VitePress sidebar in `config.mjs`

## Approach

Docs are written against the shipped behaviour from #499 (`remember_blob`, `value_type` routing) and #501 (MemoryBrowser rendering). Thresholds (`INLINE_TEXT_THRESHOLD_BYTES = 100 KB`, `MAX_BLOB_SIZE_BYTES = 10 MB`) are sourced directly from `src/hive/blob_store.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y56sF9QXGtvyZ9cajArMdV)_