### PR TITLE
release: v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,71 @@ See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) f
 
 ## [Unreleased]
 
-_Changes accumulated on `development` since v0.27.1. Will be rolled into the next release._
+_Changes accumulated on `development` since v0.28.0. Will be rolled into the next release._
+
+## v0.28.0 — 2026-06-14
+
+An MCP-correctness and consistency release. It makes every memory tool agree
+on the user-account scope — so search, listing, and deletion all see the same
+memories across a user's clients — repairs OAuth discovery so spec-compliant
+MCP clients can connect, and unblocks binary memory storage that AWS WAF was
+silently capping.
+
+### Changed
+
+#### MCP
+
+- **All memory tools now scope to the user account, not the OAuth client.**
+  `search_memories`, `pack_context`, `relate_memories`, `list_tags`,
+  `forget_all`, and the management-UI search now span every DCR client of a
+  user's account — consistent with `list_memories` / `summarize_context`.
+  Previously these were client-scoped, so a memory created from one client
+  (e.g. Claude Code) was invisible to search/listing from another (e.g. Claude
+  Desktop), and a stale-read lag could hide a just-written tag. Semantic search
+  is re-partitioned onto per-user vector indexes; run `inv migrate-vectors`
+  once after deploying to backfill them. (#666, #667, #681, #653)
+- **`summarize_context` reports its mode and leads with recent memories.** The
+  tool only synthesises prose when the calling client supports MCP Sampling
+  (#448); otherwise it returns a deterministic listing. It now signals which
+  path ran via `_meta.hive.summary_mode` (`synthesised` / `listed`) so an agent
+  that receives a listing can synthesise it client-side, and the listed
+  memories are ordered most-recent-first. (#658, #662)
+
+### Fixed
+
+#### Auth
+
+- **MCP OAuth discovery works for spec-compliant clients.** Strict clients
+  could not complete discovery against `/mcp`: the RFC 9728 path-inserted
+  metadata URL returned the SPA's HTML (CloudFront rewrote the API's 404 into a
+  200), the `WWW-Authenticate` challenge was renamed in transit by the Lambda
+  Function URL so no client ever read it, and the authorization-server metadata
+  advertised endpoints on the raw Function URL instead of the custom domain.
+  All three are fixed — the path-inserted route returns JSON, a Lambda@Edge
+  origin-response function restores the `WWW-Authenticate` header on 401s, and
+  the metadata endpoints are built from the public issuer. (#647)
+
+#### MCP
+
+- **`remember_blob` is no longer capped at ~8 KB by WAF.** The CloudFront
+  `AWSManagedRulesCommonRuleSet` `SizeRestrictions_BODY` rule returned a 403 for
+  any request body over 8 KB before it reached the MCP Lambda, so even a small
+  image failed to store. `/mcp` is now scoped out of the Common rule set (it
+  stays covered by KnownBadInputs and the rate-based rules), so multi-MB blobs
+  reach the origin. Also documents the minimum renderable image size — the
+  "Error processing image" reported for tiny fixtures was the consuming image
+  API's dimension floor, not a Hive defect. (#665, #649)
+
+### Meta
+
+- **CI reliability.** Fixed a clock-dependent frontend coverage gap that made
+  `ActivityHeatmap`'s branch coverage pass only on Saturdays (#669), and a
+  flaky `create-and-see-memory` e2e test that raced GSI propagation because the
+  e2e user is an admin (admin reads bypass the strongly-consistent path) (#679).
+- **Dependencies.** Cleared the remaining moderate npm advisories (react-router
+  open redirect, `ws` memory disclosure) via a non-breaking `npm audit fix`;
+  the dev-tooling criticals were already resolved by the move to vite 8 /
+  vitest 4. (#659)
 
 ## v0.27.1 — 2026-06-13
 

--- a/docs-site/tools/remember-blob.md
+++ b/docs-site/tools/remember-blob.md
@@ -17,7 +17,11 @@ Store a binary memory — an image, document, audio file, or any other non-text 
 - If `content_type` starts with `image/` (e.g. `image/png`, `image/jpeg`, `image/webp`), the memory gets `value_type="image"`.
 - All other MIME types produce `value_type="blob"`.
 - Calling `remember_blob` with the same key again **replaces** the existing binary content (upsert semantics, same `memory_id`).
-- The `data` payload (after Base64 decoding) must not exceed **10 MB**.
+- The `data` payload (after Base64 decoding) must not exceed **10 MB**. In practice the deployed request path (CloudFront → Lambda) caps a single request body well below that, so **several-MB blobs are the realistic ceiling** for one call.
+
+### Minimum renderable image size
+
+When you store an `image/*` blob and later `recall` it, the client renders the returned bytes through an image API (Anthropic's, for Claude clients) that **rejects images below roughly a few dozen pixels per side**. A **32×32 image (or larger) renders**; a degenerate fixture such as a 1×1 or 16×16 PNG is stored and returned **byte-exact** by Hive, but the consuming client reports `Error processing image`. This is a client/API minimum, **not** a Hive limit — store real, sensibly-sized images.
 
 ## Examples
 
@@ -38,7 +42,8 @@ Save this architecture PDF as "project/myapp/architecture-doc" with tag "docs".
 
 | Limit | Value |
 | --- | --- |
-| Maximum payload (decoded bytes) | 10 MB |
+| Maximum payload (decoded bytes) | 10 MB (single-request path caps lower; several MB is realistic) |
+| Minimum renderable image | ~32×32 px — smaller images store byte-exact but won't render in clients |
 | Supported MIME types | Any non-empty string (typically a MIME type such as `image/png`) |
 | Key length | Up to 512 characters |
 

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -644,25 +644,38 @@ class HiveStack(cdk.Stack):
         # name. No MCP client reads the remapped header, so the OAuth challenge on
         # a 401 from /mcp (which carries the resource_metadata pointer) is
         # invisible and spec-compliant header-based discovery never works (#647).
-        # This viewer-response function restores the spec header name on the way
-        # back to the client.
-        mcp_auth_header_fn = cloudfront.Function(
+        #
+        # This MUST be a Lambda@Edge *origin-response* function, not a CloudFront
+        # viewer-response Function: CloudFront does not invoke viewer-response
+        # functions when the origin returns HTTP >= 400, so a viewer-response
+        # function can never touch the 401 that carries the challenge. Lambda@Edge
+        # origin-response runs for all status codes (and WWW-Authenticate is not a
+        # read-only header there), so it can restore the spec header name. It only
+        # rewrites when the remapped header is present (i.e. on the 401), so 200s
+        # are untouched.
+        mcp_auth_header_edge = cloudfront.experimental.EdgeFunction(
             self,
-            "McpAuthHeaderRestore",
-            code=cloudfront.FunctionCode.from_inline(
+            "McpAuthHeaderEdge",
+            runtime=lambda_.Runtime.NODEJS_20_X,
+            handler="index.handler",
+            code=lambda_.Code.from_inline(
                 """
-function handler(event) {
-    var headers = event.response.headers;
+exports.handler = async (event) => {
+    var response = event.Records[0].cf.response;
+    var headers = response.headers;
     var remapped = headers['x-amzn-remapped-www-authenticate'];
-    if (remapped) {
-        headers['www-authenticate'] = remapped;
+    if (remapped && remapped.length) {
+        // Preserve every value — WWW-Authenticate may legitimately carry
+        // multiple challenges (CloudFront passes them as separate array entries).
+        headers['www-authenticate'] = remapped.map(function (h) {
+            return { key: 'WWW-Authenticate', value: h.value };
+        });
         delete headers['x-amzn-remapped-www-authenticate'];
     }
-    return event.response;
-}
+    return response;
+};
 """
             ),
-            runtime=cloudfront.FunctionRuntime.JS_2_0,
         )
 
         mcp_behavior = cloudfront.BehaviorOptions(
@@ -672,10 +685,10 @@ function handler(event) {
             origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
             allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
             response_headers_policy=security_headers_policy,
-            function_associations=[
-                cloudfront.FunctionAssociation(
-                    function=mcp_auth_header_fn,
-                    event_type=cloudfront.FunctionEventType.VIEWER_RESPONSE,
+            edge_lambdas=[
+                cloudfront.EdgeLambda(
+                    function_version=mcp_auth_header_edge.current_version,
+                    event_type=cloudfront.LambdaEdgeEventType.ORIGIN_RESPONSE,
                 )
             ],
         )

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -639,6 +639,32 @@ class HiveStack(cdk.Stack):
             allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
             response_headers_policy=security_headers_policy,
         )
+        # Lambda Function URLs rename the WWW-Authenticate response header to
+        # x-amzn-remapped-www-authenticate, and CloudFront forwards it under that
+        # name. No MCP client reads the remapped header, so the OAuth challenge on
+        # a 401 from /mcp (which carries the resource_metadata pointer) is
+        # invisible and spec-compliant header-based discovery never works (#647).
+        # This viewer-response function restores the spec header name on the way
+        # back to the client.
+        mcp_auth_header_fn = cloudfront.Function(
+            self,
+            "McpAuthHeaderRestore",
+            code=cloudfront.FunctionCode.from_inline(
+                """
+function handler(event) {
+    var headers = event.response.headers;
+    var remapped = headers['x-amzn-remapped-www-authenticate'];
+    if (remapped) {
+        headers['www-authenticate'] = remapped;
+        delete headers['x-amzn-remapped-www-authenticate'];
+    }
+    return event.response;
+}
+"""
+            ),
+            runtime=cloudfront.FunctionRuntime.JS_2_0,
+        )
+
         mcp_behavior = cloudfront.BehaviorOptions(
             origin=mcp_cf_origin,
             viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -646,6 +672,12 @@ class HiveStack(cdk.Stack):
             origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
             allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
             response_headers_policy=security_headers_policy,
+            function_associations=[
+                cloudfront.FunctionAssociation(
+                    function=mcp_auth_header_fn,
+                    event_type=cloudfront.FunctionEventType.VIEWER_RESPONSE,
+                )
+            ],
         )
 
         # ----------------------------------------------------------------

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -683,7 +683,18 @@ class HiveStack(cdk.Stack):
                 sampled_requests_enabled=True,
             ),
             rules=[
-                # Managed: OWASP Top 10 protections
+                # Managed: OWASP Top 10 protections — enforced on the whole site
+                # EXCEPT the MCP endpoint. /mcp is an OAuth-gated JSON-RPC API whose
+                # payloads include multi-MB base64 blobs (remember_blob, #665). The
+                # Common rule set breaks that two ways: SizeRestrictions_BODY (8 KB)
+                # 403s the request before it reaches the Lambda, and the SQLi/XSS
+                # *body* rules can false-positive on arbitrary base64. Scoping the
+                # group down to NOT /mcp* keeps full protection on the public surface
+                # (UI, docs, management API) while letting authenticated MCP traffic
+                # through. /mcp is still covered by AWSManagedRulesKnownBadInputs and
+                # the GlobalRateLimit rate-based rule below (OAuthRateLimit is scoped
+                # to /oauth/* and does not apply to /mcp); the next size ceiling is
+                # the Lambda Function URL ~6 MB request limit (~4 MB of binary).
                 wafv2.CfnWebACL.RuleProperty(
                     name="AWSManagedRulesCommonRuleSet",
                     priority=0,
@@ -692,6 +703,24 @@ class HiveStack(cdk.Stack):
                         managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
                             vendor_name="AWS",
                             name="AWSManagedRulesCommonRuleSet",
+                            scope_down_statement=wafv2.CfnWebACL.StatementProperty(
+                                not_statement=wafv2.CfnWebACL.NotStatementProperty(
+                                    statement=wafv2.CfnWebACL.StatementProperty(
+                                        byte_match_statement=wafv2.CfnWebACL.ByteMatchStatementProperty(
+                                            search_string="/mcp",
+                                            field_to_match=wafv2.CfnWebACL.FieldToMatchProperty(
+                                                uri_path={}
+                                            ),
+                                            text_transformations=[
+                                                wafv2.CfnWebACL.TextTransformationProperty(
+                                                    priority=0, type="NONE"
+                                                )
+                                            ],
+                                            positional_constraint="STARTS_WITH",
+                                        )
+                                    )
+                                )
+                            ),
                         ),
                     ),
                     visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(

--- a/scripts/migrate_vectors_to_user_index.py
+++ b/scripts/migrate_vectors_to_user_index.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+One-shot migration: re-index memory vectors per user account (#666).
+
+Before this migration the S3 Vectors index is partitioned per OAuth client
+(``client-{client_id}``). After #666 the vector store reads and writes per user
+account (``user-{owner_user_id}``) so semantic search spans every DCR client of
+the account, consistent with the tag/list read path.
+
+Existing vectors live in the old ``client-*`` indexes and are invisible to the
+new account-scoped search. This script rebuilds the ``user-*`` indexes from
+DynamoDB — the authoritative store — by re-embedding each memory's text. Vectors
+are derived data, so no information is lost (only Bedrock embedding cost).
+
+It is **idempotent**: re-running re-embeds and overwrites the same vector keys.
+Memories that can't or shouldn't be indexed are skipped:
+
+- ``owner_user_id`` is None (legacy/pre-#648 rows) — no account index to target.
+- ``value_type`` is ``image`` / ``blob`` — binary memories are never embedded.
+- the memory is redacted — its vector is intentionally removed from search.
+
+The old ``client-*`` indexes are left in place (orphaned, no longer queried);
+delete them separately once you've confirmed the new indexes serve search.
+
+Usage:
+
+Direct CLI (preferred for production — set ``HIVE_TABLE_NAME``,
+``HIVE_VECTORS_BUCKET`` and the appropriate ``AWS_*`` environment variables):
+
+    uv run python scripts/migrate_vectors_to_user_index.py
+    uv run python scripts/migrate_vectors_to_user_index.py --dry-run   # report only
+
+Via invoke task (targets AWS by default — set ``DYNAMODB_ENDPOINT`` for local):
+
+    uv run inv migrate-vectors
+    uv run inv migrate-vectors --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+from hive.logging_config import get_logger
+from hive.models import Memory
+from hive.storage import HiveStorage
+from hive.vector_store import VectorStore
+
+logger = get_logger("hive.migrate_vectors")
+
+# value_types that are stored as binary blobs and never embedded.
+_NON_EMBEDDABLE_TYPES = {"image", "blob"}
+
+
+@dataclass
+class MigrationStats:
+    """Per-phase counters so operators can sanity-check the run."""
+
+    memories_seen: int = 0
+    reindexed: int = 0
+    skipped_no_owner: int = 0
+    skipped_non_embeddable: int = 0
+    skipped_redacted: int = 0
+
+    def report(self) -> str:
+        return (
+            f"memories_seen={self.memories_seen} "
+            f"reindexed={self.reindexed} "
+            f"skipped_no_owner={self.skipped_no_owner} "
+            f"skipped_non_embeddable={self.skipped_non_embeddable} "
+            f"skipped_redacted={self.skipped_redacted}"
+        )
+
+
+def _resolve_text(storage: HiveStorage, memory: Memory) -> Memory:
+    """Return a copy of ``memory`` whose ``value`` holds the full text to embed.
+
+    Large text memories keep their body in S3 with a sentinel ``value``; fetch
+    the real text so the embedding matches what ``remember`` would index.
+    """
+    if memory.value_type == "text-large":
+        return memory.model_copy(update={"value": storage.fetch_blob_value(memory)})
+    return memory
+
+
+def reindex_memories(
+    storage: HiveStorage,
+    vector_store: VectorStore,
+    stats: MigrationStats,
+    *,
+    dry_run: bool,
+) -> None:
+    """Re-embed every eligible memory into its account (``user-*``) index."""
+    for memory in storage.iter_all_memories():
+        stats.memories_seen += 1
+        if memory.owner_user_id is None:
+            stats.skipped_no_owner += 1
+            continue
+        if memory.value_type in _NON_EMBEDDABLE_TYPES:
+            stats.skipped_non_embeddable += 1
+            continue
+        if memory.is_redacted:
+            stats.skipped_redacted += 1
+            continue
+        if dry_run:
+            stats.reindexed += 1
+            continue
+        vector_store.upsert_memory(_resolve_text(storage, memory))
+        stats.reindexed += 1
+
+
+def run(
+    *,
+    dry_run: bool = False,
+    storage: HiveStorage | None = None,
+    vector_store: VectorStore | None = None,
+) -> MigrationStats:
+    """Execute the migration. ``storage``/``vector_store`` are injectable for tests."""
+    store = storage if storage is not None else HiveStorage()
+    vstore = vector_store if vector_store is not None else VectorStore()
+    stats = MigrationStats()
+    logger.info("Starting vector re-index migration", extra={"dry_run": dry_run})
+    reindex_memories(store, vstore, stats, dry_run=dry_run)
+    logger.info("Vector re-index migration finished: %s", stats.report())
+    return stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Re-index Hive memory vectors per user account (#666)."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be re-indexed without calling Bedrock or S3 Vectors.",
+    )
+    args = parser.parse_args(argv)
+    stats = run(dry_run=args.dry_run)
+    print(stats.report())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hive/api/memories.py
+++ b/src/hive/api/memories.py
@@ -74,10 +74,12 @@ async def list_memories(
     owner_user_id = _user_filter(claims)
 
     if search:
-        # Semantic search — top-K, no pagination
-        client_id: str = claims["sub"]
+        # Semantic search — top-K, no pagination. The vector index is scoped to
+        # the caller's own account (#666); admins search their own memories
+        # (cross-user semantic search would need a per-user fan-out).
+        search_owner_user_id: str = claims["sub"]
         try:
-            pairs = vs.search(search, client_id, top_k=min(limit, 50))
+            pairs = vs.search(search, search_owner_user_id, top_k=min(limit, 50))
         except VectorIndexNotFoundError:
             return PagedResponse(items=[], count=0, has_more=False, next_cursor=None)
         results = storage.hydrate_memory_ids(pairs)

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -58,15 +58,19 @@ def get_storage() -> HiveStorage:  # noqa: D401
 
 
 @router.get("/.well-known/oauth-authorization-server", include_in_schema=False)
-async def oauth_metadata(request: Request) -> JSONResponse:
-    base = str(request.base_url).rstrip("/")
+async def oauth_metadata() -> JSONResponse:
+    # Build endpoints from the public ISSUER (the CloudFront custom domain),
+    # NOT request.base_url: CloudFront forwards /.well-known and /oauth to the
+    # API Lambda *without* the viewer Host header, so base_url resolves to the
+    # raw Function URL. Using it leaks the origin and trips strict RFC 8414
+    # validators on the issuer/endpoint host mismatch (#647).
     return JSONResponse(
         {
             "issuer": ISSUER,
-            "authorization_endpoint": f"{base}/oauth/authorize",
-            "token_endpoint": f"{base}/oauth/token",
-            "revocation_endpoint": f"{base}/oauth/revoke",
-            "registration_endpoint": f"{base}/oauth/register",
+            "authorization_endpoint": f"{ISSUER}/oauth/authorize",
+            "token_endpoint": f"{ISSUER}/oauth/token",
+            "revocation_endpoint": f"{ISSUER}/oauth/revoke",
+            "registration_endpoint": f"{ISSUER}/oauth/register",
             "response_types_supported": ["code"],
             "grant_types_supported": ["authorization_code", "refresh_token"],
             "token_endpoint_auth_methods_supported": [
@@ -81,13 +85,24 @@ async def oauth_metadata(request: Request) -> JSONResponse:
 
 
 @router.get("/.well-known/oauth-protected-resource", include_in_schema=False)
-async def protected_resource_metadata() -> JSONResponse:
-    """RFC 9728 protected resource metadata.
+@router.get("/.well-known/oauth-protected-resource/{resource_path:path}", include_in_schema=False)
+async def protected_resource_metadata(resource_path: str = "") -> JSONResponse:
+    """RFC 9728 protected resource metadata (root + path-inserted variants).
 
     Tells OAuth clients (e.g. Claude Desktop) which authorization server
     issues valid tokens for the Hive MCP server.  CloudFront routes
     /.well-known/* to this API Lambda, so the document must live here rather
     than on the MCP Lambda.
+
+    Spec-following clients request the *path-inserted* URL first — for a
+    resource at /mcp that is ``/.well-known/oauth-protected-resource/mcp``
+    (RFC 9728 §3.1). Without an explicit route the Lambda 404s and the
+    distribution-wide CloudFront SPA error-fallback rewrites that 404 into a
+    200 ``text/html`` index page, which makes strict clients abort discovery
+    (#647). Registering the path variant here returns the JSON document, so the
+    SPA fallback never triggers. Hive exposes a single protected resource
+    (/mcp), so ``resource_path`` is accepted for route matching but the document
+    always describes /mcp.
     """
     return JSONResponse(
         {

--- a/src/hive/auth/tokens.py
+++ b/src/hive/auth/tokens.py
@@ -20,7 +20,10 @@ from hive.models import Token
 from hive.storage import HiveStorage
 
 JWT_ALGORITHM = "HS256"
-ISSUER = os.environ.get("HIVE_ISSUER", "https://hive.example.com")
+# Normalize once at the source: a trailing slash on HIVE_ISSUER would otherwise
+# produce double-slash discovery URLs (e.g. ".../oauth-authorization-server"
+# endpoints built as f"{ISSUER}/oauth/token"), which trips strict clients (#647).
+ISSUER = os.environ.get("HIVE_ISSUER", "https://hive.example.com").rstrip("/")
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -301,6 +301,7 @@ def _tool_result(
     client_id: str,
     *,
     memory: Memory | None = None,
+    extra_meta: dict[str, Any] | None = None,
 ) -> ToolResult:
     """Wrap a tool's return value in an MCP ``ToolResult`` carrying quota +
     rate-limit metadata in ``_meta.hive``. Strings become text content;
@@ -324,6 +325,8 @@ def _tool_result(
     meta = _quota_meta(storage, client_id)
     if memory is not None:
         meta["hive"]["memory"] = {"key": memory.key, "version": memory.version}
+    if extra_meta:
+        meta["hive"].update(extra_meta)
     if isinstance(payload, dict):
         return ToolResult(structured_content=payload, meta=meta)
     structured: dict[str, Any] = {"result": payload}
@@ -346,18 +349,19 @@ async def _sampled_summary(
     topic: str,
     memories: list[Memory],
     fallback: str,
-) -> str:
+) -> tuple[str, bool]:
     """Synthesise a set of memories via MCP Sampling (#448).
 
-    Sends a ``sampling/createMessage`` request back to the client and uses
-    its model to produce the summary. If the client doesn't support
-    sampling, the transport rejects it, or ctx is unavailable (e.g. direct
-    invocation in tests), returns ``fallback`` — the deterministic
-    concatenated listing — so the tool never fails just because an agent
-    can't sample.
+    Returns ``(text, synthesised)``. ``synthesised`` is ``True`` only when the
+    client's model produced the text via ``sampling/createMessage``; it is
+    ``False`` when the client doesn't support sampling, the transport rejects
+    it, ctx is unavailable (e.g. direct invocation in tests), or the model
+    returned nothing — in which case ``text`` is ``fallback`` (the
+    deterministic listing) so the tool never fails just because an agent can't
+    sample.
     """
     if ctx is None:
-        return fallback
+        return fallback, False
 
     body = "\n\n".join(f"- **{m.key}**: {m.value}" for m in memories)
     prompt = (
@@ -371,10 +375,12 @@ async def _sampled_summary(
         )
     except Exception:
         logger.info("MCP sampling unavailable; falling back to concat summary", exc_info=True)
-        return fallback
+        return fallback, False
 
-    text = getattr(result, "text", None) or fallback
-    return text.strip() or fallback
+    text = getattr(result, "text", None)
+    if text and text.strip():
+        return text.strip(), True
+    return fallback, False
 
 
 async def _report_progress(
@@ -1398,6 +1404,11 @@ async def summarize_context(
     that do not support sampling (e.g. Claude Desktop) instead receive the
     listed memories with a count footer — there is no server-side LLM, so the
     prose synthesis only happens when the client can provide the model (#662).
+
+    The response ``_meta.hive.summary_mode`` reports which path was taken
+    (``"synthesised"`` or ``"listed"``) so an agent that receives a listing can
+    choose to synthesise it itself; the listed memories are ordered most-recent
+    first (#658).
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
@@ -1412,6 +1423,9 @@ async def summarize_context(
 
     await _report_progress(ctx, 0, 2, f"Retrieving memories for '{topic}'...")
     memories, _ = storage.list_memories_by_tag(topic, limit=500, owner_user_id=owner_user_id)
+    # Freshest first, so both the sampling prompt and the listed fallback lead
+    # with the most recent memories (#658).
+    memories.sort(key=lambda m: m.updated_at, reverse=True)
     await _report_progress(
         ctx, 1, 2, f"Retrieved {len(memories)} memories; synthesising summary..."
     )
@@ -1427,7 +1441,12 @@ async def summarize_context(
             },
         )
         await emit_metric("ToolInvocations", operation="summarize_context")
-        return _tool_result(f"No memories found for topic '{topic}'.", storage, client_id)
+        return _tool_result(
+            f"No memories found for topic '{topic}'.",
+            storage,
+            client_id,
+            extra_meta={"summary_mode": "listed"},
+        )
 
     lines = [f"## Memories tagged '{topic}'\n"]
     for m in memories:
@@ -1439,7 +1458,8 @@ async def summarize_context(
     # Try MCP Sampling first (#448). If the client supports it, we get a real
     # LLM synthesis without any server-side Bedrock cost; otherwise the
     # sampler raises and we fall back to the concatenated listing above.
-    summary = await _sampled_summary(ctx, topic, memories, concat_summary)
+    summary, synthesised = await _sampled_summary(ctx, topic, memories, concat_summary)
+    summary_mode = "synthesised" if synthesised else "listed"
 
     _log(
         storage,
@@ -1467,7 +1487,7 @@ async def summarize_context(
         unit="Milliseconds",
         operation="summarize_context",
     )
-    return _tool_result(summary, storage, client_id)
+    return _tool_result(summary, storage, client_id, extra_meta={"summary_mode": summary_mode})
 
 
 @mcp.tool(

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -210,6 +210,23 @@ def _vector_store() -> VectorStore:
     return VectorStore()
 
 
+def _require_owner_user_id(storage: HiveStorage, client_id: str) -> str:
+    """Resolve the caller's account (``owner_user_id``), failing closed if unbound.
+
+    Per-user memory scoping (#666) requires a user account on the calling
+    client. Returns the ``owner_user_id`` or raises ``ToolError`` when the
+    client record is missing or not yet bound to a user (#648).
+    """
+    client = storage.get_client(client_id)
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    if client.owner_user_id is None:
+        raise ToolError(
+            "Client is not associated with a user account; per-user memory scoping is required."
+        )
+    return client.owner_user_id
+
+
 def _log(storage: HiveStorage, event: ActivityEvent) -> None:
     """Record the event in both the user-visible activity log and the
     immutable compliance audit log (#395).
@@ -982,7 +999,7 @@ async def forget(
 
     storage.delete_memory(existing.memory_id)
     try:
-        _vector_store().delete_memory(existing.memory_id, client_id)
+        _vector_store().delete_memory(existing.memory_id, existing.owner_user_id)
     except Exception:
         logger.warning("Vector delete failed (non-fatal)", exc_info=True)
     _log(
@@ -1130,7 +1147,7 @@ async def redact_memory(
     existing.updated_at = existing.redacted_at
     storage.put_memory(existing)
     try:
-        _vector_store().delete_memory(existing.memory_id, client_id)
+        _vector_store().delete_memory(existing.memory_id, existing.owner_user_id)
     except Exception:
         logger.warning("Vector delete on redaction failed (non-fatal)", exc_info=True)
 
@@ -1509,9 +1526,10 @@ async def search_memories(
     # post-filter still leaves up to top_k survivors.
     search_top_k = 50 if required_tags else min(max(top_k * 3, 10), 50)
 
+    owner_user_id = _require_owner_user_id(storage, client_id)
     await _report_progress(ctx, 0, 3, f"Running vector search for '{query}'...")
     try:
-        pairs = _vector_store().search(query, client_id, top_k=search_top_k)
+        pairs = _vector_store().search(query, owner_user_id, top_k=search_top_k)
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
     except Exception:
@@ -1644,9 +1662,10 @@ async def relate_memories(
                 exc_info=True,
             )
 
+    owner_user_id = _require_owner_user_id(storage, client_id)
     try:
         # Fetch top_k+1 so that dropping the source still leaves up to top_k.
-        pairs = _vector_store().search(query_value, client_id, top_k=top_k + 1)
+        pairs = _vector_store().search(query_value, owner_user_id, top_k=top_k + 1)
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
     except Exception:
@@ -1872,8 +1891,9 @@ async def pack_context(
         else ("relevance+recency")
     )
 
+    owner_user_id = _require_owner_user_id(storage, client_id)
     try:
-        pairs = _vector_store().search(topic, client_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL)
+        pairs = _vector_store().search(topic, owner_user_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL)
     except VectorIndexNotFoundError:
         return _tool_result(_render_empty_within_budget(topic, budget), storage, client_id)
     except Exception:

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -705,7 +705,16 @@ async def remember_blob(
     ``data`` must be standard Base64-encoded bytes. ``content_type`` must be a
     valid MIME type — memories whose type begins with ``image/`` are stored as
     ``value_type="image"``; all others use ``value_type="blob"``. The encoded
-    payload may not exceed 10 MB.
+    payload may not exceed 10 MB (in practice the deployed request path caps a
+    single call lower — see the docs — so several-MB blobs are the realistic
+    ceiling).
+
+    For ``image/*`` content, store a real, renderable image: clients render a
+    recalled image through an image API that rejects images below roughly a few
+    dozen pixels per side. A 32×32 (or larger) image renders; degenerate
+    fixtures like a 1×1 or 16×16 PNG are stored byte-exact but the consuming
+    client reports "Error processing image" (#649). This is a client/API
+    minimum, not a hive limit.
 
     Calling ``remember_blob`` with the same key again replaces the existing
     blob (upsert semantics).  Use ``recall(key)`` to retrieve the blob as an
@@ -1018,11 +1027,21 @@ async def forget_all(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope="memories:write")
 
-    # Scope bulk deletion to the calling client so it can never delete another
-    # tenant's same-tagged memories (GHSA-h9vh-rpcv-xqrr). owner_client_id is
-    # the axis reliably set on every memory today; user-level scoping follows
-    # once DCR clients are bound to user accounts (#648).
-    deleted = storage.delete_memories_by_tag(tag, owner_client_id=client_id)
+    # Scope bulk deletion to the caller's user account: it deletes the account's
+    # same-tagged memories across all its DCR clients (consistent with
+    # list_memories / list_tags, #666) but can never reach another user's
+    # memories (GHSA-h9vh-rpcv-xqrr). Requiring owner_user_id also guarantees we
+    # never call delete_memories_by_tag with no owner filter (which would delete
+    # across every tenant). Now that DCR clients are bound to user accounts
+    # (#648), owner_user_id is reliably set.
+    client = storage.get_client(client_id)
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    if client.owner_user_id is None:
+        raise ToolError(
+            "Client is not associated with a user account; per-user memory scoping is required."
+        )
+    deleted = storage.delete_memories_by_tag(tag, owner_user_id=client.owner_user_id)
     _log(
         storage,
         ActivityEvent(
@@ -1320,7 +1339,14 @@ async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
-    tags = storage.list_distinct_tags(client_id)
+    client = storage.get_client(client_id)
+    if client is None:
+        raise ToolError("Unable to load client record for authenticated caller.")
+    if client.owner_user_id is None:
+        raise ToolError(
+            "Client is not associated with a user account; per-user memory scoping is required."
+        )
+    tags = storage.list_distinct_tags(client.owner_user_id)
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
         "Listed %d distinct tags",

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -426,29 +426,34 @@ class HiveStorage:
                 results.append((memory, score))
         return results
 
-    def list_distinct_tags(self, client_id: str) -> list[str]:
-        """Return the sorted set of distinct tags on memories owned by ``client_id``.
+    def list_distinct_tags(self, owner_user_id: str) -> list[str]:
+        """Return the sorted distinct tags across the user account's memories.
 
-        Scans the TagIndex GSI (scope is limited to tag items — the base table
-        is never scanned) filtering on ``owner_client_id`` and projecting only
-        the ``GSI2PK`` attribute, which carries the ``TAG#{name}`` marker.
+        Queries the strongly-consistent USERTAG items (PK=USERTAG#{user_id},
+        SK=TAG#{tag}#MEMORY#{id}) so the result is account-scoped — matching the
+        ``owner_user_id`` boundary used by list_memories / summarize_context
+        (#666) — and reads-your-writes without TagIndex GSI propagation lag
+        (#653). The base table is never scanned.
         """
         tags: set[str] = set()
         start_key: dict[str, Any] | None = None
         while True:
             kwargs: dict[str, Any] = {
-                "IndexName": "TagIndex",
-                "FilterExpression": "owner_client_id = :cid",
-                "ExpressionAttributeValues": {":cid": client_id},
-                "ProjectionExpression": "GSI2PK",
+                "KeyConditionExpression": Key("PK").eq(f"USERTAG#{owner_user_id}")
+                & Key("SK").begins_with("TAG#"),
+                "ProjectionExpression": "SK",
+                "ConsistentRead": True,
             }
             if start_key:
                 kwargs["ExclusiveStartKey"] = start_key
-            resp = self.table.scan(**kwargs)
+            resp = self.table.query(**kwargs)
             for item in resp.get("Items", []):
-                gsi_pk = item.get("GSI2PK", "")
-                if gsi_pk.startswith("TAG#"):
-                    tags.add(gsi_pk[len("TAG#") :])
+                sk = item.get("SK", "")
+                # SK = TAG#{tag}#MEMORY#{memory_id}; rsplit isolates the tag even
+                # if the tag itself contains '#'.
+                tag = sk[len("TAG#") :].rsplit("#MEMORY#", 1)[0] if sk.startswith("TAG#") else ""
+                if tag:
+                    tags.add(tag)
             start_key = resp.get("LastEvaluatedKey")
             if not start_key:
                 break

--- a/src/hive/vector_store.py
+++ b/src/hive/vector_store.py
@@ -2,10 +2,12 @@
 """
 Vector store for Hive — S3 Vectors + Bedrock Titan Embeddings V2.
 
-One S3 Vectors index per OAuth client (``client-{client_id}``), lazy-created
-on first write.  All operations are best-effort: errors are logged but never
-propagate to callers so that DynamoDB (the authoritative store) is unaffected
-by vector-layer failures.
+One S3 Vectors index per user account (``user-{owner_user_id}``), lazy-created
+on first write.  Account scoping keeps semantic search consistent with the
+tag/list read path (which is scoped on ``owner_user_id``, #666) and with the
+workspace transition note on ``Memory.owner_user_id`` (#490).  All operations
+are best-effort: errors are logged but never propagate to callers so that
+DynamoDB (the authoritative store) is unaffected by vector-layer failures.
 
 Embedding model: amazon.titan-embed-text-v2:0
   - 1024 dimensions, cosine distance, normalised vectors
@@ -35,7 +37,7 @@ _DISTANCE_METRIC: Literal["cosine", "euclidean"] = "cosine"
 
 
 class VectorIndexNotFoundError(Exception):
-    """Raised when querying a client that has never written a memory."""
+    """Raised when querying an account that has never written a memory."""
 
 
 class VectorStore:
@@ -62,8 +64,8 @@ class VectorStore:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _index_name(self, client_id: str) -> str:
-        return f"client-{client_id}"
+    def _index_name(self, owner_user_id: str) -> str:
+        return f"user-{owner_user_id}"
 
     def _embed(self, text: str) -> list[float]:
         """Call Bedrock Titan V2 and return a 1024-dim normalised embedding."""
@@ -76,9 +78,9 @@ class VectorStore:
         )
         return json.loads(resp["body"].read())["embedding"]
 
-    def _ensure_index(self, client_id: str) -> str:
+    def _ensure_index(self, owner_user_id: str) -> str:
         """Return the index name, creating it if it doesn't exist yet."""
-        index_name = self._index_name(client_id)
+        index_name = self._index_name(owner_user_id)
         try:
             self._s3v.create_index(
                 vectorBucketName=self._bucket,
@@ -97,9 +99,22 @@ class VectorStore:
     # ------------------------------------------------------------------
 
     def upsert_memory(self, memory: Memory) -> None:
-        """Write (or overwrite) a memory vector.  Best-effort — never raises."""
+        """Write (or overwrite) a memory vector.  Best-effort — never raises.
+
+        Memories without an ``owner_user_id`` (legacy/pre-#648 items) cannot be
+        placed in an account index and are skipped — they remain unsearchable
+        until re-saved or migrated.
+        """
+        owner_user_id = memory.owner_user_id
+        if owner_user_id is None:
+            # Log the internal memory_id, never the user-provided key (PII/secrets).
+            logger.warning(
+                "Skipping vector upsert for memory_id '%s' — no owner_user_id",  # NOSONAR — internal id, not user content
+                memory.memory_id,
+            )
+            return
         try:
-            index_name = self._ensure_index(memory.owner_client_id)
+            index_name = self._ensure_index(owner_user_id)
             text = f"{memory.key}: {memory.value}"
             embedding = self._embed(text)
             self._s3v.put_vectors(
@@ -117,43 +132,52 @@ class VectorStore:
                 ],
             )
         except Exception:
-            logger.warning(
-                "Vector upsert failed for memory '%s' (client %s)",
-                memory.key,
-                memory.owner_client_id,
+            logger.warning(  # NOSONAR — memory_id and owner_user_id are internal identifiers, not user content
+                "Vector upsert failed for memory_id '%s' (user %s)",
+                memory.memory_id,
+                owner_user_id,
                 exc_info=True,
             )
 
-    def delete_memory(self, memory_id: str, client_id: str) -> None:
-        """Remove a memory vector.  Best-effort — never raises."""
+    def delete_memory(self, memory_id: str, owner_user_id: str | None) -> None:
+        """Remove a memory vector.  Best-effort — never raises.
+
+        ``owner_user_id`` identifies the account index the vector lives in. A
+        ``None`` owner (legacy item that was never indexed under an account) is
+        a no-op.
+        """
+        if owner_user_id is None:
+            return
         try:
             self._s3v.delete_vectors(
                 vectorBucketName=self._bucket,
-                indexName=self._index_name(client_id),
+                indexName=self._index_name(owner_user_id),
                 keys=[memory_id],
             )
         except Exception:
-            logger.warning(  # NOSONAR — memory_id and client_id are internal identifiers, not user content
-                "Vector delete failed for memory_id '%s' (client %s)",
+            logger.warning(  # NOSONAR — memory_id and owner_user_id are internal identifiers, not user content
+                "Vector delete failed for memory_id '%s' (user %s)",
                 memory_id,
-                client_id,
+                owner_user_id,
                 exc_info=True,
             )
 
     def search(
         self,
         query: str,
-        client_id: str,
+        owner_user_id: str,
         top_k: int = 20,
     ) -> list[tuple[str, float]]:
         """Return ``(memory_id, score)`` pairs ranked by cosine similarity.
 
-        ``score`` is ``1.0 - distance`` so higher = more relevant.
+        ``score`` is ``1.0 - distance`` so higher = more relevant. The search is
+        scoped to the ``owner_user_id`` account index, so results span every DCR
+        client of that account (consistent with list_memories, #666).
 
-        Raises ``VectorIndexNotFoundError`` when the client has never written
-        a memory (index does not exist yet).
+        Raises ``VectorIndexNotFoundError`` when the account has never written a
+        memory (index does not exist yet).
         """
-        index_name = self._index_name(client_id)
+        index_name = self._index_name(owner_user_id)
         try:
             embedding = self._embed(query)
             resp = self._s3v.query_vectors(
@@ -166,6 +190,6 @@ class VectorStore:
             )
         except self._s3v.exceptions.NotFoundException as exc:
             raise VectorIndexNotFoundError(
-                f"No vector index for client '{client_id}' — no memories indexed yet."
+                f"No vector index for account '{owner_user_id}' — no memories indexed yet."
             ) from exc
         return [(v["key"], round(1.0 - v["distance"], 6)) for v in resp.get("vectors", [])]

--- a/tasks.py
+++ b/tasks.py
@@ -542,6 +542,38 @@ def migrate_workspaces(ctx, dry_run=False):
     ctx.run(cmd, env=migrate_env, pty=True)
 
 
+@task
+def migrate_vectors(ctx, dry_run=False):
+    """Re-index memory vectors per user account (#666).
+
+    Rebuilds the per-account (``user-{owner_user_id}``) S3 Vectors indexes from
+    DynamoDB by re-embedding each memory, so semantic search spans all of an
+    account's DCR clients. Run once after deploying the #666 change; the old
+    per-client indexes are left orphaned (delete them once search is verified).
+
+    Idempotent — re-running overwrites the same vector keys. Pass ``--dry-run``
+    to report counts without calling Bedrock / S3 Vectors.
+
+        inv migrate-vectors              # execute against AWS (uses env vars)
+        inv migrate-vectors --dry-run    # report only, no writes
+
+    Requires HIVE_VECTORS_BUCKET (the S3 Vectors bucket) in the environment.
+    """
+    migrate_env = {
+        **os.environ,
+        "HIVE_JWT_SECRET": os.environ.get("HIVE_JWT_SECRET", "dev-secret"),
+        "HIVE_TABLE_NAME": os.environ.get("HIVE_TABLE_NAME", "hive"),
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
+    if "DYNAMODB_ENDPOINT" in os.environ:
+        migrate_env["DYNAMODB_ENDPOINT"] = os.environ["DYNAMODB_ENDPOINT"]
+        migrate_env.setdefault("AWS_ACCESS_KEY_ID", "local")
+        migrate_env.setdefault("AWS_SECRET_ACCESS_KEY", "local")
+    args = ["--dry-run"] if dry_run else []
+    cmd = "uv run python scripts/migrate_vectors_to_user_index.py " + " ".join(args)
+    ctx.run(cmd, env=migrate_env, pty=True)
+
+
 # ── Bulk memory operations ────────────────────────────────────────────────────
 
 

--- a/tests/e2e/test_ui_e2e.py
+++ b/tests/e2e/test_ui_e2e.py
@@ -9,6 +9,7 @@ Requires:
 from __future__ import annotations
 
 import os
+from urllib.parse import quote
 
 import pytest
 
@@ -22,71 +23,116 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture(scope="module")
-def browser_page():
+def _chromium():
+    """One shared Chromium for the module.
+
+    Both the admin (``browser_page``) and non-admin (``nonadmin_page``) fixtures
+    open a context on this single browser. They must share one
+    ``sync_playwright`` instance — two simultaneously-open sync-Playwright
+    contexts collide with pytest-asyncio's running loop ("Sync API inside the
+    asyncio loop").
+    """
     from playwright.sync_api import sync_playwright
 
     with sync_playwright() as p:
         browser = p.chromium.launch()
-        context = browser.new_context()
-
-        # #619 shipped an OnboardingTour that renders a full-viewport
-        # backdrop with pointer-events-auto on first visit — its
-        # "click outside to dismiss" behaviour intercepts every
-        # nav-tab click until it's dismissed. An `add_init_script`
-        # pre-sets the dismissed flag on every page that loads in
-        # this context so e2e tests never see the overlay.
-        #
-        # `hive_first_memory_skipped=1` pre-disables the post-create
-        # "first memory probe" in MemoryBrowser.handleCreate (#645).
-        # The probe itself no longer clobbers the filtered list — the
-        # underlying race was fixed in the same PR (loadRef +
-        # dropping the optimistic setMemories shortcut) — but skipping
-        # it puts the e2e fixture in the same steady state real users
-        # experience after their first save: one POST + one filtered
-        # GET, no spare unfiltered round trip racing the assertion.
-        context.add_init_script(
-            "localStorage.setItem('hive_tour_dismissed', '1');"
-            "localStorage.setItem('hive_first_memory_skipped', '1');"
-        )
-        page = context.new_page()
-
-        # Navigate to the bypass login endpoint via CloudFront (same origin as
-        # the UI) so the mgmt JWT lands in the correct localStorage origin.
-        # test_email is required — HIVE_BYPASS_GOOGLE_AUTH only triggers the
-        # synthetic path when test_email is explicitly supplied (#140).
-        page.goto(
-            f"{UI_URL}/auth/login?test_email=e2e@example.com",
-            timeout=30_000,
-            wait_until="networkidle",
-        )
-
-        # Token is now in localStorage. Navigate directly to /app — the
-        # HomeRoute would also redirect there, but client-side redirects can
-        # race with wait_for_url so we go straight to the destination.
-        page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
-
-        yield page
-        context.close()
+        yield browser
         browser.close()
 
 
+def _open_authenticated_page(browser, test_email):
+    """Open a Chromium context on ``browser`` authenticated as ``test_email``.
+
+    Returns ``(context, page)``; the caller owns context teardown.
+    """
+    context = browser.new_context()
+
+    # #619 shipped an OnboardingTour that renders a full-viewport
+    # backdrop with pointer-events-auto on first visit — its
+    # "click outside to dismiss" behaviour intercepts every
+    # nav-tab click until it's dismissed. An `add_init_script`
+    # pre-sets the dismissed flag on every page that loads in
+    # this context so e2e tests never see the overlay.
+    #
+    # `hive_first_memory_skipped=1` pre-disables the post-create
+    # "first memory probe" in MemoryBrowser.handleCreate (#645).
+    # The probe itself no longer clobbers the filtered list — the
+    # underlying race was fixed in the same PR (loadRef +
+    # dropping the optimistic setMemories shortcut) — but skipping
+    # it puts the e2e fixture in the same steady state real users
+    # experience after their first save: one POST + one filtered
+    # GET, no spare unfiltered round trip racing the assertion.
+    context.add_init_script(
+        "localStorage.setItem('hive_tour_dismissed', '1');"
+        "localStorage.setItem('hive_first_memory_skipped', '1');"
+    )
+    page = context.new_page()
+
+    # Navigate to the bypass login endpoint via CloudFront (same origin as
+    # the UI) so the mgmt JWT lands in the correct localStorage origin.
+    # test_email is required — HIVE_BYPASS_GOOGLE_AUTH only triggers the
+    # synthetic path when test_email is explicitly supplied (#140).
+    page.goto(
+        # Encode the whole value — '+' (plus-addressing) would otherwise decode
+        # to a space server-side and flip the email to a different identity.
+        f"{UI_URL}/auth/login?test_email={quote(test_email, safe='')}",
+        timeout=30_000,
+        wait_until="networkidle",
+    )
+
+    # Token is now in localStorage. Navigate directly to /app — the
+    # HomeRoute would also redirect there, but client-side redirects can
+    # race with wait_for_url so we go straight to the destination.
+    page.goto(f"{UI_URL}/app", timeout=30_000, wait_until="networkidle")
+    return context, page
+
+
+@pytest.fixture(scope="module")
+def browser_page(_chromium):
+    # e2e@example.com is on the dev admin allowlist, so this is an admin session
+    # (the tab set / "see all" behaviour most UI tests exercise).
+    context, page = _open_authenticated_page(_chromium, "e2e@example.com")
+    yield page
+    context.close()
+
+
+@pytest.fixture(scope="module")
+def nonadmin_page(_chromium):
+    """Authenticated page for a NON-admin user, where read-your-writes holds.
+
+    The default ``browser_page`` user (``e2e@example.com``) is an admin: the
+    management API's ``_user_filter`` returns ``None`` for admins ("see all"),
+    so a tag-filtered list cannot use the per-user strongly-consistent USERTAG
+    path (#568) and falls back to the eventually-consistent TagIndex GSI — a
+    just-created memory can lag the filtered GET (#679). A non-allowlisted
+    ``test_email`` registers as ``role="user"``, so its reads are scoped to its
+    own ``owner_user_id`` and served from the consistent USERTAG path: a fresh
+    write is visible the instant the POST returns. Use this fixture for any
+    test that asserts a newly-created memory is immediately readable.
+    """
+    context, page = _open_authenticated_page(_chromium, "e2e-nonadmin@example.com")
+    yield page
+    context.close()
+
+
 class TestMarketingNav:
-    def test_signin_btn_border_is_visible(self):
+    def test_signin_btn_border_is_visible(self, _chromium):
         """Sign in button on marketing navbar has a visible border (not transparent).
 
         Asserts the computed border-color so CSS regressions can't sneak past a
         class-name check.  The nav variant bakes border-white/60 into the variant
         itself — no className override needed.
-        """
-        from playwright.sync_api import sync_playwright
 
-        with sync_playwright() as p:
-            browser = p.chromium.launch()
-            page = browser.new_page()
+        Uses the shared ``_chromium`` browser (its own fresh page, no auth needed
+        for the marketing root) so the module holds exactly one ``sync_playwright``
+        instance — a second one could overlap with it and trip pytest-asyncio's
+        "Sync API inside the asyncio loop" guard.
+        """
+        page = _chromium.new_page()
+        try:
             page.goto(f"{UI_URL}/", timeout=30_000, wait_until="networkidle")
             signin_btn = page.locator(".marketing-signin-btn")
             if not signin_btn.is_visible():
-                browser.close()
                 pytest.skip("Sign in button not visible (may be mobile viewport)")
             border_color = signin_btn.evaluate("el => getComputedStyle(el).borderColor")
             import re
@@ -96,7 +142,8 @@ class TestMarketingNav:
                 f"Sign in button border is transparent: {border_color!r}. "
                 "Check that the nav variant in button.jsx applies border-white/60."
             )
-            browser.close()
+        finally:
+            page.close()
 
 
 class TestUIE2E:
@@ -105,10 +152,15 @@ class TestUIE2E:
         page.goto(UI_URL)
         assert page.locator("nav button:has-text('Memories')").is_visible()
 
-    def test_create_and_see_memory(self, browser_page):
+    def test_create_and_see_memory(self, nonadmin_page):
         import time
 
-        page = browser_page
+        # Runs as a NON-admin user so the tag-filtered read is owner-scoped and
+        # served from the strongly-consistent USERTAG path — read-your-writes
+        # holds and the assertion below is deterministic. As an admin (the
+        # default browser_page user) this read would come from the eventually-
+        # consistent GSI and intermittently miss the just-created memory (#679).
+        page = nonadmin_page
         # Use a unique key AND a unique tag per run.  The key avoids ownership
         # conflicts; the tag is used to filter the list immediately after create
         # so we never depend on the new memory appearing on page 1 of an

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -262,6 +262,13 @@ class TestOAuthDiscovery:
         assert "token_endpoint" in data
         assert "code_challenge_methods_supported" in data
         assert "S256" in data["code_challenge_methods_supported"]
+        # #647 — every endpoint must be built from the issuer (the public
+        # custom domain), not the raw Function URL, so the host matches and
+        # strict RFC 8414 validators accept the document.
+        assert data["authorization_endpoint"] == f"{data['issuer']}/oauth/authorize"
+        assert data["token_endpoint"] == f"{data['issuer']}/oauth/token"
+        assert data["revocation_endpoint"] == f"{data['issuer']}/oauth/revoke"
+        assert data["registration_endpoint"] == f"{data['issuer']}/oauth/register"
 
     def test_protected_resource_metadata(self, oauth_client):
         tc, *_ = oauth_client
@@ -276,6 +283,24 @@ class TestOAuthDiscovery:
         assert "memories:read" in data["scopes_supported"]
         assert "memories:write" in data["scopes_supported"]
         assert data["bearer_methods_supported"] == ["header"]
+
+    def test_protected_resource_metadata_path_inserted(self, oauth_client):
+        """#647 — the RFC 9728 path-inserted URL must return the JSON document.
+
+        Spec-strict clients hit ``/.well-known/oauth-protected-resource/mcp``
+        first. Without this route the Lambda 404s and CloudFront's SPA fallback
+        rewrites it to 200 text/html, aborting discovery. It must serve the same
+        JSON as the root variant.
+        """
+        tc, *_ = oauth_client
+        resp = tc.get("/.well-known/oauth-protected-resource/mcp")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        data = resp.json()
+        assert data["resource"].endswith("/mcp")
+        assert "authorization_servers" in data
+        # Identical document to the root variant.
+        assert data == tc.get("/.well-known/oauth-protected-resource").json()
 
 
 class TestOAuthRegister:

--- a/tests/unit/test_migrate_vectors.py
+++ b/tests/unit/test_migrate_vectors.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for scripts/migrate_vectors_to_user_index.py — the #666 re-index."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-test-migrate-vectors")
+os.environ.setdefault("HIVE_VECTORS_BUCKET", "test-vectors-bucket")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+
+from hive.models import Memory
+from scripts.migrate_vectors_to_user_index import MigrationStats, main, run
+
+
+def _mem(**kwargs) -> Memory:
+    defaults = {
+        "key": "k",
+        "value": "v",
+        "owner_client_id": "client-1",
+        "owner_user_id": "user-1",
+    }
+    defaults.update(kwargs)
+    return Memory(**defaults)
+
+
+def _run(memories, *, dry_run=False, blob_value="large body"):
+    """Run the migration against mock storage/vector_store; return (stats, vs)."""
+    storage = MagicMock()
+    storage.iter_all_memories.return_value = iter(memories)
+    storage.fetch_blob_value.return_value = blob_value
+    vs = MagicMock()
+    stats = run(dry_run=dry_run, storage=storage, vector_store=vs)
+    return stats, vs, storage
+
+
+def test_reindexes_embeddable_memories():
+    mems = [_mem(key="a", owner_user_id="user-1"), _mem(key="b", owner_user_id="user-2")]
+    stats, vs, _ = _run(mems)
+    assert stats.memories_seen == 2
+    assert stats.reindexed == 2
+    assert vs.upsert_memory.call_count == 2
+    upserted_keys = {c.args[0].key for c in vs.upsert_memory.call_args_list}
+    assert upserted_keys == {"a", "b"}
+
+
+def test_skips_memory_without_owner_user_id():
+    stats, vs, _ = _run([_mem(owner_user_id=None)])
+    assert stats.skipped_no_owner == 1
+    assert stats.reindexed == 0
+    vs.upsert_memory.assert_not_called()
+
+
+def test_skips_non_embeddable_blob_and_image():
+    mems = [_mem(value_type="image"), _mem(value_type="blob")]
+    stats, vs, _ = _run(mems)
+    assert stats.skipped_non_embeddable == 2
+    assert stats.reindexed == 0
+    vs.upsert_memory.assert_not_called()
+
+
+def test_skips_redacted_memory():
+    stats, vs, _ = _run([_mem(redacted_at=datetime.now(timezone.utc))])
+    assert stats.skipped_redacted == 1
+    assert stats.reindexed == 0
+    vs.upsert_memory.assert_not_called()
+
+
+def test_text_large_embeds_fetched_value():
+    stats, vs, storage = _run(
+        [_mem(value_type="text-large", value="")], blob_value="the full large text"
+    )
+    assert stats.reindexed == 1
+    storage.fetch_blob_value.assert_called_once()
+    upserted = vs.upsert_memory.call_args.args[0]
+    assert upserted.value == "the full large text"
+
+
+def test_dry_run_counts_but_does_not_write():
+    stats, vs, storage = _run([_mem(), _mem(key="b")], dry_run=True)
+    assert stats.reindexed == 2
+    vs.upsert_memory.assert_not_called()
+    storage.fetch_blob_value.assert_not_called()
+
+
+def test_report_includes_all_counters():
+    stats = MigrationStats(
+        memories_seen=5,
+        reindexed=3,
+        skipped_no_owner=1,
+        skipped_non_embeddable=1,
+        skipped_redacted=0,
+    )
+    report = stats.report()
+    for field in (
+        "memories_seen=5",
+        "reindexed=3",
+        "skipped_no_owner=1",
+        "skipped_non_embeddable=1",
+        "skipped_redacted=0",
+    ):
+        assert field in report
+
+
+def test_main_returns_zero_and_prints(capsys):
+    with patch(
+        "scripts.migrate_vectors_to_user_index.run",
+        return_value=MigrationStats(memories_seen=2, reindexed=2),
+    ) as mock_run:
+        rc = main(["--dry-run"])
+    assert rc == 0
+    mock_run.assert_called_once_with(dry_run=True)
+    assert "reindexed=2" in capsys.readouterr().out

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -914,13 +914,32 @@ class TestListTags:
         from hive.server import list_tags, remember
 
         await remember("mine", "v", ["owned"], ctx=_make_ctx(jwt))
-        # Write a memory belonging to a different client directly so we bypass auth
+        # A memory belonging to a different user account must not leak in (#666).
         storage.put_memory(
-            Memory(key="theirs", value="v", tags=["not-mine"], owner_client_id="other-client")
+            Memory(
+                key="theirs",
+                value="v",
+                tags=["not-mine"],
+                owner_client_id="other-client",
+                owner_user_id="other-user",
+            )
         )
 
         result = await list_tags(ctx=_make_ctx(jwt))
         assert _body(result)["tags"] == ["owned"]
+
+    async def test_merges_tags_across_clients_of_same_account(self, server_env):
+        """Two DCR clients of the same account share one tag namespace (#666)."""
+        storage, _, _ = server_env
+        from hive.server import list_tags, remember
+
+        jwt_1 = _make_user_jwt(storage, "tag-user")
+        jwt_2 = _make_user_jwt(storage, "tag-user")
+        await remember("k1", "v", ["from-c1"], ctx=_make_ctx(jwt_1))
+        await remember("k2", "v", ["from-c2"], ctx=_make_ctx(jwt_2))
+
+        result = await list_tags(ctx=_make_ctx(jwt_1))
+        assert _body(result)["tags"] == ["from-c1", "from-c2"]
 
     async def test_requires_read_scope(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -931,6 +950,56 @@ class TestListTags:
         write_only_jwt = _make_limited_scope_jwt(storage, "memories:write")
         with pytest.raises(ToolError, match="Insufficient scope"):
             await list_tags(ctx=_make_ctx(write_only_jwt))
+
+    async def test_rejects_missing_client_record(self, server_env):
+        """list_tags fails closed when the authenticated client record is gone."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import list_tags
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Client LT", owner_user_id="ghost-user-lt")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await list_tags(ctx=_make_ctx(jwt))
+
+    async def test_requires_user_account(self, server_env):
+        """An unbound client (owner_user_id is None) fails closed."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import list_tags
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Unbound List Tags")
+        assert client.owner_user_id is None
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+
+        with pytest.raises(ToolError, match="not associated with a user account"):
+            await list_tags(ctx=_make_ctx(jwt))
 
 
 # ---------------------------------------------------------------------------
@@ -2265,6 +2334,15 @@ class TestRecallBinary:
         "DwADhgGAWjR9awAAAABJRU5ErkJggg=="
     )
 
+    # A real 32×32 RGBA PNG — above the ~few-dozen-pixel minimum that the
+    # Anthropic image API (and most clients) require to render. The 1×1 fixture
+    # round-trips byte-exact through hive but is too small for a consuming
+    # client to display, which is what the e2e rounds hit (#649).
+    _PNG_32 = (
+        "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAALUlEQVR42u3OIQEAAAgD"
+        "sOckMa0gxs3E/JLZqxIQEBAQEBAQEBAQEBAQEGgHHn/LhHlnLcV4AAAAAElFTkSuQmCC"
+    )
+
     def _setup_blob_bucket(self, monkeypatch):
         bucket = "test-recall-blob-499"
         monkeypatch.setenv("HIVE_BLOBS_BUCKET", bucket)
@@ -2286,6 +2364,27 @@ class TestRecallBinary:
         assert isinstance(block, ImageContent)
         assert block.mimeType == "image/png"
         assert block.data == self._PNG_1PX
+
+    async def test_recall_renderable_image_round_trips_byte_exact(self, server_env, monkeypatch):
+        """A ≥32×32 image (renderable in real clients) round-trips byte-exact (#649).
+
+        The reported "Error processing image" was the consuming image API
+        rejecting a sub-renderable fixture (1×1 / 16×16), not a hive
+        serialization defect — hive returns the original bytes intact.
+        """
+        from mcp.types import ImageContent
+
+        from hive.server import recall, remember_blob
+
+        self._setup_blob_bucket(monkeypatch)
+        _, _, jwt = server_env
+        await remember_blob("img-32", self._PNG_32, "image/png", ctx=_make_ctx(jwt))
+
+        result = await recall("img-32", ctx=_make_ctx(jwt))
+        block = result.content[0]
+        assert isinstance(block, ImageContent)
+        assert block.mimeType == "image/png"
+        assert block.data == self._PNG_32
 
     async def test_recall_image_includes_structured_content(self, server_env, monkeypatch):
         """#654 — recall is `-> str`, so FastMCP advertises the wrap-result
@@ -2439,45 +2538,95 @@ class TestForgetAll:
         with pytest.raises(ToolError, match="Insufficient scope"):
             await forget_all("t", ctx=_make_ctx(read_only_jwt))
 
-    async def test_forget_all_does_not_delete_other_clients_memories(self, server_env):
+    async def test_forget_all_does_not_delete_other_users_memories(self, server_env):
         """Cross-tenant data destruction guard (GHSA-h9vh-rpcv-xqrr).
 
-        forget_all must scope deletion to the calling client. A second,
-        distinct client's same-tagged memory must survive — even when neither
-        client is bound to a user account (the production DCR case where
-        owner_user_id is None), so scoping cannot rely on owner_user_id alone.
+        forget_all is scoped to the caller's user account, so a different
+        user's same-tagged memory must survive (#666).
         """
-        from hive.auth.tokens import issue_jwt
-        from hive.models import OAuthClient, Token
         from hive.server import forget_all, remember
 
-        storage, _client_a_id, jwt_a = server_env
+        storage, _, _ = server_env
+        jwt_a = _make_user_jwt(storage, "user-alice")
+        jwt_b = _make_user_jwt(storage, "user-bob")
 
-        # Client A stores a memory under a tag both clients happen to use.
-        await remember("victim", "owned by A", ["shared"], ctx=_make_ctx(jwt_a))
+        await remember("alice-note", "owned by Alice", ["shared"], ctx=_make_ctx(jwt_a))
+        await remember("bob-note", "owned by Bob", ["shared"], ctx=_make_ctx(jwt_b))
 
-        # A distinct client B, unbound to any user (mirrors production DCR).
-        client_b = OAuthClient(client_name="Other Client")
-        assert client_b.owner_user_id is None
-        storage.put_client(client_b)
+        result = await forget_all("shared", ctx=_make_ctx(jwt_b))
+
+        # Bob may only delete his own memory; Alice's must survive.
+        assert storage.get_memory_by_key("alice-note") is not None
+        assert storage.get_memory_by_key("bob-note") is None
+        assert "1" in _text(result)
+
+    async def test_forget_all_deletes_across_clients_of_same_account(self, server_env):
+        """forget_all spans every DCR client of the caller's account (#666)."""
+        from hive.server import forget_all, remember
+
+        storage, _, _ = server_env
+        # Two distinct DCR clients, same user account.
+        jwt_1 = _make_user_jwt(storage, "shared-user")
+        jwt_2 = _make_user_jwt(storage, "shared-user")
+
+        await remember("from-client-1", "v1", ["sweep"], ctx=_make_ctx(jwt_1))
+        await remember("from-client-2", "v2", ["sweep"], ctx=_make_ctx(jwt_2))
+
+        result = await forget_all("sweep", ctx=_make_ctx(jwt_1))
+
+        assert storage.get_memory_by_key("from-client-1") is None
+        assert storage.get_memory_by_key("from-client-2") is None
+        assert "2" in _text(result)
+
+    async def test_forget_all_requires_user_account(self, server_env):
+        """An unbound client (owner_user_id is None) fails closed, never a no-filter delete."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import forget_all
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Unbound Client")
+        assert client.owner_user_id is None
+        storage.put_client(client)
         now = datetime.now(timezone.utc)
-        token_b = Token(
-            client_id=client_b.client_id,
+        token = Token(
+            client_id=client.client_id,
             scope="memories:read memories:write",
             issued_at=now,
             expires_at=now + timedelta(hours=1),
         )
-        storage.put_token(token_b)
-        jwt_b = issue_jwt(token_b)
-        await remember("b-note", "owned by B", ["shared"], ctx=_make_ctx(jwt_b))
+        storage.put_token(token)
+        jwt = issue_jwt(token)
 
-        # Client B bulk-deletes by the shared tag.
-        result = await forget_all("shared", ctx=_make_ctx(jwt_b))
+        with pytest.raises(ToolError, match="not associated with a user account"):
+            await forget_all("anything", ctx=_make_ctx(jwt))
 
-        # B may only delete its own memory; A's must survive.
-        assert storage.get_memory_by_key("victim") is not None
-        assert storage.get_memory_by_key("b-note") is None
-        assert "1" in _text(result)
+    async def test_forget_all_rejects_missing_client_record(self, server_env):
+        """forget_all fails closed when the authenticated client record is gone."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import forget_all
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Client FA", owner_user_id="ghost-user-fa")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await forget_all("anything", ctx=_make_ctx(jwt))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1085,11 +1085,65 @@ class TestSummarizeContext:
         assert "verbatim detail" in _text(result)
 
     async def test_sampled_summary_handles_ctx_none(self):
-        """Direct call to the helper with ctx=None returns the fallback verbatim."""
+        """Direct call with ctx=None returns (fallback, synthesised=False)."""
         from hive.server import _sampled_summary
 
         out = await _sampled_summary(None, "t", [], "FALLBACK_TEXT")
-        assert out == "FALLBACK_TEXT"
+        assert out == ("FALLBACK_TEXT", False)
+
+    async def test_summarize_meta_reports_synthesised_mode(self, server_env):
+        """When sampling succeeds, _meta.summary_mode is 'synthesised' (#658)."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("m-syn", "detail", ["mode-syn"], ctx=_make_ctx(jwt))
+        ctx = _make_ctx(jwt)
+        sampled = MagicMock()
+        sampled.text = "SYNTH"
+        ctx.sample = AsyncMock(return_value=sampled)
+
+        result = await summarize_context("mode-syn", ctx=ctx)
+        assert _hive_meta(result)["summary_mode"] == "synthesised"
+
+    async def test_summarize_meta_reports_listed_mode_on_fallback(self, server_env):
+        """When sampling is unavailable, _meta.summary_mode is 'listed' (#658)."""
+        from unittest.mock import AsyncMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("m-list", "detail", ["mode-list"], ctx=_make_ctx(jwt))
+        ctx = _make_ctx(jwt)
+        ctx.sample = AsyncMock(side_effect=RuntimeError("no sampling"))
+
+        result = await summarize_context("mode-list", ctx=ctx)
+        assert _hive_meta(result)["summary_mode"] == "listed"
+
+    async def test_summarize_empty_reports_listed_mode(self, server_env):
+        """The no-memories path also carries a summary_mode (#658)."""
+        _, _, jwt = server_env
+        from hive.server import summarize_context
+
+        result = await summarize_context("no-such-tag-xyz", ctx=_make_ctx(jwt))
+        assert _hive_meta(result)["summary_mode"] == "listed"
+
+    async def test_summarize_listing_ordered_most_recent_first(self, server_env):
+        """The listed fallback leads with the most recently updated memory (#658)."""
+        from unittest.mock import AsyncMock
+
+        from hive.server import remember, summarize_context
+
+        _, _, jwt = server_env
+        await remember("older-key", "older value", ["recency"], ctx=_make_ctx(jwt))
+        await remember("newer-key", "newer value", ["recency"], ctx=_make_ctx(jwt))
+        ctx = _make_ctx(jwt)
+        ctx.sample = AsyncMock(side_effect=RuntimeError("no sampling"))
+
+        text = _text(await summarize_context("recency", ctx=ctx))
+        # 'newer-key' was written last → later updated_at → appears first.
+        assert text.index("newer-key") < text.index("older-key")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1722,6 +1722,56 @@ class TestSearchMemories:
 
         assert _body(result) == {"items": [], "count": 0, "query": "anything"}
 
+    async def test_requires_user_account(self, server_env):
+        """search_memories fails closed when the client isn't bound to a user (#666)."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import search_memories
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Unbound Search")
+        assert client.owner_user_id is None
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+
+        with pytest.raises(ToolError, match="not associated with a user account"):
+            await search_memories("anything", ctx=_make_ctx(jwt))
+
+    async def test_rejects_missing_client_record(self, server_env):
+        """search_memories fails closed when the authenticated client record is gone (#666)."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.auth.tokens import issue_jwt
+        from hive.models import OAuthClient, Token
+        from hive.server import search_memories
+
+        storage, _, _ = server_env
+        client = OAuthClient(client_name="Ghost Search", owner_user_id="ghost-user-search")
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        jwt = issue_jwt(token)
+        storage.delete_client(client.client_id)
+
+        with pytest.raises(ToolError, match="Unable to load client record"):
+            await search_memories("anything", ctx=_make_ctx(jwt))
+
 
 # ---------------------------------------------------------------------------
 # relate_memories

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -148,35 +148,65 @@ class TestMemoryStorage:
 
     def test_list_distinct_tags_returns_sorted_unique(self, storage):
         for m in [
-            Memory(key="a", value="1", tags=["zebra", "alpha"], owner_client_id="c1"),
-            Memory(key="b", value="2", tags=["alpha", "mango"], owner_client_id="c1"),
-            Memory(key="c", value="3", tags=[], owner_client_id="c1"),
+            Memory(
+                key="a",
+                value="1",
+                tags=["zebra", "alpha"],
+                owner_client_id="c1",
+                owner_user_id="u1",
+            ),
+            Memory(
+                key="b",
+                value="2",
+                tags=["alpha", "mango"],
+                owner_client_id="c1",
+                owner_user_id="u1",
+            ),
+            Memory(key="c", value="3", tags=[], owner_client_id="c1", owner_user_id="u1"),
         ]:
             storage.put_memory(m)
 
-        assert storage.list_distinct_tags("c1") == ["alpha", "mango", "zebra"]
+        assert storage.list_distinct_tags("u1") == ["alpha", "mango", "zebra"]
 
-    def test_list_distinct_tags_scoped_to_client(self, storage):
-        storage.put_memory(Memory(key="a", value="1", tags=["mine"], owner_client_id="c1"))
-        storage.put_memory(Memory(key="b", value="2", tags=["theirs"], owner_client_id="c2"))
+    def test_list_distinct_tags_scoped_to_account(self, storage):
+        storage.put_memory(
+            Memory(key="a", value="1", tags=["mine"], owner_client_id="c1", owner_user_id="u1")
+        )
+        storage.put_memory(
+            Memory(key="b", value="2", tags=["theirs"], owner_client_id="c2", owner_user_id="u2")
+        )
 
-        assert storage.list_distinct_tags("c1") == ["mine"]
-        assert storage.list_distinct_tags("c2") == ["theirs"]
+        assert storage.list_distinct_tags("u1") == ["mine"]
+        assert storage.list_distinct_tags("u2") == ["theirs"]
+
+    def test_list_distinct_tags_merges_clients_of_same_account(self, storage):
+        # Two DCR clients of the same user account share one tag namespace (#666).
+        storage.put_memory(
+            Memory(key="a", value="1", tags=["from-c1"], owner_client_id="c1", owner_user_id="u1")
+        )
+        storage.put_memory(
+            Memory(key="b", value="2", tags=["from-c2"], owner_client_id="c2", owner_user_id="u1")
+        )
+
+        assert storage.list_distinct_tags("u1") == ["from-c1", "from-c2"]
 
     def test_list_distinct_tags_empty_when_no_memories(self, storage):
-        assert storage.list_distinct_tags("c1") == []
+        assert storage.list_distinct_tags("u1") == []
 
-    def test_list_distinct_tags_follows_scan_pages(self, storage):
+    def test_list_distinct_tags_follows_query_pages(self, storage):
         from unittest.mock import patch
 
         responses = iter(
             [
-                {"Items": [{"GSI2PK": "TAG#alpha"}], "LastEvaluatedKey": {"PK": "x"}},
-                {"Items": [{"GSI2PK": "TAG#beta"}, {"GSI2PK": "NOT_A_TAG"}]},
+                {
+                    "Items": [{"SK": "TAG#alpha#MEMORY#m1"}],
+                    "LastEvaluatedKey": {"PK": "USERTAG#u1", "SK": "TAG#alpha#MEMORY#m1"},
+                },
+                {"Items": [{"SK": "TAG#beta#MEMORY#m2"}, {"SK": "NOT_A_TAG"}]},
             ]
         )
-        with patch.object(storage.table, "scan", side_effect=lambda **_kw: next(responses)):
-            result = storage.list_distinct_tags("c1")
+        with patch.object(storage.table, "query", side_effect=lambda **_kw: next(responses)):
+            result = storage.list_distinct_tags("u1")
 
         assert result == ["alpha", "beta"]
 

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -49,6 +49,7 @@ def _make_memory(**kwargs) -> Memory:
         "value": "test value",
         "tags": ["t1"],
         "owner_client_id": "client-abc",
+        "owner_user_id": "user-abc",
     }
     defaults.update(kwargs)
     return Memory(**defaults)
@@ -87,11 +88,11 @@ class TestEnsureIndex:
     def test_creates_index_on_first_call(self):
         s3v = _make_s3v_client()
         vs = VectorStore(bucket_name="mybucket", _s3v_client=s3v, _bedrock_client=MagicMock())
-        name = vs._ensure_index("client-123")
-        assert name == "client-client-123"
+        name = vs._ensure_index("user-123")
+        assert name == "user-user-123"
         s3v.create_index.assert_called_once_with(
             vectorBucketName="mybucket",
-            indexName="client-client-123",
+            indexName="user-user-123",
             dataType="float32",
             dimension=1024,
             distanceMetric="cosine",
@@ -103,7 +104,7 @@ class TestEnsureIndex:
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=MagicMock())
         # Must not raise
         name = vs._ensure_index("abc")
-        assert name == "client-abc"
+        assert name == "user-abc"
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +122,7 @@ class TestUpsertMemory:
         s3v.put_vectors.assert_called_once()
         call_kwargs = s3v.put_vectors.call_args.kwargs
         assert call_kwargs["vectorBucketName"] == "bkt"
-        assert call_kwargs["indexName"] == f"client-{m.owner_client_id}"
+        assert call_kwargs["indexName"] == f"user-{m.owner_user_id}"
         vectors = call_kwargs["vectors"]
         assert len(vectors) == 1
         assert vectors[0]["key"] == m.memory_id
@@ -135,6 +136,16 @@ class TestUpsertMemory:
         embedded_text = bedrock.invoke_model.call_args.kwargs["body"]
         assert "mykey" in embedded_text
         assert "myvalue" in embedded_text
+
+    def test_skips_when_no_owner_user_id(self):
+        # Legacy/pre-#648 memory with no account owner can't be placed in an
+        # account index — upsert is a silent no-op (#666).
+        s3v = _make_s3v_client()
+        bedrock = _make_bedrock_client()
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=bedrock)
+        vs.upsert_memory(_make_memory(owner_user_id=None))
+        s3v.put_vectors.assert_not_called()
+        bedrock.invoke_model.assert_not_called()
 
     def test_swallows_exceptions_best_effort(self):
         s3v = _make_s3v_client()
@@ -154,19 +165,27 @@ class TestDeleteMemory:
     def test_calls_delete_vectors(self):
         s3v = _make_s3v_client()
         vs = VectorStore(bucket_name="bkt", _s3v_client=s3v, _bedrock_client=MagicMock())
-        vs.delete_memory("mem-id-123", "client-xyz")
+        vs.delete_memory("mem-id-123", "user-xyz")
         s3v.delete_vectors.assert_called_once_with(
             vectorBucketName="bkt",
-            indexName="client-client-xyz",
+            indexName="user-user-xyz",
             keys=["mem-id-123"],
         )
+
+    def test_noop_when_owner_user_id_none(self):
+        # A memory never indexed under an account (owner_user_id None) has no
+        # vector to remove — delete is a no-op, never touching S3 (#666).
+        s3v = _make_s3v_client()
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=MagicMock())
+        vs.delete_memory("id", None)
+        s3v.delete_vectors.assert_not_called()
 
     def test_swallows_exceptions_best_effort(self):
         s3v = _make_s3v_client()
         s3v.delete_vectors.side_effect = RuntimeError("gone")
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=MagicMock())
         # Must not raise
-        vs.delete_memory("id", "client")
+        vs.delete_memory("id", "user-1")
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +204,7 @@ class TestSearch:
         }
         bedrock = _make_bedrock_client()
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=bedrock)
-        results = vs.search("query text", "client-1", top_k=5)
+        results = vs.search("query text", "user-1", top_k=5)
         assert results == [("mem-a", round(0.9, 6)), ("mem-b", round(0.6, 6))]
 
     def test_calls_query_vectors_with_correct_args(self):
@@ -193,10 +212,10 @@ class TestSearch:
         s3v.query_vectors.return_value = {"vectors": []}
         bedrock = _make_bedrock_client()
         vs = VectorStore(bucket_name="mybucket", _s3v_client=s3v, _bedrock_client=bedrock)
-        vs.search("hello", "myclient", top_k=7)
+        vs.search("hello", "myuser", top_k=7)
         call_kwargs = s3v.query_vectors.call_args.kwargs
         assert call_kwargs["vectorBucketName"] == "mybucket"
-        assert call_kwargs["indexName"] == "client-myclient"
+        assert call_kwargs["indexName"] == "user-myuser"
         assert call_kwargs["topK"] == 7
         assert call_kwargs["returnDistance"] is True
         assert call_kwargs["returnMetadata"] is False
@@ -207,18 +226,18 @@ class TestSearch:
         bedrock = _make_bedrock_client()
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=bedrock)
         with pytest.raises(VectorIndexNotFoundError):
-            vs.search("query", "client-never-wrote")
+            vs.search("query", "user-never-wrote")
 
     def test_caps_top_k_at_100(self):
         s3v = _make_s3v_client()
         s3v.query_vectors.return_value = {"vectors": []}
         bedrock = _make_bedrock_client()
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=bedrock)
-        vs.search("q", "c", top_k=999)
+        vs.search("q", "u", top_k=999)
         assert s3v.query_vectors.call_args.kwargs["topK"] == 100
 
     def test_returns_empty_list_when_no_vectors(self):
         s3v = _make_s3v_client()
         s3v.query_vectors.return_value = {"vectors": []}
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
-        assert vs.search("q", "c") == []
+        assert vs.search("q", "u") == []

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1138,9 +1138,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -5848,12 +5848,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5863,13 +5863,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7368,9 +7368,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/src/components/stats/ActivityHeatmap.test.jsx
+++ b/ui/src/components/stats/ActivityHeatmap.test.jsx
@@ -59,6 +59,22 @@ describe("buildGrid", () => {
       expect(col).toHaveLength(7);
     }
   });
+
+  it("does not flush a trailing empty column when the span ends on a Saturday", () => {
+    // buildGrid pushes each column the instant it fills the Saturday row
+    // (dayOfWeek 6) and resets `col`. When the span's final day IS a Saturday,
+    // that reset leaves an all-null trailing column, so the flush guard must
+    // skip it. Pinning an explicit Saturday keeps that guard's false branch
+    // covered regardless of the weekday the suite runs on — it was previously
+    // only exercised when the real clock happened to land on a Saturday, so
+    // coverage silently dropped on the other six days.
+    const saturday = new Date("2026-06-13T12:00:00Z"); // Saturday
+    const { cells, weeks } = buildGrid([], saturday);
+    expect(cells[cells.length - 1].dayOfWeek).toBe(6);
+    // The last column is a real, fully-populated final week — not an empty flush.
+    expect(weeks[weeks.length - 1][6]).not.toBeNull();
+    expect(weeks.every((col) => col.some((c) => c !== null))).toBe(true);
+  });
 });
 
 const _sampleData = [


### PR DESCRIPTION
Release **v0.28.0**. See `CHANGELOG.md` for full notes.

## Highlights
- **MCP scope unification** — `search_memories`, `pack_context`, `relate_memories`, `list_tags`, `forget_all`, and the management-UI search now scope to the **user account** (not the OAuth client), consistent with `list_memories`. Semantic search moves to per-user vector indexes. (#666, #667, #681)
- **OAuth discovery fixed for spec-compliant MCP clients** — path-inserted RFC 9728 metadata URL, `WWW-Authenticate` via Lambda@Edge, and issuer/endpoint host. (#647)
- **`remember_blob` unblocked** — `/mcp` exempted from the WAF Common rule set's 8 KB body limit. (#665)
- **`summarize_context`** signals `summary_mode` and recency-orders its fallback. (#658)
- Meta: CI flake fixes (#669, #679) and moderate npm advisories cleared (#659).

## Post-deploy step
After the prod deploy, run the vector backfill once:
```
HIVE_TABLE_NAME=hive HIVE_VECTORS_BUCKET=hive-vectors inv migrate-vectors --dry-run   # check counts
HIVE_TABLE_NAME=hive HIVE_VECTORS_BUCKET=hive-vectors inv migrate-vectors             # backfill
```
Until it runs, semantic search returns only newly-written memories (per-user indexes start empty). The prod CloudFront deploy also includes the new **Lambda@Edge** function (first-time edge replication adds a few minutes).