### PR TITLE
release: v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,96 @@ See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) f
 
 ## [Unreleased]
 
-_Changes accumulated on `development` since v0.26.0. Will be rolled into the next release._
+_Changes accumulated on `development` since v0.27.1. Will be rolled into the next release._
+
+## v0.27.1 — 2026-06-13
+
+A follow-up patch with MCP tool refinements surfaced by end-to-end testing.
+
+### Fixed
+
+#### MCP
+
+- **`recall` surfaces the optimistic-lock `version`.** The version token is now
+  included in `recall`'s `structured_content` (not only `_meta`, which clients
+  don't expose), so a single-key read-modify-write — `recall` →
+  `remember(version=…)` — works without a tag-scoped `list_memories`. (#650)
+- **`relate_memories` reports its semantic score.** Each item's
+  `semantic_score` now carries the actual similarity (this is a pure-semantic
+  endpoint); `keyword_score` / `recency_score` are documented as not computed
+  here rather than silently returned as `0.0`. (#652)
+- **Tool docs made accurate.** `search_memories`' `include_redacted` is
+  documented as normally having no effect — redaction removes the vector-index
+  entry, so redacted memories don't appear in semantic search — and
+  `summarize_context`'s docstring notes that prose synthesis happens only when
+  the client supports MCP Sampling; sampling-less clients (e.g. Claude Desktop)
+  receive the listed memories. (#651, #662)
+
+## v0.27.0 — 2026-06-13
+
+A hardening release. It closes a cross-tenant data-destruction hole in
+`forget_all`, restores MCP spec compliance so strict clients can use every
+tool, and fixes production user-account binding so per-user tools work
+outside the e2e bypass. It also lands the data-model foundation for
+workspaces, Hive's tenancy root.
+
+### Added
+
+#### Workspaces
+
+- **Workspaces data model, storage, and migration.** Introduces the
+  `Workspace` / `WorkspaceMember` models, single-table storage, and the
+  migration path that backfills existing data — the foundation for
+  workspaces as the tenancy root (#482). No user-facing surface yet; this
+  is the plumbing future multi-tenancy features build on. (#490, #639)
+
+### Fixed
+
+#### Security
+
+- **`forget_all` no longer deletes other tenants' memories.** The bulk
+  delete-by-tag issued an unscoped `TagIndex` query, so any authenticated
+  client could destroy every tenant's memories that shared a tag (and their
+  S3 blobs) with a single call. Deletion is now scoped to the calling client
+  at the query level (`owner_client_id`, applied as a DynamoDB
+  `FilterExpression` so other tenants' items are never read), with a
+  post-hydration backstop against stale index items. Tracked as security
+  advisory `GHSA-h9vh-rpcv-xqrr`. (#655)
+
+#### MCP
+
+- **String-returning tools now return conforming `structuredContent`.**
+  FastMCP 3.2 auto-generates an `outputSchema` for every `-> str` tool, but
+  the server returned content-only results, so spec-strict MCP clients (for
+  example AWS Strands-based clients) rejected 11 of 16 tools — `ping`
+  included. Tool results now wrap string payloads to satisfy the advertised
+  schema while keeping the human-readable text and binary content intact.
+  (#654, #657)
+
+#### Auth
+
+- **Production Google OAuth callback binds the DCR client to a user.**
+  `owner_user_id` was only set by the `HIVE_BYPASS_GOOGLE_AUTH` shortcut, so
+  in production `list_memories` and `summarize_context` always failed with
+  *"Client is not associated with a user account."* The real callback now
+  upserts the user from the verified Google claims and binds the client,
+  with an integration test that exercises the non-bypass path. (#648, #656)
+
+#### Reliability
+
+- **Tag-filter lag eliminated.** Filtering memories by tag now reads through
+  the strongly-consistent USERTAG path, removing the GSI propagation delay
+  that made newly-tagged memories briefly invisible. (#642)
+- **MemoryBrowser stale-load race closed.** A newly-created memory is no
+  longer hidden from a tag-filtered list when a slower in-flight load
+  resolves after it. (#646)
+
+### Meta
+
+- **CI: `backup-test` job OIDC auth fixed** by adding
+  `environment: production` so the job can assume the deploy role. (#640)
+- **CI: synthetic-traffic schedule disabled** until the production release
+  to avoid load against an unreleased environment. (#641)
 
 ## v0.26.0 — 2026-04-24
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -298,15 +298,21 @@ def _tool_result(
     text is kept as human-readable content.
 
     When the tool operated on a specific memory, pass it via ``memory=`` so
-    its optimistic-lock version is surfaced as ``_meta.hive.memory.version``
-    — the agent can thread that back into a subsequent ``remember`` call.
+    its optimistic-lock ``version`` is surfaced both in ``_meta.hive.memory``
+    and (for non-dict returns) in ``structured_content`` — the latter is what
+    clients actually expose to the agent, so a single-key read-modify-write
+    (``recall`` → ``remember(version=…)``) works without a tag-scoped list
+    (#650). The agent threads that token back into a subsequent ``remember``.
     """
     meta = _quota_meta(storage, client_id)
     if memory is not None:
         meta["hive"]["memory"] = {"key": memory.key, "version": memory.version}
     if isinstance(payload, dict):
         return ToolResult(structured_content=payload, meta=meta)
-    return ToolResult(content=payload, structured_content={"result": payload}, meta=meta)
+    structured: dict[str, Any] = {"result": payload}
+    if memory is not None:
+        structured["version"] = memory.version
+    return ToolResult(content=payload, structured_content=structured, meta=meta)
 
 
 _SUMMARY_MAX_TOKENS = 512
@@ -1341,10 +1347,14 @@ async def summarize_context(
     ctx: Context | None = None,
 ) -> str:
     """
-    Retrieve all memories related to a topic and return a synthesised summary.
+    Retrieve all memories related to a topic and summarise them.
 
-    Memories are retrieved by tag matching the topic.  The summary lists each
-    memory and then provides a combined overview paragraph.
+    Memories are retrieved by tag matching the topic. When the calling client
+    supports MCP Sampling (``sampling/createMessage``), the retrieved set is
+    synthesised into a prose overview via the client's model (#448). Clients
+    that do not support sampling (e.g. Claude Desktop) instead receive the
+    listed memories with a count footer — there is no server-side LLM, so the
+    prose synthesis only happens when the client can provide the model (#662).
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
@@ -1445,7 +1455,12 @@ async def search_memories(
     ] = DEFAULT_W_RECENCY,
     include_redacted: Annotated[
         bool,
-        "Include tombstoned (redacted) memories in the result. False by default.",
+        "Normally has no effect on search: redaction removes the vector-index "
+        "entry, so redacted memories don't appear in semantic results and there "
+        "is nothing to un-filter. It only matters in the edge case where that "
+        "vector delete failed (or hasn't propagated), where True keeps such a "
+        "stray tombstone in the results. Use list_memories(include_redacted=True) "
+        "to view tombstones by tag. Defaults to False.",
     ] = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
@@ -1578,6 +1593,11 @@ async def relate_memories(
     The source memory's value is used as the vector search query and the
     source memory itself is excluded from the results.  ``score`` ranges
     from 0.0 to 1.0 where higher means more semantically similar.
+
+    This is a pure-semantic search, so each item's ``semantic_score`` equals
+    its ``score``; ``keyword_score`` and ``recency_score`` are not computed for
+    this endpoint and are always 0.0 (use ``search_memories`` for the hybrid
+    breakdown).
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
@@ -1639,7 +1659,9 @@ async def relate_memories(
     return _tool_result(
         {
             "items": [
-                MemorySearchResult.from_memory_and_score(m, score).model_dump()
+                MemorySearchResult.from_memory_and_score(
+                    m, score, semantic_score=score
+                ).model_dump()
                 for m, score in results
             ],
             "count": len(results),

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -546,6 +546,24 @@ class TestRecall:
         result = await recall("rec-key", ctx=_make_ctx(jwt))
         assert _text(result) == "the-value"
 
+    async def test_recall_surfaces_version_for_read_modify_write(self, server_env):
+        """#650 — recall exposes the optimistic-lock version in
+        structured_content (where clients can see it), so a single-key
+        read-modify-write works without a tag-scoped list_memories."""
+        _, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        from hive.server import recall, remember
+
+        await remember("rmw", "v1", ctx=ctx)
+        result = await recall("rmw", ctx=ctx)
+        assert result.structured_content["result"] == "v1"
+        version = result.structured_content["version"]
+        assert version  # non-empty optimistic-lock token
+
+        # The token threads straight into a conditional write.
+        updated = await remember("rmw", "v2", version=version, ctx=ctx)
+        assert "Updated" in _text(updated)
+
     async def test_recall_nonexistent_raises(self, server_env):
         from fastmcp.exceptions import ToolError
 
@@ -1668,6 +1686,32 @@ class TestRelateMemories:
         assert keys == ["a", "b"]
         assert body["count"] == 2
         assert body["key"] == "source"
+
+    async def test_populates_semantic_score_from_blended_score(self, server_env):
+        """#652 — relate_memories is a pure-semantic search, so each item's
+        semantic_score equals its blended score (not zeroed); keyword and
+        recency sub-scores stay 0.0 because they are not computed here."""
+        from unittest.mock import patch
+
+        from hive.server import relate_memories, remember
+
+        storage, _, jwt = server_env
+        ctx = _make_ctx(jwt)
+        await remember("source", "about cats", ["t"], ctx=ctx)
+        await remember("a", "cats are great", ["t"], ctx=ctx)
+        src = storage.get_memory_by_key("source")
+        a = storage.get_memory_by_key("a")
+        mock_vs = _make_mock_vector_store([(src.memory_id, 0.99), (a.memory_id, 0.42)])
+
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await relate_memories("source", top_k=1, ctx=ctx)
+
+        item = _body(result)["items"][0]
+        assert item["key"] == "a"
+        assert item["score"] == 0.42
+        assert item["semantic_score"] == 0.42
+        assert item["keyword_score"] == 0.0
+        assert item["recency_score"] == 0.0
 
     async def test_uses_source_value_as_query(self, server_env):
         from unittest.mock import patch


### PR DESCRIPTION
Release v0.27.1. See CHANGELOG for details.

Patch release with the MCP tool refinements from end-to-end round-2 testing: recall surfaces the optimistic-lock version (#650), relate_memories reports its semantic score (#652), and search_memories/summarize_context docs made accurate (#651, #662).

Also restores the v0.27.0 CHANGELOG section, which was dropped from development by the post-release back-merge.

Merge with **--merge** (not squash) once CI passes; the pipeline then creates the release + tag, deploys to prod, and back-merges to development.