### PR TITLE
fix(mcp): account-scope list_tags & forget_all; document image-min for remember_blob

### DIFF
--- a/docs-site/tools/remember-blob.md
+++ b/docs-site/tools/remember-blob.md
@@ -17,7 +17,11 @@ Store a binary memory — an image, document, audio file, or any other non-text 
 - If `content_type` starts with `image/` (e.g. `image/png`, `image/jpeg`, `image/webp`), the memory gets `value_type="image"`.
 - All other MIME types produce `value_type="blob"`.
 - Calling `remember_blob` with the same key again **replaces** the existing binary content (upsert semantics, same `memory_id`).
-- The `data` payload (after Base64 decoding) must not exceed **10 MB**.
+- The `data` payload (after Base64 decoding) must not exceed **10 MB**. In practice the deployed request path (CloudFront → Lambda) caps a single request body well below that, so **several-MB blobs are the realistic ceiling** for one call.
+
+### Minimum renderable image size
+
+When you store an `image/*` blob and later `recall` it, the client renders the returned bytes through an image API (Anthropic's, for Claude clients) that **rejects images below roughly a few dozen pixels per side**. A **32×32 image (or larger) renders**; a degenerate fixture such as a 1×1 or 16×16 PNG is stored and returned **byte-exact** by Hive, but the consuming client reports `Error processing image`. This is a client/API minimum, **not** a Hive limit — store real, sensibly-sized images.
 
 ## Examples
 
@@ -38,7 +42,8 @@ Save this architecture PDF as "project/myapp/architecture-doc" with tag "docs".
 
 | Limit | Value |
 | --- | --- |
-| Maximum payload (decoded bytes) | 10 MB |
+| Maximum payload (decoded bytes) | 10 MB (single-request path caps lower; several MB is realistic) |
+| Minimum renderable image | ~32×32 px — smaller images store byte-exact but won't render in clients |
 | Supported MIME types | Any non-empty string (typically a MIME type such as `image/png`) |
 | Key length | Up to 512 characters |
 

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -705,7 +705,16 @@ async def remember_blob(
     ``data`` must be standard Base64-encoded bytes. ``content_type`` must be a
     valid MIME type — memories whose type begins with ``image/`` are stored as
     ``value_type="image"``; all others use ``value_type="blob"``. The encoded
-    payload may not exceed 10 MB.
+    payload may not exceed 10 MB (in practice the deployed request path caps a
+    single call lower — see the docs — so several-MB blobs are the realistic
+    ceiling).
+
+    For ``image/*`` content, store a real, renderable image: clients render a
+    recalled image through an image API that rejects images below roughly a few
+    dozen pixels per side. A 32×32 (or larger) image renders; degenerate
+    fixtures like a 1×1 or 16×16 PNG are stored byte-exact but the consuming
+    client reports "Error processing image" (#649). This is a client/API
+    minimum, not a hive limit.
 
     Calling ``remember_blob`` with the same key again replaces the existing
     blob (upsert semantics).  Use ``recall(key)`` to retrieve the blob as an
@@ -1018,11 +1027,21 @@ async def forget_all(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope="memories:write")
 
-    # Scope bulk deletion to the calling client so it can never delete another
-    # tenant's same-tagged memories (GHSA-h9vh-rpcv-xqrr). owner_client_id is
-    # the axis reliably set on every memory today; user-level scoping follows
-    # once DCR clients are bound to user accounts (#648).
-    deleted = storage.delete_memories_by_tag(tag, owner_client_id=client_id)
+    # Scope bulk deletion to the caller's user account: it deletes the account's
+    # same-tagged memories across all its DCR clients (consistent with
+    # list_memories / list_tags, #666) but can never reach another user's
+    # memories (GHSA-h9vh-rpcv-xqrr). Requiring owner_user_id also guarantees we
+    # never call delete_memories_by_tag with no owner filter (which would delete
+    # across every tenant). Now that DCR clients are bound to user accounts
+    # (#648), owner_user_id is reliably set.
+    client = storage.get_client(client_id)
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    if client.owner_user_id is None:
+        raise ToolError(
+            "Client is not associated with a user account; per-user memory scoping is required."
+        )
+    deleted = storage.delete_memories_by_tag(tag, owner_user_id=client.owner_user_id)
     _log(
         storage,
         ActivityEvent(
@@ -1320,7 +1339,14 @@ async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
-    tags = storage.list_distinct_tags(client_id)
+    client = storage.get_client(client_id)
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    if client.owner_user_id is None:
+        raise ToolError(
+            "Client is not associated with a user account; per-user memory scoping is required."
+        )
+    tags = storage.list_distinct_tags(client.owner_user_id)
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
         "Listed %d distinct tags",

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -426,29 +426,34 @@ class HiveStorage:
                 results.append((memory, score))
         return results
 
-    def list_distinct_tags(self, client_id: str) -> list[str]:
-        """Return the sorted set of distinct tags on memories owned by ``client_id``.
+    def list_distinct_tags(self, owner_user_id: str) -> list[str]:
+        """Return the sorted distinct tags across the user account's memories.
 
-        Scans the TagIndex GSI (scope is limited to tag items — the base table
-        is never scanned) filtering on ``owner_client_id`` and projecting only
-        the ``GSI2PK`` attribute, which carries the ``TAG#{name}`` marker.
+        Queries the strongly-consistent USERTAG items (PK=USERTAG#{user_id},
+        SK=TAG#{tag}#MEMORY#{id}) so the result is account-scoped — matching the
+        ``owner_user_id`` boundary used by list_memories / summarize_context
+        (#666) — and reads-your-writes without TagIndex GSI propagation lag
+        (#653). The base table is never scanned.
         """
         tags: set[str] = set()
         start_key: dict[str, Any] | None = None
         while True:
             kwargs: dict[str, Any] = {
-                "IndexName": "TagIndex",
-                "FilterExpression": "owner_client_id = :cid",
-                "ExpressionAttributeValues": {":cid": client_id},
-                "ProjectionExpression": "GSI2PK",
+                "KeyConditionExpression": Key("PK").eq(f"USERTAG#{owner_user_id}")
+                & Key("SK").begins_with("TAG#"),
+                "ProjectionExpression": "SK",
+                "ConsistentRead": True,
             }
             if start_key:
                 kwargs["ExclusiveStartKey"] = start_key
-            resp = self.table.scan(**kwargs)
+            resp = self.table.query(**kwargs)
             for item in resp.get("Items", []):
-                gsi_pk = item.get("GSI2PK", "")
-                if gsi_pk.startswith("TAG#"):
-                    tags.add(gsi_pk[len("TAG#") :])
+                sk = item.get("SK", "")
+                # SK = TAG#{tag}#MEMORY#{memory_id}; rsplit isolates the tag even
+                # if the tag itself contains '#'.
+                tag = sk[len("TAG#") :].rsplit("#MEMORY#", 1)[0] if sk.startswith("TAG#") else ""
+                if tag:
+                    tags.add(tag)
             start_key = resp.get("LastEvaluatedKey")
             if not start_key:
                 break

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -914,13 +914,32 @@ class TestListTags:
         from hive.server import list_tags, remember
 
         await remember("mine", "v", ["owned"], ctx=_make_ctx(jwt))
-        # Write a memory belonging to a different client directly so we bypass auth
+        # A memory belonging to a different user account must not leak in (#666).
         storage.put_memory(
-            Memory(key="theirs", value="v", tags=["not-mine"], owner_client_id="other-client")
+            Memory(
+                key="theirs",
+                value="v",
+                tags=["not-mine"],
+                owner_client_id="other-client",
+                owner_user_id="other-user",
+            )
         )
 
         result = await list_tags(ctx=_make_ctx(jwt))
         assert _body(result)["tags"] == ["owned"]
+
+    async def test_merges_tags_across_clients_of_same_account(self, server_env):
+        """Two DCR clients of the same account share one tag namespace (#666)."""
+        storage, _, _ = server_env
+        from hive.server import list_tags, remember
+
+        jwt_1 = _make_user_jwt(storage, "tag-user")
+        jwt_2 = _make_user_jwt(storage, "tag-user")
+        await remember("k1", "v", ["from-c1"], ctx=_make_ctx(jwt_1))
+        await remember("k2", "v", ["from-c2"], ctx=_make_ctx(jwt_2))
+
+        result = await list_tags(ctx=_make_ctx(jwt_1))
+        assert _body(result)["tags"] == ["from-c1", "from-c2"]
 
     async def test_requires_read_scope(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -931,6 +950,56 @@ class TestListTags:
         write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
         with pytest.raises(ToolError, match="Insufficient scope"):
             await list_tags(ctx=_make_ctx(write_only_jwt))
+
+    async def test_rejects_missing_client_record(self, server_env):
+        """list_tags fails closed when the authenticated client record is gone."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import list_tags
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Client LT", owner_user_id="ghost-user-lt")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await list_tags(ctx=_make_ctx(jwt))
+
+    async def test_requires_user_account(self, server_env):
+        """An unbound client (owner_user_id is None) fails closed."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import list_tags
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Unbound List Tags")
+        assert client.owner_user_id is None
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+
+        with pytest.raises(ToolError, match="not associated with a user account"):
+            await list_tags(ctx=_make_ctx(jwt))
 
 
 # ---------------------------------------------------------------------------
@@ -2265,6 +2334,15 @@ class TestRecallBinary:
         "DwADhgGAWjR9awAAAABJRU5ErkJggg=="
     )
 
+    # A real 32×32 RGBA PNG — above the ~few-dozen-pixel minimum that the
+    # Anthropic image API (and most clients) require to render. The 1×1 fixture
+    # round-trips byte-exact through hive but is too small for a consuming
+    # client to display, which is what the e2e rounds hit (#649).
+    _PNG_32 = (
+        "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAALUlEQVR42u3OIQEAAAgD"
+        "sOckMa0gxs3E/JLZqxIQEBAQEBAQEBAQEBAQEGgHHn/LhHlnLcV4AAAAAElFTkSuQmCC"
+    )
+
     def _setup_blob_bucket(self, monkeypatch):
         bucket = "test-recall-blob-499"
         monkeypatch.setenv("HIVE_BLOBS_BUCKET", bucket)
@@ -2286,6 +2364,27 @@ class TestRecallBinary:
         assert isinstance(block, ImageContent)
         assert block.mimeType == "image/png"
         assert block.data == self._PNG_1PX
+
+    async def test_recall_renderable_image_round_trips_byte_exact(self, server_env, monkeypatch):
+        """A ≥32×32 image (renderable in real clients) round-trips byte-exact (#649).
+
+        The reported "Error processing image" was the consuming image API
+        rejecting a sub-renderable fixture (1×1 / 16×16), not a hive
+        serialization defect — hive returns the original bytes intact.
+        """
+        from mcp.types import ImageContent
+
+        from hive.server import recall, remember_blob
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        await remember_blob("img-32", self._PNG_32, "image/png", ctx=_make_ctx(jwt))
+
+        result = await recall("img-32", ctx=_make_ctx(jwt))
+        block = result.content[0]
+        assert isinstance(block, ImageContent)
+        assert block.mimeType == "image/png"
+        assert block.data == self._PNG_32
 
     async def test_recall_image_includes_structured_content(self, server_env, monkeypatch):
         """#654 — recall is `-> str`, so FastMCP advertises the wrap-result
@@ -2439,45 +2538,95 @@ class TestForgetAll:
         with pytest.raises(ToolError, match="Insufficient scope"):
             await forget_all("t", ctx=_make_ctx(read_only_jwt))
 
-    async def test_forget_all_does_not_delete_other_clients_memories(self, server_env):
+    async def test_forget_all_does_not_delete_other_users_memories(self, server_env):
         """Cross-tenant data destruction guard (GHSA-h9vh-rpcv-xqrr).
 
-        forget_all must scope deletion to the calling client. A second,
-        distinct client's same-tagged memory must survive — even when neither
-        client is bound to a user account (the production DCR case where
-        owner_user_id is None), so scoping cannot rely on owner_user_id alone.
+        forget_all is scoped to the caller's user account, so a different
+        user's same-tagged memory must survive (#666).
         """
-        from hive.auth.tokens import issue_jwt
-        from hive.models import OAuthClient, Token
         from hive.server import forget_all, remember
 
-        storage, _client_a_id, jwt_a = server_env
+        storage, _, _ = server_env
+        jwt_a = _make_user_jwt(storage, "user-alice")
+        jwt_b = _make_user_jwt(storage, "user-bob")
 
-        # Client A stores a memory under a tag both clients happen to use.
-        await remember("victim", "owned by A", ["shared"], ctx=_make_ctx(jwt_a))
+        await remember("alice-note", "owned by Alice", ["shared"], ctx=_make_ctx(jwt_a))
+        await remember("bob-note", "owned by Bob", ["shared"], ctx=_make_ctx(jwt_b))
 
-        # A distinct client B, unbound to any user (mirrors production DCR).
-        client_b = OAuthClient(client_name="Other Client")
-        assert client_b.owner_user_id is None
-        storage.put_client(client_b)
+        result = await forget_all("shared", ctx=_make_ctx(jwt_b))
+
+        # Bob may only delete his own memory; Alice's must survive.
+        assert storage.get_memory_by_key("alice-note") is not None
+        assert storage.get_memory_by_key("bob-note") is None
+        assert "1" in _text(result)
+
+    async def test_forget_all_deletes_across_clients_of_same_account(self, server_env):
+        """forget_all spans every DCR client of the caller's account (#666)."""
+        from hive.server import forget_all, remember
+
+        storage, _, _ = server_env
+        # Two distinct DCR clients, same user account.
+        jwt_1 = _make_user_jwt(storage, "shared-user")
+        jwt_2 = _make_user_jwt(storage, "shared-user")
+
+        await remember("from-client-1", "v1", ["sweep"], ctx=_make_ctx(jwt_1))
+        await remember("from-client-2", "v2", ["sweep"], ctx=_make_ctx(jwt_2))
+
+        result = await forget_all("sweep", ctx=_make_ctx(jwt_1))
+
+        assert storage.get_memory_by_key("from-client-1") is None
+        assert storage.get_memory_by_key("from-client-2") is None
+        assert "2" in _text(result)
+
+    async def test_forget_all_requires_user_account(self, server_env):
+        """An unbound client (owner_user_id is None) fails closed, never a no-filter delete."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import forget_all
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Unbound Client")
+        assert client.owner_user_id is None
+        storage.put_client(client)
         now = datetime.now(timezone.utc)
-        token_b = Token(
-            client_id=client_b.client_id,
+        token = Token(
+            client_id=client.client_id,
             scope="memories:read memories:write",
             issued_at=now,
             expires_at=now + timedelta(hours=1),
         )
-        storage.put_token(token_b)
-        jwt_b = issue_jwt(token_b)
-        await remember("b-note", "owned by B", ["shared"], ctx=_make_ctx(jwt_b))
+        storage.put_token(token)
+        jwt = issue_jwt(token)
 
-        # Client B bulk-deletes by the shared tag.
-        result = await forget_all("shared", ctx=_make_ctx(jwt_b))
+        with pytest.raises(ToolError, match="not associated with a user account"):
+            await forget_all("anything", ctx=_make_ctx(jwt))
 
-        # B may only delete its own memory; A's must survive.
-        assert storage.get_memory_by_key("victim") is not None
-        assert storage.get_memory_by_key("b-note") is None
-        assert "1" in _text(result)
+    async def test_forget_all_rejects_missing_client_record(self, server_env):
+        """forget_all fails closed when the authenticated client record is gone."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import forget_all
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Client FA", owner_user_id="ghost-user-fa")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await forget_all("anything", ctx=_make_ctx(jwt))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -148,35 +148,65 @@ class TestMemoryStorage:
 
     def test_list_distinct_tags_returns_sorted_unique(self, storage):
         for m in [
-            Memory(key="a", value="1", tags=["zebra", "alpha"], owner_client_id="c1"),
-            Memory(key="b", value="2", tags=["alpha", "mango"], owner_client_id="c1"),
-            Memory(key="c", value="3", tags=[], owner_client_id="c1"),
+            Memory(
+                key="a",
+                value="1",
+                tags=["zebra", "alpha"],
+                owner_client_id="c1",
+                owner_user_id="u1",
+            ),
+            Memory(
+                key="b",
+                value="2",
+                tags=["alpha", "mango"],
+                owner_client_id="c1",
+                owner_user_id="u1",
+            ),
+            Memory(key="c", value="3", tags=[], owner_client_id="c1", owner_user_id="u1"),
         ]:
             storage.put_memory(m)
 
-        assert storage.list_distinct_tags("c1") == ["alpha", "mango", "zebra"]
+        assert storage.list_distinct_tags("u1") == ["alpha", "mango", "zebra"]
 
-    def test_list_distinct_tags_scoped_to_client(self, storage):
-        storage.put_memory(Memory(key="a", value="1", tags=["mine"], owner_client_id="c1"))
-        storage.put_memory(Memory(key="b", value="2", tags=["theirs"], owner_client_id="c2"))
+    def test_list_distinct_tags_scoped_to_account(self, storage):
+        storage.put_memory(
+            Memory(key="a", value="1", tags=["mine"], owner_client_id="c1", owner_user_id="u1")
+        )
+        storage.put_memory(
+            Memory(key="b", value="2", tags=["theirs"], owner_client_id="c2", owner_user_id="u2")
+        )
 
-        assert storage.list_distinct_tags("c1") == ["mine"]
-        assert storage.list_distinct_tags("c2") == ["theirs"]
+        assert storage.list_distinct_tags("u1") == ["mine"]
+        assert storage.list_distinct_tags("u2") == ["theirs"]
+
+    def test_list_distinct_tags_merges_clients_of_same_account(self, storage):
+        # Two DCR clients of the same user account share one tag namespace (#666).
+        storage.put_memory(
+            Memory(key="a", value="1", tags=["from-c1"], owner_client_id="c1", owner_user_id="u1")
+        )
+        storage.put_memory(
+            Memory(key="b", value="2", tags=["from-c2"], owner_client_id="c2", owner_user_id="u1")
+        )
+
+        assert storage.list_distinct_tags("u1") == ["from-c1", "from-c2"]
 
     def test_list_distinct_tags_empty_when_no_memories(self, storage):
-        assert storage.list_distinct_tags("c1") == []
+        assert storage.list_distinct_tags("u1") == []
 
-    def test_list_distinct_tags_follows_scan_pages(self, storage):
+    def test_list_distinct_tags_follows_query_pages(self, storage):
         from unittest.mock import patch
 
         responses = iter(
             [
-                {"Items": [{"GSI2PK": "TAG#alpha"}], "LastEvaluatedKey": {"PK": "x"}},
-                {"Items": [{"GSI2PK": "TAG#beta"}, {"GSI2PK": "NOT_A_TAG"}]},
+                {
+                    "Items": [{"SK": "TAG#alpha#MEMORY#m1"}],
+                    "LastEvaluatedKey": {"PK": "USERTAG#u1", "SK": "TAG#alpha#MEMORY#m1"},
+                },
+                {"Items": [{"SK": "TAG#beta#MEMORY#m2"}, {"SK": "NOT_A_TAG"}]},
             ]
         )
-        with patch.object(storage.table, "scan", side_effect=lambda **_kw: next(responses)):
-            result = storage.list_distinct_tags("c1")
+        with patch.object(storage.table, "query", side_effect=lambda **_kw: next(responses)):
+            result = storage.list_distinct_tags("u1")
 
         assert result == ["alpha", "beta"]
 


### PR DESCRIPTION
Closes #649
Part of #666

## Summary
Two round-3 e2e fixes for the MCP tools.

**Account-scope `list_tags` & `forget_all` (#666, partial).** Both tools resolve `owner_user_id` from the calling client and operate on the account boundary, matching `list_memories` / `summarize_context`:
- `list_distinct_tags` queries the strongly-consistent USERTAG items (`PK=USERTAG#{user_id}`) instead of scanning the TagIndex GSI by `owner_client_id`. The tag namespace is now account-scoped and read-your-writes (no GSI propagation lag, #653).
- `forget_all` deletes the account's same-tagged memories across all of its DCR clients, and **fails closed** when the client is unbound — it can never call `delete_memories_by_tag` with no owner filter (the GHSA-h9vh-rpcv-xqrr cross-tenant-delete guard).

**Document the renderable-image minimum for `remember_blob` (#649).** The reported "Error processing image" was the consuming image API rejecting a sub-renderable fixture (1×1 / 16×16), **not** a hive defect — hive returns the bytes byte-exact (16×16 fails, 32×32 renders, confirmed live). Documented the ~32px minimum in the tool docstring and docs page, added a 32×32 byte-exact round-trip test, and corrected the docs for the realistic single-request payload ceiling.

## Scope note on #666
This lands the tag-tool slices of #666. The remaining piece — re-partitioning the S3 Vectors index from `client_id` to `owner_user_id` so `search_memories` and `pack_context` also use the account boundary — is a larger change with a prod re-index and stays tracked on #666.

## Testing
- `inv lint-backend`, `inv typecheck`, `inv test-unit` all green (948 passed).
- New unit tests cover account-scope isolation, same-account cross-client merge, the fail-closed guards, and the 32×32 round-trip; the changed lines are 100% covered.
- Local e2e not run — the local stack isn't running this session; CI covers it on the development deploy.

## Approach
- Chose the user-account boundary per the #666 recommendation; `forget_all` widening from client to account scope is the deliberate behaviour change (a user's clients now share one delete domain, still isolated across users).