### PR TITLE
feat(mcp): signal summarize_context mode + recency-order the fallback

### DIFF
--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -301,6 +301,7 @@ def _tool_result(
     client_id: str,
     *,
     memory: Memory | None = None,
+    extra_meta: dict[str, Any] | None = None,
 ) -> ToolResult:
     """Wrap a tool's return value in an MCP ``ToolResult`` carrying quota +
     rate-limit metadata in ``_meta.hive``. Strings become text content;
@@ -324,6 +325,8 @@ def _tool_result(
     meta = _quota_meta(storage, client_id)
     if memory is not None:
         meta["hive"]["memory"] = {"key": memory.key, "version": memory.version}
+    if extra_meta:
+        meta["hive"].update(extra_meta)
     if isinstance(payload, dict):
         return ToolResult(structured_content=payload, meta=meta)
     structured: dict[str, Any] = {"result": payload}
@@ -346,18 +349,19 @@ async def _sampled_summary(
     topic: str,
     memories: list[Memory],
     fallback: str,
-) -> str:
+) -> tuple[str, bool]:
     """Synthesise a set of memories via MCP Sampling (#448).
 
-    Sends a ``sampling/createMessage`` request back to the client and uses
-    its model to produce the summary. If the client doesn't support
-    sampling, the transport rejects it, or ctx is unavailable (e.g. direct
-    invocation in tests), returns ``fallback`` — the deterministic
-    concatenated listing — so the tool never fails just because an agent
-    can't sample.
+    Returns ``(text, synthesised)``. ``synthesised`` is ``True`` only when the
+    client's model produced the text via ``sampling/createMessage``; it is
+    ``False`` when the client doesn't support sampling, the transport rejects
+    it, ctx is unavailable (e.g. direct invocation in tests), or the model
+    returned nothing — in which case ``text`` is ``fallback`` (the
+    deterministic listing) so the tool never fails just because an agent can't
+    sample.
     """
     if ctx is None:
-        return fallback
+        return fallback, False
 
     body = "\n\n".join(f"- **{m.key}**: {m.value}" for m in memories)
     prompt = (
@@ -371,10 +375,12 @@ async def _sampled_summary(
         )
     except Exception:
         logger.info("MCP sampling unavailable; falling back to concat summary", exc_info=True)
-        return fallback
+        return fallback, False
 
-    text = getattr(result, "text", None) or fallback
-    return text.strip() or fallback
+    text = getattr(result, "text", None)
+    if text and text.strip():
+        return text.strip(), True
+    return fallback, False
 
 
 async def _report_progress(
@@ -1398,6 +1404,11 @@ async def summarize_context(
     that do not support sampling (e.g. Claude Desktop) instead receive the
     listed memories with a count footer — there is no server-side LLM, so the
     prose synthesis only happens when the client can provide the model (#662).
+
+    The response ``_meta.hive.summary_mode`` reports which path was taken
+    (``"synthesised"`` or ``"listed"``) so an agent that receives a listing can
+    choose to synthesise it itself; the listed memories are ordered most-recent
+    first (#658).
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
@@ -1412,6 +1423,9 @@ async def summarize_context(
 
     await _report_progress(ctx, 0, 2, f"Retrieving memories for '{topic}'...")
     memories, _ = storage.list_memories_by_tag(topic, limit=500, owner_user_id=owner_user_id)
+    # Freshest first, so both the sampling prompt and the listed fallback lead
+    # with the most recent memories (#658).
+    memories.sort(key=lambda m: m.updated_at, reverse=True)
     await _report_progress(
         ctx, 1, 2, f"Retrieved {len(memories)} memories; synthesising summary..."
     )
@@ -1427,7 +1441,12 @@ async def summarize_context(
             },
         )
         await emit_metric("ToolInvocations", operation="summarize_context")
-        return _tool_result(f"No memories found for topic '{topic}'.", storage, client_id)
+        return _tool_result(
+            f"No memories found for topic '{topic}'.",
+            storage,
+            client_id,
+            extra_meta={"summary_mode": "listed"},
+        )
 
     lines = [f"## Memories tagged '{topic}'\n"]
     for m in memories:
@@ -1439,7 +1458,8 @@ async def summarize_context(
     # Try MCP Sampling first (#448). If the client supports it, we get a real
     # LLM synthesis without any server-side Bedrock cost; otherwise the
     # sampler raises and we fall back to the concatenated listing above.
-    summary = await _sampled_summary(ctx, topic, memories, concat_summary)
+    summary, synthesised = await _sampled_summary(ctx, topic, memories, concat_summary)
+    summary_mode = "synthesised" if synthesised else "listed"
 
     _log(
         storage,
@@ -1467,7 +1487,7 @@ async def summarize_context(
         unit="Milliseconds",
         operation="summarize_context",
     )
-    return _tool_result(summary, storage, client_id)
+    return _tool_result(summary, storage, client_id, extra_meta={"summary_mode": summary_mode})
 
 
 @mcp.tool(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1085,11 +1085,65 @@ class TestSummarizeContext:
         assert "verbatim detail" in _text(result)
 
     async def test_sampled_summary_handles_ctx_none(self):
-        """Direct call to the helper with ctx=None returns the fallback verbatim."""
+        """Direct call with ctx=None returns (fallback, synthesised=False)."""
         from hive.server import _sampled_summary
 
         out = await _sampled_summary(None, "t", [], "FALLBACK_TEXT")
-        assert out == "FALLBACK_TEXT"
+        assert out == ("FALLBACK_TEXT", False)
+
+    async def test_summarize_meta_reports_synthesised_mode(self, server_env):
+        """When sampling succeeds, _meta.summary_mode is 'synthesised' (#658)."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("m-syn", "detail", ["mode-syn"], ctx=_make_ctx(jwt))
+        ctx = _make_ctx(jwt)
+        sampled = MagicMock()
+        sampled.text = "SYNTH"
+        ctx.sample = AsyncMock(return_value=sampled)
+
+        result = await summarize_context("mode-syn", ctx=ctx)
+        assert _hive_meta(result)["summary_mode"] == "synthesised"
+
+    async def test_summarize_meta_reports_listed_mode_on_fallback(self, server_env):
+        """When sampling is unavailable, _meta.summary_mode is 'listed' (#658)."""
+        from unittest.mock import AsyncMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("m-list", "detail", ["mode-list"], ctx=_make_ctx(jwt))
+        ctx = _make_ctx(jwt)
+        ctx.sample = AsyncMock(side_effect=RuntimeError("no sampling"))
+
+        result = await summarize_context("mode-list", ctx=ctx)
+        assert _hive_meta(result)["summary_mode"] == "listed"
+
+    async def test_summarize_empty_reports_listed_mode(self, server_env):
+        """The no-memories path also carries a summary_mode (#658)."""
+        _, _, jwt = server_env
+        from hive.server import summarize_context
+
+        result = await summarize_context("no-such-tag-xyz", ctx=_make_ctx(jwt))
+        assert _hive_meta(result)["summary_mode"] == "listed"
+
+    async def test_summarize_listing_ordered_most_recent_first(self, server_env):
+        """The listed fallback leads with the most recently updated memory (#658)."""
+        from unittest.mock import AsyncMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("older-key", "older value", ["recency"], ctx=_make_ctx(jwt))
+        await remember("newer-key", "newer value", ["recency"], ctx=_make_ctx(jwt))
+        ctx = _make_ctx(jwt)
+        ctx.sample = AsyncMock(side_effect=RuntimeError("no sampling"))
+
+        text = _text(await summarize_context("recency", ctx=ctx))
+        # 'newer-key' was written last → later updated_at → appears first.
+        assert text.index("newer-key") < text.index("older-key")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #658

## Summary
`summarize_context` synthesises memories into prose **only** when the client supports MCP Sampling (#448); without it (Claude Desktop, Channel, most clients) it returns a deterministic listing. #662 made the docstring honest about this — #658 makes it **observable at runtime** and the fallback more useful. Implements the [design-review decisions](https://github.com/warlordofmars/hive/issues/658) posted on the issue:

- **Mode signal** — `_sampled_summary` now returns `(text, synthesised)`, and the response carries `_meta.hive.summary_mode` (`"synthesised"` | `"listed"`). An agent that gets a `listed` result knows it should synthesise client-side. Added via a small `extra_meta` hook on `_tool_result`; the `-> str` contract and `structured_content` shape are unchanged, so existing callers are unaffected.
- **Recency-ordered fallback** — the retrieved set is sorted most-recent-first (`updated_at` desc) before both the sampling prompt and the listed fallback, so the freshest memories lead.
- **No server-side model** — stays within the client-side-LLM-preferred decision (#448); the caller is itself an agent that can synthesise a listing. Deferred heavier structuring (co-tag grouping / fuzzy dedup) as out of scope for `size:s`.

## Testing
- New unit tests: `summary_mode` is `synthesised` (sampling succeeds), `listed` (sampling raises), `listed` (empty), and the listed fallback is ordered most-recent-first. Updated the `_sampled_summary` direct-call test for the tuple return.
- `inv lint-backend`, `inv typecheck` clean; `test_server.py` 236 pass; the changed lines are covered (server.py 99% in the unit run — the 2 missing are the pre-existing integration-covered quota handler).

## Design-review trail
Ran the formal design review on #658 first (decisions comment + `status:design-needed` → `status:ready`).