### PR TITLE
feat: workspaces data model, storage, migration (#490)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,6 +569,12 @@ jobs:
           VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: uv run inv deploy --env dev
 
+      - name: Run workspace migration (dev)
+        run: |
+          TABLE=$(aws cloudformation describe-stacks --stack-name HiveStack-dev --region us-east-1 \
+            --query "Stacks[0].Outputs[?OutputKey=='TableName'].OutputValue" --output text)
+          HIVE_TABLE_NAME="$TABLE" uv run python scripts/migrate_workspaces.py
+
       - name: Export stack URLs
         id: urls
         run: |
@@ -813,6 +819,12 @@ jobs:
           APP_VERSION: ${{ needs.release.outputs.version }}
           VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
         run: uv run inv deploy --env prod
+
+      - name: Run workspace migration (prod)
+        run: |
+          TABLE=$(aws cloudformation describe-stacks --stack-name HiveStack --region us-east-1 \
+            --query "Stacks[0].Outputs[?OutputKey=='TableName'].OutputValue" --output text)
+          HIVE_TABLE_NAME="$TABLE" uv run python scripts/migrate_workspaces.py
 
       - name: Export stack URLs
         id: urls

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -128,6 +128,18 @@ class HiveStack(cdk.Stack):
             projection_type=dynamodb.ProjectionType.ALL,
         )
 
+        # GSI 5 — WorkspaceMemberIndex: list workspaces a user belongs to.
+        # Key layout on workspace-member items:
+        #   GSI5PK = USER#{user_id}
+        #   GSI5SK = WORKSPACE#{workspace_id}
+        # Added in #490 as part of the workspaces tenancy model (#482).
+        table.add_global_secondary_index(
+            index_name="WorkspaceMemberIndex",
+            partition_key=dynamodb.Attribute(name="GSI5PK", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="GSI5SK", type=dynamodb.AttributeType.STRING),
+            projection_type=dynamodb.ProjectionType.ALL,
+        )
+
         # ----------------------------------------------------------------
         # SSM Parameters
         # ----------------------------------------------------------------

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -84,7 +84,9 @@ def _personal_workspace_name(email: str) -> str:
     return f"{email}'s Personal"
 
 
-def _find_personal_workspace(storage: HiveStorage, user_id: str) -> Workspace | None:
+def _find_personal_workspace(
+    storage: HiveStorage, user_id: str, *, dry_run: bool = False
+) -> Workspace | None:
     """Return the user's Personal workspace, or None if they have none yet.
 
     Checks via WorkspaceMemberIndex first (fast path). Falls back to a
@@ -92,8 +94,9 @@ def _find_personal_workspace(storage: HiveStorage, user_id: str) -> Workspace | 
     from a prior partial run where the META row was written but the MEMBER
     row was not — which would cause ``list_workspaces_for_user`` (GSI-backed)
     to return nothing, making a naïve re-run create a duplicate workspace.
-    When the slow-path scan finds an orphaned META, the MEMBER row is
-    repaired in place so subsequent lookups work correctly.
+    When the slow-path scan finds an orphaned META and ``dry_run`` is False,
+    the MEMBER row is repaired in place so subsequent lookups work correctly.
+    In dry-run mode the repair is skipped so no writes occur.
     """
     for ws in storage.list_workspaces_for_user(user_id):
         if ws.is_personal and ws.owner_user_id == user_id:
@@ -114,12 +117,13 @@ def _find_personal_workspace(storage: HiveStorage, user_id: str) -> Workspace | 
         for item in resp.get("Items", []):
             ws = Workspace.from_dynamo(item)
             if ws.is_personal:
-                # Repair the missing MEMBER row so GSI lookups work going forward.
-                storage.add_workspace_member(
-                    workspace_id=ws.workspace_id,
-                    user_id=user_id,
-                    role=WorkspaceRole.owner,
-                )
+                if not dry_run:
+                    # Repair the missing MEMBER row so GSI lookups work going forward.
+                    storage.add_workspace_member(
+                        workspace_id=ws.workspace_id,
+                        user_id=user_id,
+                        role=WorkspaceRole.owner,
+                    )
                 return ws
         lek = resp.get("LastEvaluatedKey")
         if lek is None:
@@ -152,7 +156,7 @@ def migrate_users(
     user_to_workspace: dict[str, str] = {}
     for user in _iter_all_users(storage):
         stats.users_seen += 1
-        existing = _find_personal_workspace(storage, user.user_id)
+        existing = _find_personal_workspace(storage, user.user_id, dry_run=dry_run)
         if existing is not None:
             stats.workspaces_skipped += 1
             user_to_workspace[user.user_id] = existing.workspace_id

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -182,13 +182,16 @@ def migrate_memories(
                 Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"},
                 UpdateExpression="SET workspace_id = :wsid",
                 ExpressionAttributeValues={":wsid": workspace_id},
-                ConditionExpression="attribute_exists(PK) AND attribute_exists(SK)",
+                ConditionExpression=(
+                    "attribute_exists(PK) AND attribute_exists(SK)"
+                    " AND attribute_not_exists(workspace_id)"
+                ),
             )
         except ClientError as exc:
             if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
                 stats.memories_skipped += 1
                 logger.warning(
-                    "Memory disappeared during migration; skipping workspace stamp",
+                    "Memory missing or already stamped during migration; skipping",
                     extra={"memory_id": memory.memory_id},
                 )
                 continue
@@ -238,13 +241,16 @@ def migrate_clients(
                     Key={"PK": f"CLIENT#{client.client_id}", "SK": "META"},
                     UpdateExpression="SET workspace_id = :wsid",
                     ExpressionAttributeValues={":wsid": workspace_id},
-                    ConditionExpression="attribute_exists(PK) AND attribute_exists(SK)",
+                    ConditionExpression=(
+                        "attribute_exists(PK) AND attribute_exists(SK)"
+                        " AND attribute_not_exists(workspace_id)"
+                    ),
                 )
             except ClientError as exc:
                 if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
                     stats.clients_skipped += 1
                     logger.warning(
-                        "Client disappeared during migration; skipping workspace stamp",
+                        "Client missing or already stamped during migration; skipping",
                         extra={"client_id": client.client_id},
                     )
                     continue

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -30,8 +30,9 @@ appropriate ``AWS_*`` environment variables before running):
     uv run python scripts/migrate_workspaces.py
     uv run python scripts/migrate_workspaces.py --dry-run    # report only
 
-Via invoke task (targets DynamoDB Local by default; pass
-``DYNAMODB_ENDPOINT`` to override):
+Via invoke task (targets AWS by default — set ``DYNAMODB_ENDPOINT`` for
+local development; dummy AWS keys are injected automatically when
+``DYNAMODB_ENDPOINT`` is set):
 
     DYNAMODB_ENDPOINT=http://localhost:8000 uv run inv migrate-workspaces
     DYNAMODB_ENDPOINT=http://localhost:8000 uv run inv migrate-workspaces --dry-run

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -85,10 +85,46 @@ def _personal_workspace_name(email: str) -> str:
 
 
 def _find_personal_workspace(storage: HiveStorage, user_id: str) -> Workspace | None:
-    """Return the user's Personal workspace, or None if they have none yet."""
+    """Return the user's Personal workspace, or None if they have none yet.
+
+    Checks via WorkspaceMemberIndex first (fast path). Falls back to a
+    full-table scan of WORKSPACE META items owned by this user to recover
+    from a prior partial run where the META row was written but the MEMBER
+    row was not — which would cause ``list_workspaces_for_user`` (GSI-backed)
+    to return nothing, making a naïve re-run create a duplicate workspace.
+    When the slow-path scan finds an orphaned META, the MEMBER row is
+    repaired in place so subsequent lookups work correctly.
+    """
     for ws in storage.list_workspaces_for_user(user_id):
         if ws.is_personal and ws.owner_user_id == user_id:
             return ws
+    # Slow-path: scan for orphaned WORKSPACE META (partial prior run).
+    scan_kwargs: dict[str, Any] = {
+        "FilterExpression": (
+            "SK = :sk AND begins_with(PK, :prefix) AND owner_user_id = :uid"
+        ),
+        "ExpressionAttributeValues": {
+            ":sk": "META",
+            ":prefix": "WORKSPACE#",
+            ":uid": user_id,
+        },
+    }
+    while True:
+        resp = storage.table.scan(**scan_kwargs)
+        for item in resp.get("Items", []):
+            ws = Workspace.from_dynamo(item)
+            if ws.is_personal:
+                # Repair the missing MEMBER row so GSI lookups work going forward.
+                storage.add_workspace_member(
+                    workspace_id=ws.workspace_id,
+                    user_id=user_id,
+                    role=WorkspaceRole.owner,
+                )
+                return ws
+        lek = resp.get("LastEvaluatedKey")
+        if lek is None:
+            break
+        scan_kwargs["ExclusiveStartKey"] = lek
     return None
 
 

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -26,7 +26,6 @@ Usage:
 
     uv run inv migrate-workspaces              # execute against HIVE_TABLE_NAME
     uv run inv migrate-workspaces --dry-run    # report only, no writes
-    uv run inv migrate-workspaces --env jc     # migrate a specific env stack
 
 Direct CLI:
 
@@ -40,6 +39,8 @@ import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
+
+from botocore.exceptions import ClientError
 
 from hive.logging_config import get_logger
 from hive.models import Workspace, WorkspaceRole
@@ -176,11 +177,22 @@ def migrate_memories(
         if dry_run:
             stats.memories_migrated += 1
             continue
-        storage.table.update_item(
-            Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"},
-            UpdateExpression="SET workspace_id = :wsid",
-            ExpressionAttributeValues={":wsid": workspace_id},
-        )
+        try:
+            storage.table.update_item(
+                Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"},
+                UpdateExpression="SET workspace_id = :wsid",
+                ExpressionAttributeValues={":wsid": workspace_id},
+                ConditionExpression="attribute_exists(PK) AND attribute_exists(SK)",
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                stats.memories_skipped += 1
+                logger.warning(
+                    "Memory disappeared during migration; skipping workspace stamp",
+                    extra={"memory_id": memory.memory_id},
+                )
+                continue
+            raise
         stats.memories_migrated += 1
 
 
@@ -221,11 +233,22 @@ def migrate_clients(
             if dry_run:
                 stats.clients_migrated += 1
                 continue
-            storage.table.update_item(
-                Key={"PK": f"CLIENT#{client.client_id}", "SK": "META"},
-                UpdateExpression="SET workspace_id = :wsid",
-                ExpressionAttributeValues={":wsid": workspace_id},
-            )
+            try:
+                storage.table.update_item(
+                    Key={"PK": f"CLIENT#{client.client_id}", "SK": "META"},
+                    UpdateExpression="SET workspace_id = :wsid",
+                    ExpressionAttributeValues={":wsid": workspace_id},
+                    ConditionExpression="attribute_exists(PK) AND attribute_exists(SK)",
+                )
+            except ClientError as exc:
+                if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                    stats.clients_skipped += 1
+                    logger.warning(
+                        "Client disappeared during migration; skipping workspace stamp",
+                        extra={"client_id": client.client_id},
+                    )
+                    continue
+                raise
             stats.clients_migrated += 1
         if cursor is None:
             break

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+One-shot migration to the workspaces tenancy model (#482, #490).
+
+Before this migration the tenancy root is the user: every memory and OAuth
+client carries an ``owner_user_id`` and no workspace concept exists. After
+the migration:
+
+1. Every user has a ``{email}'s Personal`` workspace where they are the sole
+   owner.
+2. Every memory's ``workspace_id`` points to the Personal workspace of its
+   ``owner_user_id``.
+3. Every OAuth client's ``workspace_id`` points to the Personal workspace of
+   its ``owner_user_id``.
+4. Every outstanding access/refresh token is revoked so callers re-auth with
+   a fresh token that carries the ``workspace_id`` claim (wired by #491).
+
+The migration is **idempotent** — re-running it on a partially-migrated
+table is safe:
+
+- Users that already own a Personal workspace are skipped.
+- Memories / clients that already have a ``workspace_id`` are left alone.
+- Token revocation is a no-op on already-revoked tokens.
+
+Usage:
+
+    uv run inv migrate-workspaces              # execute against HIVE_TABLE_NAME
+    uv run inv migrate-workspaces --dry-run    # report only, no writes
+    uv run inv migrate-workspaces --env jc     # migrate a specific env stack
+
+Direct CLI:
+
+    uv run python scripts/migrate_workspaces.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from hive.logging_config import get_logger
+from hive.models import Workspace, WorkspaceRole
+from hive.storage import HiveStorage
+
+logger = get_logger("hive.migrate_workspaces")
+
+
+@dataclass
+class MigrationStats:
+    """Per-phase counters so operators can sanity-check the run."""
+
+    users_seen: int = 0
+    workspaces_created: int = 0
+    workspaces_skipped: int = 0
+    memories_seen: int = 0
+    memories_migrated: int = 0
+    memories_skipped: int = 0
+    clients_seen: int = 0
+    clients_migrated: int = 0
+    clients_skipped: int = 0
+    tokens_revoked: int = 0
+
+    def report(self) -> str:
+        return (
+            f"users_seen={self.users_seen} "
+            f"workspaces_created={self.workspaces_created} "
+            f"workspaces_skipped={self.workspaces_skipped} "
+            f"memories_seen={self.memories_seen} "
+            f"memories_migrated={self.memories_migrated} "
+            f"memories_skipped={self.memories_skipped} "
+            f"clients_seen={self.clients_seen} "
+            f"clients_migrated={self.clients_migrated} "
+            f"clients_skipped={self.clients_skipped} "
+            f"tokens_revoked={self.tokens_revoked}"
+        )
+
+
+def _personal_workspace_name(email: str) -> str:
+    """Display name used for every auto-created Personal workspace."""
+    return f"{email}'s Personal"
+
+
+def _find_personal_workspace(storage: HiveStorage, user_id: str) -> Workspace | None:
+    """Return the user's Personal workspace, or None if they have none yet."""
+    for ws in storage.list_workspaces_for_user(user_id):
+        if ws.is_personal and ws.owner_user_id == user_id:
+            return ws
+    return None
+
+
+def _iter_all_users(storage: HiveStorage) -> Iterator[Any]:
+    """Yield every User, paginating through ``list_users``."""
+    cursor: str | None = None
+    while True:
+        users, cursor = storage.list_users(limit=100, cursor=cursor)
+        yield from users
+        if cursor is None:
+            return
+
+
+def migrate_users(
+    storage: HiveStorage,
+    stats: MigrationStats,
+    *,
+    dry_run: bool,
+) -> dict[str, str]:
+    """Ensure every user has a Personal workspace.
+
+    Returns a mapping of ``user_id → workspace_id`` that the memory/client
+    passes use for the rewrite step.
+    """
+    user_to_workspace: dict[str, str] = {}
+    for user in _iter_all_users(storage):
+        stats.users_seen += 1
+        existing = _find_personal_workspace(storage, user.user_id)
+        if existing is not None:
+            stats.workspaces_skipped += 1
+            user_to_workspace[user.user_id] = existing.workspace_id
+            continue
+        ws = Workspace(
+            name=_personal_workspace_name(user.email),
+            owner_user_id=user.user_id,
+            is_personal=True,
+        )
+        if not dry_run:
+            storage.put_workspace(ws)
+            storage.add_workspace_member(
+                workspace_id=ws.workspace_id,
+                user_id=user.user_id,
+                role=WorkspaceRole.owner,
+            )
+        stats.workspaces_created += 1
+        user_to_workspace[user.user_id] = ws.workspace_id
+        logger.info(
+            "Created personal workspace",
+            extra={"user_id": user.user_id, "workspace_id": ws.workspace_id},
+        )
+    return user_to_workspace
+
+
+def migrate_memories(
+    storage: HiveStorage,
+    user_to_workspace: dict[str, str],
+    stats: MigrationStats,
+    *,
+    dry_run: bool,
+) -> None:
+    """Stamp every memory with the workspace_id that matches its owner_user_id.
+
+    Memories missing ``owner_user_id`` (pre-v0.23 legacy rows) are skipped —
+    they have no user attribution to map from.
+    """
+    # iter_all_memories() yields only META items across all users.
+    for memory in storage.iter_all_memories():
+        stats.memories_seen += 1
+        if memory.workspace_id is not None:
+            stats.memories_skipped += 1
+            continue
+        if memory.owner_user_id is None:
+            stats.memories_skipped += 1
+            continue
+        workspace_id = user_to_workspace.get(memory.owner_user_id)
+        if workspace_id is None:
+            stats.memories_skipped += 1
+            logger.warning(
+                "Memory references unknown user; skipping",
+                extra={
+                    "memory_id": memory.memory_id,
+                    "owner_user_id": memory.owner_user_id,
+                },
+            )
+            continue
+        if dry_run:
+            stats.memories_migrated += 1
+            continue
+        storage.table.update_item(
+            Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"},
+            UpdateExpression="SET workspace_id = :wsid",
+            ExpressionAttributeValues={":wsid": workspace_id},
+        )
+        stats.memories_migrated += 1
+
+
+def migrate_clients(
+    storage: HiveStorage,
+    user_to_workspace: dict[str, str],
+    stats: MigrationStats,
+    *,
+    dry_run: bool,
+) -> None:
+    """Stamp every OAuth client with the workspace_id of its owner_user_id.
+
+    Clients without ``owner_user_id`` are pre-v0.22 legacy shells and stay
+    unbound — the auth layer (#491) will refuse to mint tokens for them.
+    """
+    cursor: str | None = None
+    while True:
+        clients, cursor = storage.list_clients(limit=100, cursor=cursor)
+        for client in clients:
+            stats.clients_seen += 1
+            if client.workspace_id is not None:
+                stats.clients_skipped += 1
+                continue
+            if client.owner_user_id is None:
+                stats.clients_skipped += 1
+                continue
+            workspace_id = user_to_workspace.get(client.owner_user_id)
+            if workspace_id is None:
+                stats.clients_skipped += 1
+                logger.warning(
+                    "Client references unknown user; skipping",
+                    extra={
+                        "client_id": client.client_id,
+                        "owner_user_id": client.owner_user_id,
+                    },
+                )
+                continue
+            if dry_run:
+                stats.clients_migrated += 1
+                continue
+            storage.table.update_item(
+                Key={"PK": f"CLIENT#{client.client_id}", "SK": "META"},
+                UpdateExpression="SET workspace_id = :wsid",
+                ExpressionAttributeValues={":wsid": workspace_id},
+            )
+            stats.clients_migrated += 1
+        if cursor is None:
+            break
+
+
+def run(*, dry_run: bool = False, storage: HiveStorage | None = None) -> MigrationStats:
+    """Execute the full migration. ``storage`` is injectable for tests."""
+    store = storage if storage is not None else HiveStorage()
+    stats = MigrationStats()
+    logger.info("Starting workspace migration", extra={"dry_run": dry_run})
+
+    user_to_workspace = migrate_users(store, stats, dry_run=dry_run)
+    migrate_memories(store, user_to_workspace, stats, dry_run=dry_run)
+    migrate_clients(store, user_to_workspace, stats, dry_run=dry_run)
+
+    if dry_run:
+        logger.info("Dry-run complete; skipping token revocation", extra=vars(stats))
+    else:
+        stats.tokens_revoked = store.revoke_all_tokens()
+
+    logger.info("Workspace migration finished: %s", stats.report())
+    return stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Migrate Hive to the workspaces model.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing.",
+    )
+    args = parser.parse_args(argv)
+    stats = run(dry_run=args.dry_run)
+    print(stats.report())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -24,12 +24,17 @@ table is safe:
 
 Usage:
 
-    uv run inv migrate-workspaces              # execute against HIVE_TABLE_NAME
-    uv run inv migrate-workspaces --dry-run    # report only, no writes
+Direct CLI (preferred for production — set ``HIVE_TABLE_NAME`` and the
+appropriate ``AWS_*`` environment variables before running):
 
-Direct CLI:
+    uv run python scripts/migrate_workspaces.py
+    uv run python scripts/migrate_workspaces.py --dry-run    # report only
 
-    uv run python scripts/migrate_workspaces.py [--dry-run]
+Via invoke task (targets DynamoDB Local by default; pass
+``DYNAMODB_ENDPOINT`` to override):
+
+    DYNAMODB_ENDPOINT=http://localhost:8000 uv run inv migrate-workspaces
+    DYNAMODB_ENDPOINT=http://localhost:8000 uv run inv migrate-workspaces --dry-run
 """
 
 from __future__ import annotations

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -17,7 +17,7 @@ DynamoDB single-table design:
 
 GSIs:
   TagIndex:              PK=TAG#{tag}, SK=memory_id   — list_memories(tag)
-  ClientIdIndex:         PK=CLIENT#{client_id}        — client lookups
+  ClientIndex:           PK=CLIENT#{client_id}        — client lookups
   UserEmailIndex:        PK=EMAIL#{email}             — user lookups by email
   WorkspaceMemberIndex:  PK=USER#{user_id},
                          SK=WORKSPACE#{ws_id}         — list workspaces a user

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -3,19 +3,25 @@
 Data models for Hive — shared persistent memory MCP server.
 
 DynamoDB single-table design:
-  Memory items:  PK=MEMORY#{memory_id}   SK=TAG#{tag}
-                 PK=MEMORY#{memory_id}   SK=META          (canonical item)
-  OAuth clients: PK=CLIENT#{client_id}   SK=META
-  Token items:   PK=TOKEN#{jti}          SK=META          (TTL enabled)
-  Activity log:  PK=LOG#{date}#{hour}     SK={timestamp}#{event_id}  (hour sharding)
-  User items:    PK=USER#{user_id}        SK=META
-  Mgmt state:    PK=MGMT_STATE#{state}    SK=META          (TTL enabled)
-  API key items: PK=APIKEY#{key_id}       SK=META
+  Memory items:     PK=MEMORY#{memory_id}   SK=TAG#{tag}
+                    PK=MEMORY#{memory_id}   SK=META          (canonical item)
+  OAuth clients:    PK=CLIENT#{client_id}   SK=META
+  Token items:      PK=TOKEN#{jti}          SK=META          (TTL enabled)
+  Activity log:     PK=LOG#{date}#{hour}    SK={timestamp}#{event_id}  (hour sharding)
+  User items:       PK=USER#{user_id}       SK=META
+  Workspace items:  PK=WORKSPACE#{ws_id}    SK=META
+                    PK=WORKSPACE#{ws_id}    SK=MEMBER#{user_id}
+  Invite items:     PK=INVITE#{invite_id}   SK=META          (TTL enabled)
+  Mgmt state:       PK=MGMT_STATE#{state}   SK=META          (TTL enabled)
+  API key items:    PK=APIKEY#{key_id}      SK=META
 
 GSIs:
-  TagIndex:       PK=tag, SK=memory_id    — for list_memories(tag)
-  ClientIdIndex:  PK=client_id            — for client lookups by client_id
-  UserEmailIndex: PK=EMAIL#{email}        — for user lookups by email
+  TagIndex:              PK=TAG#{tag}, SK=memory_id   — list_memories(tag)
+  ClientIdIndex:         PK=CLIENT#{client_id}        — client lookups
+  UserEmailIndex:        PK=EMAIL#{email}             — user lookups by email
+  WorkspaceMemberIndex:  PK=USER#{user_id},
+                         SK=WORKSPACE#{ws_id}         — list workspaces a user
+                                                        belongs to
 """
 
 from __future__ import annotations
@@ -58,6 +64,11 @@ class Memory(BaseModel):
     updated_at: datetime = Field(default_factory=_now_utc)
     owner_client_id: str  # which OAuth client owns this memory
     owner_user_id: str | None = None  # which user owns this memory (None for pre-migration items)
+    # Workspaces (#490): scoping unit that eventually replaces owner_user_id.
+    # None until the one-shot migration (scripts/migrate_workspaces.py) runs;
+    # keep owner_user_id populated in parallel through the transition so tool
+    # handlers (#493) and API (#492) can cut over without churn here.
+    workspace_id: str | None = None
     expires_at: datetime | None = None  # optional TTL; None means never expires
     recall_count: int = 0  # incremented on every successful recall
     last_accessed_at: datetime | None = None  # set on every successful recall
@@ -100,6 +111,8 @@ class Memory(BaseModel):
         }
         if self.owner_user_id is not None:
             item["owner_user_id"] = self.owner_user_id
+        if self.workspace_id is not None:
+            item["workspace_id"] = self.workspace_id
         if self.expires_at is not None:
             item["expires_at"] = self.expires_at.isoformat()
             item["ttl"] = int(self.expires_at.timestamp())
@@ -159,6 +172,7 @@ class Memory(BaseModel):
             updated_at=datetime.fromisoformat(item["updated_at"]),
             owner_client_id=item["owner_client_id"],
             owner_user_id=item.get("owner_user_id"),
+            workspace_id=item.get("workspace_id"),
             expires_at=expires_at,
             recall_count=int(item.get("recall_count", 0) or 0),
             last_accessed_at=last_accessed_at,
@@ -217,6 +231,10 @@ class OAuthClient(BaseModel):
     owner_user_id: str | None = (
         None  # which user registered this client (None for pre-migration items)
     )
+    # Workspaces (#490): each DCR registration binds to exactly one
+    # workspace. None until the migration runs — #491 tightens DCR so
+    # new registrations always carry a workspace_id.
+    workspace_id: str | None = None
 
     # ------------------------------------------------------------------
     # DynamoDB serialisation
@@ -242,6 +260,8 @@ class OAuthClient(BaseModel):
         }
         if self.owner_user_id is not None:
             item["owner_user_id"] = self.owner_user_id
+        if self.workspace_id is not None:
+            item["workspace_id"] = self.workspace_id
         return item
 
     @classmethod
@@ -258,6 +278,7 @@ class OAuthClient(BaseModel):
             token_endpoint_auth_method=item.get("token_endpoint_auth_method", "none"),
             created_at=datetime.fromisoformat(item["created_at"]),
             owner_user_id=item.get("owner_user_id"),
+            workspace_id=item.get("workspace_id"),
         )
 
 
@@ -356,6 +377,144 @@ class User(BaseModel):
             memory_limit=item.get("memory_limit"),
             storage_bytes_limit=item.get("storage_bytes_limit"),
         )
+
+
+# ---------------------------------------------------------------------------
+# Workspaces (#482, #490) — tenancy root for memory sharing
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceRole(str, Enum):
+    """Membership roles inside a workspace.
+
+    `guest` (read-only) was cut from v1 per the #482 design review —
+    ship `owner` / `admin` / `member` and revisit once there is demand.
+    """
+
+    owner = "owner"
+    admin = "admin"
+    member = "member"
+
+
+class Workspace(BaseModel):
+    """A tenancy root that owns memories, OAuth clients, and members."""
+
+    workspace_id: str = Field(default_factory=_new_id)
+    name: str  # per-user unique display name; routing still uses workspace_id
+    owner_user_id: str
+    created_at: datetime = Field(default_factory=_now_utc)
+    # Personal workspaces are auto-created on signup and cannot be deleted
+    # without deleting the account. Shared workspaces require an explicit
+    # create action and have N >= 1 members.
+    is_personal: bool = False
+    description: str | None = None
+
+    def to_dynamo(self) -> dict[str, Any]:
+        item: dict[str, Any] = {
+            "PK": f"WORKSPACE#{self.workspace_id}",
+            "SK": "META",
+            "workspace_id": self.workspace_id,
+            "name": self.name,
+            "owner_user_id": self.owner_user_id,
+            "created_at": self.created_at.isoformat(),
+            "is_personal": self.is_personal,
+        }
+        if self.description is not None:
+            item["description"] = self.description
+        return item
+
+    @classmethod
+    def from_dynamo(cls, item: dict[str, Any]) -> Workspace:
+        return cls(
+            workspace_id=item["workspace_id"],
+            name=item["name"],
+            owner_user_id=item["owner_user_id"],
+            created_at=datetime.fromisoformat(item["created_at"]),
+            is_personal=bool(item.get("is_personal", False)),
+            description=item.get("description"),
+        )
+
+
+class WorkspaceMember(BaseModel):
+    """A (user, workspace, role) binding.
+
+    Stored under the workspace partition (``PK=WORKSPACE#{ws}, SK=MEMBER#{user}``)
+    so members of a workspace can be queried with a single partition query.
+    A GSI on ``USER#{user_id}`` → ``WORKSPACE#{ws_id}`` (``WorkspaceMemberIndex``)
+    inverts that for "list all workspaces a user belongs to".
+    """
+
+    workspace_id: str
+    user_id: str
+    role: WorkspaceRole = WorkspaceRole.member
+    joined_at: datetime = Field(default_factory=_now_utc)
+
+    def to_dynamo(self) -> dict[str, Any]:
+        return {
+            "PK": f"WORKSPACE#{self.workspace_id}",
+            "SK": f"MEMBER#{self.user_id}",
+            "workspace_id": self.workspace_id,
+            "user_id": self.user_id,
+            "role": self.role.value,
+            "joined_at": self.joined_at.isoformat(),
+            # GSI: list workspaces a user belongs to
+            "GSI5PK": f"USER#{self.user_id}",
+            "GSI5SK": f"WORKSPACE#{self.workspace_id}",
+        }
+
+    @classmethod
+    def from_dynamo(cls, item: dict[str, Any]) -> WorkspaceMember:
+        return cls(
+            workspace_id=item["workspace_id"],
+            user_id=item["user_id"],
+            role=WorkspaceRole(item["role"]),
+            joined_at=datetime.fromisoformat(item["joined_at"]),
+        )
+
+
+class Invite(BaseModel):
+    """A pending invitation for a user to join a workspace.
+
+    Expires via DynamoDB TTL — unaccepted invites disappear on their own.
+    """
+
+    invite_id: str = Field(default_factory=_new_id)
+    workspace_id: str
+    email: str
+    role: WorkspaceRole = WorkspaceRole.member
+    invited_by_user_id: str
+    created_at: datetime = Field(default_factory=_now_utc)
+    expires_at: datetime
+
+    def to_dynamo(self) -> dict[str, Any]:
+        return {
+            "PK": f"INVITE#{self.invite_id}",
+            "SK": "META",
+            "invite_id": self.invite_id,
+            "workspace_id": self.workspace_id,
+            "email": self.email,
+            "role": self.role.value,
+            "invited_by_user_id": self.invited_by_user_id,
+            "created_at": self.created_at.isoformat(),
+            "expires_at": self.expires_at.isoformat(),
+            "ttl": int(self.expires_at.timestamp()),
+        }
+
+    @classmethod
+    def from_dynamo(cls, item: dict[str, Any]) -> Invite:
+        return cls(
+            invite_id=item["invite_id"],
+            workspace_id=item["workspace_id"],
+            email=item["email"],
+            role=WorkspaceRole(item["role"]),
+            invited_by_user_id=item["invited_by_user_id"],
+            created_at=datetime.fromisoformat(item["created_at"]),
+            expires_at=datetime.fromisoformat(item["expires_at"]),
+        )
+
+    @property
+    def is_expired(self) -> bool:
+        return _now_utc() >= self.expires_at
 
 
 # ---------------------------------------------------------------------------

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -984,12 +984,20 @@ class HiveStorage:
         return WorkspaceMember.from_dynamo(item) if item else None
 
     def list_workspace_members(self, workspace_id: str) -> list[WorkspaceMember]:
-        """List every member of a workspace (single partition query)."""
-        resp = self.table.query(
-            KeyConditionExpression=Key("PK").eq(f"WORKSPACE#{workspace_id}")
+        """List every member of a workspace (paginated partition query)."""
+        members: list[WorkspaceMember] = []
+        kwargs: dict[str, Any] = {
+            "KeyConditionExpression": Key("PK").eq(f"WORKSPACE#{workspace_id}")
             & Key("SK").begins_with("MEMBER#"),
-        )
-        return [WorkspaceMember.from_dynamo(item) for item in resp.get("Items", [])]
+        }
+        while True:
+            resp = self.table.query(**kwargs)
+            members.extend(WorkspaceMember.from_dynamo(item) for item in resp.get("Items", []))
+            lek = resp.get("LastEvaluatedKey")
+            if lek is None:
+                break
+            kwargs["ExclusiveStartKey"] = lek
+        return members
 
     def remove_workspace_member(self, workspace_id: str, user_id: str) -> bool:
         """Delete a (workspace, user) binding. Returns True if it existed."""
@@ -1030,16 +1038,22 @@ class HiveStorage:
         stable by workspace_id (GSI5SK) so callers can rely on it for
         deterministic UI rendering.
         """
-        resp = self.table.query(
-            IndexName="WorkspaceMemberIndex",
-            KeyConditionExpression=Key("GSI5PK").eq(f"USER#{user_id}")
+        kwargs: dict[str, Any] = {
+            "IndexName": "WorkspaceMemberIndex",
+            "KeyConditionExpression": Key("GSI5PK").eq(f"USER#{user_id}")
             & Key("GSI5SK").begins_with("WORKSPACE#"),
-        )
+        }
         workspaces: list[Workspace] = []
-        for item in resp.get("Items", []):
-            ws = self.get_workspace(item["workspace_id"])
-            if ws is not None:
-                workspaces.append(ws)
+        while True:
+            resp = self.table.query(**kwargs)
+            for item in resp.get("Items", []):
+                ws = self.get_workspace(item["workspace_id"])
+                if ws is not None:
+                    workspaces.append(ws)
+            lek = resp.get("LastEvaluatedKey")
+            if lek is None:
+                break
+            kwargs["ExclusiveStartKey"] = lek
         return workspaces
 
     # ------------------------------------------------------------------
@@ -1068,28 +1082,42 @@ class HiveStorage:
         the invite-accept flow (user logs in, we surface pending invites).
         If invite volume grows we'd back this with a GSI.
         """
-        resp = self.table.scan(
-            FilterExpression="SK = :sk AND begins_with(PK, :prefix) AND email = :email",
-            ExpressionAttributeValues={
+        scan_kwargs: dict[str, Any] = {
+            "FilterExpression": "SK = :sk AND begins_with(PK, :prefix) AND email = :email",
+            "ExpressionAttributeValues": {
                 ":sk": "META",
                 _PK_PREFIX_KEY: "INVITE#",
                 ":email": email,
             },
-        )
-        invites = [Invite.from_dynamo(item) for item in resp.get("Items", [])]
+        }
+        invites: list[Invite] = []
+        while True:
+            resp = self.table.scan(**scan_kwargs)
+            invites.extend(Invite.from_dynamo(item) for item in resp.get("Items", []))
+            lek = resp.get("LastEvaluatedKey")
+            if lek is None:
+                break
+            scan_kwargs["ExclusiveStartKey"] = lek
         return [i for i in invites if not i.is_expired]
 
     def list_pending_invites_for_workspace(self, workspace_id: str) -> list[Invite]:
         """Return every non-expired invite for the given workspace."""
-        resp = self.table.scan(
-            FilterExpression=("SK = :sk AND begins_with(PK, :prefix) AND workspace_id = :wsid"),
-            ExpressionAttributeValues={
+        scan_kwargs: dict[str, Any] = {
+            "FilterExpression": "SK = :sk AND begins_with(PK, :prefix) AND workspace_id = :wsid",
+            "ExpressionAttributeValues": {
                 ":sk": "META",
                 _PK_PREFIX_KEY: "INVITE#",
                 ":wsid": workspace_id,
             },
-        )
-        invites = [Invite.from_dynamo(item) for item in resp.get("Items", [])]
+        }
+        invites: list[Invite] = []
+        while True:
+            resp = self.table.scan(**scan_kwargs)
+            invites.extend(Invite.from_dynamo(item) for item in resp.get("Items", []))
+            lek = resp.get("LastEvaluatedKey")
+            if lek is None:
+                break
+            scan_kwargs["ExclusiveStartKey"] = lek
         return [i for i in invites if not i.is_expired]
 
     # ------------------------------------------------------------------

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -932,22 +932,22 @@ class HiveStorage:
         """Delete the workspace META item and every MEMBER item under it.
 
         Returns True when the META item existed, False when it was already
-        absent. Member items are deleted unconditionally — orphan members
-        under a deleted workspace would still surface through the
-        ``WorkspaceMemberIndex`` lookup and confuse the per-user list.
+        absent. Member items are deleted unconditionally even when META is
+        absent — orphan members under a deleted workspace would still surface
+        through the ``WorkspaceMemberIndex`` GSI and confuse per-user lists.
         """
-        resp = self.table.get_item(Key={"PK": f"WORKSPACE#{workspace_id}", "SK": "META"})
-        if not resp.get("Item"):
-            return False
-        # Delete every MEMBER#{user_id} item in the partition, then the META.
+        meta_resp = self.table.get_item(Key={"PK": f"WORKSPACE#{workspace_id}", "SK": "META"})
+        meta_existed = bool(meta_resp.get("Item"))
+        # Always clean up MEMBER rows to prevent orphaned WorkspaceMemberIndex entries.
         members = self.list_workspace_members(workspace_id)
         with self.table.batch_writer() as batch:
             for m in members:
                 batch.delete_item(
                     Key={"PK": f"WORKSPACE#{workspace_id}", "SK": f"MEMBER#{m.user_id}"}
                 )
-            batch.delete_item(Key={"PK": f"WORKSPACE#{workspace_id}", "SK": "META"})
-        return True
+            if meta_existed:
+                batch.delete_item(Key={"PK": f"WORKSPACE#{workspace_id}", "SK": "META"})
+        return meta_existed
 
     def rename_workspace(self, workspace_id: str, name: str) -> bool:
         """Update a workspace's display name. Returns False if missing."""

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -29,6 +29,7 @@ from hive.models import (
     ActivityEvent,
     ApiKey,
     AuthorizationCode,
+    Invite,
     Memory,
     MemoryVersion,
     MgmtPendingState,
@@ -37,6 +38,9 @@ from hive.models import (
     Token,
     TokenType,
     User,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceRole,
 )
 
 logger = get_logger("hive.storage")
@@ -47,6 +51,7 @@ DYNAMODB_ENDPOINT = os.environ.get("DYNAMODB_ENDPOINT")
 
 # Reusable DynamoDB filter expression fragments
 _UID_FILTER = " AND owner_user_id = :uid"
+_WSID_FILTER = " AND workspace_id = :wsid"
 _PK_PREFIX_KEY = ":prefix"
 _SK_PK_PREFIX_EXPR = "SK = :sk AND begins_with(PK, :prefix)"
 
@@ -437,12 +442,15 @@ class HiveStorage:
         limit: int = 100,
         cursor: str | None = None,
         owner_user_id: str | None = None,
+        workspace_id: str | None = None,
     ) -> tuple[list[Memory], str | None]:
         """Query TagIndex GSI to find memories with a given tag.
 
-        When owner_user_id is provided, only memories belonging to that user
-        are returned (within-user cross-client sharing is intentional product
-        behaviour; cross-user isolation is enforced here).
+        ``owner_user_id`` and ``workspace_id`` are both optional scoping
+        filters — both are applied in-memory on the hydrated items. The
+        workspace_id path exists ahead of the migration (#490) so that
+        post-migration callers can scope by workspace while the
+        owner_user_id path keeps working for pre-cutover callers.
 
         Returns (memories, next_cursor). next_cursor is None when exhausted.
         """
@@ -458,8 +466,13 @@ class HiveStorage:
         memories: list[Memory] = []
         for item in resp.get("Items", []):
             m = self.get_memory_by_id(item["memory_id"])
-            if m is not None and (owner_user_id is None or m.owner_user_id == owner_user_id):
-                memories.append(m)
+            if m is None:
+                continue
+            if owner_user_id is not None and m.owner_user_id != owner_user_id:
+                continue
+            if workspace_id is not None and m.workspace_id != workspace_id:
+                continue
+            memories.append(m)
 
         lek = resp.get("LastEvaluatedKey")
         next_cursor = _encode_cursor(lek) if lek else None
@@ -469,10 +482,12 @@ class HiveStorage:
         self,
         client_id: str | None = None,
         owner_user_id: str | None = None,
+        workspace_id: str | None = None,
         limit: int = 50,
         cursor: str | None = None,
     ) -> tuple[list[Memory], str | None]:
-        """Scan for all META memory items (optionally filtered by owner_client_id or owner_user_id).
+        """Scan for all META memory items (optionally filtered by owner_client_id,
+        owner_user_id, or workspace_id).
 
         Returns (memories, next_cursor). Use sparingly — prefer tag-based queries.
 
@@ -488,6 +503,9 @@ class HiveStorage:
         if owner_user_id:
             filter_expr += _UID_FILTER
             expr_vals[":uid"] = owner_user_id
+        if workspace_id:
+            filter_expr += _WSID_FILTER
+            expr_vals[":wsid"] = workspace_id
 
         start_key = _decode_cursor(cursor) if cursor else None
         memories: list[Memory] = []
@@ -519,17 +537,22 @@ class HiveStorage:
         self,
         tag: str,
         owner_user_id: str | None = None,
+        workspace_id: str | None = None,
     ) -> int:
         """Delete all memories with the given tag.
 
-        If owner_user_id is provided, only memories owned by that user are deleted.
-        Returns the count of memories deleted.
+        If owner_user_id or workspace_id is provided, only memories matching
+        the filter are deleted. Returns the count of memories deleted.
         """
         deleted = 0
         cursor: str | None = None
         while True:
             items, cursor = self.list_memories_by_tag(
-                tag, limit=100, cursor=cursor, owner_user_id=owner_user_id
+                tag,
+                limit=100,
+                cursor=cursor,
+                owner_user_id=owner_user_id,
+                workspace_id=workspace_id,
             )
             for memory in items:
                 self._delete_tag_items(memory)
@@ -543,9 +566,10 @@ class HiveStorage:
     def iter_all_memories(
         self,
         owner_user_id: str | None = None,
+        workspace_id: str | None = None,
         tag: str | None = None,
     ) -> Iterator[Memory]:
-        """Yield all memories, optionally filtered by owner or tag.
+        """Yield all memories, optionally filtered by owner, workspace, or tag.
 
         For tag-filtered export, iterates TagIndex pages.
         For unfiltered export, scans all META items.
@@ -555,7 +579,11 @@ class HiveStorage:
             cursor: str | None = None
             while True:
                 items, cursor = self.list_memories_by_tag(
-                    tag, limit=100, cursor=cursor, owner_user_id=owner_user_id
+                    tag,
+                    limit=100,
+                    cursor=cursor,
+                    owner_user_id=owner_user_id,
+                    workspace_id=workspace_id,
                 )
                 yield from items
                 if cursor is None:
@@ -566,6 +594,9 @@ class HiveStorage:
             if owner_user_id:
                 filter_expr += _UID_FILTER
                 expr_vals[":uid"] = owner_user_id
+            if workspace_id:
+                filter_expr += _WSID_FILTER
+                expr_vals[":wsid"] = workspace_id
             start_key: dict[str, Any] | None = None
             while True:
                 kwargs: dict[str, Any] = {
@@ -603,6 +634,7 @@ class HiveStorage:
     def list_clients(
         self,
         owner_user_id: str | None = None,
+        workspace_id: str | None = None,
         limit: int = 50,
         cursor: str | None = None,
     ) -> tuple[list[OAuthClient], str | None]:
@@ -611,6 +643,9 @@ class HiveStorage:
         if owner_user_id:
             filter_expr += _UID_FILTER
             expr_vals[":uid"] = owner_user_id
+        if workspace_id:
+            filter_expr += _WSID_FILTER
+            expr_vals[":wsid"] = workspace_id
 
         start_key = _decode_cursor(cursor) if cursor else None
         clients: list[OAuthClient] = []
@@ -736,6 +771,32 @@ class HiveStorage:
             ExpressionAttributeValues={":t": True},
         )
 
+    def revoke_all_tokens(self) -> int:
+        """Mark every outstanding token as revoked.
+
+        Used by the workspaces migration (#490) — existing tokens don't carry
+        the ``workspace_id`` claim, so forcing a re-auth is the cheapest
+        correct cutover. Returns the count of tokens revoked.
+        """
+        revoked = 0
+        start_key: dict[str, Any] | None = None
+        while True:
+            kwargs: dict[str, Any] = {
+                "FilterExpression": "SK = :sk AND begins_with(PK, :prefix)",
+                "ExpressionAttributeValues": {":sk": "META", _PK_PREFIX_KEY: "TOKEN#"},
+                "ProjectionExpression": "jti",
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            resp = self.table.scan(**kwargs)
+            for item in resp.get("Items", []):
+                self.revoke_token(item["jti"])
+                revoked += 1
+            start_key = resp.get("LastEvaluatedKey")
+            if start_key is None:
+                break
+        return revoked
+
     def create_token_pair(self, client_id: str, scope: str) -> tuple[Token, Token]:
         """Issue a new (access_token, refresh_token) pair."""
         now = _now()
@@ -855,6 +916,183 @@ class HiveStorage:
             start_key = lek
 
     # ------------------------------------------------------------------
+    # Workspaces (#490) — tenancy root; replaces per-user scoping post-cutover
+    # ------------------------------------------------------------------
+
+    def put_workspace(self, workspace: Workspace) -> None:
+        """Create or overwrite a workspace META item."""
+        self.table.put_item(Item=workspace.to_dynamo())
+
+    def get_workspace(self, workspace_id: str) -> Workspace | None:
+        resp = self.table.get_item(Key={"PK": f"WORKSPACE#{workspace_id}", "SK": "META"})
+        item = resp.get("Item")
+        return Workspace.from_dynamo(item) if item else None
+
+    def delete_workspace(self, workspace_id: str) -> bool:
+        """Delete the workspace META item and every MEMBER item under it.
+
+        Returns True when the META item existed, False when it was already
+        absent. Member items are deleted unconditionally — orphan members
+        under a deleted workspace would still surface through the
+        ``WorkspaceMemberIndex`` lookup and confuse the per-user list.
+        """
+        resp = self.table.get_item(Key={"PK": f"WORKSPACE#{workspace_id}", "SK": "META"})
+        if not resp.get("Item"):
+            return False
+        # Delete every MEMBER#{user_id} item in the partition, then the META.
+        members = self.list_workspace_members(workspace_id)
+        with self.table.batch_writer() as batch:
+            for m in members:
+                batch.delete_item(
+                    Key={"PK": f"WORKSPACE#{workspace_id}", "SK": f"MEMBER#{m.user_id}"}
+                )
+            batch.delete_item(Key={"PK": f"WORKSPACE#{workspace_id}", "SK": "META"})
+        return True
+
+    def rename_workspace(self, workspace_id: str, name: str) -> bool:
+        """Update a workspace's display name. Returns False if missing."""
+        try:
+            self.table.update_item(
+                Key={"PK": f"WORKSPACE#{workspace_id}", "SK": "META"},
+                UpdateExpression="SET #n = :name",
+                ConditionExpression="attribute_exists(PK)",
+                ExpressionAttributeNames={"#n": "name"},
+                ExpressionAttributeValues={":name": name},
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return False
+            raise
+        return True
+
+    def add_workspace_member(
+        self,
+        workspace_id: str,
+        user_id: str,
+        role: WorkspaceRole = WorkspaceRole.member,
+    ) -> WorkspaceMember:
+        """Insert a (workspace, user, role) binding. Overwrites if it exists."""
+        member = WorkspaceMember(workspace_id=workspace_id, user_id=user_id, role=role)
+        self.table.put_item(Item=member.to_dynamo())
+        return member
+
+    def get_workspace_member(self, workspace_id: str, user_id: str) -> WorkspaceMember | None:
+        resp = self.table.get_item(
+            Key={"PK": f"WORKSPACE#{workspace_id}", "SK": f"MEMBER#{user_id}"}
+        )
+        item = resp.get("Item")
+        return WorkspaceMember.from_dynamo(item) if item else None
+
+    def list_workspace_members(self, workspace_id: str) -> list[WorkspaceMember]:
+        """List every member of a workspace (single partition query)."""
+        resp = self.table.query(
+            KeyConditionExpression=Key("PK").eq(f"WORKSPACE#{workspace_id}")
+            & Key("SK").begins_with("MEMBER#"),
+        )
+        return [WorkspaceMember.from_dynamo(item) for item in resp.get("Items", [])]
+
+    def remove_workspace_member(self, workspace_id: str, user_id: str) -> bool:
+        """Delete a (workspace, user) binding. Returns True if it existed."""
+        resp = self.table.get_item(
+            Key={"PK": f"WORKSPACE#{workspace_id}", "SK": f"MEMBER#{user_id}"}
+        )
+        if not resp.get("Item"):
+            return False
+        self.table.delete_item(Key={"PK": f"WORKSPACE#{workspace_id}", "SK": f"MEMBER#{user_id}"})
+        return True
+
+    def update_workspace_member_role(
+        self,
+        workspace_id: str,
+        user_id: str,
+        role: WorkspaceRole,
+    ) -> bool:
+        """Change a member's role. Returns False if the membership is missing."""
+        try:
+            self.table.update_item(
+                Key={"PK": f"WORKSPACE#{workspace_id}", "SK": f"MEMBER#{user_id}"},
+                UpdateExpression="SET #r = :role",
+                ConditionExpression="attribute_exists(PK)",
+                ExpressionAttributeNames={"#r": "role"},
+                ExpressionAttributeValues={":role": role.value},
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return False
+            raise
+        return True
+
+    def list_workspaces_for_user(self, user_id: str) -> list[Workspace]:
+        """Return every workspace the user is a member of.
+
+        Queries ``WorkspaceMemberIndex`` on ``USER#{user_id}`` to collect
+        workspace ids, then fetches the META item for each. Ordering is
+        stable by workspace_id (GSI5SK) so callers can rely on it for
+        deterministic UI rendering.
+        """
+        resp = self.table.query(
+            IndexName="WorkspaceMemberIndex",
+            KeyConditionExpression=Key("GSI5PK").eq(f"USER#{user_id}")
+            & Key("GSI5SK").begins_with("WORKSPACE#"),
+        )
+        workspaces: list[Workspace] = []
+        for item in resp.get("Items", []):
+            ws = self.get_workspace(item["workspace_id"])
+            if ws is not None:
+                workspaces.append(ws)
+        return workspaces
+
+    # ------------------------------------------------------------------
+    # Workspace invites (#490) — pending invitations to join a workspace
+    # ------------------------------------------------------------------
+
+    def put_invite(self, invite: Invite) -> None:
+        self.table.put_item(Item=invite.to_dynamo())
+
+    def get_invite(self, invite_id: str) -> Invite | None:
+        resp = self.table.get_item(Key={"PK": f"INVITE#{invite_id}", "SK": "META"})
+        item = resp.get("Item")
+        return Invite.from_dynamo(item) if item else None
+
+    def delete_invite(self, invite_id: str) -> bool:
+        resp = self.table.get_item(Key={"PK": f"INVITE#{invite_id}", "SK": "META"})
+        if not resp.get("Item"):
+            return False
+        self.table.delete_item(Key={"PK": f"INVITE#{invite_id}", "SK": "META"})
+        return True
+
+    def list_pending_invites_for_email(self, email: str) -> list[Invite]:
+        """Return every non-expired invite targeting the given email.
+
+        Scans the INVITE# partition with a filter — acceptable volume for
+        the invite-accept flow (user logs in, we surface pending invites).
+        If invite volume grows we'd back this with a GSI.
+        """
+        resp = self.table.scan(
+            FilterExpression="SK = :sk AND begins_with(PK, :prefix) AND email = :email",
+            ExpressionAttributeValues={
+                ":sk": "META",
+                _PK_PREFIX_KEY: "INVITE#",
+                ":email": email,
+            },
+        )
+        invites = [Invite.from_dynamo(item) for item in resp.get("Items", [])]
+        return [i for i in invites if not i.is_expired]
+
+    def list_pending_invites_for_workspace(self, workspace_id: str) -> list[Invite]:
+        """Return every non-expired invite for the given workspace."""
+        resp = self.table.scan(
+            FilterExpression=("SK = :sk AND begins_with(PK, :prefix) AND workspace_id = :wsid"),
+            ExpressionAttributeValues={
+                ":sk": "META",
+                _PK_PREFIX_KEY: "INVITE#",
+                ":wsid": workspace_id,
+            },
+        )
+        invites = [Invite.from_dynamo(item) for item in resp.get("Items", [])]
+        return [i for i in invites if not i.is_expired]
+
+    # ------------------------------------------------------------------
     # Management pending state (nonce for management UI Google login)
     # ------------------------------------------------------------------
 
@@ -924,12 +1162,19 @@ class HiveStorage:
     # Stats
     # ------------------------------------------------------------------
 
-    def count_memories(self, owner_user_id: str | None = None) -> int:
+    def count_memories(
+        self,
+        owner_user_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> int:
         filter_expr = "SK = :sk AND begins_with(PK, :prefix)"
         expr_vals: dict[str, Any] = {":sk": "META", _PK_PREFIX_KEY: "MEMORY#"}
         if owner_user_id:
             filter_expr += _UID_FILTER
             expr_vals[":uid"] = owner_user_id
+        if workspace_id:
+            filter_expr += _WSID_FILTER
+            expr_vals[":wsid"] = workspace_id
         resp = self.table.scan(
             Select="COUNT",
             FilterExpression=filter_expr,
@@ -937,12 +1182,19 @@ class HiveStorage:
         )
         return resp.get("Count", 0)
 
-    def count_clients(self, owner_user_id: str | None = None) -> int:
+    def count_clients(
+        self,
+        owner_user_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> int:
         filter_expr = "SK = :sk AND begins_with(PK, :prefix)"
         expr_vals: dict[str, Any] = {":sk": "META", _PK_PREFIX_KEY: "CLIENT#"}
         if owner_user_id:
             filter_expr += _UID_FILTER
             expr_vals[":uid"] = owner_user_id
+        if workspace_id:
+            filter_expr += _WSID_FILTER
+            expr_vals[":wsid"] = workspace_id
         resp = self.table.scan(
             Select="COUNT",
             FilterExpression=filter_expr,
@@ -958,13 +1210,21 @@ class HiveStorage:
         )
         return resp.get("Count", 0)
 
-    def sum_storage_bytes(self, owner_user_id: str | None = None) -> int:
-        """Return the total stored bytes across all memories for the given user (or all users)."""
+    def sum_storage_bytes(
+        self,
+        owner_user_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> int:
+        """Return the total stored bytes across all memories for the given
+        user or workspace (or all memories if both are None)."""
         filter_expr = "SK = :sk AND begins_with(PK, :prefix)"
         expr_vals: dict[str, Any] = {":sk": "META", _PK_PREFIX_KEY: "MEMORY#"}
         if owner_user_id:
             filter_expr += _UID_FILTER
             expr_vals[":uid"] = owner_user_id
+        if workspace_id:
+            filter_expr += _WSID_FILTER
+            expr_vals[":wsid"] = workspace_id
         scan_kwargs: dict[str, Any] = {
             "FilterExpression": filter_expr,
             "ExpressionAttributeValues": expr_vals,

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -765,11 +765,17 @@ class HiveStorage:
         return Token.from_dynamo(item) if item else None
 
     def revoke_token(self, jti: str) -> None:
-        self.table.update_item(
-            Key={"PK": f"TOKEN#{jti}", "SK": "META"},
-            UpdateExpression="SET revoked = :t",
-            ExpressionAttributeValues={":t": True},
-        )
+        try:
+            self.table.update_item(
+                Key={"PK": f"TOKEN#{jti}", "SK": "META"},
+                UpdateExpression="SET revoked = :t",
+                ExpressionAttributeValues={":t": True},
+                ConditionExpression="attribute_exists(PK)",
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return  # token already expired/deleted — nothing to revoke
+            raise
 
     def revoke_all_tokens(self) -> int:
         """Mark every outstanding token as revoked.
@@ -1078,8 +1084,9 @@ class HiveStorage:
     def list_pending_invites_for_email(self, email: str) -> list[Invite]:
         """Return every non-expired invite targeting the given email.
 
-        Scans the INVITE# partition with a filter — acceptable volume for
-        the invite-accept flow (user logs in, we surface pending invites).
+        Scans the full table and filters to invite META items for the given
+        email — acceptable volume for the invite-accept flow (user logs in,
+        we surface pending invites).
         If invite volume grows we'd back this with a GSI.
         """
         scan_kwargs: dict[str, Any] = {

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -782,7 +782,8 @@ class HiveStorage:
 
         Used by the workspaces migration (#490) — existing tokens don't carry
         the ``workspace_id`` claim, so forcing a re-auth is the cheapest
-        correct cutover. Returns the count of tokens revoked.
+        correct cutover. Returns the count of token rows processed (includes
+        tokens that were already revoked before this call).
         """
         revoked = 0
         start_key: dict[str, Any] | None = None

--- a/tasks.py
+++ b/tasks.py
@@ -505,6 +505,34 @@ def seed(ctx, env=None, token=None, reset=False):
     ctx.run(cmd, env=seed_env, pty=True)
 
 
+@task
+def migrate_workspaces(ctx, dry_run=False):
+    """Run the one-shot workspaces migration (#490).
+
+    Creates a `{email}'s Personal` workspace for every user, stamps every
+    memory and OAuth client with the workspace_id of its owner, and revokes
+    all outstanding tokens so callers re-auth with workspace-scoped tokens.
+
+    Idempotent — re-running skips users / rows that are already migrated.
+    Pass ``--dry-run`` to report counts without writing.
+
+        inv migrate-workspaces              # execute locally
+        inv migrate-workspaces --dry-run    # report only
+    """
+    migrate_env = {
+        **os.environ,
+        "HIVE_JWT_SECRET": os.environ.get("HIVE_JWT_SECRET", "dev-secret"),
+        "HIVE_TABLE_NAME": os.environ.get("HIVE_TABLE_NAME", "hive"),
+        "DYNAMODB_ENDPOINT": os.environ.get("DYNAMODB_ENDPOINT", f"http://localhost:{DYNAMO_PORT}"),
+        "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "local"),
+        "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "local"),
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
+    args = ["--dry-run"] if dry_run else []
+    cmd = "uv run python scripts/migrate_workspaces.py " + " ".join(args)
+    ctx.run(cmd, env=migrate_env, pty=True)
+
+
 # ── Bulk memory operations ────────────────────────────────────────────────────
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -516,18 +516,26 @@ def migrate_workspaces(ctx, dry_run=False):
     Idempotent — re-running skips users / rows that are already migrated.
     Pass ``--dry-run`` to report counts without writing.
 
-        inv migrate-workspaces              # execute locally
-        inv migrate-workspaces --dry-run    # report only
+        inv migrate-workspaces              # execute against AWS (uses env vars)
+        inv migrate-workspaces --dry-run    # report only, no writes
+
+    For local development against DynamoDB Local, set DYNAMODB_ENDPOINT
+    before running::
+
+        DYNAMODB_ENDPOINT=http://localhost:8000 inv migrate-workspaces
     """
     migrate_env = {
         **os.environ,
         "HIVE_JWT_SECRET": os.environ.get("HIVE_JWT_SECRET", "dev-secret"),
         "HIVE_TABLE_NAME": os.environ.get("HIVE_TABLE_NAME", "hive"),
-        "DYNAMODB_ENDPOINT": os.environ.get("DYNAMODB_ENDPOINT", f"http://localhost:{DYNAMO_PORT}"),
         "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "local"),
         "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "local"),
         "AWS_DEFAULT_REGION": "us-east-1",
     }
+    # Only override DYNAMODB_ENDPOINT when explicitly set in the environment so
+    # production runs (where it should be unset) default to the AWS endpoint.
+    if "DYNAMODB_ENDPOINT" in os.environ:
+        migrate_env["DYNAMODB_ENDPOINT"] = os.environ["DYNAMODB_ENDPOINT"]
     args = ["--dry-run"] if dry_run else []
     cmd = "uv run python scripts/migrate_workspaces.py " + " ".join(args)
     ctx.run(cmd, env=migrate_env, pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -528,14 +528,15 @@ def migrate_workspaces(ctx, dry_run=False):
         **os.environ,
         "HIVE_JWT_SECRET": os.environ.get("HIVE_JWT_SECRET", "dev-secret"),
         "HIVE_TABLE_NAME": os.environ.get("HIVE_TABLE_NAME", "hive"),
-        "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "local"),
-        "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "local"),
         "AWS_DEFAULT_REGION": "us-east-1",
     }
-    # Only override DYNAMODB_ENDPOINT when explicitly set in the environment so
-    # production runs (where it should be unset) default to the AWS endpoint.
+    # Only inject DYNAMODB_ENDPOINT + dummy creds when targeting DynamoDB Local.
+    # Leaving them unset lets boto3 resolve real AWS credentials normally (profile,
+    # SSO, instance role, etc.) for production runs.
     if "DYNAMODB_ENDPOINT" in os.environ:
         migrate_env["DYNAMODB_ENDPOINT"] = os.environ["DYNAMODB_ENDPOINT"]
+        migrate_env.setdefault("AWS_ACCESS_KEY_ID", "local")
+        migrate_env.setdefault("AWS_SECRET_ACCESS_KEY", "local")
     args = ["--dry-run"] if dry_run else []
     cmd = "uv run python scripts/migrate_workspaces.py " + " ".join(args)
     ctx.run(cmd, env=migrate_env, pty=True)

--- a/tests/unit/test_migrate_workspaces.py
+++ b/tests/unit/test_migrate_workspaces.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for scripts/migrate_workspaces.py — the #490 cutover."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import pytest
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-test-migrate")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+
+from moto import mock_aws
+
+from hive.models import Memory, OAuthClient, Token, User, WorkspaceRole
+from hive.storage import HiveStorage
+from scripts.migrate_workspaces import (
+    MigrationStats,
+    _personal_workspace_name,
+    main,
+    run,
+)
+
+TABLE_NAME = "hive-test-migrate"
+
+
+@pytest.fixture()
+def storage():
+    with mock_aws():
+        _create_table()
+        yield HiveStorage(table_name=TABLE_NAME, region="us-east-1")
+
+
+def _create_table():
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName=TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "UserEmailIndex",
+                "KeySchema": [{"AttributeName": "GSI4PK", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _seed_user(storage, email: str = "alice@example.com") -> User:
+    user = User(email=email, display_name=email.split("@")[0].title())
+    storage.put_user(user)
+    return user
+
+
+def _seed_memory(storage, *, owner_user_id: str | None, value: str = "v", key: str = "m") -> Memory:
+    # owner_client_id is irrelevant for migration; workspace_id comes from user.
+    mem = Memory(
+        key=key,
+        value=value,
+        owner_client_id="client-1",
+        owner_user_id=owner_user_id,
+    )
+    storage.put_memory(mem)
+    return mem
+
+
+def _seed_client(storage, *, owner_user_id: str | None, name: str = "Test") -> OAuthClient:
+    client = OAuthClient(client_name=name, owner_user_id=owner_user_id)
+    storage.put_client(client)
+    return client
+
+
+def _seed_token(storage, client_id: str = "c1") -> Token:
+    now = datetime.now(timezone.utc)
+    token = Token(
+        client_id=client_id,
+        scope="memories:read",
+        issued_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    storage.put_token(token)
+    return token
+
+
+class TestHelpers:
+    def test_personal_workspace_name(self):
+        assert _personal_workspace_name("alice@example.com") == "alice@example.com's Personal"
+
+    def test_stats_report_includes_every_counter(self):
+        s = MigrationStats(
+            users_seen=1,
+            workspaces_created=1,
+            memories_seen=2,
+            memories_migrated=2,
+            clients_seen=1,
+            clients_migrated=1,
+            tokens_revoked=3,
+        )
+        text = s.report()
+        assert "users_seen=1" in text
+        assert "workspaces_created=1" in text
+        assert "memories_migrated=2" in text
+        assert "clients_migrated=1" in text
+        assert "tokens_revoked=3" in text
+
+
+class TestUserMigration:
+    def test_creates_personal_workspace_for_each_user(self, storage):
+        alice = _seed_user(storage, "alice@example.com")
+        bob = _seed_user(storage, "bob@example.com")
+        stats = run(storage=storage)
+        assert stats.users_seen == 2
+        assert stats.workspaces_created == 2
+        assert stats.workspaces_skipped == 0
+
+        alice_ws = storage.list_workspaces_for_user(alice.user_id)
+        bob_ws = storage.list_workspaces_for_user(bob.user_id)
+        assert len(alice_ws) == 1 and alice_ws[0].is_personal
+        assert len(bob_ws) == 1 and bob_ws[0].is_personal
+        assert alice_ws[0].name == "alice@example.com's Personal"
+
+    def test_makes_user_the_owner_of_their_personal_workspace(self, storage):
+        alice = _seed_user(storage)
+        run(storage=storage)
+        ws = storage.list_workspaces_for_user(alice.user_id)[0]
+        member = storage.get_workspace_member(ws.workspace_id, alice.user_id)
+        assert member is not None
+        assert member.role is WorkspaceRole.owner
+
+    def test_rerun_is_idempotent_for_users(self, storage):
+        _seed_user(storage)
+        run(storage=storage)
+        stats2 = run(storage=storage)
+        assert stats2.workspaces_skipped == 1
+        assert stats2.workspaces_created == 0
+
+
+class TestMemoryMigration:
+    def test_stamps_workspace_id_on_each_memory(self, storage):
+        alice = _seed_user(storage)
+        mem = _seed_memory(storage, owner_user_id=alice.user_id)
+        stats = run(storage=storage)
+        assert stats.memories_migrated == 1
+        fetched = storage.get_memory_by_id(mem.memory_id)
+        assert fetched.workspace_id is not None
+        ws = storage.list_workspaces_for_user(alice.user_id)[0]
+        assert fetched.workspace_id == ws.workspace_id
+
+    def test_skips_memories_without_owner_user_id(self, storage):
+        _seed_user(storage)
+        mem = _seed_memory(storage, owner_user_id=None, key="legacy")
+        stats = run(storage=storage)
+        assert stats.memories_skipped == 1
+        assert storage.get_memory_by_id(mem.memory_id).workspace_id is None
+
+    def test_skips_already_migrated_memories(self, storage):
+        alice = _seed_user(storage)
+        mem = _seed_memory(storage, owner_user_id=alice.user_id)
+        run(storage=storage)
+        stats2 = run(storage=storage)
+        # Second run sees the same memory but skips it because workspace_id is set.
+        assert stats2.memories_migrated == 0
+        assert stats2.memories_skipped == 1
+        assert storage.get_memory_by_id(mem.memory_id).workspace_id is not None
+
+    def test_skips_memories_referencing_unknown_user(self, storage):
+        # Seed a memory pointing at a user_id that has no User record.
+        mem = _seed_memory(storage, owner_user_id="ghost-user", key="orphan")
+        stats = run(storage=storage)
+        assert stats.memories_skipped == 1
+        assert storage.get_memory_by_id(mem.memory_id).workspace_id is None
+
+
+class TestClientMigration:
+    def test_stamps_workspace_id_on_each_client(self, storage):
+        alice = _seed_user(storage)
+        client = _seed_client(storage, owner_user_id=alice.user_id)
+        stats = run(storage=storage)
+        assert stats.clients_migrated == 1
+        fetched = storage.get_client(client.client_id)
+        ws = storage.list_workspaces_for_user(alice.user_id)[0]
+        assert fetched.workspace_id == ws.workspace_id
+
+    def test_skips_clients_without_owner_user_id(self, storage):
+        _seed_user(storage)
+        client = _seed_client(storage, owner_user_id=None)
+        stats = run(storage=storage)
+        assert stats.clients_skipped == 1
+        assert storage.get_client(client.client_id).workspace_id is None
+
+    def test_skips_already_migrated_clients(self, storage):
+        alice = _seed_user(storage)
+        _seed_client(storage, owner_user_id=alice.user_id)
+        run(storage=storage)
+        stats2 = run(storage=storage)
+        assert stats2.clients_migrated == 0
+        assert stats2.clients_skipped == 1
+
+    def test_skips_clients_referencing_unknown_user(self, storage):
+        client = _seed_client(storage, owner_user_id="ghost-user")
+        stats = run(storage=storage)
+        assert stats.clients_skipped == 1
+        assert storage.get_client(client.client_id).workspace_id is None
+
+
+class TestTokenRevocation:
+    def test_revokes_every_token(self, storage):
+        _seed_user(storage)
+        token = _seed_token(storage)
+        stats = run(storage=storage)
+        assert stats.tokens_revoked >= 1
+        assert storage.get_token(token.jti).revoked is True
+
+
+class TestDryRun:
+    def test_dry_run_reports_without_writing_workspaces(self, storage):
+        alice = _seed_user(storage)
+        _seed_memory(storage, owner_user_id=alice.user_id)
+        _seed_client(storage, owner_user_id=alice.user_id)
+        stats = run(storage=storage, dry_run=True)
+        assert stats.workspaces_created == 1
+        assert stats.memories_migrated == 1
+        assert stats.clients_migrated == 1
+        # Nothing should actually have landed.
+        assert storage.list_workspaces_for_user(alice.user_id) == []
+
+    def test_dry_run_skips_token_revocation(self, storage):
+        _seed_user(storage)
+        token = _seed_token(storage)
+        stats = run(storage=storage, dry_run=True)
+        assert stats.tokens_revoked == 0
+        assert storage.get_token(token.jti).revoked is False
+
+
+class TestCli:
+    def test_main_runs_without_args(self, storage, capsys, monkeypatch):
+        _seed_user(storage)
+        # main() constructs its own HiveStorage; point it at the moto-backed table.
+        monkeypatch.setenv("HIVE_TABLE_NAME", TABLE_NAME)
+        assert main([]) == 0
+        out = capsys.readouterr().out
+        assert "users_seen=1" in out
+
+    def test_main_dry_run(self, storage, capsys, monkeypatch):
+        _seed_user(storage)
+        monkeypatch.setenv("HIVE_TABLE_NAME", TABLE_NAME)
+        assert main(["--dry-run"]) == 0
+        out = capsys.readouterr().out
+        assert "workspaces_created=1" in out

--- a/tests/unit/test_migrate_workspaces.py
+++ b/tests/unit/test_migrate_workspaces.py
@@ -213,6 +213,23 @@ class TestMemoryMigration:
         assert stats.memories_skipped == 1
         assert storage.get_memory_by_id(mem.memory_id).workspace_id is None
 
+    def test_skips_memory_that_disappears_mid_migration(self, storage):
+        """ConditionalCheckFailedException during update_item is treated as a skip."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        alice = _seed_user(storage)
+        _seed_memory(storage, owner_user_id=alice.user_id, key="vanishing")
+        error = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": ""}},
+            "UpdateItem",
+        )
+        with patch.object(storage.table, "update_item", side_effect=error):
+            stats = run(storage=storage)
+        assert stats.memories_skipped == 1
+        assert stats.memories_migrated == 0
+
 
 class TestClientMigration:
     def test_stamps_workspace_id_on_each_client(self, storage):
@@ -244,6 +261,23 @@ class TestClientMigration:
         stats = run(storage=storage)
         assert stats.clients_skipped == 1
         assert storage.get_client(client.client_id).workspace_id is None
+
+    def test_skips_client_that_disappears_mid_migration(self, storage):
+        """ConditionalCheckFailedException during update_item is treated as a skip."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        alice = _seed_user(storage)
+        _seed_client(storage, owner_user_id=alice.user_id)
+        error = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": ""}},
+            "UpdateItem",
+        )
+        with patch.object(storage.table, "update_item", side_effect=error):
+            stats = run(storage=storage)
+        assert stats.clients_skipped == 1
+        assert stats.clients_migrated == 0
 
 
 class TestTokenRevocation:

--- a/tests/unit/test_migrate_workspaces.py
+++ b/tests/unit/test_migrate_workspaces.py
@@ -335,6 +335,24 @@ class TestDryRun:
         assert stats.tokens_revoked == 0
         assert storage.get_token(token.jti).revoked is False
 
+    def test_dry_run_does_not_repair_orphaned_member_row(self, storage):
+        """dry_run must not write the MEMBER row even when repairing a partial prior run."""
+        alice = _seed_user(storage)
+        partial_ws = Workspace(
+            name="alice@example.com's Personal",
+            owner_user_id=alice.user_id,
+            is_personal=True,
+        )
+        storage.put_workspace(partial_ws)
+        # MEMBER row intentionally absent.
+        assert storage.list_workspaces_for_user(alice.user_id) == []
+
+        stats = run(storage=storage, dry_run=True)
+        assert stats.workspaces_skipped == 1
+        assert stats.workspaces_created == 0
+        # Dry-run must leave the MEMBER row absent.
+        assert storage.list_workspaces_for_user(alice.user_id) == []
+
 
 class TestCli:
     def test_main_runs_without_args(self, storage, capsys, monkeypatch):

--- a/tests/unit/test_migrate_workspaces.py
+++ b/tests/unit/test_migrate_workspaces.py
@@ -16,7 +16,7 @@ os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
 
 from moto import mock_aws
 
-from hive.models import Memory, OAuthClient, Token, User, WorkspaceRole
+from hive.models import Memory, OAuthClient, Token, User, Workspace, WorkspaceRole
 from hive.storage import HiveStorage
 from scripts.migrate_workspaces import (
     MigrationStats,
@@ -176,6 +176,33 @@ class TestUserMigration:
         stats2 = run(storage=storage)
         assert stats2.workspaces_skipped == 1
         assert stats2.workspaces_created == 0
+
+    def test_repairs_partial_run_where_meta_exists_but_member_missing(self, storage):
+        """A prior partial run may have written the Workspace META but not the MEMBER row.
+
+        The fallback scan in _find_personal_workspace must detect this and repair
+        it rather than creating a duplicate workspace.
+        """
+        alice = _seed_user(storage)
+        # Simulate a partial prior run: write the workspace META directly
+        # but intentionally skip add_workspace_member so the MEMBER row is absent.
+        partial_ws = Workspace(
+            name="alice@example.com's Personal",
+            owner_user_id=alice.user_id,
+            is_personal=True,
+        )
+        storage.put_workspace(partial_ws)
+        # No add_workspace_member call — MEMBER row is missing.
+        assert storage.list_workspaces_for_user(alice.user_id) == []
+
+        # Re-running the migration should detect the orphaned META, repair the
+        # MEMBER row, and NOT create a second workspace.
+        stats = run(storage=storage)
+        assert stats.workspaces_created == 0
+        assert stats.workspaces_skipped == 1
+        ws_list = storage.list_workspaces_for_user(alice.user_id)
+        assert len(ws_list) == 1
+        assert ws_list[0].workspace_id == partial_ws.workspace_id
 
 
 class TestMemoryMigration:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -7,10 +7,14 @@ from datetime import datetime, timedelta, timezone
 
 from hive.models import (
     AuthorizationCode,
+    Invite,
     Memory,
     OAuthClient,
     OAuthClientType,
     Token,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceRole,
 )
 
 
@@ -353,3 +357,158 @@ class TestApiKey:
         assert resp.key_id == k.key_id
         assert resp.name == "Test"
         assert "key_hash" not in resp.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Workspaces (#490)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceModel:
+    def test_defaults(self):
+        ws = Workspace(name="Acme", owner_user_id="u1")
+        assert ws.workspace_id
+        assert ws.is_personal is False
+        assert ws.description is None
+        assert ws.created_at.tzinfo == timezone.utc
+
+    def test_to_dynamo_skips_unset_description(self):
+        ws = Workspace(name="Acme", owner_user_id="u1")
+        item = ws.to_dynamo()
+        assert item["PK"] == f"WORKSPACE#{ws.workspace_id}"
+        assert item["SK"] == "META"
+        assert item["is_personal"] is False
+        assert "description" not in item
+
+    def test_to_dynamo_includes_description(self):
+        ws = Workspace(name="Acme", owner_user_id="u1", description="notes")
+        item = ws.to_dynamo()
+        assert item["description"] == "notes"
+
+    def test_from_dynamo_roundtrip(self):
+        ws = Workspace(
+            name="Acme",
+            owner_user_id="u1",
+            is_personal=True,
+            description="personal",
+        )
+        item = ws.to_dynamo()
+        ws2 = Workspace.from_dynamo(item)
+        assert ws2.workspace_id == ws.workspace_id
+        assert ws2.name == ws.name
+        assert ws2.owner_user_id == ws.owner_user_id
+        assert ws2.is_personal is True
+        assert ws2.description == "personal"
+
+    def test_from_dynamo_without_is_personal_defaults_to_false(self):
+        item = {
+            "workspace_id": "ws-1",
+            "name": "Any",
+            "owner_user_id": "u1",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        ws = Workspace.from_dynamo(item)
+        assert ws.is_personal is False
+
+
+class TestWorkspaceMemberModel:
+    def test_defaults(self):
+        m = WorkspaceMember(workspace_id="ws", user_id="u1")
+        assert m.role is WorkspaceRole.member
+        assert m.joined_at.tzinfo == timezone.utc
+
+    def test_to_dynamo_includes_gsi5_keys(self):
+        m = WorkspaceMember(workspace_id="ws-1", user_id="u1", role=WorkspaceRole.owner)
+        item = m.to_dynamo()
+        assert item["PK"] == "WORKSPACE#ws-1"
+        assert item["SK"] == "MEMBER#u1"
+        assert item["GSI5PK"] == "USER#u1"
+        assert item["GSI5SK"] == "WORKSPACE#ws-1"
+        assert item["role"] == "owner"
+
+    def test_from_dynamo_roundtrip(self):
+        m = WorkspaceMember(workspace_id="ws-1", user_id="u1", role=WorkspaceRole.admin)
+        item = m.to_dynamo()
+        m2 = WorkspaceMember.from_dynamo(item)
+        assert m2.workspace_id == "ws-1"
+        assert m2.user_id == "u1"
+        assert m2.role is WorkspaceRole.admin
+        assert m2.joined_at == m.joined_at
+
+
+class TestInviteModel:
+    def _invite(self, **overrides):
+        defaults = dict(
+            workspace_id="ws-1",
+            email="invitee@example.com",
+            invited_by_user_id="inviter",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        defaults.update(overrides)
+        return Invite(**defaults)
+
+    def test_defaults(self):
+        inv = self._invite()
+        assert inv.invite_id
+        assert inv.role is WorkspaceRole.member
+        assert inv.created_at.tzinfo == timezone.utc
+
+    def test_to_dynamo_sets_ttl(self):
+        inv = self._invite()
+        item = inv.to_dynamo()
+        assert item["PK"] == f"INVITE#{inv.invite_id}"
+        assert item["SK"] == "META"
+        assert item["ttl"] == int(inv.expires_at.timestamp())
+
+    def test_from_dynamo_roundtrip(self):
+        inv = self._invite(role=WorkspaceRole.admin)
+        item = inv.to_dynamo()
+        inv2 = Invite.from_dynamo(item)
+        assert inv2.invite_id == inv.invite_id
+        assert inv2.workspace_id == inv.workspace_id
+        assert inv2.email == inv.email
+        assert inv2.role is WorkspaceRole.admin
+        assert inv2.invited_by_user_id == inv.invited_by_user_id
+
+    def test_is_expired_detects_past_timestamp(self):
+        inv = self._invite(expires_at=datetime.now(timezone.utc) - timedelta(seconds=1))
+        assert inv.is_expired is True
+
+    def test_is_expired_false_for_future(self):
+        assert self._invite().is_expired is False
+
+
+class TestMemoryWorkspaceIdField:
+    def test_workspace_id_defaults_to_none(self):
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        assert m.workspace_id is None
+
+    def test_workspace_id_roundtrips_via_dynamo(self):
+        m = Memory(key="k", value="v", owner_client_id="c1", workspace_id="ws-1")
+        item = m.to_dynamo_meta()
+        assert item["workspace_id"] == "ws-1"
+        m2 = Memory.from_dynamo(item)
+        assert m2.workspace_id == "ws-1"
+
+    def test_workspace_id_absent_from_dynamo_when_none(self):
+        m = Memory(key="k", value="v", owner_client_id="c1")
+        item = m.to_dynamo_meta()
+        assert "workspace_id" not in item
+
+
+class TestOAuthClientWorkspaceIdField:
+    def test_workspace_id_defaults_to_none(self):
+        c = OAuthClient(client_name="Test")
+        assert c.workspace_id is None
+
+    def test_workspace_id_roundtrips_via_dynamo(self):
+        c = OAuthClient(client_name="Test", workspace_id="ws-1")
+        item = c.to_dynamo()
+        assert item["workspace_id"] == "ws-1"
+        c2 = OAuthClient.from_dynamo(item)
+        assert c2.workspace_id == "ws-1"
+
+    def test_workspace_id_absent_from_dynamo_when_none(self):
+        c = OAuthClient(client_name="Test")
+        item = c.to_dynamo()
+        assert "workspace_id" not in item

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -22,11 +22,14 @@ from hive.models import (
     ActivityEvent,
     ApiKey,
     EventType,
+    Invite,
     Memory,
     OAuthClient,
     TokenType,
     User,
     UserResponse,
+    Workspace,
+    WorkspaceRole,
 )
 from hive.storage import HiveStorage
 
@@ -55,6 +58,8 @@ def _create_table():
             {"AttributeName": "GSI2PK", "AttributeType": "S"},
             {"AttributeName": "GSI2SK", "AttributeType": "S"},
             {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -77,6 +82,14 @@ def _create_table():
                 "IndexName": "UserEmailIndex",
                 "KeySchema": [
                     {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
@@ -1738,3 +1751,373 @@ class TestBulkMemoryOperations:
             result = list(storage.iter_all_memories())
 
         assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Workspaces (#490) — tenancy root
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceStorage:
+    def test_put_and_get(self, storage):
+        ws = Workspace(name="Team Acme", owner_user_id="u1")
+        storage.put_workspace(ws)
+        fetched = storage.get_workspace(ws.workspace_id)
+        assert fetched is not None
+        assert fetched.name == "Team Acme"
+        assert fetched.owner_user_id == "u1"
+        assert fetched.is_personal is False
+
+    def test_get_nonexistent_returns_none(self, storage):
+        assert storage.get_workspace("no-such-ws") is None
+
+    def test_rename(self, storage):
+        ws = Workspace(name="Old Name", owner_user_id="u1")
+        storage.put_workspace(ws)
+        assert storage.rename_workspace(ws.workspace_id, "New Name") is True
+        fetched = storage.get_workspace(ws.workspace_id)
+        assert fetched.name == "New Name"
+
+    def test_rename_nonexistent_returns_false(self, storage):
+        assert storage.rename_workspace("no-such-ws", "Any") is False
+
+    def test_rename_unexpected_client_error_propagates(self, storage):
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        ws = Workspace(name="X", owner_user_id="u1")
+        storage.put_workspace(ws)
+        error = ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException", "Message": ""}},
+            "UpdateItem",
+        )
+        with (
+            patch.object(storage.table, "update_item", side_effect=error),
+            pytest.raises(ClientError),
+        ):
+            storage.rename_workspace(ws.workspace_id, "Y")
+
+    def test_delete_removes_meta_and_members(self, storage):
+        ws = Workspace(name="Doomed", owner_user_id="u1")
+        storage.put_workspace(ws)
+        storage.add_workspace_member(ws.workspace_id, "u1", WorkspaceRole.owner)
+        storage.add_workspace_member(ws.workspace_id, "u2", WorkspaceRole.member)
+        assert storage.delete_workspace(ws.workspace_id) is True
+        assert storage.get_workspace(ws.workspace_id) is None
+        assert storage.list_workspace_members(ws.workspace_id) == []
+
+    def test_delete_nonexistent_returns_false(self, storage):
+        assert storage.delete_workspace("no-such-ws") is False
+
+    def test_personal_flag_roundtrips(self, storage):
+        ws = Workspace(name="Me Personal", owner_user_id="u1", is_personal=True)
+        storage.put_workspace(ws)
+        fetched = storage.get_workspace(ws.workspace_id)
+        assert fetched.is_personal is True
+
+    def test_description_roundtrips(self, storage):
+        ws = Workspace(name="Docs", owner_user_id="u1", description="Company-wide documentation")
+        storage.put_workspace(ws)
+        fetched = storage.get_workspace(ws.workspace_id)
+        assert fetched.description == "Company-wide documentation"
+
+
+class TestWorkspaceMemberStorage:
+    def test_add_and_get_member(self, storage):
+        ws_id = "ws-1"
+        member = storage.add_workspace_member(ws_id, "u1", WorkspaceRole.owner)
+        assert member.role is WorkspaceRole.owner
+        fetched = storage.get_workspace_member(ws_id, "u1")
+        assert fetched is not None
+        assert fetched.role is WorkspaceRole.owner
+
+    def test_get_nonexistent_member_returns_none(self, storage):
+        assert storage.get_workspace_member("ws-1", "u-missing") is None
+
+    def test_default_role_is_member(self, storage):
+        member = storage.add_workspace_member("ws-1", "u1")
+        assert member.role is WorkspaceRole.member
+
+    def test_list_members(self, storage):
+        ws_id = "ws-1"
+        storage.add_workspace_member(ws_id, "u1", WorkspaceRole.owner)
+        storage.add_workspace_member(ws_id, "u2", WorkspaceRole.admin)
+        storage.add_workspace_member(ws_id, "u3", WorkspaceRole.member)
+        members = storage.list_workspace_members(ws_id)
+        assert {m.user_id for m in members} == {"u1", "u2", "u3"}
+        assert {m.role for m in members} == {
+            WorkspaceRole.owner,
+            WorkspaceRole.admin,
+            WorkspaceRole.member,
+        }
+
+    def test_list_members_only_returns_target_workspace(self, storage):
+        storage.add_workspace_member("ws-a", "u1", WorkspaceRole.member)
+        storage.add_workspace_member("ws-b", "u2", WorkspaceRole.member)
+        members = storage.list_workspace_members("ws-a")
+        assert [m.user_id for m in members] == ["u1"]
+
+    def test_remove_member(self, storage):
+        storage.add_workspace_member("ws-1", "u1", WorkspaceRole.member)
+        assert storage.remove_workspace_member("ws-1", "u1") is True
+        assert storage.get_workspace_member("ws-1", "u1") is None
+
+    def test_remove_nonexistent_member_returns_false(self, storage):
+        assert storage.remove_workspace_member("ws-1", "u-missing") is False
+
+    def test_update_member_role(self, storage):
+        storage.add_workspace_member("ws-1", "u1", WorkspaceRole.member)
+        assert storage.update_workspace_member_role("ws-1", "u1", WorkspaceRole.admin) is True
+        fetched = storage.get_workspace_member("ws-1", "u1")
+        assert fetched.role is WorkspaceRole.admin
+
+    def test_update_member_role_nonexistent_returns_false(self, storage):
+        assert (
+            storage.update_workspace_member_role("ws-1", "u-missing", WorkspaceRole.admin) is False
+        )
+
+    def test_update_member_role_unexpected_client_error_propagates(self, storage):
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        storage.add_workspace_member("ws-1", "u1", WorkspaceRole.member)
+        error = ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException", "Message": ""}},
+            "UpdateItem",
+        )
+        with (
+            patch.object(storage.table, "update_item", side_effect=error),
+            pytest.raises(ClientError),
+        ):
+            storage.update_workspace_member_role("ws-1", "u1", WorkspaceRole.admin)
+
+    def test_list_workspaces_for_user_via_gsi(self, storage):
+        a = Workspace(name="A", owner_user_id="u1", is_personal=True)
+        b = Workspace(name="B", owner_user_id="u2", is_personal=False)
+        storage.put_workspace(a)
+        storage.put_workspace(b)
+        storage.add_workspace_member(a.workspace_id, "u1", WorkspaceRole.owner)
+        storage.add_workspace_member(b.workspace_id, "u2", WorkspaceRole.owner)
+        storage.add_workspace_member(b.workspace_id, "u1", WorkspaceRole.member)
+
+        names = {ws.name for ws in storage.list_workspaces_for_user("u1")}
+        assert names == {"A", "B"}
+
+    def test_list_workspaces_for_user_skips_orphaned_members(self, storage):
+        """Orphaned member rows (workspace META deleted) don't crash the list."""
+        a = Workspace(name="Real", owner_user_id="u1")
+        storage.put_workspace(a)
+        storage.add_workspace_member(a.workspace_id, "u1", WorkspaceRole.owner)
+        # Add a member for a workspace whose META never existed.
+        storage.add_workspace_member("ghost-ws", "u1", WorkspaceRole.member)
+        workspaces = storage.list_workspaces_for_user("u1")
+        assert [w.workspace_id for w in workspaces] == [a.workspace_id]
+
+    def test_list_workspaces_for_unknown_user_returns_empty(self, storage):
+        assert storage.list_workspaces_for_user("u-nobody") == []
+
+
+class TestInviteStorage:
+    def _invite(self, email: str = "invitee@example.com", workspace_id: str = "ws-1"):
+        from datetime import datetime, timedelta, timezone
+
+        return Invite(
+            workspace_id=workspace_id,
+            email=email,
+            role=WorkspaceRole.member,
+            invited_by_user_id="inviter",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+
+    def test_put_and_get(self, storage):
+        inv = self._invite()
+        storage.put_invite(inv)
+        fetched = storage.get_invite(inv.invite_id)
+        assert fetched is not None
+        assert fetched.email == "invitee@example.com"
+        assert fetched.role is WorkspaceRole.member
+
+    def test_get_nonexistent_returns_none(self, storage):
+        assert storage.get_invite("no-such-invite") is None
+
+    def test_delete(self, storage):
+        inv = self._invite()
+        storage.put_invite(inv)
+        assert storage.delete_invite(inv.invite_id) is True
+        assert storage.get_invite(inv.invite_id) is None
+
+    def test_delete_nonexistent_returns_false(self, storage):
+        assert storage.delete_invite("no-such-invite") is False
+
+    def test_list_pending_invites_for_email_filters_by_email(self, storage):
+        a = self._invite(email="a@example.com")
+        b = self._invite(email="b@example.com")
+        storage.put_invite(a)
+        storage.put_invite(b)
+        invites = storage.list_pending_invites_for_email("a@example.com")
+        assert [i.invite_id for i in invites] == [a.invite_id]
+
+    def test_list_pending_invites_for_email_skips_expired(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        fresh = self._invite(email="a@example.com")
+        expired = Invite(
+            workspace_id="ws-1",
+            email="a@example.com",
+            role=WorkspaceRole.member,
+            invited_by_user_id="inviter",
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+        storage.put_invite(fresh)
+        storage.put_invite(expired)
+        invites = storage.list_pending_invites_for_email("a@example.com")
+        assert [i.invite_id for i in invites] == [fresh.invite_id]
+
+    def test_list_pending_invites_for_workspace(self, storage):
+        a = self._invite(email="a@example.com", workspace_id="ws-a")
+        b = self._invite(email="b@example.com", workspace_id="ws-b")
+        storage.put_invite(a)
+        storage.put_invite(b)
+        invites = storage.list_pending_invites_for_workspace("ws-a")
+        assert [i.invite_id for i in invites] == [a.invite_id]
+
+    def test_list_pending_invites_for_workspace_skips_expired(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        fresh = self._invite(email="a@example.com", workspace_id="ws-a")
+        expired = Invite(
+            workspace_id="ws-a",
+            email="b@example.com",
+            role=WorkspaceRole.member,
+            invited_by_user_id="inviter",
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+        storage.put_invite(fresh)
+        storage.put_invite(expired)
+        invites = storage.list_pending_invites_for_workspace("ws-a")
+        assert [i.invite_id for i in invites] == [fresh.invite_id]
+
+
+class TestWorkspaceIdFiltering:
+    """Covers the new workspace_id filter on existing list / count methods."""
+
+    def test_list_all_memories_filters_by_workspace_id(self, storage):
+        m1 = Memory(key="m1", value="v", owner_client_id="c1", workspace_id="ws-a")
+        m2 = Memory(key="m2", value="v", owner_client_id="c1", workspace_id="ws-b")
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        items, _ = storage.list_all_memories(workspace_id="ws-a")
+        assert [m.memory_id for m in items] == [m1.memory_id]
+
+    def test_list_memories_by_tag_filters_by_workspace_id(self, storage):
+        m1 = Memory(key="m1", value="v", owner_client_id="c1", workspace_id="ws-a", tags=["shared"])
+        m2 = Memory(key="m2", value="v", owner_client_id="c1", workspace_id="ws-b", tags=["shared"])
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        items, _ = storage.list_memories_by_tag("shared", workspace_id="ws-a")
+        assert [m.memory_id for m in items] == [m1.memory_id]
+
+    def test_iter_all_memories_filters_by_workspace_id(self, storage):
+        m1 = Memory(key="m1", value="v", owner_client_id="c1", workspace_id="ws-a")
+        m2 = Memory(key="m2", value="v", owner_client_id="c1", workspace_id="ws-b")
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        items = list(storage.iter_all_memories(workspace_id="ws-a"))
+        assert [m.memory_id for m in items] == [m1.memory_id]
+
+    def test_iter_all_memories_by_tag_filters_by_workspace_id(self, storage):
+        m1 = Memory(key="m1", value="v", owner_client_id="c1", workspace_id="ws-a", tags=["t"])
+        m2 = Memory(key="m2", value="v", owner_client_id="c1", workspace_id="ws-b", tags=["t"])
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        items = list(storage.iter_all_memories(workspace_id="ws-a", tag="t"))
+        assert [m.memory_id for m in items] == [m1.memory_id]
+
+    def test_delete_memories_by_tag_filters_by_workspace_id(self, storage):
+        m1 = Memory(key="m1", value="v", owner_client_id="c1", workspace_id="ws-a", tags=["gone"])
+        m2 = Memory(key="m2", value="v", owner_client_id="c1", workspace_id="ws-b", tags=["gone"])
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        deleted = storage.delete_memories_by_tag("gone", workspace_id="ws-a")
+        assert deleted == 1
+        assert storage.get_memory_by_id(m1.memory_id) is None
+        assert storage.get_memory_by_id(m2.memory_id) is not None
+
+    def test_count_memories_filters_by_workspace_id(self, storage):
+        storage.put_memory(Memory(key="m1", value="v", owner_client_id="c1", workspace_id="ws-a"))
+        storage.put_memory(Memory(key="m2", value="v", owner_client_id="c1", workspace_id="ws-a"))
+        storage.put_memory(Memory(key="m3", value="v", owner_client_id="c1", workspace_id="ws-b"))
+        assert storage.count_memories(workspace_id="ws-a") == 2
+
+    def test_count_clients_filters_by_workspace_id(self, storage):
+        storage.put_client(OAuthClient(client_name="A", workspace_id="ws-a"))
+        storage.put_client(OAuthClient(client_name="B", workspace_id="ws-b"))
+        assert storage.count_clients(workspace_id="ws-a") == 1
+
+    def test_sum_storage_bytes_filters_by_workspace_id(self, storage):
+        # size_bytes is derived from value during put_memory, not set by the
+        # caller; use distinguishable payload lengths per workspace so the
+        # filter assertion is meaningful regardless of actual encoded length.
+        m1 = Memory(key="m1", value="x" * 10, owner_client_id="c1", workspace_id="ws-a")
+        m2 = Memory(key="m2", value="x" * 500, owner_client_id="c1", workspace_id="ws-b")
+        storage.put_memory(m1)
+        storage.put_memory(m2)
+        assert storage.sum_storage_bytes(workspace_id="ws-a") == 10
+        assert storage.sum_storage_bytes(workspace_id="ws-b") == 500
+
+    def test_list_clients_filters_by_workspace_id(self, storage):
+        storage.put_client(OAuthClient(client_name="A", workspace_id="ws-a"))
+        storage.put_client(OAuthClient(client_name="B", workspace_id="ws-b"))
+        clients, _ = storage.list_clients(workspace_id="ws-a")
+        assert [c.client_name for c in clients] == ["A"]
+
+
+class TestRevokeAllTokens:
+    """Bulk token revocation used by the workspaces migration (#490)."""
+
+    def _issue_token(self, storage, client_id: str = "c1"):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import Token
+
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client_id,
+            scope="memories:read",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        return token
+
+    def test_revoke_all_tokens_marks_every_token(self, storage):
+        a = self._issue_token(storage)
+        b = self._issue_token(storage)
+        count = storage.revoke_all_tokens()
+        assert count == 2
+        assert storage.get_token(a.jti).revoked is True
+        assert storage.get_token(b.jti).revoked is True
+
+    def test_revoke_all_tokens_is_idempotent(self, storage):
+        self._issue_token(storage)
+        assert storage.revoke_all_tokens() == 1
+        # Re-running still returns 1 (the already-revoked token is still counted)
+        # but the item stays revoked without raising.
+        assert storage.revoke_all_tokens() == 1
+
+    def test_revoke_all_tokens_handles_empty_table(self, storage):
+        assert storage.revoke_all_tokens() == 0
+
+    def test_revoke_all_tokens_paginates(self, storage):
+        from unittest.mock import patch
+
+        page1 = {"Items": [{"jti": "t1"}], "LastEvaluatedKey": {"PK": "TOKEN#t1", "SK": "META"}}
+        page2 = {"Items": [{"jti": "t2"}]}
+        with (
+            patch.object(storage.table, "scan", side_effect=[page1, page2]),
+            patch.object(storage.table, "update_item") as upd,
+        ):
+            assert storage.revoke_all_tokens() == 2
+        assert upd.call_count == 2

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -799,6 +799,20 @@ class TestTokenStorage:
         assert fetched is not None
         assert fetched.revoked
 
+    def test_revoke_token_silently_ignores_missing_token(self, storage):
+        """revoke_token must not upsert a phantom row when the token is gone."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        error = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException", "Message": ""}},
+            "UpdateItem",
+        )
+        with patch.object(storage.table, "update_item", side_effect=error):
+            # Should not raise.
+            storage.revoke_token("nonexistent-jti")
+
 
 class TestAuthCodeAtomicRedemption:
     """#584 — OAuth authorization codes are single-use (RFC 6749 §10.5).

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1824,6 +1824,17 @@ class TestWorkspaceStorage:
     def test_delete_nonexistent_returns_false(self, storage):
         assert storage.delete_workspace("no-such-ws") is False
 
+    def test_delete_cleans_up_orphaned_members_when_meta_absent(self, storage):
+        """MEMBER rows are deleted even when META is already gone (prevents orphaned GSI entries)."""
+        ws_id = "ghost-ws"
+        # Add member rows directly without a META item.
+        storage.add_workspace_member(ws_id, "u1", WorkspaceRole.owner)
+        storage.add_workspace_member(ws_id, "u2", WorkspaceRole.member)
+        # META is absent → should return False but still clean up members.
+        result = storage.delete_workspace(ws_id)
+        assert result is False
+        assert storage.list_workspace_members(ws_id) == []
+
     def test_personal_flag_roundtrips(self, storage):
         ws = Workspace(name="Me Personal", owner_user_id="u1", is_personal=True)
         storage.put_workspace(ws)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -29,6 +29,7 @@ from hive.models import (
     User,
     UserResponse,
     Workspace,
+    WorkspaceMember,
     WorkspaceRole,
 )
 from hive.storage import HiveStorage
@@ -1835,6 +1836,20 @@ class TestWorkspaceStorage:
         fetched = storage.get_workspace(ws.workspace_id)
         assert fetched.description == "Company-wide documentation"
 
+    def test_put_workspace_overwrites_existing(self, storage):
+        ws = Workspace(name="Original", owner_user_id="u1")
+        storage.put_workspace(ws)
+        updated = Workspace(
+            workspace_id=ws.workspace_id,
+            name="Updated",
+            owner_user_id="u1",
+            created_at=ws.created_at,
+        )
+        storage.put_workspace(updated)
+        fetched = storage.get_workspace(ws.workspace_id)
+        assert fetched is not None
+        assert fetched.name == "Updated"
+
 
 class TestWorkspaceMemberStorage:
     def test_add_and_get_member(self, storage):
@@ -1931,6 +1946,50 @@ class TestWorkspaceMemberStorage:
     def test_list_workspaces_for_unknown_user_returns_empty(self, storage):
         assert storage.list_workspaces_for_user("u-nobody") == []
 
+    def test_list_workspace_members_paginates(self, storage):
+        """Covers the LastEvaluatedKey continuation path in list_workspace_members."""
+        from unittest.mock import patch
+
+        m1 = WorkspaceMember(workspace_id="ws-1", user_id="u1", role=WorkspaceRole.owner)
+        m2 = WorkspaceMember(workspace_id="ws-1", user_id="u2", role=WorkspaceRole.member)
+        page1 = {
+            "Items": [m1.to_dynamo()],
+            "LastEvaluatedKey": {"PK": "WORKSPACE#ws-1", "SK": "MEMBER#u1"},
+        }
+        page2 = {"Items": [m2.to_dynamo()]}
+        with patch.object(storage.table, "query", side_effect=[page1, page2]) as mock_q:
+            members = storage.list_workspace_members("ws-1")
+        assert {m.user_id for m in members} == {"u1", "u2"}
+        assert mock_q.call_count == 2
+
+    def test_list_workspaces_for_user_paginates(self, storage):
+        """Covers the LastEvaluatedKey continuation path in list_workspaces_for_user."""
+        from unittest.mock import patch
+
+        ws_a = Workspace(name="A", owner_user_id="u1")
+        ws_b = Workspace(name="B", owner_user_id="u1")
+        storage.put_workspace(ws_a)
+        storage.put_workspace(ws_b)
+        gsi_a = {
+            "workspace_id": ws_a.workspace_id,
+            "GSI5PK": "USER#u1",
+            "GSI5SK": f"WORKSPACE#{ws_a.workspace_id}",
+        }
+        gsi_b = {
+            "workspace_id": ws_b.workspace_id,
+            "GSI5PK": "USER#u1",
+            "GSI5SK": f"WORKSPACE#{ws_b.workspace_id}",
+        }
+        page1 = {
+            "Items": [gsi_a],
+            "LastEvaluatedKey": {"PK": f"WORKSPACE#{ws_a.workspace_id}", "SK": "MEMBER#u1"},
+        }
+        page2 = {"Items": [gsi_b]}
+        with patch.object(storage.table, "query", side_effect=[page1, page2]) as mock_q:
+            workspaces = storage.list_workspaces_for_user("u1")
+        assert {ws.name for ws in workspaces} == {"A", "B"}
+        assert mock_q.call_count == 2
+
 
 class TestInviteStorage:
     def _invite(self, email: str = "invitee@example.com", workspace_id: str = "ws-1"):
@@ -2011,6 +2070,38 @@ class TestInviteStorage:
         storage.put_invite(expired)
         invites = storage.list_pending_invites_for_workspace("ws-a")
         assert [i.invite_id for i in invites] == [fresh.invite_id]
+
+    def test_list_pending_invites_for_email_paginates(self, storage):
+        """Covers the LastEvaluatedKey continuation path in list_pending_invites_for_email."""
+        from unittest.mock import patch
+
+        inv1 = self._invite(email="a@example.com")
+        inv2 = self._invite(email="a@example.com")
+        page1 = {
+            "Items": [inv1.to_dynamo()],
+            "LastEvaluatedKey": {"PK": f"INVITE#{inv1.invite_id}", "SK": "META"},
+        }
+        page2 = {"Items": [inv2.to_dynamo()]}
+        with patch.object(storage.table, "scan", side_effect=[page1, page2]) as mock_scan:
+            invites = storage.list_pending_invites_for_email("a@example.com")
+        assert {i.invite_id for i in invites} == {inv1.invite_id, inv2.invite_id}
+        assert mock_scan.call_count == 2
+
+    def test_list_pending_invites_for_workspace_paginates(self, storage):
+        """Covers the LastEvaluatedKey continuation path in list_pending_invites_for_workspace."""
+        from unittest.mock import patch
+
+        inv1 = self._invite(workspace_id="ws-1")
+        inv2 = self._invite(workspace_id="ws-1")
+        page1 = {
+            "Items": [inv1.to_dynamo()],
+            "LastEvaluatedKey": {"PK": f"INVITE#{inv1.invite_id}", "SK": "META"},
+        }
+        page2 = {"Items": [inv2.to_dynamo()]}
+        with patch.object(storage.table, "scan", side_effect=[page1, page2]) as mock_scan:
+            invites = storage.list_pending_invites_for_workspace("ws-1")
+        assert {i.invite_id for i in invites} == {inv1.invite_id, inv2.invite_id}
+        assert mock_scan.call_count == 2
 
 
 class TestWorkspaceIdFiltering:

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1152,6 +1152,19 @@ class TestPagination:
         all_keys = {m.key for m in page1 + page2}
         assert all_keys == {f"pg-{i}" for i in range(5)}
 
+    def test_list_memories_by_tag_skips_when_meta_deleted(self, storage):
+        """A tag GSI entry whose META was removed mid-flight is skipped, not raised.
+
+        The tag index is updated in a best-effort batch alongside the META, so
+        a torn delete (META gone, TAG still present) can surface to the query.
+        """
+        m = Memory(key="k1", value="v", owner_client_id="c1", tags=["torn"])
+        storage.put_memory(m)
+        # Delete just the META, leaving the TAG item behind.
+        storage.table.delete_item(Key={"PK": f"MEMORY#{m.memory_id}", "SK": "META"})
+        result, _ = storage.list_memories_by_tag("torn")
+        assert result == []
+
     def test_list_memories_by_tag_cursor(self, storage):
         for i in range(4):
             storage.put_memory(

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -813,6 +813,22 @@ class TestTokenStorage:
             # Should not raise.
             storage.revoke_token("nonexistent-jti")
 
+    def test_revoke_token_reraises_unexpected_client_error(self, storage):
+        """Non-ConditionalCheck ClientErrors must propagate."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        error = ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException", "Message": ""}},
+            "UpdateItem",
+        )
+        with (
+            patch.object(storage.table, "update_item", side_effect=error),
+            pytest.raises(ClientError),
+        ):
+            storage.revoke_token("some-jti")
+
 
 class TestAuthCodeAtomicRedemption:
     """#584 — OAuth authorization codes are single-use (RFC 6749 §10.5).

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -11,6 +11,22 @@ globalThis.URL.revokeObjectURL = vi.fn();
 // do not throw and coverage branches are reachable.
 globalThis.HTMLElement.prototype.scrollIntoView = function () {};
 
+// Node.js v22+ ships a built-in localStorage stub that is missing standard
+// methods (removeItem, setItem, etc.) that jsdom 24.x does not fully override.
+// Replace it with a complete in-memory implementation so tests that call any
+// Storage method don't throw on Node v22+.
+if (typeof globalThis.localStorage?.removeItem !== "function") {
+  const _store = {};
+  globalThis.localStorage = {
+    getItem: (k) => Object.prototype.hasOwnProperty.call(_store, k) ? _store[k] : null,
+    setItem: (k, v) => { _store[String(k)] = String(v); },
+    removeItem: (k) => { delete _store[String(k)]; },
+    clear: () => { Object.keys(_store).forEach((k) => delete _store[k]); },
+    get length() { return Object.keys(_store).length; },
+    key: (i) => Object.keys(_store)[i] ?? null,
+  };
+}
+
 // useTheme reads `matchMedia("(prefers-color-scheme: dark)")` on first render.
 // jsdom doesn't ship matchMedia, so stub a default-light response. Individual
 // tests that need a different value (e.g. the useTheme suite) can override

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -17,14 +17,21 @@ globalThis.HTMLElement.prototype.scrollIntoView = function () {};
 // Storage method don't throw on Node v22+.
 if (typeof globalThis.localStorage?.removeItem !== "function") {
   const _store = Object.create(null);
-  globalThis.localStorage = {
-    getItem: (k) => Object.prototype.hasOwnProperty.call(_store, k) ? _store[k] : null,
-    setItem: (k, v) => { _store[String(k)] = String(v); },
-    removeItem: (k) => { delete _store[String(k)]; },
-    clear: () => { Object.keys(_store).forEach((k) => delete _store[k]); },
-    get length() { return Object.keys(_store).length; },
-    key: (i) => Object.keys(_store)[i] ?? null,
-  };
+  // Use Object.defineProperty so the override works even if the Node.js
+  // built-in exposes localStorage as a read-only accessor, and so the
+  // replacement persists across tests (vi.stubGlobal restores between tests).
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: {
+      getItem: (k) => Object.prototype.hasOwnProperty.call(_store, k) ? _store[k] : null,
+      setItem: (k, v) => { _store[String(k)] = String(v); },
+      removeItem: (k) => { delete _store[String(k)]; },
+      clear: () => { Object.keys(_store).forEach((k) => delete _store[k]); },
+      get length() { return Object.keys(_store).length; },
+      key: (i) => Object.keys(_store)[i] ?? null,
+    },
+  });
 }
 
 // useTheme reads `matchMedia("(prefers-color-scheme: dark)")` on first render.

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -16,7 +16,7 @@ globalThis.HTMLElement.prototype.scrollIntoView = function () {};
 // Replace it with a complete in-memory implementation so tests that call any
 // Storage method don't throw on Node v22+.
 if (typeof globalThis.localStorage?.removeItem !== "function") {
-  const _store = {};
+  const _store = Object.create(null);
   globalThis.localStorage = {
     getItem: (k) => Object.prototype.hasOwnProperty.call(_store, k) ? _store[k] : null,
     setItem: (k, v) => { _store[String(k)] = String(v); },

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -24,7 +24,7 @@ if (typeof globalThis.localStorage?.removeItem !== "function") {
     configurable: true,
     writable: true,
     value: {
-      getItem: (k) => Object.prototype.hasOwnProperty.call(_store, k) ? _store[k] : null,
+      getItem: (k) => { const key = String(k); return Object.prototype.hasOwnProperty.call(_store, key) ? _store[key] : null; },
       setItem: (k, v) => { _store[String(k)] = String(v); },
       removeItem: (k) => { delete _store[String(k)]; },
       clear: () => { Object.keys(_store).forEach((k) => delete _store[k]); },


### PR DESCRIPTION
Closes #490

Foundation PR for the v0.27 Workspaces milestone (#482). Introduces the workspace tenancy unit alongside the existing per-user model so downstream PRs (#491 auth, #492 API, #493 MCP tools, #494 UI, #495 compliance) can migrate without schema churn.

## Summary

- **Models** — new `Workspace`, `WorkspaceMember` (roles `owner` / `admin` / `member`), `Invite`. `Memory` and `OAuthClient` gain an optional `workspace_id`; `owner_user_id` stays populated through the cutover.
- **Storage** — CRUD for workspaces / members / invites; `list_workspaces_for_user` powered by a new `WorkspaceMemberIndex` GSI (`GSI5PK=USER#{user_id}`, `GSI5SK=WORKSPACE#{id}`). `workspace_id` filter added to every memory/client list/count/sum helper in parallel with the existing `owner_user_id` filter.
- **Infra** — GSI5 added to the single DynamoDB table (projection ALL).
- **Migration** — `scripts/migrate_workspaces.py` + `inv migrate-workspaces [--dry-run]` creates a `{email}'s Personal` workspace per user, stamps every memory and OAuth client with the resolved `workspace_id`, and revokes every outstanding token so callers re-auth with a workspace-scoped token once #491 lands. Idempotent across reruns.

## Approach

Per the design-review decision (one-shot migration, forced re-auth — confirmed explicitly for this PR), all of the above land together. Nothing in this PR changes tool handlers, API endpoints, or the UI — those live in #491–#494 so each layer can cut over in isolation once the schema is in place.

Routing decisions worth flagging:

- Invites live under `PK=INVITE#{id}, SK=META` as the issue scope specified; per-workspace and per-email invite listings scan+filter (low-volume flows — can index later if needed).
- `list_workspaces_for_user` does an N+1 fetch (GSI5 query → per-workspace META `get_item`). Fine at expected membership counts; worth optimising only if a user joins dozens of workspaces.
- `revoke_all_tokens` is table-scan + conditional update loop; run once at migration, never again.

## Test plan

- [x] `uv run inv pre-push` — lint, typecheck, unit tests (1062 passed), frontend tests (887 passed)
- [x] 43 new storage tests covering workspace/member/invite CRUD, GSI5 lookups, workspace_id filters, bulk token revocation
- [x] 16 new model tests covering round-trip serialisation incl. GSI5 keys and invite expiry
- [x] 18 new migration tests covering user/memory/client/token phases, dry-run, idempotency, and orphan-reference handling
- [ ] CI `Infra Synth` job (local `inv synth` not runnable — no AWS creds in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pws345BLe4hJdH2Qqrt7qb)_