### PR TITLE
fix: eliminate tag filter lag with USERTAG consistent-read path

### DIFF
--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -94,9 +94,9 @@ async def list_memories(
         )
 
     if tag:
-        items, next_cursor = storage.list_memories_by_tag(tag, limit=limit, cursor=cursor)
-        if owner_user_id:
-            items = [m for m in items if m.owner_user_id == owner_user_id]
+        items, next_cursor = storage.list_memories_by_tag(
+            tag, limit=limit, cursor=cursor, owner_user_id=owner_user_id
+        )
     else:
         items, next_cursor = storage.list_all_memories(
             owner_user_id=owner_user_id, limit=limit, cursor=cursor

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -93,14 +93,17 @@ async def list_memories(
             next_cursor=None,
         )
 
-    if tag:
-        items, next_cursor = storage.list_memories_by_tag(
-            tag, limit=limit, cursor=cursor, owner_user_id=owner_user_id
-        )
-    else:
-        items, next_cursor = storage.list_all_memories(
-            owner_user_id=owner_user_id, limit=limit, cursor=cursor
-        )
+    try:
+        if tag:
+            items, next_cursor = storage.list_memories_by_tag(
+                tag, limit=limit, cursor=cursor, owner_user_id=owner_user_id
+            )
+        else:
+            items, next_cursor = storage.list_all_memories(
+                owner_user_id=owner_user_id, limit=limit, cursor=cursor
+            )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return PagedResponse(
         items=[MemoryResponse.from_memory(m).model_dump() for m in items],
         count=len(items),

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -150,6 +150,28 @@ class Memory(BaseModel):
             )
         return items
 
+    def to_dynamo_user_tag_items(self, owner_user_id: str) -> list[dict[str, Any]]:
+        """One USERTAG item per tag for strongly-consistent owner-scoped tag queries.
+
+        These items live on the base table (PK=USERTAG#{user_id},
+        SK=TAG#{tag}#MEMORY#{memory_id}) and can be queried with
+        ConsistentRead=True, eliminating the TagIndex GSI propagation lag
+        that causes read-your-writes failures (#568).
+        """
+        items = []
+        for tag in self.tags:
+            items.append(
+                {
+                    "PK": f"USERTAG#{owner_user_id}",
+                    "SK": f"TAG#{tag}#MEMORY#{self.memory_id}",
+                    "memory_id": self.memory_id,
+                    "key": self.key,
+                    "owner_client_id": self.owner_client_id,
+                    "owner_user_id": owner_user_id,
+                }
+            )
+        return items
+
     @classmethod
     def from_dynamo(cls, item: dict[str, Any]) -> Memory:
         expires_at = None

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -150,7 +150,7 @@ class Memory(BaseModel):
             )
         return items
 
-    def to_dynamo_user_tag_items(self, owner_user_id: str) -> list[dict[str, Any]]:
+    def to_dynamo_user_tag_items(self) -> list[dict[str, Any]]:
         """One USERTAG item per tag for strongly-consistent owner-scoped tag queries.
 
         These items live on the base table (PK=USERTAG#{user_id},
@@ -158,16 +158,18 @@ class Memory(BaseModel):
         ConsistentRead=True, eliminating the TagIndex GSI propagation lag
         that causes read-your-writes failures (#568).
         """
+        if self.owner_user_id is None:
+            raise ValueError("owner_user_id required to build USERTAG items")
         items = []
         for tag in self.tags:
             items.append(
                 {
-                    "PK": f"USERTAG#{owner_user_id}",
+                    "PK": f"USERTAG#{self.owner_user_id}",
                     "SK": f"TAG#{tag}#MEMORY#{self.memory_id}",
                     "memory_id": self.memory_id,
                     "key": self.key,
                     "owner_client_id": self.owner_client_id,
-                    "owner_user_id": owner_user_id,
+                    "owner_user_id": self.owner_user_id,
                 }
             )
         return items

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -122,6 +122,15 @@ def _decode_cursor(cursor: str) -> dict[str, Any]:
         raise ValueError(f"Invalid pagination cursor: {cursor!r}") from exc
 
 
+def _is_usertag_cursor(decoded: dict[str, Any]) -> bool:
+    """Return True when the decoded cursor belongs to the USERTAG consistent path.
+
+    USERTAG LastEvaluatedKeys have PK=USERTAG#{user_id}, making them naturally
+    distinguishable from TagIndex GSI cursors which carry GSI2PK/GSI2SK fields.
+    """
+    return str(decoded.get("PK", "")).startswith("USERTAG#")
+
+
 class HiveStorage:
     """All DynamoDB read/write operations for Hive."""
 
@@ -202,6 +211,10 @@ class HiveStorage:
             self.save_memory_version(old)
 
         meta_item = memory.to_dynamo_meta()
+        tag_items = memory.to_dynamo_tag_items()
+        user_tag_items = (
+            memory.to_dynamo_user_tag_items(memory.owner_user_id) if memory.owner_user_id else []
+        )
         try:
             if expected_version is not None:
                 # Conditional put on the META item to close the TOCTOU window
@@ -213,13 +226,17 @@ class HiveStorage:
                     ConditionExpression=Attr("updated_at").eq(expected_version),
                 )
                 with self.table.batch_writer() as batch:
-                    for tag_item in memory.to_dynamo_tag_items():
+                    for tag_item in tag_items:
                         batch.put_item(Item=tag_item)
+                    for user_tag_item in user_tag_items:
+                        batch.put_item(Item=user_tag_item)
             else:
                 with self.table.batch_writer() as batch:
                     batch.put_item(Item=meta_item)
-                    for tag_item in memory.to_dynamo_tag_items():
+                    for tag_item in tag_items:
                         batch.put_item(Item=tag_item)
+                    for user_tag_item in user_tag_items:
+                        batch.put_item(Item=user_tag_item)
         except ClientError as exc:
             code = exc.response["Error"]["Code"]
             msg = exc.response["Error"]["Message"]
@@ -444,16 +461,32 @@ class HiveStorage:
         owner_user_id: str | None = None,
         workspace_id: str | None = None,
     ) -> tuple[list[Memory], str | None]:
-        """Query TagIndex GSI to find memories with a given tag.
+        """Query for memories with a given tag.
 
-        ``owner_user_id`` and ``workspace_id`` are both optional scoping
-        filters — both are applied in-memory on the hydrated items. The
-        workspace_id path exists ahead of the migration (#490) so that
-        post-migration callers can scope by workspace while the
-        owner_user_id path keeps working for pre-cutover callers.
+        When ``owner_user_id`` is provided, the strongly-consistent USERTAG
+        path is used: items live on the base table
+        (PK=USERTAG#{user_id}, SK=TAG#{tag}#MEMORY#{id}) and support
+        ConsistentRead=True, giving read-your-writes guarantees (#568).
+        USERTAG cursors are detected by a ``PK`` starting with ``USERTAG#``
+        in the decoded key; subsequent pages continue on the consistent path.
+
+        When owner_user_id is absent (or the cursor belongs to the GSI path),
+        the TagIndex GSI is used (eventually consistent). The ``workspace_id``
+        filter is always applied in-memory on the hydrated results.
 
         Returns (memories, next_cursor). next_cursor is None when exhausted.
         """
+        if owner_user_id is not None:
+            decoded_cursor = _decode_cursor(cursor) if cursor else None
+            if decoded_cursor is None or _is_usertag_cursor(decoded_cursor):
+                return self._list_memories_by_tag_consistent(
+                    tag=tag,
+                    owner_user_id=owner_user_id,
+                    limit=limit,
+                    workspace_id=workspace_id,
+                    start_key=decoded_cursor,
+                )
+
         kwargs: dict[str, Any] = {
             "IndexName": "TagIndex",
             "KeyConditionExpression": Key("GSI2PK").eq(f"TAG#{tag}"),
@@ -469,6 +502,44 @@ class HiveStorage:
             if m is None:
                 continue
             if owner_user_id is not None and m.owner_user_id != owner_user_id:
+                continue
+            if workspace_id is not None and m.workspace_id != workspace_id:
+                continue
+            memories.append(m)
+
+        lek = resp.get("LastEvaluatedKey")
+        next_cursor = _encode_cursor(lek) if lek else None
+        return memories, next_cursor
+
+    def _list_memories_by_tag_consistent(
+        self,
+        tag: str,
+        owner_user_id: str,
+        limit: int = 100,
+        workspace_id: str | None = None,
+        start_key: dict[str, Any] | None = None,
+    ) -> tuple[list[Memory], str | None]:
+        """Strongly-consistent tag query via USERTAG base-table items.
+
+        Queries PK=USERTAG#{owner_user_id} with SK beginning with
+        TAG#{tag}#MEMORY# using ConsistentRead=True. Returns immediately
+        after the first write without waiting for GSI propagation (#568).
+        Supports full cursor-based pagination via DynamoDB LastEvaluatedKey.
+        """
+        kwargs: dict[str, Any] = {
+            "KeyConditionExpression": Key("PK").eq(f"USERTAG#{owner_user_id}")
+            & Key("SK").begins_with(f"TAG#{tag}#MEMORY#"),
+            "ConsistentRead": True,
+            "Limit": limit,
+        }
+        if start_key:
+            kwargs["ExclusiveStartKey"] = start_key
+
+        resp = self.table.query(**kwargs)
+        memories: list[Memory] = []
+        for item in resp.get("Items", []):
+            m = self.get_memory_by_id(item["memory_id"])
+            if m is None:
                 continue
             if workspace_id is not None and m.workspace_id != workspace_id:
                 continue
@@ -1542,3 +1613,10 @@ class HiveStorage:
         with self.table.batch_writer() as batch:
             for tag in memory.tags:
                 batch.delete_item(Key={"PK": f"MEMORY#{memory.memory_id}", "SK": f"TAG#{tag}"})
+                if memory.owner_user_id:
+                    batch.delete_item(
+                        Key={
+                            "PK": f"USERTAG#{memory.owner_user_id}",
+                            "SK": f"TAG#{tag}#MEMORY#{memory.memory_id}",
+                        }
+                    )

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -212,9 +212,7 @@ class HiveStorage:
 
         meta_item = memory.to_dynamo_meta()
         tag_items = memory.to_dynamo_tag_items()
-        user_tag_items = (
-            memory.to_dynamo_user_tag_items(memory.owner_user_id) if memory.owner_user_id else []
-        )
+        user_tag_items = memory.to_dynamo_user_tag_items() if memory.owner_user_id else []
         try:
             if expected_version is not None:
                 # Conditional put on the META item to close the TOCTOU window
@@ -526,9 +524,18 @@ class HiveStorage:
         after the first write without waiting for GSI propagation (#568).
         Supports full cursor-based pagination via DynamoDB LastEvaluatedKey.
         """
+        expected_pk = f"USERTAG#{owner_user_id}"
+        expected_sk_prefix = f"TAG#{tag}#MEMORY#"
+        if start_key is not None:
+            sk = start_key.get("SK", "")
+            if start_key.get("PK") != expected_pk or not (
+                isinstance(sk, str) and sk.startswith(expected_sk_prefix)
+            ):
+                raise ValueError("Invalid pagination cursor for this query")
+
         kwargs: dict[str, Any] = {
-            "KeyConditionExpression": Key("PK").eq(f"USERTAG#{owner_user_id}")
-            & Key("SK").begins_with(f"TAG#{tag}#MEMORY#"),
+            "KeyConditionExpression": Key("PK").eq(expected_pk)
+            & Key("SK").begins_with(expected_sk_prefix),
             "ConsistentRead": True,
             "Limit": limit,
         }
@@ -540,6 +547,10 @@ class HiveStorage:
         for item in resp.get("Items", []):
             m = self.get_memory_by_id(item["memory_id"])
             if m is None:
+                continue
+            # Defence-in-depth: META owner must still match — guards against
+            # stale/corrupt USERTAG items pointing at a re-owned memory.
+            if m.owner_user_id != owner_user_id:
                 continue
             if workspace_id is not None and m.workspace_id != workspace_id:
                 continue

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -117,9 +117,12 @@ def _encode_cursor(last_evaluated_key: dict[str, Any]) -> str:
 def _decode_cursor(cursor: str) -> dict[str, Any]:
     """Decode a base64 cursor back to a DynamoDB ExclusiveStartKey."""
     try:
-        return json.loads(base64.urlsafe_b64decode(cursor.encode()))
+        decoded = json.loads(base64.urlsafe_b64decode(cursor.encode()))
     except Exception as exc:
-        raise ValueError(f"Invalid pagination cursor: {cursor!r}") from exc
+        raise ValueError("Invalid pagination cursor") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError("Invalid pagination cursor")
+    return decoded
 
 
 def _is_usertag_cursor(decoded: dict[str, Any]) -> bool:
@@ -531,7 +534,7 @@ class HiveStorage:
             if start_key.get("PK") != expected_pk or not (
                 isinstance(sk, str) and sk.startswith(expected_sk_prefix)
             ):
-                raise ValueError("Invalid pagination cursor for this query")
+                raise ValueError("Invalid pagination cursor")
 
         kwargs: dict[str, Any] = {
             "KeyConditionExpression": Key("PK").eq(expected_pk)

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -126,12 +126,12 @@ class TestUIE2E:
         # Wait for the list to reload after save.
         page.wait_for_load_state("networkidle")
 
-        # Apply tag filter and retry to handle DynamoDB GSI eventual consistency.
-        # The TagIndex GSI may not immediately reflect a new write; if the filtered
-        # list comes back empty, clear the chip and reapply the filter until the
-        # memory appears (or we exhaust retries). 24 × 5s = 120s total — GSI has
-        # been observed taking north of 60s under load in the dev pipeline.
-        _RETRIES = 24
+        # Apply tag filter and retry to handle transient delays (network, Lambda
+        # cold start, etc.).  The USERTAG strongly-consistent path (#568) removed
+        # the GSI propagation lag, so the memory should appear immediately after
+        # the POST returns.  Keep a short retry budget for cold-start jitter.
+        # 6 × 5s = 30s total.
+        _RETRIES = 6
         for attempt in range(_RETRIES):
             # If a chip is already showing, clear it first so we can re-type.
             if page.locator("[aria-label='Clear tag filter']").count() > 0:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -385,6 +385,17 @@ class TestMemories:
         assert "tagged" in keys
         assert "untagged" not in keys
 
+    def test_list_with_invalid_cursor_returns_400(self, client):
+        """Bad pagination cursors must surface as 400, not 500."""
+        tc, *_ = client
+        # Non-base64 garbage triggers _decode_cursor's ValueError
+        resp = tc.get("/api/memories", params={"cursor": "not-valid-base64!!!"})
+        assert resp.status_code == 400
+        assert "cursor" in resp.json()["detail"].lower()
+        # Same path on the tag-filter branch
+        resp = tc.get("/api/memories", params={"tag": "t", "cursor": "not-valid-base64!!!"})
+        assert resp.status_code == 400
+
     def test_get_by_id(self, client):
         tc, *_ = client
         mid = tc.post("/api/memories", json={"key": "gid", "value": "v"}).json()["memory_id"]

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -57,6 +57,33 @@ class TestMemory:
         m = Memory(key="k", value="v", owner_client_id="c1")
         assert m.to_dynamo_tag_items() == []
 
+    def test_to_dynamo_user_tag_items(self):
+        m = Memory(
+            key="foo",
+            value="bar",
+            tags=["alpha", "beta"],
+            owner_client_id="c1",
+            owner_user_id="user-1",
+        )
+        items = m.to_dynamo_user_tag_items("user-1")
+        assert len(items) == 2
+        pks = {item["PK"] for item in items}
+        assert pks == {"USERTAG#user-1"}
+        sks = {item["SK"] for item in items}
+        assert sks == {
+            f"TAG#alpha#MEMORY#{m.memory_id}",
+            f"TAG#beta#MEMORY#{m.memory_id}",
+        }
+        for item in items:
+            assert item["memory_id"] == m.memory_id
+            assert item["key"] == "foo"
+            assert item["owner_client_id"] == "c1"
+            assert item["owner_user_id"] == "user-1"
+
+    def test_to_dynamo_user_tag_items_no_tags(self):
+        m = Memory(key="k", value="v", owner_client_id="c1", owner_user_id="user-1")
+        assert m.to_dynamo_user_tag_items("user-1") == []
+
     def test_default_value_type_is_text(self):
         # #497: existing memories stay "text" with no pointer
         # fields, so legacy items round-trip byte-identical through

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from hive.models import (
     AuthorizationCode,
     Invite,
@@ -65,7 +67,7 @@ class TestMemory:
             owner_client_id="c1",
             owner_user_id="user-1",
         )
-        items = m.to_dynamo_user_tag_items("user-1")
+        items = m.to_dynamo_user_tag_items()
         assert len(items) == 2
         pks = {item["PK"] for item in items}
         assert pks == {"USERTAG#user-1"}
@@ -82,7 +84,12 @@ class TestMemory:
 
     def test_to_dynamo_user_tag_items_no_tags(self):
         m = Memory(key="k", value="v", owner_client_id="c1", owner_user_id="user-1")
-        assert m.to_dynamo_user_tag_items("user-1") == []
+        assert m.to_dynamo_user_tag_items() == []
+
+    def test_to_dynamo_user_tag_items_raises_without_owner_user_id(self):
+        m = Memory(key="k", value="v", tags=["t"], owner_client_id="c1")
+        with pytest.raises(ValueError, match="owner_user_id required"):
+            m.to_dynamo_user_tag_items()
 
     def test_default_value_type_is_text(self):
         # #497: existing memories stay "text" with no pointer

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1293,6 +1293,124 @@ class TestPagination:
         mems, _ = storage.list_memories_by_tag("open")
         assert {m.key for m in mems} == {"xa", "ya"}
 
+    def test_list_memories_by_tag_consistent_path_returns_own_memories(self, storage):
+        """owner_user_id uses the USERTAG consistent path and filters cross-user (#568)."""
+        storage.put_memory(
+            Memory(key="mine", value="v", tags=["greet"], owner_client_id="c1", owner_user_id="u1")
+        )
+        storage.put_memory(
+            Memory(key="other", value="v", tags=["greet"], owner_client_id="c2", owner_user_id="u2")
+        )
+        mems, cursor = storage.list_memories_by_tag("greet", owner_user_id="u1")
+        assert [m.key for m in mems] == ["mine"]
+        assert cursor is None  # only one item, no next page
+
+    def test_list_memories_by_tag_consistent_path_write_then_read(self, storage):
+        """USERTAG items written by put_memory are immediately visible via consistent read."""
+        m = Memory(key="instant", value="v", tags=["now"], owner_client_id="c1", owner_user_id="u1")
+        storage.put_memory(m)
+        # Should find the memory immediately — no GSI propagation lag
+        mems, _ = storage.list_memories_by_tag("now", owner_user_id="u1")
+        assert len(mems) == 1
+        assert mems[0].key == "instant"
+
+    def test_list_memories_by_tag_consistent_path_deleted_memory_not_returned(self, storage):
+        """USERTAG items are cleaned up on delete; deleted memories are not returned."""
+        m = Memory(key="gone", value="v", tags=["fade"], owner_client_id="c1", owner_user_id="u1")
+        storage.put_memory(m)
+        storage.delete_memory(m.memory_id)
+        mems, _ = storage.list_memories_by_tag("fade", owner_user_id="u1")
+        assert mems == []
+
+    def test_list_memories_by_tag_consistent_path_update_replaces_old_tags(self, storage):
+        """After a tag update, only the new tags appear via the consistent path."""
+        m = Memory(
+            key="shift",
+            value="v",
+            tags=["old-tag"],
+            owner_client_id="c1",
+            owner_user_id="u1",
+        )
+        storage.put_memory(m)
+        updated = Memory(
+            memory_id=m.memory_id,
+            key="shift",
+            value="v2",
+            tags=["new-tag"],
+            owner_client_id="c1",
+            owner_user_id="u1",
+        )
+        storage.put_memory(updated)
+        # old tag must be gone
+        old_mems, _ = storage.list_memories_by_tag("old-tag", owner_user_id="u1")
+        assert old_mems == []
+        # new tag must be present
+        new_mems, _ = storage.list_memories_by_tag("new-tag", owner_user_id="u1")
+        assert len(new_mems) == 1 and new_mems[0].key == "shift"
+
+    def test_list_memories_by_tag_no_owner_user_id_still_uses_gsi(self, storage):
+        """When owner_user_id is absent, the GSI path is used (no ConsistentRead)."""
+        storage.put_memory(Memory(key="gsi-mem", value="v", tags=["probe"], owner_client_id="c1"))
+        # Must still return the memory via the GSI path
+        mems, _ = storage.list_memories_by_tag("probe")
+        assert [m.key for m in mems] == ["gsi-mem"]
+
+    def test_list_memories_by_tag_cursor_routing(self, storage):
+        """USERTAG cursor continues on consistent path; GSI cursor falls back to GSI."""
+        import base64
+        import json
+        from unittest.mock import patch
+
+        storage.put_memory(
+            Memory(key="paged", value="v", tags=["page"], owner_client_id="c1", owner_user_id="u1")
+        )
+
+        # Build a valid USERTAG cursor (PK=USERTAG#...) — should stay on consistent path
+        usertag_lek = {"PK": "USERTAG#u1", "SK": "TAG#page#MEMORY#no-such-id"}
+        usertag_cursor = base64.urlsafe_b64encode(json.dumps(usertag_lek).encode()).decode()
+
+        # Build a valid GSI cursor (GSI2PK=TAG#...) — should fall to GSI path
+        gsi_lek = {
+            "PK": "MEMORY#no-such-id",
+            "SK": "TAG#page",
+            "GSI2PK": "TAG#page",
+            "GSI2SK": "no-such-id",
+        }
+        gsi_cursor = base64.urlsafe_b64encode(json.dumps(gsi_lek).encode()).decode()
+
+        with patch.object(
+            storage,
+            "_list_memories_by_tag_consistent",
+            wraps=storage._list_memories_by_tag_consistent,
+        ) as mock_consistent:
+            # no cursor + owner_user_id → consistent path (call #1)
+            storage.list_memories_by_tag("page", owner_user_id="u1")
+            assert mock_consistent.call_count == 1
+
+            # USERTAG cursor + owner_user_id → consistent path continues (call #2)
+            storage.list_memories_by_tag("page", owner_user_id="u1", cursor=usertag_cursor)
+            assert mock_consistent.call_count == 2
+
+            # GSI cursor + owner_user_id → GSI path, consistent NOT called again
+            storage.list_memories_by_tag("page", owner_user_id="u1", cursor=gsi_cursor)
+            assert mock_consistent.call_count == 2
+
+    def test_put_memory_without_owner_user_id_writes_no_usertag_items(self, storage):
+        """Memories without owner_user_id must not write any USERTAG items."""
+        import boto3
+        from boto3.dynamodb.conditions import Key as DKey
+
+        m = Memory(key="anon", value="v", tags=["t"], owner_client_id="c1")
+        storage.put_memory(m)
+
+        ddb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = ddb.Table("hive-test")
+        # There should be no USERTAG# items at all — owner_user_id was absent
+        resp = table.query(
+            KeyConditionExpression=DKey("PK").eq("USERTAG#None"),
+        )
+        assert resp["Count"] == 0
+
     def test_invalid_cursor_raises(self, storage):
         with pytest.raises(ValueError, match="Invalid pagination cursor"):
             storage.list_all_memories(cursor="not-valid-base64!!!")

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1411,6 +1411,136 @@ class TestPagination:
         )
         assert resp["Count"] == 0
 
+    def test_put_memory_conditional_write_writes_usertag_items(self, storage):
+        """expected_version path writes USERTAG items when owner_user_id is set (line 232)."""
+        from datetime import datetime, timezone
+
+        m = Memory(
+            key="cond-ver",
+            value="v1",
+            tags=["tag-x"],
+            owner_client_id="c1",
+            owner_user_id="u-cond",
+        )
+        storage.put_memory(m)
+        stored = storage.get_memory_by_id(m.memory_id)
+        assert stored is not None
+
+        stored.value = "v2"
+        stored.updated_at = datetime.now(timezone.utc)
+        storage.put_memory(stored, expected_version=m.version)
+
+        # USERTAG item must exist for the updated memory
+        mems, _ = storage.list_memories_by_tag("tag-x", owner_user_id="u-cond")
+        assert len(mems) == 1 and mems[0].value == "v2"
+
+    def test_list_memories_by_tag_gsi_path_filters_cross_user(self, storage):
+        """GSI path's in-memory owner_user_id filter drops cross-user memories (line 505).
+
+        We need a cursor to avoid the `decoded_cursor is None` short-circuit that always
+        routes to the consistent path.  Use a cursor whose PK sorts *before* any real UUID
+        so the GSI scan returns all items; then patch _is_usertag_cursor to return False
+        so the routing stays on the GSI path.
+        """
+        import base64
+        import json
+        from unittest.mock import patch
+
+        storage.put_memory(
+            Memory(
+                key="u1-cross2",
+                value="v",
+                tags=["cross2"],
+                owner_client_id="c1",
+                owner_user_id="u1",
+            )
+        )
+        storage.put_memory(
+            Memory(
+                key="u2-cross2",
+                value="v",
+                tags=["cross2"],
+                owner_client_id="c2",
+                owner_user_id="u2",
+            )
+        )
+
+        # Build a GSI cursor pointing before all real UUIDs (min UUID sorts first).
+        # The GSI scan from this position returns all items for the tag.
+        early_lek = {
+            "PK": "MEMORY#00000000-0000-0000-0000-000000000000",
+            "SK": "TAG#cross2",
+            "GSI2PK": "TAG#cross2",
+            "GSI2SK": "00000000-0000-0000-0000-000000000000",
+        }
+        early_cursor = base64.urlsafe_b64encode(json.dumps(early_lek).encode()).decode()
+
+        # Patch _is_usertag_cursor → False so the GSI path is taken.
+        # Without the patch: PK="MEMORY#..." → not a USERTAG cursor → GSI path already
+        # (the "USERTAG#" prefix check catches the right shape).  But we patch anyway
+        # to be explicit about what branch we're testing.
+        with patch("hive.storage._is_usertag_cursor", return_value=False):
+            mems, _ = storage.list_memories_by_tag(
+                "cross2", owner_user_id="u1", cursor=early_cursor
+            )
+
+        assert [m.key for m in mems] == ["u1-cross2"]
+
+    def test_list_memories_by_tag_consistent_skips_missing_meta(self, storage):
+        """Consistent path skips USERTAG items whose META was deleted externally (line 543)."""
+        import boto3
+
+        m = Memory(
+            key="orphan",
+            value="v",
+            tags=["phantom"],
+            owner_client_id="c1",
+            owner_user_id="u-orphan",
+        )
+        storage.put_memory(m)
+
+        # Manually delete the META item to simulate an external tombstone,
+        # leaving the USERTAG item intact.
+        ddb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = ddb.Table("hive-test")
+        table.delete_item(Key={"PK": f"MEMORY#{m.memory_id}", "SK": "META"})
+
+        mems, _ = storage.list_memories_by_tag("phantom", owner_user_id="u-orphan")
+        assert mems == []
+
+    def test_list_memories_by_tag_consistent_filters_workspace(self, storage):
+        """Consistent path drops memories whose workspace_id doesn't match (line 545)."""
+        from hive.models import OAuthClient
+
+        client = OAuthClient(client_name="ws-client", owner_user_id="u-ws")
+        storage.put_client(client)
+
+        storage.put_memory(
+            Memory(
+                key="ws-a-mem",
+                value="v",
+                tags=["wsfilter"],
+                owner_client_id=client.client_id,
+                owner_user_id="u-ws",
+                workspace_id="ws-a",
+            )
+        )
+        storage.put_memory(
+            Memory(
+                key="ws-b-mem",
+                value="v",
+                tags=["wsfilter"],
+                owner_client_id=client.client_id,
+                owner_user_id="u-ws",
+                workspace_id="ws-b",
+            )
+        )
+
+        mems, _ = storage.list_memories_by_tag(
+            "wsfilter", owner_user_id="u-ws", workspace_id="ws-a"
+        )
+        assert [m.key for m in mems] == ["ws-a-mem"]
+
     def test_invalid_cursor_raises(self, storage):
         with pytest.raises(ValueError, match="Invalid pagination cursor"):
             storage.list_all_memories(cursor="not-valid-base64!!!")

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1603,7 +1603,9 @@ class TestPagination:
         import base64
         import json
 
-        non_dict_cursor = base64.urlsafe_b64encode(json.dumps(["not", "a", "dict"]).encode()).decode()
+        non_dict_cursor = base64.urlsafe_b64encode(
+            json.dumps(["not", "a", "dict"]).encode()
+        ).decode()
         with pytest.raises(ValueError, match="Invalid pagination cursor"):
             storage.list_all_memories(cursor=non_dict_cursor)
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1598,6 +1598,19 @@ class TestPagination:
         with pytest.raises(ValueError, match="Invalid pagination cursor"):
             storage.list_all_memories(cursor="not-valid-base64!!!")
 
+    def test_non_dict_cursor_raises(self, storage):
+        """A base64 cursor that decodes to a non-dict JSON value (e.g. a list) must raise."""
+        import base64
+        import json
+
+        non_dict_cursor = base64.urlsafe_b64encode(json.dumps(["not", "a", "dict"]).encode()).decode()
+        with pytest.raises(ValueError, match="Invalid pagination cursor"):
+            storage.list_all_memories(cursor=non_dict_cursor)
+
+        string_cursor = base64.urlsafe_b64encode(json.dumps("just-a-string").encode()).decode()
+        with pytest.raises(ValueError, match="Invalid pagination cursor"):
+            storage.list_memories_by_tag("t", owner_user_id="u1", cursor=string_cursor)
+
     def test_list_all_memories_follows_scan_pages(self, storage):
         """Covers the scan-loop continuation path when DynamoDB returns LastEvaluatedKey."""
         from unittest.mock import patch

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1395,19 +1395,72 @@ class TestPagination:
             storage.list_memories_by_tag("page", owner_user_id="u1", cursor=gsi_cursor)
             assert mock_consistent.call_count == 2
 
+    def test_consistent_path_rejects_cursor_for_different_owner(self, storage):
+        """A USERTAG cursor whose PK belongs to a different owner must be rejected."""
+        import base64
+        import json
+
+        storage.put_memory(
+            Memory(key="m", value="v", tags=["t"], owner_client_id="c1", owner_user_id="u1")
+        )
+        forged_lek = {"PK": "USERTAG#u2", "SK": "TAG#t#MEMORY#anything"}
+        forged_cursor = base64.urlsafe_b64encode(json.dumps(forged_lek).encode()).decode()
+
+        with pytest.raises(ValueError, match="Invalid pagination cursor"):
+            storage.list_memories_by_tag("t", owner_user_id="u1", cursor=forged_cursor)
+
+    def test_consistent_path_rejects_cursor_for_different_tag(self, storage):
+        """A USERTAG cursor whose SK targets a different tag must be rejected."""
+        import base64
+        import json
+
+        storage.put_memory(
+            Memory(key="m", value="v", tags=["t"], owner_client_id="c1", owner_user_id="u1")
+        )
+        forged_lek = {"PK": "USERTAG#u1", "SK": "TAG#other#MEMORY#anything"}
+        forged_cursor = base64.urlsafe_b64encode(json.dumps(forged_lek).encode()).decode()
+
+        with pytest.raises(ValueError, match="Invalid pagination cursor"):
+            storage.list_memories_by_tag("t", owner_user_id="u1", cursor=forged_cursor)
+
+    def test_consistent_path_skips_memory_when_meta_owner_differs(self, storage):
+        """Defence-in-depth: stale USERTAG pointing at a re-owned memory is skipped."""
+        # Create a memory owned by u1 with tag "shared"
+        m = Memory(key="orig", value="v", tags=["shared"], owner_client_id="c1", owner_user_id="u1")
+        storage.put_memory(m)
+
+        # Forge a stale USERTAG row under u2's partition still pointing at u1's memory
+        storage.table.put_item(
+            Item={
+                "PK": "USERTAG#u2",
+                "SK": f"TAG#shared#MEMORY#{m.memory_id}",
+                "memory_id": m.memory_id,
+                "key": "orig",
+                "owner_client_id": "c1",
+                "owner_user_id": "u2",
+            }
+        )
+
+        mems, _ = storage.list_memories_by_tag("shared", owner_user_id="u2")
+        assert mems == [], "stale USERTAG must be filtered by META owner check"
+
     def test_put_memory_without_owner_user_id_writes_no_usertag_items(self, storage):
         """Memories without owner_user_id must not write any USERTAG items."""
         import boto3
-        from boto3.dynamodb.conditions import Key as DKey
+        from boto3.dynamodb.conditions import Attr as DAttr
 
         m = Memory(key="anon", value="v", tags=["t"], owner_client_id="c1")
         storage.put_memory(m)
 
         ddb = boto3.resource("dynamodb", region_name="us-east-1")
         table = ddb.Table("hive-test")
-        # There should be no USERTAG# items at all — owner_user_id was absent
-        resp = table.query(
-            KeyConditionExpression=DKey("PK").eq("USERTAG#None"),
+        # Scan for any USERTAG# items referencing this memory_id — there
+        # should be none, since the memory had no owner_user_id. A naive
+        # query on PK="USERTAG#None" would vacuously pass even if the
+        # code wrote items under a real user PK.
+        resp = table.scan(
+            FilterExpression=DAttr("PK").begins_with("USERTAG#")
+            & DAttr("memory_id").eq(m.memory_id),
         )
         assert resp["Count"] == 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -1382,11 +1382,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -2190,11 +2190,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]
@@ -2754,11 +2754,11 @@ cryptography = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -3142,15 +3142,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]
@@ -3275,11 +3275,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #568

## Summary

DynamoDB GSI propagation can lag 60–120s under load, causing `list_memories(tag)` to return empty immediately after a `remember()` call even though the write succeeded. The e2e test was retrying for 120s (24 × 5s) to compensate.

## Approach

Adds a secondary index pattern alongside the existing TagIndex GSI:

**Write path** (`put_memory`, `_delete_tag_items`): for memories with `owner_user_id` set, write/delete USERTAG items on the base table:
- `PK=USERTAG#{owner_user_id}`, `SK=TAG#{tag}#MEMORY#{memory_id}`

**Read path** (`list_memories_by_tag`): when `owner_user_id` is provided, query the base table with `ConsistentRead=True` instead of the GSI. USERTAG cursors (detected by `PK.startswith("USERTAG#")`) continue on the consistent path across pages; GSI cursors fall back to the GSI path.

**E2e test**: lowered `_RETRIES` from 24 → 6 (30s budget). The consistent path gives read-your-writes guarantees so no GSI wait is needed.

The GSI path remains unchanged for anonymous/no-owner queries.