### PR TITLE
test(ui): fix clock-dependent ActivityHeatmap branch coverage

### DIFF
--- a/ui/src/components/stats/ActivityHeatmap.test.jsx
+++ b/ui/src/components/stats/ActivityHeatmap.test.jsx
@@ -59,6 +59,22 @@ describe("buildGrid", () => {
       expect(col).toHaveLength(7);
     }
   });
+
+  it("does not flush a trailing empty column when the span ends on a Saturday", () => {
+    // buildGrid pushes each column the instant it fills the Saturday row
+    // (dayOfWeek 6) and resets `col`. When the span's final day IS a Saturday,
+    // that reset leaves an all-null trailing column, so the flush guard must
+    // skip it. Pinning an explicit Saturday keeps that guard's false branch
+    // covered regardless of the weekday the suite runs on — it was previously
+    // only exercised when the real clock happened to land on a Saturday, so
+    // coverage silently dropped on the other six days.
+    const saturday = new Date("2026-06-13T12:00:00Z"); // Saturday
+    const { cells, weeks } = buildGrid([], saturday);
+    expect(cells[cells.length - 1].dayOfWeek).toBe(6);
+    // The last column is a real, fully-populated final week — not an empty flush.
+    expect(weeks[weeks.length - 1][6]).not.toBeNull();
+    expect(weeks.every((col) => col.some((c) => c !== null))).toBe(true);
+  });
 });
 
 const _sampleData = [


### PR DESCRIPTION
Closes #669

## Summary
Frontend CI's 100% branch-coverage gate was passing **only on Saturdays**. `ActivityHeatmap.jsx`'s trailing-empty-column flush guard (`if (col.some((c) => c !== null)) weeks.push(col)`) takes its **false** branch only when the heatmap span ends on a Saturday, and the existing tests drive `buildGrid` with the real clock (default `today = new Date()`) or pin Sundays. So the branch — and the global threshold — was satisfied only when CI ran on a Saturday (UTC).

`development`'s last green run was Saturday 2026-06-13; runs on Sunday 2026-06-14 fail at 99.91% branches, blocking **every** PR off `development` six days a week (this is currently blocking #667 and #668).

This pins an explicit Saturday `today` in a `buildGrid` unit test so the false branch is covered deterministically.

## Verification
```bash
cd ui
# Before: fails on a non-Saturday
TZ=UTC npx vitest run src/components/stats/ActivityHeatmap.test.jsx --coverage --coverage.thresholds.100=false
#   -> ActivityHeatmap.jsx | 96 (branch) | ... | 58
# After: full suite passes at 100% under the Sunday condition
TZ=UTC npm run test:coverage   # 905 passed, no threshold error, exit 0
```

Test-only change, no production code touched.