### PR TITLE
fix(mcp): scope forget_all to the calling client (cross-tenant delete)

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -998,7 +998,11 @@ async def forget_all(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope="memories:write")
 
-    deleted = storage.delete_memories_by_tag(tag)
+    # Scope bulk deletion to the calling client so it can never delete another
+    # tenant's same-tagged memories (GHSA-h9vh-rpcv-xqrr). owner_client_id is
+    # the axis reliably set on every memory today; user-level scoping follows
+    # once DCR clients are bound to user accounts (#648).
+    deleted = storage.delete_memories_by_tag(tag, owner_client_id=client_id)
     _log(
         storage,
         ActivityEvent(

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -495,6 +495,14 @@ class HiveStorage:
             "KeyConditionExpression": Key("GSI2PK").eq(f"TAG#{tag}"),
             "Limit": limit,
         }
+        # TAG items carry owner_client_id, so when scoping by client filter them
+        # server-side: other tenants' items are never hydrated via
+        # get_memory_by_id (cheaper on the bulk-delete path) and never leave
+        # DynamoDB — defense-in-depth for the cross-tenant guard
+        # (GHSA-h9vh-rpcv-xqrr). The post-hydration owner check below stays as a
+        # second line of defence against stale tag items.
+        if owner_client_id is not None:
+            kwargs["FilterExpression"] = Attr("owner_client_id").eq(owner_client_id)
         if cursor:
             kwargs["ExclusiveStartKey"] = _decode_cursor(cursor)
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -460,6 +460,7 @@ class HiveStorage:
         limit: int = 100,
         cursor: str | None = None,
         owner_user_id: str | None = None,
+        owner_client_id: str | None = None,
         workspace_id: str | None = None,
     ) -> tuple[list[Memory], str | None]:
         """Query for memories with a given tag.
@@ -483,6 +484,7 @@ class HiveStorage:
                 return self._list_memories_by_tag_consistent(
                     tag=tag,
                     owner_user_id=owner_user_id,
+                    owner_client_id=owner_client_id,
                     limit=limit,
                     workspace_id=workspace_id,
                     start_key=decoded_cursor,
@@ -504,6 +506,8 @@ class HiveStorage:
                 continue
             if owner_user_id is not None and m.owner_user_id != owner_user_id:
                 continue
+            if owner_client_id is not None and m.owner_client_id != owner_client_id:
+                continue
             if workspace_id is not None and m.workspace_id != workspace_id:
                 continue
             memories.append(m)
@@ -516,6 +520,7 @@ class HiveStorage:
         self,
         tag: str,
         owner_user_id: str,
+        owner_client_id: str | None = None,
         limit: int = 100,
         workspace_id: str | None = None,
         start_key: dict[str, Any] | None = None,
@@ -554,6 +559,8 @@ class HiveStorage:
             # Defence-in-depth: META owner must still match — guards against
             # stale/corrupt USERTAG items pointing at a re-owned memory.
             if m.owner_user_id != owner_user_id:
+                continue
+            if owner_client_id is not None and m.owner_client_id != owner_client_id:
                 continue
             if workspace_id is not None and m.workspace_id != workspace_id:
                 continue
@@ -622,12 +629,17 @@ class HiveStorage:
         self,
         tag: str,
         owner_user_id: str | None = None,
+        owner_client_id: str | None = None,
         workspace_id: str | None = None,
     ) -> int:
         """Delete all memories with the given tag.
 
-        If owner_user_id or workspace_id is provided, only memories matching
-        the filter are deleted. Returns the count of memories deleted.
+        Deletion is scoped to whichever owner filter is supplied
+        (``owner_user_id``, ``owner_client_id``, and/or ``workspace_id``); only
+        matching memories are deleted. Passing **no** filter deletes every
+        memory with the tag across all owners, so a caller acting on behalf of
+        a single tenant MUST pass its scope (``owner_client_id`` at minimum) to
+        avoid cross-tenant deletion. Returns the count of memories deleted.
         """
         deleted = 0
         cursor: str | None = None
@@ -637,6 +649,7 @@ class HiveStorage:
                 limit=100,
                 cursor=cursor,
                 owner_user_id=owner_user_id,
+                owner_client_id=owner_client_id,
                 workspace_id=workspace_id,
             )
             for memory in items:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2332,6 +2332,46 @@ class TestForgetAll:
         with pytest.raises(ToolError, match="Insufficient scope"):
             await forget_all("t", ctx=_make_ctx(read_only_jwt))
 
+    async def test_forget_all_does_not_delete_other_clients_memories(self, server_env):
+        """Cross-tenant data destruction guard (GHSA-h9vh-rpcv-xqrr).
+
+        forget_all must scope deletion to the calling client. A second,
+        distinct client's same-tagged memory must survive — even when neither
+        client is bound to a user account (the production DCR case where
+        owner_user_id is None), so scoping cannot rely on owner_user_id alone.
+        """
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import forget_all, remember
+
+        storage, _client_a_id, jwt_a = server_env
+
+        # Client A stores a memory under a tag both clients happen to use.
+        await remember("victim", "owned by A", ["shared"], ctx=_make_ctx(jwt_a))
+
+        # A distinct client B, unbound to any user (mirrors production DCR).
+        client_b = OAuthClient(client_name="Other Client")
+        assert client_b.owner_user_id is None
+        storage.put_client(client_b)
+        now = datetime.now(timezone.utc)
+        token_b = Token(
+            client_id=client_b.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token_b)
+        jwt_b = issue_jwt(token_b)
+        await remember("b-note", "owned by B", ["shared"], ctx=_make_ctx(jwt_b))
+
+        # Client B bulk-deletes by the shared tag.
+        result = await forget_all("shared", ctx=_make_ctx(jwt_b))
+
+        # B may only delete its own memory; A's must survive.
+        assert storage.get_memory_by_key("victim") is not None
+        assert storage.get_memory_by_key("b-note") is None
+        assert "1" in _text(result)
+
 
 # ---------------------------------------------------------------------------
 # memory_history

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1370,6 +1370,19 @@ class TestPagination:
         mems, _ = storage.list_memories_by_tag("fade", owner_user_id="u1")
         assert mems == []
 
+    def test_list_memories_by_tag_consistent_path_owner_client_id_filter(self, storage):
+        """The strongly-consistent USERTAG path also honours owner_client_id:
+        a same-user memory created by a different client is filtered out when
+        owner_client_id is supplied (defence-in-depth for #654/GHSA scoping)."""
+        storage.put_memory(
+            Memory(key="ca", value="v", tags=["dual"], owner_client_id="cA", owner_user_id="u1")
+        )
+        storage.put_memory(
+            Memory(key="cb", value="v", tags=["dual"], owner_client_id="cB", owner_user_id="u1")
+        )
+        mems, _ = storage.list_memories_by_tag("dual", owner_user_id="u1", owner_client_id="cB")
+        assert [m.key for m in mems] == ["cb"]
+
     def test_list_memories_by_tag_consistent_path_update_replaces_old_tags(self, storage):
         """After a tag update, only the new tags appear via the consistent path."""
         m = Memory(
@@ -2089,6 +2102,21 @@ class TestBulkMemoryOperations:
         assert deleted == 1
         assert storage.get_memory_by_key("x") is None
         assert storage.get_memory_by_key("y") is not None
+
+    def test_delete_memories_by_tag_with_owner_client_id_filter(self, storage):
+        """Bulk delete scoped by owner_client_id removes only the calling
+        client's memories — cross-tenant deletion guard (GHSA-h9vh-rpcv-xqrr).
+        Both memories are unbound to a user (owner_user_id=None), the
+        production DCR case, so scoping relies on owner_client_id via the GSI
+        path."""
+        m1 = Memory(key="mine", value="1", tags=["t"], owner_client_id="cA")
+        m2 = Memory(key="theirs", value="2", tags=["t"], owner_client_id="cB")
+        for m in [m1, m2]:
+            storage.put_memory(m)
+        deleted = storage.delete_memories_by_tag("t", owner_client_id="cA")
+        assert deleted == 1
+        assert storage.get_memory_by_key("mine") is None
+        assert storage.get_memory_by_key("theirs") is not None
 
     def test_delete_memories_by_tag_empty(self, storage):
         assert storage.delete_memories_by_tag("no-such-tag") == 0

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1505,6 +1505,29 @@ class TestPagination:
         mems, _ = storage.list_memories_by_tag("shared", owner_user_id="u2")
         assert mems == [], "stale USERTAG must be filtered by META owner check"
 
+    def test_gsi_path_skips_memory_when_meta_owner_client_differs(self, storage):
+        """Defence-in-depth on the GSI path: a stale TagIndex item whose
+        owner_client_id passes the server-side FilterExpression but whose
+        hydrated META owner_client_id differs is still skipped by the
+        post-hydration owner check (#654/GHSA-h9vh-rpcv-xqrr)."""
+        m = Memory(key="orig", value="v", tags=["shared"], owner_client_id="c-real")
+        storage.put_memory(m)
+        # Forge the TAG item to claim owner_client_id "c-filter" (so it passes
+        # the FilterExpression) while the memory's META keeps "c-real".
+        storage.table.put_item(
+            Item={
+                "PK": f"MEMORY#{m.memory_id}",
+                "SK": "TAG#shared",
+                "memory_id": m.memory_id,
+                "key": "orig",
+                "owner_client_id": "c-filter",
+                "GSI2PK": "TAG#shared",
+                "GSI2SK": m.memory_id,
+            }
+        )
+        mems, _ = storage.list_memories_by_tag("shared", owner_client_id="c-filter")
+        assert mems == [], "stale TAG item must be rejected by the META owner check"
+
     def test_put_memory_without_owner_user_id_writes_no_usertag_items(self, storage):
         """Memories without owner_user_id must not write any USERTAG items."""
         import boto3


### PR DESCRIPTION
Fixes the cross-tenant data-destruction issue tracked privately in advisory
`GHSA-h9vh-rpcv-xqrr`.

> Rebased onto `development` and reduced to the security fix only — the
> dependency/frontend remediation that earlier lived here landed independently
> via #656, so those commits were dropped. This PR now touches just the four
> security-relevant files.

## Problem

`forget_all` called `delete_memories_by_tag(tag)` with **no owner filter**, so
the `TagIndex` query matched every owner's memories carrying that tag and
deleted them (+ their S3 blobs). Any authenticated client (the documented
DCR/PKCE path) with `memories:write` could destroy other tenants' data with a
common tag. This is the destructive-write counterpart to the cross-tenant read
leak fixed in #587.

## Fix (3 commits)

1. **`fix(mcp)`: scope forget_all to the calling client** — thread
   `owner_client_id` from the tool through `delete_memories_by_tag` into
   `list_memories_by_tag` and filter on it in both the GSI and
   strongly-consistent USERTAG paths. Scoped on `owner_client_id` (reliably set
   on every memory); worst case is under-delete, never cross-tenant over-delete.
2. **`perf(storage)`: server-side filter** — push the `owner_client_id` filter
   into the DynamoDB query (`FilterExpression`) so other tenants' TAG items are
   never hydrated, and never leave DynamoDB (defense-in-depth). From Copilot review.
3. **`test(storage)`: defensive-branch coverage** — forge a stale TagIndex item
   (owner_client_id passes the filter, hydrated META differs) so the
   post-hydration backstop is exercised; keeps combined coverage at 100%.

## Validation

Lint/format/mypy clean; the cross-tenant guard tests confirm a second client's
same-tagged memory survives. Combined coverage 100%.

## Note

No `Closes #NNN` — tracked by the private advisory. **Merge → deploy → then
publish `GHSA-h9vh-rpcv-xqrr`.**
