### PR TITLE
fix(auth): repair MCP OAuth discovery for spec-compliant clients

### DIFF
--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -639,6 +639,32 @@ class HiveStack(cdk.Stack):
             allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
             response_headers_policy=security_headers_policy,
         )
+        # Lambda Function URLs rename the WWW-Authenticate response header to
+        # x-amzn-remapped-www-authenticate, and CloudFront forwards it under that
+        # name. No MCP client reads the remapped header, so the OAuth challenge on
+        # a 401 from /mcp (which carries the resource_metadata pointer) is
+        # invisible and spec-compliant header-based discovery never works (#647).
+        # This viewer-response function restores the spec header name on the way
+        # back to the client.
+        mcp_auth_header_fn = cloudfront.Function(
+            self,
+            "McpAuthHeaderRestore",
+            code=cloudfront.FunctionCode.from_inline(
+                """
+function handler(event) {
+    var headers = event.response.headers;
+    var remapped = headers['x-amzn-remapped-www-authenticate'];
+    if (remapped) {
+        headers['www-authenticate'] = remapped;
+        delete headers['x-amzn-remapped-www-authenticate'];
+    }
+    return event.response;
+}
+"""
+            ),
+            runtime=cloudfront.FunctionRuntime.JS_2_0,
+        )
+
         mcp_behavior = cloudfront.BehaviorOptions(
             origin=mcp_cf_origin,
             viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -646,6 +672,12 @@ class HiveStack(cdk.Stack):
             origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
             allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
             response_headers_policy=security_headers_policy,
+            function_associations=[
+                cloudfront.FunctionAssociation(
+                    function=mcp_auth_header_fn,
+                    event_type=cloudfront.FunctionEventType.VIEWER_RESPONSE,
+                )
+            ],
         )
 
         # ----------------------------------------------------------------

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -58,15 +58,19 @@ def get_storage() -> HiveStorage:  # noqa: D401
 
 
 @router.get("/.well-known/oauth-authorization-server", include_in_schema=False)
-async def oauth_metadata(request: Request) -> JSONResponse:
-    base = str(request.base_url).rstrip("/")
+async def oauth_metadata() -> JSONResponse:
+    # Build endpoints from the public ISSUER (the CloudFront custom domain),
+    # NOT request.base_url: CloudFront forwards /.well-known and /oauth to the
+    # API Lambda *without* the viewer Host header, so base_url resolves to the
+    # raw Function URL. Using it leaks the origin and trips strict RFC 8414
+    # validators on the issuer/endpoint host mismatch (#647).
     return JSONResponse(
         {
             "issuer": ISSUER,
-            "authorization_endpoint": f"{base}/oauth/authorize",
-            "token_endpoint": f"{base}/oauth/token",
-            "revocation_endpoint": f"{base}/oauth/revoke",
-            "registration_endpoint": f"{base}/oauth/register",
+            "authorization_endpoint": f"{ISSUER}/oauth/authorize",
+            "token_endpoint": f"{ISSUER}/oauth/token",
+            "revocation_endpoint": f"{ISSUER}/oauth/revoke",
+            "registration_endpoint": f"{ISSUER}/oauth/register",
             "response_types_supported": ["code"],
             "grant_types_supported": ["authorization_code", "refresh_token"],
             "token_endpoint_auth_methods_supported": [
@@ -81,13 +85,24 @@ async def oauth_metadata(request: Request) -> JSONResponse:
 
 
 @router.get("/.well-known/oauth-protected-resource", include_in_schema=False)
-async def protected_resource_metadata() -> JSONResponse:
-    """RFC 9728 protected resource metadata.
+@router.get("/.well-known/oauth-protected-resource/{resource_path:path}", include_in_schema=False)
+async def protected_resource_metadata(resource_path: str = "") -> JSONResponse:
+    """RFC 9728 protected resource metadata (root + path-inserted variants).
 
     Tells OAuth clients (e.g. Claude Desktop) which authorization server
     issues valid tokens for the Hive MCP server.  CloudFront routes
     /.well-known/* to this API Lambda, so the document must live here rather
     than on the MCP Lambda.
+
+    Spec-following clients request the *path-inserted* URL first — for a
+    resource at /mcp that is ``/.well-known/oauth-protected-resource/mcp``
+    (RFC 9728 §3.1). Without an explicit route the Lambda 404s and the
+    distribution-wide CloudFront SPA error-fallback rewrites that 404 into a
+    200 ``text/html`` index page, which makes strict clients abort discovery
+    (#647). Registering the path variant here returns the JSON document, so the
+    SPA fallback never triggers. Hive exposes a single protected resource
+    (/mcp), so ``resource_path`` is accepted for route matching but the document
+    always describes /mcp.
     """
     return JSONResponse(
         {

--- a/src/hive/auth/tokens.py
+++ b/src/hive/auth/tokens.py
@@ -20,7 +20,10 @@ from hive.models import Token
 from hive.storage import HiveStorage
 
 JWT_ALGORITHM = "HS256"
-ISSUER = os.environ.get("HIVE_ISSUER", "https://hive.example.com")
+# Normalize once at the source: a trailing slash on HIVE_ISSUER would otherwise
+# produce double-slash discovery URLs (e.g. ".../oauth-authorization-server"
+# endpoints built as f"{ISSUER}/oauth/token"), which trips strict clients (#647).
+ISSUER = os.environ.get("HIVE_ISSUER", "https://hive.example.com").rstrip("/")
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -262,6 +262,13 @@ class TestOAuthDiscovery:
         assert "token_endpoint" in data
         assert "code_challenge_methods_supported" in data
         assert "S256" in data["code_challenge_methods_supported"]
+        # #647 — every endpoint must be built from the issuer (the public
+        # custom domain), not the raw Function URL, so the host matches and
+        # strict RFC 8414 validators accept the document.
+        assert data["authorization_endpoint"] == f"{data['issuer']}/oauth/authorize"
+        assert data["token_endpoint"] == f"{data['issuer']}/oauth/token"
+        assert data["revocation_endpoint"] == f"{data['issuer']}/oauth/revoke"
+        assert data["registration_endpoint"] == f"{data['issuer']}/oauth/register"
 
     def test_protected_resource_metadata(self, oauth_client):
         tc, *_ = oauth_client
@@ -276,6 +283,24 @@ class TestOAuthDiscovery:
         assert "memories:read" in data["scopes_supported"]
         assert "memories:write" in data["scopes_supported"]
         assert data["bearer_methods_supported"] == ["header"]
+
+    def test_protected_resource_metadata_path_inserted(self, oauth_client):
+        """#647 — the RFC 9728 path-inserted URL must return the JSON document.
+
+        Spec-strict clients hit ``/.well-known/oauth-protected-resource/mcp``
+        first. Without this route the Lambda 404s and CloudFront's SPA fallback
+        rewrites it to 200 text/html, aborting discovery. It must serve the same
+        JSON as the root variant.
+        """
+        tc, *_ = oauth_client
+        resp = tc.get("/.well-known/oauth-protected-resource/mcp")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        data = resp.json()
+        assert data["resource"].endswith("/mcp")
+        assert "authorization_servers" in data
+        # Identical document to the root variant.
+        assert data == tc.get("/.well-known/oauth-protected-resource").json()
 
 
 class TestOAuthRegister:


### PR DESCRIPTION
Closes #647

## Summary
Fixes the **p0** that blocks spec-strict MCP clients from completing OAuth discovery against `/mcp` (the top finding from the prod e2e verification on 2026-06-12). Three compounding failures, one fix each:

### 1. Path-inserted protected-resource URL served SPA HTML
`GET /.well-known/oauth-protected-resource/mcp` (RFC 9728 §3.1 — the URL spec-following clients try *first*) returned **200 `text/html`** (the React app). Only the root variant was registered; the path variant 404'd on the API Lambda, and CloudFront's distribution-wide SPA error-fallback (`404 → /index.html`, status 200) rewrote that into a fake success, so strict clients aborted discovery.
**Fix:** register `/.well-known/oauth-protected-resource/{resource_path:path}` (stacked with the root route) so the Lambda returns the JSON document — no 404, so the SPA fallback never triggers.

### 2. `WWW-Authenticate` invisible through CloudFront
Lambda Function URLs rename `WWW-Authenticate` → `x-amzn-remapped-www-authenticate`; CloudFront forwards it under that name and no MCP client reads it, so header-based discovery (the primary mechanism) never worked.
**Fix:** a CloudFront **viewer-response Function** on `/mcp*` that restores the spec header name (`McpAuthHeaderRestore`).

### 3. AS-metadata issuer/endpoint host mismatch
`/.well-known/oauth-authorization-server` advertised `issuer: <custom domain>` but built its endpoints from `request.base_url` — which resolves to the raw Function URL (CloudFront forwards `/.well-known` and `/oauth` without the viewer Host header). RFC 8414 validators reject the mismatch, and it leaks the origin the CloudFront-only architecture hides.
**Fix:** build the endpoints from `ISSUER`.

## Testing
- Unit: new `test_protected_resource_metadata_path_inserted` (Fix 1) + discovery-doc assertions that endpoints share the issuer host (Fix 3). `oauth.py` **100% covered**, 101 auth tests pass, full unit suite (961) green, lint/typecheck/copyright clean.
- Infra: `cdk synth` validates the CloudFront Function + association (`McpAuthHeaderRestore` is in the template).
- **Post-deploy verification (I'll run against dev once merged):** the issue's three `curl` repro steps —
  - `/.well-known/oauth-protected-resource/mcp` → 200 JSON (not HTML)
  - unauthenticated `POST /mcp` → 401 with a readable `WWW-Authenticate` header
  - AS metadata endpoints on `https://hive-dev.warlordofmars.net/oauth/...`

## Review note
Touches `infra/stacks/hive_stack.py` (a new CloudFront Function on the `/mcp*` behavior — prod request path). Fix 2 (the header rename) can only be fully verified once deployed; I'll confirm against dev before this should ride into a prod release.