### PR TITLE
fix: associate DCR clients with test user in OAuth bypass mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,6 +632,7 @@ jobs:
         env:
           HIVE_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
           HIVE_MCP_URL: ${{ needs.deploy-dev.outputs.mcp_url }}
+          HIVE_E2E_EMAIL: ${{ vars.HIVE_ADMIN_EMAIL }}
         run: uv run pytest tests/e2e/test_auth_e2e.py tests/e2e/test_mcp_e2e.py -v
 
       - name: Run admin metrics e2e tests

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -140,10 +140,18 @@ def _bypass_associate_user(storage: HiveStorage, client_id: str, email: str) -> 
     /oauth/authorize.  This mirrors the production Google-callback path so that
     user-scoped MCP tools (list_memories, summarize_context) work in e2e tests.
     """
+    from hive.auth.google import is_admin_email
+
     now = datetime.now(timezone.utc)
+    display_name = email.split("@")[0]
+    role = "admin" if is_admin_email(email) else "user"
+
     user = storage.get_user_by_email(email)
     if user is None:
-        user = User(email=email, display_name=email.split("@")[0], role="user", created_at=now)
+        user = User(email=email, display_name=display_name, role=role, created_at=now)
+    else:
+        user.display_name = display_name
+        user.role = role
     user.last_login_at = now
     storage.put_user(user)
 
@@ -190,10 +198,14 @@ async def authorize(
 
     # In bypass mode (non-prod / e2e testing), skip Google and issue code directly.
     if _BYPASS_GOOGLE_AUTH:
+        from hive.auth.google import is_email_allowed
+
         # If test_email is provided, upsert the user and associate the client so
         # that user-scoped tools (list_memories, summarize_context) work in e2e.
         test_email = request.query_params.get("test_email", "").strip()
         if test_email:
+            if not is_email_allowed(test_email):
+                raise HTTPException(status_code=403, detail="test_email is not allowed")
             _bypass_associate_user(storage, client_id, test_email)
         auth_code = storage.create_auth_code(
             client_id=client_id,

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -31,6 +31,7 @@ from hive.models import (
     ClientRegistrationRequest,
     EventType,
     TokenResponse,
+    User,
 )
 from hive.storage import AuthCodeAlreadyUsed, HiveStorage
 
@@ -132,8 +133,29 @@ async def register(
 # ---------------------------------------------------------------------------
 
 
+def _bypass_associate_user(storage: HiveStorage, client_id: str, email: str) -> None:
+    """Upsert a test user and associate the DCR client with them.
+
+    Only called in HIVE_BYPASS_GOOGLE_AUTH mode when test_email is supplied to
+    /oauth/authorize.  This mirrors the production Google-callback path so that
+    user-scoped MCP tools (list_memories, summarize_context) work in e2e tests.
+    """
+    now = datetime.now(timezone.utc)
+    user = storage.get_user_by_email(email)
+    if user is None:
+        user = User(email=email, display_name=email.split("@")[0], role="user", created_at=now)
+    user.last_login_at = now
+    storage.put_user(user)
+
+    client = storage.get_client(client_id)
+    if client is not None and client.owner_user_id is None:
+        client.owner_user_id = user.user_id
+        storage.put_client(client)
+
+
 @router.get("/oauth/authorize", responses={400: {"description": "Invalid authorization request"}})
 async def authorize(
+    request: Request,
     storage: Annotated[HiveStorage, Depends(get_storage)],
     response_type: str,
     client_id: str,
@@ -168,6 +190,11 @@ async def authorize(
 
     # In bypass mode (non-prod / e2e testing), skip Google and issue code directly.
     if _BYPASS_GOOGLE_AUTH:
+        # If test_email is provided, upsert the user and associate the client so
+        # that user-scoped tools (list_memories, summarize_context) work in e2e.
+        test_email = request.query_params.get("test_email", "").strip()
+        if test_email:
+            _bypass_associate_user(storage, client_id, test_email)
         auth_code = storage.create_auth_code(
             client_id=client_id,
             redirect_uri=redirect_uri,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -17,6 +17,7 @@ import pytest
 
 API_URL = os.environ.get("HIVE_API_URL", "")
 ADMIN_EMAIL = os.environ.get("HIVE_ADMIN_EMAIL", "")
+E2E_EMAIL = os.environ.get("HIVE_E2E_EMAIL", "")
 
 # The deployed API runs on AWS Lambda, and the first request after a quiet
 # period pays a cold-start cost that can run 5–10s on a fresh container. The
@@ -55,16 +56,16 @@ async def _issue_token(client_name: str) -> str:
         reg.raise_for_status()
         client_id = reg.json()["client_id"]
 
-        auth = await http.get(
-            "/oauth/authorize",
-            params={
-                "response_type": "code",
-                "client_id": client_id,
-                "redirect_uri": "http://localhost/cb",
-                "code_challenge": challenge,
-                "code_challenge_method": "S256",
-            },
-        )
+        authorize_params: dict[str, str] = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": "http://localhost/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }
+        if E2E_EMAIL:
+            authorize_params["test_email"] = E2E_EMAIL
+        auth = await http.get("/oauth/authorize", params=authorize_params)
         location = auth.headers.get("location", "")
         if "accounts.google.com" in location:
             pytest.fail(

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -10,6 +10,7 @@ import base64
 import hashlib
 import os
 import secrets
+from unittest.mock import patch
 
 import pytest
 
@@ -163,17 +164,18 @@ class TestAuthorizationCodeFlow:
         client_id = reg.json()["client_id"]
 
         _, challenge = _pkce_pair()
-        auth_resp = client.get(
-            "/oauth/authorize",
-            params={
-                "response_type": "code",
-                "client_id": client_id,
-                "redirect_uri": "http://localhost/cb",
-                "code_challenge": challenge,
-                "code_challenge_method": "S256",
-                "test_email": "e2e-test@example.com",
-            },
-        )
+        with patch("hive.auth.google.is_email_allowed", return_value=True):
+            auth_resp = client.get(
+                "/oauth/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": client_id,
+                    "redirect_uri": "http://localhost/cb",
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "test_email": "e2e-test@example.com",
+                },
+            )
         assert auth_resp.status_code == 302
 
         storage = HiveStorage()

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -164,7 +164,10 @@ class TestAuthorizationCodeFlow:
         client_id = reg.json()["client_id"]
 
         _, challenge = _pkce_pair()
-        with patch("hive.auth.google.is_email_allowed", return_value=True):
+        with (
+            patch("hive.auth.google.is_email_allowed", return_value=True),
+            patch("hive.auth.google.is_admin_email", return_value=False),
+        ):
             auth_resp = client.get(
                 "/oauth/authorize",
                 params={

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -146,3 +146,36 @@ class TestAuthorizationCodeFlow:
             },
         )
         assert token_resp.status_code == 400
+
+    def test_authorize_bypass_test_email_associates_user(self, client):
+        """Passing test_email to /oauth/authorize in bypass mode sets owner_user_id."""
+        from hive.storage import HiveStorage
+
+        reg = client.post(
+            "/oauth/register",
+            json={"client_name": "Email Assoc Client", "redirect_uris": ["http://localhost/cb"]},
+        )
+        assert reg.status_code == 201
+        client_id = reg.json()["client_id"]
+
+        _, challenge = _pkce_pair()
+        auth_resp = client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": "http://localhost/cb",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "test_email": "e2e-test@example.com",
+            },
+        )
+        assert auth_resp.status_code == 302
+
+        storage = HiveStorage()
+        oauth_client = storage.get_client(client_id)
+        assert oauth_client is not None
+        assert oauth_client.owner_user_id is not None
+        user = storage.get_user_by_id(oauth_client.owner_user_id)
+        assert user is not None
+        assert user.email == "e2e-test@example.com"

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -147,6 +147,10 @@ class TestAuthorizationCodeFlow:
         )
         assert token_resp.status_code == 400
 
+    @pytest.mark.skipif(
+        not os.environ.get("HIVE_BYPASS_GOOGLE_AUTH"),
+        reason="HIVE_BYPASS_GOOGLE_AUTH not set — bypass user-association test requires bypass mode",
+    )
     def test_authorize_bypass_test_email_associates_user(self, client):
         """Passing test_email to /oauth/authorize in bypass mode sets owner_user_id."""
         from hive.storage import HiveStorage

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -407,6 +407,31 @@ class TestOAuthAuthorize:
         assert "state=bypass-state" in location
         assert "accounts.google.com" not in location
 
+    def test_bypass_test_email_associates_user(self, oauth_client):
+        """test_email in bypass mode creates a user and sets client.owner_user_id."""
+        tc, storage, client = oauth_client
+        _, challenge = _pkce_pair()
+        with patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True):
+            resp = tc.get(
+                "/oauth/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": client.client_id,
+                    "redirect_uri": "https://app.example.com/cb",
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "test_email": "bypass@example.com",
+                },
+                follow_redirects=False,
+            )
+        assert resp.status_code == 302
+        updated = storage.get_client(client.client_id)
+        assert updated is not None
+        assert updated.owner_user_id is not None
+        user = storage.get_user_by_id(updated.owner_user_id)
+        assert user is not None
+        assert user.email == "bypass@example.com"
+
 
 # ---------------------------------------------------------------------------
 # Google OAuth callback endpoint tests

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -414,6 +414,7 @@ class TestOAuthAuthorize:
         with (
             patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True),
             patch("hive.auth.google.is_email_allowed", return_value=True),
+            patch("hive.auth.google.is_admin_email", return_value=False),
         ):
             resp = tc.get(
                 "/oauth/authorize",

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -411,7 +411,10 @@ class TestOAuthAuthorize:
         """test_email in bypass mode creates a user and sets client.owner_user_id."""
         tc, storage, client = oauth_client
         _, challenge = _pkce_pair()
-        with patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True):
+        with (
+            patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True),
+            patch("hive.auth.google.is_email_allowed", return_value=True),
+        ):
             resp = tc.get(
                 "/oauth/authorize",
                 params={
@@ -460,6 +463,7 @@ class TestOAuthAuthorize:
         _, challenge = _pkce_pair()
         with (
             patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True),
+            patch("hive.auth.google.is_email_allowed", return_value=True),
             patch("hive.auth.google.is_admin_email", return_value=True),
         ):
             resp = tc.get(
@@ -496,6 +500,7 @@ class TestOAuthAuthorize:
         _, challenge = _pkce_pair()
         with (
             patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True),
+            patch("hive.auth.google.is_email_allowed", return_value=True),
             patch("hive.auth.google.is_admin_email", return_value=True),
         ):
             resp = tc.get(

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -432,6 +432,90 @@ class TestOAuthAuthorize:
         assert user is not None
         assert user.email == "bypass@example.com"
 
+    def test_bypass_test_email_disallowed_returns_403(self, oauth_client):
+        """test_email that fails the allowlist check returns 403."""
+        tc, _, client = oauth_client
+        _, challenge = _pkce_pair()
+        with (
+            patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True),
+            patch("hive.auth.google.is_email_allowed", return_value=False),
+        ):
+            resp = tc.get(
+                "/oauth/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": client.client_id,
+                    "redirect_uri": "https://app.example.com/cb",
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "test_email": "blocked@example.com",
+                },
+                follow_redirects=False,
+            )
+        assert resp.status_code == 403
+
+    def test_bypass_test_email_assigns_admin_role(self, oauth_client):
+        """test_email matching is_admin_email creates user with admin role."""
+        tc, storage, client = oauth_client
+        _, challenge = _pkce_pair()
+        with (
+            patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True),
+            patch("hive.auth.google.is_admin_email", return_value=True),
+        ):
+            resp = tc.get(
+                "/oauth/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": client.client_id,
+                    "redirect_uri": "https://app.example.com/cb",
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "test_email": "admin@example.com",
+                },
+                follow_redirects=False,
+            )
+        assert resp.status_code == 302
+        updated = storage.get_client(client.client_id)
+        user = storage.get_user_by_id(updated.owner_user_id)
+        assert user.role == "admin"
+
+    def test_bypass_test_email_updates_existing_user(self, oauth_client):
+        """test_email in bypass mode updates display_name and role for an existing user."""
+        tc, storage, client = oauth_client
+        now = datetime.now(timezone.utc)
+        from hive.models import User as UserModel
+
+        existing = UserModel(
+            email="existing@example.com",
+            display_name="oldname",
+            role="user",
+            created_at=now,
+        )
+        storage.put_user(existing)
+
+        _, challenge = _pkce_pair()
+        with (
+            patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True),
+            patch("hive.auth.google.is_admin_email", return_value=True),
+        ):
+            resp = tc.get(
+                "/oauth/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": client.client_id,
+                    "redirect_uri": "https://app.example.com/cb",
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "test_email": "existing@example.com",
+                },
+                follow_redirects=False,
+            )
+        assert resp.status_code == 302
+        user = storage.get_user_by_email("existing@example.com")
+        assert user is not None
+        assert user.display_name == "existing"
+        assert user.role == "admin"
+
 
 # ---------------------------------------------------------------------------
 # Google OAuth callback endpoint tests


### PR DESCRIPTION
## Summary

PR #631 added user-scoping guards to `list_memories` and `summarize_context` (raising an error when `client.owner_user_id is None`), but the e2e test client — created via DCR + PKCE bypass without a `test_email` — never gets a user associated. This caused 4 e2e tests to fail in the last dev pipeline:

- `test_list_memories_by_tag`
- `test_list_memories_empty_tag`
- `test_summarize_context`
- `test_summarize_context_empty_topic`

All failing with: *"Client is not associated with a user account; per-user memory scoping is required."*

## Approach

- **`src/hive/auth/oauth.py`**: In `HIVE_BYPASS_GOOGLE_AUTH` mode, `/oauth/authorize` now accepts an optional `test_email` query param. When present, it upserts the user (same pattern as the management `/auth/login` bypass) and sets `owner_user_id` on the DCR client — mirroring what the production Google callback path does.
- **`tests/e2e/conftest.py`**: `_issue_token` reads `HIVE_E2E_EMAIL` from env and includes it as `test_email` in the authorize request.
- **`.github/workflows/ci.yml`**: The auth+MCP e2e step now passes `HIVE_E2E_EMAIL: ${{ vars.HIVE_ADMIN_EMAIL }}`.
- **`tests/unit/test_auth.py`**: New unit test `test_bypass_test_email_associates_user` covers the new code path.
- **`tests/integration/test_oauth.py`**: New integration test verifies end-to-end that `owner_user_id` is set after the bypass authorize call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y56sF9QXGtvyZ9cajArMdV)_