### PR TITLE
feat(mcp): account-scope semantic search via per-user vector indexes

### DIFF
--- a/scripts/migrate_vectors_to_user_index.py
+++ b/scripts/migrate_vectors_to_user_index.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+One-shot migration: re-index memory vectors per user account (#666).
+
+Before this migration the S3 Vectors index is partitioned per OAuth client
+(``client-{client_id}``). After #666 the vector store reads and writes per user
+account (``user-{owner_user_id}``) so semantic search spans every DCR client of
+the account, consistent with the tag/list read path.
+
+Existing vectors live in the old ``client-*`` indexes and are invisible to the
+new account-scoped search. This script rebuilds the ``user-*`` indexes from
+DynamoDB — the authoritative store — by re-embedding each memory's text. Vectors
+are derived data, so no information is lost (only Bedrock embedding cost).
+
+It is **idempotent**: re-running re-embeds and overwrites the same vector keys.
+Memories that can't or shouldn't be indexed are skipped:
+
+- ``owner_user_id`` is None (legacy/pre-#648 rows) — no account index to target.
+- ``value_type`` is ``image`` / ``blob`` — binary memories are never embedded.
+- the memory is redacted — its vector is intentionally removed from search.
+
+The old ``client-*`` indexes are left in place (orphaned, no longer queried);
+delete them separately once you've confirmed the new indexes serve search.
+
+Usage:
+
+Direct CLI (preferred for production — set ``HIVE_TABLE_NAME``,
+``HIVE_VECTORS_BUCKET`` and the appropriate ``AWS_*`` environment variables):
+
+    uv run python scripts/migrate_vectors_to_user_index.py
+    uv run python scripts/migrate_vectors_to_user_index.py --dry-run   # report only
+
+Via invoke task (targets AWS by default — set ``DYNAMODB_ENDPOINT`` for local):
+
+    uv run inv migrate-vectors
+    uv run inv migrate-vectors --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+from hive.logging_config import get_logger
+from hive.models import Memory
+from hive.storage import HiveStorage
+from hive.vector_store import VectorStore
+
+logger = get_logger("hive.migrate_vectors")
+
+# value_types that are stored as binary blobs and never embedded.
+_NON_EMBEDDABLE_TYPES = {"image", "blob"}
+
+
+@dataclass
+class MigrationStats:
+    """Per-phase counters so operators can sanity-check the run."""
+
+    memories_seen: int = 0
+    reindexed: int = 0
+    skipped_no_owner: int = 0
+    skipped_non_embeddable: int = 0
+    skipped_redacted: int = 0
+
+    def report(self) -> str:
+        return (
+            f"memories_seen={self.memories_seen} "
+            f"reindexed={self.reindexed} "
+            f"skipped_no_owner={self.skipped_no_owner} "
+            f"skipped_non_embeddable={self.skipped_non_embeddable} "
+            f"skipped_redacted={self.skipped_redacted}"
+        )
+
+
+def _resolve_text(storage: HiveStorage, memory: Memory) -> Memory:
+    """Return a copy of ``memory`` whose ``value`` holds the full text to embed.
+
+    Large text memories keep their body in S3 with a sentinel ``value``; fetch
+    the real text so the embedding matches what ``remember`` would index.
+    """
+    if memory.value_type == "text-large":
+        return memory.model_copy(update={"value": storage.fetch_blob_value(memory)})
+    return memory
+
+
+def reindex_memories(
+    storage: HiveStorage,
+    vector_store: VectorStore,
+    stats: MigrationStats,
+    *,
+    dry_run: bool,
+) -> None:
+    """Re-embed every eligible memory into its account (``user-*``) index."""
+    for memory in storage.iter_all_memories():
+        stats.memories_seen += 1
+        if memory.owner_user_id is None:
+            stats.skipped_no_owner += 1
+            continue
+        if memory.value_type in _NON_EMBEDDABLE_TYPES:
+            stats.skipped_non_embeddable += 1
+            continue
+        if memory.is_redacted:
+            stats.skipped_redacted += 1
+            continue
+        if dry_run:
+            stats.reindexed += 1
+            continue
+        vector_store.upsert_memory(_resolve_text(storage, memory))
+        stats.reindexed += 1
+
+
+def run(
+    *,
+    dry_run: bool = False,
+    storage: HiveStorage | None = None,
+    vector_store: VectorStore | None = None,
+) -> MigrationStats:
+    """Execute the migration. ``storage``/``vector_store`` are injectable for tests."""
+    store = storage if storage is not None else HiveStorage()
+    vstore = vector_store if vector_store is not None else VectorStore()
+    stats = MigrationStats()
+    logger.info("Starting vector re-index migration", extra={"dry_run": dry_run})
+    reindex_memories(store, vstore, stats, dry_run=dry_run)
+    logger.info("Vector re-index migration finished: %s", stats.report())
+    return stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Re-index Hive memory vectors per user account (#666)."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be re-indexed without calling Bedrock or S3 Vectors.",
+    )
+    args = parser.parse_args(argv)
+    stats = run(dry_run=args.dry_run)
+    print(stats.report())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -74,10 +74,12 @@ async def list_memories(
     owner_user_id = _user_filter(claims)
 
     if search:
-        # Semantic search — top-K, no pagination
-        client_id: str = claims["sub"]
+        # Semantic search — top-K, no pagination. The vector index is scoped to
+        # the caller's own account (#666); admins search their own memories
+        # (cross-user semantic search would need a per-user fan-out).
+        search_owner_user_id: str = claims["sub"]
         try:
-            pairs = vs.search(search, client_id, top_k=min(limit, 50))
+            pairs = vs.search(search, search_owner_user_id, top_k=min(limit, 50))
         except VectorIndexNotFoundError:
             return PagedResponse(items=[], count=0, has_more=False, next_cursor=None)
         results = storage.hydrate_memory_ids(pairs)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -210,6 +210,23 @@ def _vector_store() -> VectorStore:
     return VectorStore()
 
 
+def _require_owner_user_id(storage: HiveStorage, client_id: str) -> str:
+    """Resolve the caller's account (``owner_user_id``), failing closed if unbound.
+
+    Per-user memory scoping (#666) requires a user account on the calling
+    client. Returns the ``owner_user_id`` or raises ``ToolError`` when the
+    client record is missing or not yet bound to a user (#648).
+    """
+    client = storage.get_client(client_id)
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    if client.owner_user_id is None:
+        raise ToolError(
+            "Client is not associated with a user account; per-user memory scoping is required."
+        )
+    return client.owner_user_id
+
+
 def _log(storage: HiveStorage, event: ActivityEvent) -> None:
     """Record the event in both the user-visible activity log and the
     immutable compliance audit log (#395).
@@ -982,7 +999,7 @@ async def forget(
 
     storage.delete_memory(existing.memory_id)
     try:
-        _vector_store().delete_memory(existing.memory_id, client_id)
+        _vector_store().delete_memory(existing.memory_id, existing.owner_user_id)
     except Exception:
         logger.warning("Vector delete failed (non-fatal)", exc_info=True)
     _log(
@@ -1130,7 +1147,7 @@ async def redact_memory(
     existing.updated_at = existing.redacted_at
     storage.put_memory(existing)
     try:
-        _vector_store().delete_memory(existing.memory_id, client_id)
+        _vector_store().delete_memory(existing.memory_id, existing.owner_user_id)
     except Exception:
         logger.warning("Vector delete on redaction failed (non-fatal)", exc_info=True)
 
@@ -1509,9 +1526,10 @@ async def search_memories(
     # post-filter still leaves up to top_k survivors.
     search_top_k = 50 if required_tags else min(max(top_k * 3, 10), 50)
 
+    owner_user_id = _require_owner_user_id(storage, client_id)
     await _report_progress(ctx, 0, 3, f"Running vector search for '{query}'...")
     try:
-        pairs = _vector_store().search(query, client_id, top_k=search_top_k)
+        pairs = _vector_store().search(query, owner_user_id, top_k=search_top_k)
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
     except Exception:
@@ -1644,9 +1662,10 @@ async def relate_memories(
                 exc_info=True,
             )
 
+    owner_user_id = _require_owner_user_id(storage, client_id)
     try:
         # Fetch top_k+1 so that dropping the source still leaves up to top_k.
-        pairs = _vector_store().search(query_value, client_id, top_k=top_k + 1)
+        pairs = _vector_store().search(query_value, owner_user_id, top_k=top_k + 1)
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
     except Exception:
@@ -1872,8 +1891,9 @@ async def pack_context(
         else ("relevance+recency")
     )
 
+    owner_user_id = _require_owner_user_id(storage, client_id)
     try:
-        pairs = _vector_store().search(topic, client_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL)
+        pairs = _vector_store().search(topic, owner_user_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL)
     except VectorIndexNotFoundError:
         return _tool_result(_render_empty_within_budget(topic, budget), storage, client_id)
     except Exception:

--- a/src/hive/vector_store.py
+++ b/src/hive/vector_store.py
@@ -2,10 +2,12 @@
 """
 Vector store for Hive — S3 Vectors + Bedrock Titan Embeddings V2.
 
-One S3 Vectors index per OAuth client (``client-{client_id}``), lazy-created
-on first write.  All operations are best-effort: errors are logged but never
-propagate to callers so that DynamoDB (the authoritative store) is unaffected
-by vector-layer failures.
+One S3 Vectors index per user account (``user-{owner_user_id}``), lazy-created
+on first write.  Account scoping keeps semantic search consistent with the
+tag/list read path (which is scoped on ``owner_user_id``, #666) and with the
+workspace transition note on ``Memory.owner_user_id`` (#490).  All operations
+are best-effort: errors are logged but never propagate to callers so that
+DynamoDB (the authoritative store) is unaffected by vector-layer failures.
 
 Embedding model: amazon.titan-embed-text-v2:0
   - 1024 dimensions, cosine distance, normalised vectors
@@ -35,7 +37,7 @@ _DISTANCE_METRIC: Literal["cosine", "euclidean"] = "cosine"
 
 
 class VectorIndexNotFoundError(Exception):
-    """Raised when querying a client that has never written a memory."""
+    """Raised when querying an account that has never written a memory."""
 
 
 class VectorStore:
@@ -62,8 +64,8 @@ class VectorStore:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _index_name(self, client_id: str) -> str:
-        return f"client-{client_id}"
+    def _index_name(self, owner_user_id: str) -> str:
+        return f"user-{owner_user_id}"
 
     def _embed(self, text: str) -> list[float]:
         """Call Bedrock Titan V2 and return a 1024-dim normalised embedding."""
@@ -76,9 +78,9 @@ class VectorStore:
         )
         return json.loads(resp["body"].read())["embedding"]
 
-    def _ensure_index(self, client_id: str) -> str:
+    def _ensure_index(self, owner_user_id: str) -> str:
         """Return the index name, creating it if it doesn't exist yet."""
-        index_name = self._index_name(client_id)
+        index_name = self._index_name(owner_user_id)
         try:
             self._s3v.create_index(
                 vectorBucketName=self._bucket,
@@ -97,9 +99,22 @@ class VectorStore:
     # ------------------------------------------------------------------
 
     def upsert_memory(self, memory: Memory) -> None:
-        """Write (or overwrite) a memory vector.  Best-effort — never raises."""
+        """Write (or overwrite) a memory vector.  Best-effort — never raises.
+
+        Memories without an ``owner_user_id`` (legacy/pre-#648 items) cannot be
+        placed in an account index and are skipped — they remain unsearchable
+        until re-saved or migrated.
+        """
+        owner_user_id = memory.owner_user_id
+        if owner_user_id is None:
+            # Log the internal memory_id, never the user-provided key (PII/secrets).
+            logger.warning(
+                "Skipping vector upsert for memory_id '%s' — no owner_user_id",  # NOSONAR — internal id, not user content
+                memory.memory_id,
+            )
+            return
         try:
-            index_name = self._ensure_index(memory.owner_client_id)
+            index_name = self._ensure_index(owner_user_id)
             text = f"{memory.key}: {memory.value}"
             embedding = self._embed(text)
             self._s3v.put_vectors(
@@ -117,43 +132,52 @@ class VectorStore:
                 ],
             )
         except Exception:
-            logger.warning(
-                "Vector upsert failed for memory '%s' (client %s)",
-                memory.key,
-                memory.owner_client_id,
+            logger.warning(  # NOSONAR — memory_id and owner_user_id are internal identifiers, not user content
+                "Vector upsert failed for memory_id '%s' (user %s)",
+                memory.memory_id,
+                owner_user_id,
                 exc_info=True,
             )
 
-    def delete_memory(self, memory_id: str, client_id: str) -> None:
-        """Remove a memory vector.  Best-effort — never raises."""
+    def delete_memory(self, memory_id: str, owner_user_id: str | None) -> None:
+        """Remove a memory vector.  Best-effort — never raises.
+
+        ``owner_user_id`` identifies the account index the vector lives in. A
+        ``None`` owner (legacy item that was never indexed under an account) is
+        a no-op.
+        """
+        if owner_user_id is None:
+            return
         try:
             self._s3v.delete_vectors(
                 vectorBucketName=self._bucket,
-                indexName=self._index_name(client_id),
+                indexName=self._index_name(owner_user_id),
                 keys=[memory_id],
             )
         except Exception:
-            logger.warning(  # NOSONAR — memory_id and client_id are internal identifiers, not user content
-                "Vector delete failed for memory_id '%s' (client %s)",
+            logger.warning(  # NOSONAR — memory_id and owner_user_id are internal identifiers, not user content
+                "Vector delete failed for memory_id '%s' (user %s)",
                 memory_id,
-                client_id,
+                owner_user_id,
                 exc_info=True,
             )
 
     def search(
         self,
         query: str,
-        client_id: str,
+        owner_user_id: str,
         top_k: int = 20,
     ) -> list[tuple[str, float]]:
         """Return ``(memory_id, score)`` pairs ranked by cosine similarity.
 
-        ``score`` is ``1.0 - distance`` so higher = more relevant.
+        ``score`` is ``1.0 - distance`` so higher = more relevant. The search is
+        scoped to the ``owner_user_id`` account index, so results span every DCR
+        client of that account (consistent with list_memories, #666).
 
-        Raises ``VectorIndexNotFoundError`` when the client has never written
-        a memory (index does not exist yet).
+        Raises ``VectorIndexNotFoundError`` when the account has never written a
+        memory (index does not exist yet).
         """
-        index_name = self._index_name(client_id)
+        index_name = self._index_name(owner_user_id)
         try:
             embedding = self._embed(query)
             resp = self._s3v.query_vectors(
@@ -166,6 +190,6 @@ class VectorStore:
             )
         except self._s3v.exceptions.NotFoundException as exc:
             raise VectorIndexNotFoundError(
-                f"No vector index for client '{client_id}' — no memories indexed yet."
+                f"No vector index for account '{owner_user_id}' — no memories indexed yet."
             ) from exc
         return [(v["key"], round(1.0 - v["distance"], 6)) for v in resp.get("vectors", [])]

--- a/tasks.py
+++ b/tasks.py
@@ -542,6 +542,38 @@ def migrate_workspaces(ctx, dry_run=False):
     ctx.run(cmd, env=migrate_env, pty=True)
 
 
+@task
+def migrate_vectors(ctx, dry_run=False):
+    """Re-index memory vectors per user account (#666).
+
+    Rebuilds the per-account (``user-{owner_user_id}``) S3 Vectors indexes from
+    DynamoDB by re-embedding each memory, so semantic search spans all of an
+    account's DCR clients. Run once after deploying the #666 change; the old
+    per-client indexes are left orphaned (delete them once search is verified).
+
+    Idempotent — re-running overwrites the same vector keys. Pass ``--dry-run``
+    to report counts without calling Bedrock / S3 Vectors.
+
+        inv migrate-vectors              # execute against AWS (uses env vars)
+        inv migrate-vectors --dry-run    # report only, no writes
+
+    Requires HIVE_VECTORS_BUCKET (the S3 Vectors bucket) in the environment.
+    """
+    migrate_env = {
+        **os.environ,
+        "HIVE_JWT_SECRET": os.environ.get("HIVE_JWT_SECRET", "dev-secret"),
+        "HIVE_TABLE_NAME": os.environ.get("HIVE_TABLE_NAME", "hive"),
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
+    if "DYNAMODB_ENDPOINT" in os.environ:
+        migrate_env["DYNAMODB_ENDPOINT"] = os.environ["DYNAMODB_ENDPOINT"]
+        migrate_env.setdefault("AWS_ACCESS_KEY_ID", "local")
+        migrate_env.setdefault("AWS_SECRET_ACCESS_KEY", "local")
+    args = ["--dry-run"] if dry_run else []
+    cmd = "uv run python scripts/migrate_vectors_to_user_index.py " + " ".join(args)
+    ctx.run(cmd, env=migrate_env, pty=True)
+
+
 # ── Bulk memory operations ────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_migrate_vectors.py
+++ b/tests/unit/test_migrate_vectors.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for scripts/migrate_vectors_to_user_index.py — the #666 re-index."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-test-migrate-vectors")
+os.environ.setdefault("HIVE_VECTORS_BUCKET", "test-vectors-bucket")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+
+from hive.models import Memory
+from scripts.migrate_vectors_to_user_index import MigrationStats, main, run
+
+
+def _mem(**kwargs) -> Memory:
+    defaults = {
+        "key": "k",
+        "value": "v",
+        "owner_client_id": "client-1",
+        "owner_user_id": "user-1",
+    }
+    defaults.update(kwargs)
+    return Memory(**defaults)
+
+
+def _run(memories, *, dry_run=False, blob_value="large body"):
+    """Run the migration against mock storage/vector_store; return (stats, vs)."""
+    storage = MagicMock()
+    storage.iter_all_memories.return_value = iter(memories)
+    storage.fetch_blob_value.return_value = blob_value
+    vs = MagicMock()
+    stats = run(dry_run=dry_run, storage=storage, vector_store=vs)
+    return stats, vs, storage
+
+
+def test_reindexes_embeddable_memories():
+    mems = [_mem(key="a", owner_user_id="user-1"), _mem(key="b", owner_user_id="user-2")]
+    stats, vs, _ = _run(mems)
+    assert stats.memories_seen == 2
+    assert stats.reindexed == 2
+    assert vs.upsert_memory.call_count == 2
+    upserted_keys = {c.args[0].key for c in vs.upsert_memory.call_args_list}
+    assert upserted_keys == {"a", "b"}
+
+
+def test_skips_memory_without_owner_user_id():
+    stats, vs, _ = _run([_mem(owner_user_id=None)])
+    assert stats.skipped_no_owner == 1
+    assert stats.reindexed == 0
+    vs.upsert_memory.assert_not_called()
+
+
+def test_skips_non_embeddable_blob_and_image():
+    mems = [_mem(value_type="image"), _mem(value_type="blob")]
+    stats, vs, _ = _run(mems)
+    assert stats.skipped_non_embeddable == 2
+    assert stats.reindexed == 0
+    vs.upsert_memory.assert_not_called()
+
+
+def test_skips_redacted_memory():
+    stats, vs, _ = _run([_mem(redacted_at=datetime.now(timezone.utc))])
+    assert stats.skipped_redacted == 1
+    assert stats.reindexed == 0
+    vs.upsert_memory.assert_not_called()
+
+
+def test_text_large_embeds_fetched_value():
+    stats, vs, storage = _run(
+        [_mem(value_type="text-large", value="")], blob_value="the full large text"
+    )
+    assert stats.reindexed == 1
+    storage.fetch_blob_value.assert_called_once()
+    upserted = vs.upsert_memory.call_args.args[0]
+    assert upserted.value == "the full large text"
+
+
+def test_dry_run_counts_but_does_not_write():
+    stats, vs, storage = _run([_mem(), _mem(key="b")], dry_run=True)
+    assert stats.reindexed == 2
+    vs.upsert_memory.assert_not_called()
+    storage.fetch_blob_value.assert_not_called()
+
+
+def test_report_includes_all_counters():
+    stats = MigrationStats(
+        memories_seen=5,
+        reindexed=3,
+        skipped_no_owner=1,
+        skipped_non_embeddable=1,
+        skipped_redacted=0,
+    )
+    report = stats.report()
+    for field in (
+        "memories_seen=5",
+        "reindexed=3",
+        "skipped_no_owner=1",
+        "skipped_non_embeddable=1",
+        "skipped_redacted=0",
+    ):
+        assert field in report
+
+
+def test_main_returns_zero_and_prints(capsys):
+    with patch(
+        "scripts.migrate_vectors_to_user_index.run",
+        return_value=MigrationStats(memories_seen=2, reindexed=2),
+    ) as mock_run:
+        rc = main(["--dry-run"])
+    assert rc == 0
+    mock_run.assert_called_once_with(dry_run=True)
+    assert "reindexed=2" in capsys.readouterr().out

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1722,6 +1722,56 @@ class TestSearchMemories:
 
         assert _body(result) == {"items": [], "count": 0, "query": "anything"}
 
+    async def test_requires_user_account(self, server_env):
+        """search_memories fails closed when the client isn't bound to a user (#666)."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import search_memories
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Unbound Search")
+        assert client.owner_user_id is None
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+
+        with pytest.raises(ToolError, match="not associated with a user account"):
+            await search_memories("anything", ctx=_make_ctx(jwt))
+
+    async def test_rejects_missing_client_record(self, server_env):
+        """search_memories fails closed when the authenticated client record is gone (#666)."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import search_memories
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Search", owner_user_id="ghost-user-search")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await search_memories("anything", ctx=_make_ctx(jwt))
+
 
 # ---------------------------------------------------------------------------
 # relate_memories

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -49,6 +49,7 @@ def _make_memory(**kwargs) -> Memory:
         "value": "test value",
         "tags": ["t1"],
         "owner_client_id": "client-abc",
+        "owner_user_id": "user-abc",
     }
     defaults.update(kwargs)
     return Memory(**defaults)
@@ -87,11 +88,11 @@ class TestEnsureIndex:
     def test_creates_index_on_first_call(self):
         s3v = _make_s3v_client()
         vs = VectorStore(bucket_name="mybucket", _s3v_client=s3v, _bedrock_client=MagicMock())
-        name = vs._ensure_index("client-123")
-        assert name == "client-client-123"
+        name = vs._ensure_index("user-123")
+        assert name == "user-user-123"
         s3v.create_index.assert_called_once_with(
             vectorBucketName="mybucket",
-            indexName="client-client-123",
+            indexName="user-user-123",
             dataType="float32",
             dimension=1024,
             distanceMetric="cosine",
@@ -103,7 +104,7 @@ class TestEnsureIndex:
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=MagicMock())
         # Must not raise
         name = vs._ensure_index("abc")
-        assert name == "client-abc"
+        assert name == "user-abc"
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +122,7 @@ class TestUpsertMemory:
         s3v.put_vectors.assert_called_once()
         call_kwargs = s3v.put_vectors.call_args.kwargs
         assert call_kwargs["vectorBucketName"] == "bkt"
-        assert call_kwargs["indexName"] == f"client-{m.owner_client_id}"
+        assert call_kwargs["indexName"] == f"user-{m.owner_user_id}"
         vectors = call_kwargs["vectors"]
         assert len(vectors) == 1
         assert vectors[0]["key"] == m.memory_id
@@ -135,6 +136,16 @@ class TestUpsertMemory:
         embedded_text = bedrock.invoke_model.call_args.kwargs["body"]
         assert "mykey" in embedded_text
         assert "myvalue" in embedded_text
+
+    def test_skips_when_no_owner_user_id(self):
+        # Legacy/pre-#648 memory with no account owner can't be placed in an
+        # account index — upsert is a silent no-op (#666).
+        s3v = _make_s3v_client()
+        bedrock = _make_bedrock_client()
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=bedrock)
+        vs.upsert_memory(_make_memory(owner_user_id=None))
+        s3v.put_vectors.assert_not_called()
+        bedrock.invoke_model.assert_not_called()
 
     def test_swallows_exceptions_best_effort(self):
         s3v = _make_s3v_client()
@@ -154,19 +165,27 @@ class TestDeleteMemory:
     def test_calls_delete_vectors(self):
         s3v = _make_s3v_client()
         vs = VectorStore(bucket_name="bkt", _s3v_client=s3v, _bedrock_client=MagicMock())
-        vs.delete_memory("mem-id-123", "client-xyz")
+        vs.delete_memory("mem-id-123", "user-xyz")
         s3v.delete_vectors.assert_called_once_with(
             vectorBucketName="bkt",
-            indexName="client-client-xyz",
+            indexName="user-user-xyz",
             keys=["mem-id-123"],
         )
+
+    def test_noop_when_owner_user_id_none(self):
+        # A memory never indexed under an account (owner_user_id None) has no
+        # vector to remove — delete is a no-op, never touching S3 (#666).
+        s3v = _make_s3v_client()
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=MagicMock())
+        vs.delete_memory("id", None)
+        s3v.delete_vectors.assert_not_called()
 
     def test_swallows_exceptions_best_effort(self):
         s3v = _make_s3v_client()
         s3v.delete_vectors.side_effect = RuntimeError("gone")
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=MagicMock())
         # Must not raise
-        vs.delete_memory("id", "client")
+        vs.delete_memory("id", "user-1")
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +204,7 @@ class TestSearch:
         }
         bedrock = _make_bedrock_client()
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=bedrock)
-        results = vs.search("query text", "client-1", top_k=5)
+        results = vs.search("query text", "user-1", top_k=5)
         assert results == [("mem-a", round(0.9, 6)), ("mem-b", round(0.6, 6))]
 
     def test_calls_query_vectors_with_correct_args(self):
@@ -193,10 +212,10 @@ class TestSearch:
         s3v.query_vectors.return_value = {"vectors": []}
         bedrock = _make_bedrock_client()
         vs = VectorStore(bucket_name="mybucket", _s3v_client=s3v, _bedrock_client=bedrock)
-        vs.search("hello", "myclient", top_k=7)
+        vs.search("hello", "myuser", top_k=7)
         call_kwargs = s3v.query_vectors.call_args.kwargs
         assert call_kwargs["vectorBucketName"] == "mybucket"
-        assert call_kwargs["indexName"] == "client-myclient"
+        assert call_kwargs["indexName"] == "user-myuser"
         assert call_kwargs["topK"] == 7
         assert call_kwargs["returnDistance"] is True
         assert call_kwargs["returnMetadata"] is False
@@ -207,18 +226,18 @@ class TestSearch:
         bedrock = _make_bedrock_client()
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=bedrock)
         with pytest.raises(VectorIndexNotFoundError):
-            vs.search("query", "client-never-wrote")
+            vs.search("query", "user-never-wrote")
 
     def test_caps_top_k_at_100(self):
         s3v = _make_s3v_client()
         s3v.query_vectors.return_value = {"vectors": []}
         bedrock = _make_bedrock_client()
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=bedrock)
-        vs.search("q", "c", top_k=999)
+        vs.search("q", "u", top_k=999)
         assert s3v.query_vectors.call_args.kwargs["topK"] == 100
 
     def test_returns_empty_list_when_no_vectors(self):
         s3v = _make_s3v_client()
         s3v.query_vectors.return_value = {"vectors": []}
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
-        assert vs.search("q", "c") == []
+        assert vs.search("q", "u") == []


### PR DESCRIPTION
Closes #666

## Summary
Completes the scope-unification tracked in #666. #667 unified the **tag** tools (`list_tags`, `forget_all`) on the `owner_user_id` account boundary; this does the same for the **semantic-search** side, which was still client-scoped because the S3 Vectors index was partitioned per OAuth client (`client-{client_id}`).

A user's memories are spread across all their DCR client indexes, so a per-client index can't serve an account-wide search. This re-partitions to **one index per user account** (`user-{owner_user_id}`), matching `list_memories`/USERTAG and the `Memory.owner_user_id` workspace-transition note (#490).

## Changes
- **`vector_store.py`** — `_index_name`/`upsert`/`delete`/`search` key on `owner_user_id`; `upsert` skips and `delete` no-ops when `owner_user_id` is `None` (legacy/pre-#648 items).
- **`server.py`** — new `_require_owner_user_id` helper (fail-closed for unbound clients, same guard as #667); wired into `search_memories`, `relate_memories`, `pack_context`; the two vector-delete sites now scope to the memory's own `owner_user_id`.
- **`api/memories.py`** — semantic search scoped to the caller's account. This also **fixes a latent bug**: it was searching `client-{user_sub}`, so it only ever matched management-UI-created memories, never MCP-created ones (whose `owner_client_id` is the OAuth client id, not the user sub).

## Migration (must run after deploy)
`scripts/migrate_vectors_to_user_index.py` + `inv migrate-vectors` (`--dry-run` supported) rebuilds the `user-*` indexes from DynamoDB by re-embedding each memory — vectors are derived data, so the DynamoDB text is the source of truth (no data loss, only Bedrock embedding cost). Idempotent; skips unowned / binary (`image`/`blob`) / redacted memories.

**Rollout:** deploy → run `inv migrate-vectors --dry-run` to sanity-check counts → run `inv migrate-vectors`. Between deploy and migration, search returns only newly-written memories (account indexes are empty until backfilled). The old `client-*` indexes are left orphaned — delete them once you've confirmed the new ones serve search.

## Testing
- `vector_store` tests rewritten for the per-user scheme + `None`-owner guards; fail-closed tests for the search path; full migration test suite.
- `inv lint-backend`, `inv typecheck`, full `inv test-unit` (960 passed) green; **100% coverage** on all changed modules (`server`, `vector_store`, `api/memories`, the migration script).
- Local e2e not run (stack not up this session); CI covers it on the development deploy.

## Decisions (resolved from the codebase)
- **Partition key = `owner_user_id`** — per the `Memory.owner_user_id` directive that tools scope on it through the workspace transition (#490); not a new tenancy axis (#482).
- **Admin search** scoped to the admin's own account (cross-user semantic search would need a per-user fan-out) — no regression, since search was already effectively client-scoped.