### PR TITLE
chore(ci): disable synthetic traffic schedule until prod release

### DIFF
--- a/.github/workflows/synthetic-traffic.yml
+++ b/.github/workflows/synthetic-traffic.yml
@@ -4,9 +4,10 @@
 name: Synthetic Traffic
 
 on:
-  schedule:
-    - cron: "*/15 * * * *"
   workflow_dispatch:
+  # Schedule disabled until prod release — re-enable once tokens are valid on prod.
+  # schedule:
+  #   - cron: "*/15 * * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Synthetic traffic runs every 15 min against dev, but the bearer token is stale after the workspace migration (all tokens were revoked as part of #490). This causes every scheduled run to fail until clients re-auth.

Commenting out the schedule trigger stops the noise. The `workflow_dispatch` trigger is left so it can still be run manually. Re-enable by uncommenting the cron line once the full release reaches prod and a fresh synthetic token is minted.