### PR TITLE
fix(ci): add environment: production to backup-test job to fix OIDC auth

### DIFF
--- a/.github/workflows/backup-test.yml
+++ b/.github/workflows/backup-test.yml
@@ -18,6 +18,7 @@ jobs:
   backup-restore-test:
     name: DynamoDB PITR Restore Test
     runs-on: ubuntu-latest
+    environment: production
     env:
       RESTORE_TABLE: hive-backup-test-${{ github.run_id }}
       SOURCE_TABLE: hive


### PR DESCRIPTION
Closes #548

## Summary

The backup restore test has been failing because the OIDC role trust policy requires the `sub` claim to be `repo:warlordofmars/hive:environment:production`, but scheduled workflows without an `environment:` key in their job produce a ref-scoped claim (e.g. `repo:warlordofmars/hive:ref:refs/heads/main`) that never matches the `StringEquals` condition.

Adding `environment: production` to the `backup-restore-test` job produces the correct environment-scoped claim, matching the trust policy exactly — the same fix used by the `deploy-prod` job in `ci.yml`.

## Approach

One-line change to `backup-test.yml`: add `environment: production` under the job definition. No CDK changes needed — the existing OIDC trust condition and role permissions already cover this workflow once the claim matches.