### PR TITLE
fix(infra): exempt /mcp from the Common WAF rule set so blobs aren't blocked

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -683,7 +683,18 @@ class HiveStack(cdk.Stack):
                 sampled_requests_enabled=True,
             ),
             rules=[
-                # Managed: OWASP Top 10 protections
+                # Managed: OWASP Top 10 protections — enforced on the whole site
+                # EXCEPT the MCP endpoint. /mcp is an OAuth-gated JSON-RPC API whose
+                # payloads include multi-MB base64 blobs (remember_blob, #665). The
+                # Common rule set breaks that two ways: SizeRestrictions_BODY (8 KB)
+                # 403s the request before it reaches the Lambda, and the SQLi/XSS
+                # *body* rules can false-positive on arbitrary base64. Scoping the
+                # group down to NOT /mcp* keeps full protection on the public surface
+                # (UI, docs, management API) while letting authenticated MCP traffic
+                # through. /mcp is still covered by AWSManagedRulesKnownBadInputs and
+                # the GlobalRateLimit rate-based rule below (OAuthRateLimit is scoped
+                # to /oauth/* and does not apply to /mcp); the next size ceiling is
+                # the Lambda Function URL ~6 MB request limit (~4 MB of binary).
                 wafv2.CfnWebACL.RuleProperty(
                     name="AWSManagedRulesCommonRuleSet",
                     priority=0,
@@ -692,6 +703,24 @@ class HiveStack(cdk.Stack):
                         managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
                             vendor_name="AWS",
                             name="AWSManagedRulesCommonRuleSet",
+                            scope_down_statement=wafv2.CfnWebACL.StatementProperty(
+                                not_statement=wafv2.CfnWebACL.NotStatementProperty(
+                                    statement=wafv2.CfnWebACL.StatementProperty(
+                                        byte_match_statement=wafv2.CfnWebACL.ByteMatchStatementProperty(
+                                            search_string="/mcp",
+                                            field_to_match=wafv2.CfnWebACL.FieldToMatchProperty(
+                                                uri_path={}
+                                            ),
+                                            text_transformations=[
+                                                wafv2.CfnWebACL.TextTransformationProperty(
+                                                    priority=0, type="NONE"
+                                                )
+                                            ],
+                                            positional_constraint="STARTS_WITH",
+                                        )
+                                    )
+                                )
+                            ),
                         ),
                     ),
                     visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(


### PR DESCRIPTION
Closes #665

## Summary
`remember_blob` is effectively capped at ~8 KB in the deployed environment: the CloudFront WebACL runs `AWSManagedRulesCommonRuleSet` in enforced mode, and its `SizeRestrictions_BODY` rule returns a 403 for any request body over 8 KB **before** the request reaches the MCP Lambda. A ~10 KB image is ~14 KB of base64, so it is blocked — which is what the e2e rounds hit. The same rule set's SQLi/XSS **body** rules can also false-positive on arbitrary base64.

**Approach (revised after review):** rather than relax `SizeRestrictions_BODY` globally (which would drop body-size protection for the UI/docs/API too), this scopes the Common rule set **down to NOT `/mcp*`**. The public surface keeps full Common protection (body-size + SQLi/XSS); the OAuth-gated `/mcp` JSON-RPC endpoint is exempted so multi-MB blobs pass. It's a single byte-match scope-down — no extra WAF capacity (a two-rule split would roughly double the Common rule set's ~700 WCU and risk the 1500-WCU WebACL budget).

`/mcp` remains covered by `AWSManagedRulesKnownBadInputsRuleSet` and the global (1000/5 min) rate-based rule (OAuthRateLimit is scoped to /oauth/* and does not apply to /mcp). The next size ceiling is the Lambda Function URL ~6 MB request limit (~4 MB binary).

## Security posture note
This intentionally exempts `/mcp` from the OWASP Common rule set. Justification: `/mcp` requires a valid OAuth Bearer token, speaks JSON-RPC against DynamoDB (no SQL), and its responses are consumed by an AI client (not rendered as browser HTML), so the SQLi/XSS rules add little there while actively breaking base64 blobs. **Please confirm this trade-off at deploy time** — it changes prod WAF enforcement.

## Testing
- Validated the CDK construct API (`scope_down_statement` / `not_statement` / `byte_match_statement`) compiles against `aws-cdk-lib`; ruff clean.
- Full `cdk synth` not run locally (needs AWS creds for account / hosted-zone lookup); CI runs the authoritative synth + Trivy IaC scan on this PR.

## Note
The `remember_blob` docs/ceiling update referenced in #649 lands in #667 (this PR is infra-only).

## Review note
Modifies `infra/stacks/hive_stack.py` (the prod WebACL); should land via human review + `inv deploy --env prod`, not autonomous merge.