### PR TITLE
fix(mcp): emit structuredContent for string-returning tools (#654)

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -289,6 +289,14 @@ def _tool_result(
     rate-limit metadata in ``_meta.hive``. Strings become text content;
     dicts become structured content so clients can still use them directly.
 
+    Both branches set ``structured_content`` because FastMCP auto-generates an
+    ``outputSchema`` from every tool's return annotation. A ``-> str`` tool
+    advertises ``{"result": str, "x-fastmcp-wrap-result": true}``; a response
+    with no ``structuredContent`` violates that schema, and spec-strict MCP
+    clients (e.g. AWS Strands) reject the call (#654). Strings are wrapped as
+    ``{"result": <value>}`` to match the auto-generated schema while the plain
+    text is kept as human-readable content.
+
     When the tool operated on a specific memory, pass it via ``memory=`` so
     its optimistic-lock version is surfaced as ``_meta.hive.memory.version``
     — the agent can thread that back into a subsequent ``remember`` call.
@@ -298,7 +306,7 @@ def _tool_result(
         meta["hive"]["memory"] = {"key": memory.key, "version": memory.version}
     if isinstance(payload, dict):
         return ToolResult(structured_content=payload, meta=meta)
-    return ToolResult(content=payload, meta=meta)
+    return ToolResult(content=payload, structured_content={"result": payload}, meta=meta)
 
 
 _SUMMARY_MAX_TOKENS = 512
@@ -902,8 +910,14 @@ async def recall(
             mime = memory.content_type or "application/octet-stream"
             meta = _quota_meta(storage, client_id)
             meta["hive"]["memory"] = {"key": memory.key, "version": memory.version}
+            # recall is `-> str`, so FastMCP advertises the wrap-result
+            # outputSchema; the binary block must still carry conforming
+            # structured_content or spec-strict clients reject it (#654). The
+            # bytes stay in the ImageContent block; structured_content is a
+            # human-readable descriptor.
             return ToolResult(
                 content=[ImageContent(type="image", data=b64, mimeType=mime)],
+                structured_content={"result": f"[binary content: {mime}]"},
                 meta=meta,
             )
         except Exception:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -144,6 +144,37 @@ def server_env():
 
 
 # ---------------------------------------------------------------------------
+# _tool_result schema contract (#654)
+# ---------------------------------------------------------------------------
+
+
+class TestToolResultSchemaContract:
+    """Every tool routes its return value through ``_tool_result``. FastMCP
+    auto-generates an ``outputSchema`` from each tool's return annotation, and
+    the MCP spec requires a conforming ``structuredContent`` whenever an
+    ``outputSchema`` is declared. Guard the shared chokepoint so a new tool
+    can't reintroduce the spec violation that broke spec-strict clients (#654).
+    """
+
+    def test_string_payload_wraps_as_result(self, server_env):
+        storage, client_id, _ = server_env
+        from hive.server import _tool_result
+
+        r = _tool_result("hello", storage, client_id)
+        # Matches the FastMCP `x-fastmcp-wrap-result` schema for `-> str` tools.
+        assert r.structured_content == {"result": "hello"}
+        # Human-readable text is preserved for display.
+        assert r.content[0].text == "hello"
+
+    def test_dict_payload_passes_through_as_structured_content(self, server_env):
+        storage, client_id, _ = server_env
+        from hive.server import _tool_result
+
+        r = _tool_result({"count": 2}, storage, client_id)
+        assert r.structured_content == {"count": 2}
+
+
+# ---------------------------------------------------------------------------
 # ping
 # ---------------------------------------------------------------------------
 
@@ -159,6 +190,20 @@ class TestPing:
         meta = _hive_meta(result)
         assert "memory_quota" in meta
         assert "rate_limit" in meta
+
+    async def test_result_conforms_to_advertised_output_schema(self, server_env):
+        """#654 — FastMCP auto-generates an outputSchema for `-> str` tools
+        ({"result": str, "x-fastmcp-wrap-result": true}). A ToolResult that
+        carries no structured_content violates that schema, and spec-strict
+        MCP clients (e.g. AWS Strands) reject the call with "has an output
+        schema but did not return structured content". The wrapped result must
+        be present AND the human-readable text preserved."""
+        _, _, jwt = server_env
+        from hive.server import ping
+
+        result = await ping(ctx=_make_ctx(jwt))
+        assert result.structured_content == {"result": "ok"}
+        assert _text(result) == "ok"
 
     async def test_missing_auth_raises_tool_error(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -2197,6 +2242,24 @@ class TestRecallBinary:
         assert isinstance(block, ImageContent)
         assert block.mimeType == "image/png"
         assert block.data == self._PNG_1PX
+
+    async def test_recall_image_includes_structured_content(self, server_env, monkeypatch):
+        """#654 — recall is `-> str`, so FastMCP advertises the wrap-result
+        outputSchema even for the binary branch. That branch returns an
+        ImageContent block, so it must ALSO carry schema-conforming
+        structured_content or spec-strict MCP clients reject the call. The
+        image bytes remain in the content block."""
+        from mcp.types import ImageContent
+
+        from hive.server import recall, remember_blob
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        await remember_blob("img-sc", self._PNG_1PX, "image/png", ctx=_make_ctx(jwt))
+
+        result = await recall("img-sc", ctx=_make_ctx(jwt))
+        assert result.structured_content == {"result": "[binary content: image/png]"}
+        assert isinstance(result.content[0], ImageContent)
 
     async def test_recall_non_image_blob_returns_image_content(self, server_env, monkeypatch):
         """recall() returns ImageContent for non-image binary blobs."""


### PR DESCRIPTION
Closes #654

## Problem

FastMCP 3.2 auto-generates an `outputSchema` from each tool's return
annotation. A `-> str` tool advertises `{"result": str, "x-fastmcp-wrap-result": true}`,
and the MCP spec requires conforming `structuredContent` whenever an
`outputSchema` is declared. The shared `_tool_result` helper returned
content-only for string payloads, so 11 of 16 tools (`ping`, `remember`,
`recall`-text, `forget`, …) returned no `structuredContent` — spec-strict MCP
clients (e.g. AWS Strands) reject every one, including `ping`. Lenient clients
(Claude Desktop, Claude Code) ignore the mismatch, which is why prior e2e
passes missed it.

## Fix

- `_tool_result` wraps string payloads as `structured_content={"result": value}`
  to match the auto-generated schema, keeping plain text as human-readable content.
- The binary `recall` branch (image/blob) now also carries conforming
  `structured_content` (a short descriptor); the bytes stay in the
  `ImageContent` block.

## Tests (TDD — failing tests written first)

- `TestPing::test_result_conforms_to_advertised_output_schema`
- `TestRecallBinary::test_recall_image_includes_structured_content`
- `TestToolResultSchemaContract` — guards the shared chokepoint against regressions.

Full `inv pre-push` green (backend 922 + frontend 887); ruff/format/mypy clean.

## Note

CI will show **Security Audit** red — a repo-wide `pip-audit` failure from
newly-published dependency CVEs (aiohttp/authlib/pyjwt/pip), unrelated to this
change. Resolved once the dependency bump (rolled into #655) reaches
`development` and this branch rebases.
