### PR TITLE
fix(ui): close stale-load race in MemoryBrowser hiding new memories from filtered list

### DIFF
--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -38,13 +38,12 @@ def browser_page():
         #
         # `hive_first_memory_skipped=1` pre-disables the post-create
         # "first memory probe" in MemoryBrowser.handleCreate (#645).
-        # The probe fires an unfiltered listMemories() whose response
-        # arrives AFTER the test has applied a tag filter, and its
-        # setMemories() with a closure-stale tagFilter clobbers the
-        # filtered list — making the new memory invisible. Real users
-        # only hit this on their first-ever create (when there's
-        # almost nothing to clobber); e2e fixtures start fresh every
-        # run so they hit it every time.
+        # The probe itself no longer clobbers the filtered list — the
+        # underlying race was fixed in the same PR (loadRef +
+        # dropping the optimistic setMemories shortcut) — but skipping
+        # it puts the e2e fixture in the same steady state real users
+        # experience after their first save: one POST + one filtered
+        # GET, no spare unfiltered round trip racing the assertion.
         context.add_init_script(
             "localStorage.setItem('hive_tour_dismissed', '1');"
             "localStorage.setItem('hive_first_memory_skipped', '1');"

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -35,7 +35,20 @@ def browser_page():
         # nav-tab click until it's dismissed. An `add_init_script`
         # pre-sets the dismissed flag on every page that loads in
         # this context so e2e tests never see the overlay.
-        context.add_init_script("localStorage.setItem('hive_tour_dismissed', '1');")
+        #
+        # `hive_first_memory_skipped=1` pre-disables the post-create
+        # "first memory probe" in MemoryBrowser.handleCreate (#645).
+        # The probe fires an unfiltered listMemories() whose response
+        # arrives AFTER the test has applied a tag filter, and its
+        # setMemories() with a closure-stale tagFilter clobbers the
+        # filtered list — making the new memory invisible. Real users
+        # only hit this on their first-ever create (when there's
+        # almost nothing to clobber); e2e fixtures start fresh every
+        # run so they hit it every time.
+        context.add_init_script(
+            "localStorage.setItem('hive_tour_dismissed', '1');"
+            "localStorage.setItem('hive_first_memory_skipped', '1');"
+        )
         page = context.new_page()
 
         # Navigate to the bypass login endpoint via CloudFront (same origin as
@@ -126,28 +139,20 @@ class TestUIE2E:
         # Wait for the list to reload after save.
         page.wait_for_load_state("networkidle")
 
-        # Apply tag filter and retry to handle transient delays (network, Lambda
-        # cold start, etc.).  The USERTAG strongly-consistent path (#568) removed
-        # the GSI propagation lag, so the memory should appear immediately after
-        # the POST returns.  Keep a short retry budget for cold-start jitter.
-        # 6 × 5s = 30s total.
-        _RETRIES = 6
-        for attempt in range(_RETRIES):
-            # If a chip is already showing, clear it first so we can re-type.
-            if page.locator("[aria-label='Clear tag filter']").count() > 0:
-                page.locator("[aria-label='Clear tag filter']").click()
-                page.wait_for_selector("input[placeholder='Filter by tag']")
-            tag_input = page.locator("input[placeholder='Filter by tag']")
-            tag_input.fill(unique_tag)
-            tag_input.press("Enter")
-            page.wait_for_load_state("networkidle")
-            if page.locator(f"text={memory_key}").count() > 0:
-                break
-            if attempt < _RETRIES - 1:
-                time.sleep(5)  # wait for GSI propagation before retrying
-        assert page.locator(f"text={memory_key}").first.is_visible(), (
-            f"Memory '{memory_key}' not visible after filtering by tag '{unique_tag}'"
-        )
+        # Apply tag filter. The USERTAG strongly-consistent path (#568) means
+        # the memory is visible to the GET as soon as the POST returns — but
+        # the previous wait_for_load_state("networkidle") + manual retry
+        # pattern raced the React useEffect that fires the tag-filtered GET
+        # (#645): networkidle returns immediately when the page is already
+        # loaded, so the assertion runs before the in-flight GET resolves.
+        # Use Playwright's auto-waiting expect() instead — it polls until the
+        # locator becomes visible or the timeout elapses.
+        from playwright.sync_api import expect
+
+        tag_input = page.locator("input[placeholder='Filter by tag']")
+        tag_input.fill(unique_tag)
+        tag_input.press("Enter")
+        expect(page.locator(f"text={memory_key}").first).to_be_visible(timeout=15_000)
 
     def test_clients_tab(self, browser_page):
         page = browser_page

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -479,7 +479,7 @@ export default function MemoryBrowser() {
       // Use the ref so we always call the latest `load` closure,
       // which sees the current tagFilter rather than the value
       // captured when handleCreate started (#645).
-      (loadRef.current ?? load)();
+      loadRef.current();
     } catch (err) {
       handleMutationError(err);
     }
@@ -498,7 +498,7 @@ export default function MemoryBrowser() {
       body.ttl_seconds = form.ttl === "" ? 0 : parseInt(form.ttl, 10);
       await api.updateMemory(editing.memory_id, body);
       setEditing(null);
-      (loadRef.current ?? load)();
+      loadRef.current();
     } catch (err) {
       setError(err.message);
     }
@@ -507,7 +507,7 @@ export default function MemoryBrowser() {
   async function handleDelete(id) {
     try {
       await api.deleteMemory(id);
-      (loadRef.current ?? load)();
+      loadRef.current();
     } catch (err) {
       setError(err.message);
     } finally {
@@ -597,7 +597,7 @@ export default function MemoryBrowser() {
     try {
       await api.restoreMemoryVersion(viewingHistory.memory_id, versionTimestamp);
       closeHistory();
-      (loadRef.current ?? load)();
+      loadRef.current();
     } catch (err) {
       setError(err.message);
     }

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -266,14 +266,6 @@ export default function MemoryBrowser() {
   }, []);
   const searchDebounceRef = useRef(null);
   const listRef = useRef(null);
-  // Always points at the latest `load` so that async handlers like
-  // handleCreate, which capture `load` in their closure when they
-  // start, refresh against the *current* tagFilter rather than the
-  // filter that was active when the handler began (#645). Without
-  // this, a user who changes the tag filter while a create POST is
-  // in flight can see the post-create refresh clobber their freshly
-  // filtered list with the unfiltered fetch.
-  const loadRef = useRef(null);
 
   // Quota / rate-limit hits get a richer banner that points back to
   // the Setup tab's Usage section, instead of the bare server detail
@@ -319,6 +311,19 @@ export default function MemoryBrowser() {
       setLoading(false);
     }
   }, [tagFilter]);
+
+  // Always points at the latest `load` so that async handlers like
+  // handleCreate, which capture `load` in their closure when they
+  // start, refresh against the *current* tagFilter rather than the
+  // filter that was active when the handler began (#645). Without
+  // this, a user who changes the tag filter while a create POST is
+  // in flight can see the post-create refresh clobber their freshly
+  // filtered list with the unfiltered fetch.
+  //
+  // Seeded with the first-render `load` (useRef only honours the arg
+  // on the initial render) so the ref is non-null by construction.
+  // The useEffect below keeps it in sync with subsequent renders.
+  const loadRef = useRef(load);
 
   const runSearch = useCallback(async (query, topK) => {
     setLoading(true);

--- a/ui/src/components/MemoryBrowser.jsx
+++ b/ui/src/components/MemoryBrowser.jsx
@@ -266,6 +266,14 @@ export default function MemoryBrowser() {
   }, []);
   const searchDebounceRef = useRef(null);
   const listRef = useRef(null);
+  // Always points at the latest `load` so that async handlers like
+  // handleCreate, which capture `load` in their closure when they
+  // start, refresh against the *current* tagFilter rather than the
+  // filter that was active when the handler began (#645). Without
+  // this, a user who changes the tag filter while a create POST is
+  // in flight can see the post-create refresh clobber their freshly
+  // filtered list with the unfiltered fetch.
+  const loadRef = useRef(null);
 
   // Quota / rate-limit hits get a richer banner that points back to
   // the Setup tab's Usage section, instead of the bare server detail
@@ -326,8 +334,11 @@ export default function MemoryBrowser() {
     }
   }, []);
 
-  // When tag filter changes, run list (not search)
+  // When tag filter changes, run list (not search). Also stash the
+  // current `load` in a ref so async mutation handlers can call the
+  // latest version (avoiding the stale-closure race in #645).
   useEffect(() => {
+    loadRef.current = load;
     if (!isSearchMode) load();
   }, [load, isSearchMode]);
 
@@ -455,25 +466,20 @@ export default function MemoryBrowser() {
             // every subsequent create.
             localStorage.setItem("hive_first_memory_skipped", "1");
           }
-          if (!tagFilter && !isSearchMode) {
-            setMemories(fresh.items ?? []);
-            setNextCursor(fresh.next_cursor ?? null);
-            // load() normally clears `error` via setError("") on
-            // its happy path. We're skipping load() here, so do the
-            // clear explicitly — otherwise a stale error from an
-            // earlier failed mutation can stay visible after a
-            // successful create.
-            setError("");
-            return;
-          }
-          // Filtered view — fall through to load() so we re-fetch
-          // the user's current slice instead of clobbering it.
+          // Skip the optimistic setMemories — if the user has switched
+          // to a filtered/search view *during* the create flow, this
+          // would clobber their current slice with the unfiltered
+          // probe result (#645). Always fall through to load() via the
+          // ref so the refresh uses the *current* tagFilter.
         } catch {
           // Transient list failure shouldn't surface as a create
           // error since the create itself succeeded.
         }
       }
-      load();
+      // Use the ref so we always call the latest `load` closure,
+      // which sees the current tagFilter rather than the value
+      // captured when handleCreate started (#645).
+      (loadRef.current ?? load)();
     } catch (err) {
       handleMutationError(err);
     }
@@ -492,7 +498,7 @@ export default function MemoryBrowser() {
       body.ttl_seconds = form.ttl === "" ? 0 : parseInt(form.ttl, 10);
       await api.updateMemory(editing.memory_id, body);
       setEditing(null);
-      load();
+      (loadRef.current ?? load)();
     } catch (err) {
       setError(err.message);
     }
@@ -501,7 +507,7 @@ export default function MemoryBrowser() {
   async function handleDelete(id) {
     try {
       await api.deleteMemory(id);
-      load();
+      (loadRef.current ?? load)();
     } catch (err) {
       setError(err.message);
     } finally {
@@ -591,7 +597,7 @@ export default function MemoryBrowser() {
     try {
       await api.restoreMemoryVersion(viewingHistory.memory_id, versionTimestamp);
       closeHistory();
-      load();
+      (loadRef.current ?? load)();
     } catch (err) {
       setError(err.message);
     }


### PR DESCRIPTION
Closes #645.

## Summary

- **UI bug**: `MemoryBrowser.handleCreate` (and `handleUpdate` / `handleDelete`) captured `load` in their closure when invoked. If the user changed the tag filter while a mutation was in flight, the post-mutation refresh ran with the stale closure and clobbered the freshly filtered list with an unfiltered fetch. For real users this only triggered on the first-ever create per browser; for the dev e2e fixture it triggered every run.
- **Test bug** (root cause of #645's failure on the merge of #642): `test_create_and_see_memory` relied on `wait_for_load_state("networkidle")` + a manual 6×5s retry loop. `networkidle` returns immediately when the page is already loaded — so the assertion ran before the React-fired GET even started. The old 24×5s retry budget masked it because the slow GSI path meant the assertion often happened to land after a coincidental React render.

## Approach

UI:
- Add `loadRef` that's kept in sync with the latest `load` via the existing `useEffect`. Mutation handlers invoke `(loadRef.current ?? load)()` so the refresh always sees the current `tagFilter`.
- Drop the optimistic `setMemories(fresh.items)` shortcut inside the first-memory probe — always fall through to `load()`. Costs one extra `GET` on first-ever create in a fresh browser; eliminates the clobber.

Test:
- Replace the retry loop with `expect(locator).to_be_visible(timeout=15s)` (Playwright auto-polls).
- Fixture pre-sets `hive_first_memory_skipped=1` so the probe doesn't fire during e2e, matching the steady state real users see after their first save.

## Test plan

- [x] 132 frontend tests pass (`vitest run src/components/MemoryBrowser.test.jsx`)
- [x] `inv pre-push` green
- [x] Manual repro against deployed dev confirmed the UI race (probe response overwrites filtered list)
- [ ] development pipeline e2e on this merge to confirm the test passes consistently