### PR TITLE
fix(auth): stop rotating refresh tokens to end frequent re-auth

### DIFF
--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -506,14 +506,19 @@ async def token(  # NOSONAR — complexity inherent in OAuth grant type dispatch
         if stored.client_id != client_id:
             raise HTTPException(status_code=400, detail="refresh_token not issued to this client")
 
-        # Rotate: revoke old refresh token, issue new pair
-        # Re-intersect scope in case client's registered scope was narrowed since issuance
+        # Non-rotating refresh tokens (#693): mint a fresh access token but keep
+        # the presented refresh token valid and echo it back unchanged. Rotation
+        # (revoke-on-use) forced a full browser re-auth whenever a still-good
+        # refresh token was reused — by a concurrent MCP connection, a retry, or
+        # a stale persisted copy — because only the single newest token stayed
+        # valid. Reusing the token makes the silent-refresh path tolerant of all
+        # three. The access token is still re-intersected with the client's
+        # current registered scope in case it was narrowed since issuance.
         effective_scope = (
             " ".join(sorted(set(stored.scope.split()) & set(client.scope.split()))) or stored.scope
         )
-        assert jti is not None
-        storage.revoke_token(jti)
-        access, refresh = storage.create_token_pair(client_id, effective_scope)
+        access = storage.create_access_token(client_id, effective_scope)
+        refresh = stored
 
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported grant_type: {grant_type}")

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -513,10 +513,15 @@ async def token(  # NOSONAR — complexity inherent in OAuth grant type dispatch
         # a stale persisted copy — because only the single newest token stayed
         # valid. Reusing the token makes the silent-refresh path tolerant of all
         # three. The access token is still re-intersected with the client's
-        # current registered scope in case it was narrowed since issuance.
-        effective_scope = (
-            " ".join(sorted(set(stored.scope.split()) & set(client.scope.split()))) or stored.scope
-        )
+        # current registered scope in case it was narrowed since issuance — and,
+        # mirroring /oauth/authorize, a now-disjoint scope fails rather than
+        # falling back to the token's original (now-unauthorized) scope.
+        effective_scope = " ".join(sorted(set(stored.scope.split()) & set(client.scope.split())))
+        if not effective_scope:
+            raise HTTPException(
+                status_code=400,
+                detail="refresh_token scope has no overlap with client's registered scope",
+            )
         access = storage.create_access_token(client_id, effective_scope)
         refresh = stored
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -938,6 +938,24 @@ class HiveStorage:
                 break
         return revoked
 
+    def create_access_token(self, client_id: str, scope: str) -> Token:
+        """Issue and persist a standalone access token.
+
+        Used by the non-rotating refresh-token grant (#693), which mints a
+        fresh access token while keeping the caller's existing refresh token
+        valid instead of rotating it.
+        """
+        now = _now()
+        access = Token(
+            client_id=client_id,
+            scope=scope,
+            token_type=TokenType.access,
+            issued_at=now,
+            expires_at=now + timedelta(seconds=ACCESS_TOKEN_TTL_SECONDS),
+        )
+        self.put_token(access)
+        return access
+
     def create_token_pair(self, client_id: str, scope: str) -> tuple[Token, Token]:
         """Issue a new (access_token, refresh_token) pair."""
         now = _now()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -948,6 +948,49 @@ class TestOAuthToken:
         assert resp.status_code == 200
         assert resp.json()["access_token"]
 
+    def test_refresh_token_is_reusable_not_rotated(self, oauth_client):
+        """Refresh tokens are non-rotating (#693): the same refresh token can be
+        redeemed more than once.
+
+        Rotation (revoke-on-use) forced a full browser re-auth whenever a
+        still-good refresh token was reused — by a concurrent MCP connection, a
+        retry, or a stale persisted copy — because only the single newest token
+        stayed valid. The grant must instead mint a fresh access token while
+        leaving the presented refresh token valid and echoing it back unchanged.
+        """
+        tc, storage, client = oauth_client
+        code, verifier = self._get_auth_code(tc, storage, client)
+        refresh_token = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": "https://app.example.com/cb",
+                "client_id": client.client_id,
+                "code_verifier": verifier,
+            },
+        ).json()["refresh_token"]
+        original_jti = decode_jwt(refresh_token)["jti"]
+
+        # Redeem the refresh token twice with the exact same token value.
+        for _ in range(2):
+            resp = tc.post(
+                "/oauth/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "client_id": client.client_id,
+                    "refresh_token": refresh_token,
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["access_token"]
+            # Same refresh token comes back — not a rotated replacement.
+            assert decode_jwt(body["refresh_token"])["jti"] == original_jti
+
+        # The underlying refresh-token record was never revoked.
+        assert storage.get_token(original_jti).is_valid
+
     def test_missing_client_id_returns_400(self, oauth_client):
         tc, *_ = oauth_client
         resp = tc.post(

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1634,6 +1634,57 @@ class TestRefreshTokenScopeNarrowing:
         assert "memories:write" not in claims["scope"]
         assert "memories:read" in claims["scope"]
 
+    def test_refresh_with_disjoint_client_scope_returns_400(self, oauth_client):
+        """If the client's registered scope no longer overlaps the refresh
+        token's scope, the grant must fail — not fall back to the token's
+        original (now-unauthorized) scope and mint a privileged access token.
+        Mirrors /oauth/authorize's no-overlap handling.
+        """
+        from hive.models import OAuthClient
+
+        tc, storage, _ = oauth_client
+
+        wide_client = OAuthClient(
+            client_name="Disjoint Scope Client",
+            redirect_uris=["https://app.example.com/cb"],
+            scope="memories:read memories:write",
+        )
+        storage.put_client(wide_client)
+
+        verifier, challenge = _pkce_pair()
+        auth_code = storage.create_auth_code(
+            client_id=wide_client.client_id,
+            redirect_uri="https://app.example.com/cb",
+            scope="memories:read memories:write",
+            code_challenge=challenge,
+            code_challenge_method="S256",
+        )
+        refresh_token = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": auth_code.code,
+                "redirect_uri": "https://app.example.com/cb",
+                "client_id": wide_client.client_id,
+                "code_verifier": verifier,
+            },
+        ).json()["refresh_token"]
+
+        # Narrow the client to a scope disjoint from the refresh token's scope.
+        wide_client.scope = "admin:console"
+        storage.put_client(wide_client)
+
+        resp = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": wide_client.client_id,
+                "refresh_token": refresh_token,
+            },
+        )
+        assert resp.status_code == 400
+        assert "overlap" in resp.json()["detail"].lower()
+
 
 class TestTokenScopeIntersection:
     def test_access_token_carries_restricted_scope(self, oauth_client):

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -822,6 +822,17 @@ class TestTokenStorage:
         assert fetched.client_id == "c1"
         assert fetched.token_type == TokenType.access
 
+    def test_create_access_token_persists_access_only(self, storage):
+        # The non-rotating refresh grant (#693) mints a lone access token and
+        # leaves the refresh token untouched.
+        access = storage.create_access_token("c1", "memories:read")
+        assert access.token_type == TokenType.access
+        fetched = storage.get_token(access.jti)
+        assert fetched is not None
+        assert fetched.client_id == "c1"
+        assert fetched.scope == "memories:read"
+        assert fetched.is_valid
+
     def test_revoke(self, storage):
         access, _ = storage.create_token_pair("c1", "s")
         storage.revoke_token(access.jti)


### PR DESCRIPTION
Closes #693

## Summary
The MCP server rotated refresh tokens on every `refresh_token` grant (revoke-the-presented-token, issue a new pair), so only the single newest refresh token was ever valid. Any reuse of a prior refresh token — by a **concurrent MCP connection**, a **retry**, or a **stale persisted copy** — returned `400`, and the client fell back to a full browser re-authorization. Users were re-authing roughly hourly despite a 30-day refresh TTL.

## Diagnosis (prod evidence)
- `/oauth/token` timeline: refresh `200`, refresh `200`, then `400`, then a full `/oauth/authorize` flow, then another refresh `400` **4 minutes after** a fresh re-auth — so this was not access-token expiry (access TTL is 1h).
- Token table: **73 refresh tokens, 72 revoked, 1 valid** — the rotation-churn fingerprint.
- `/register` count was 0 — not DCR re-registration churn; the client reuses its `client_id`, only the refresh token kept getting invalidated.

## Approach
Make refresh tokens **non-rotating**: on the `refresh_token` grant, mint a fresh access token (new `HiveStorage.create_access_token`) but keep the presented refresh token valid and echo it back unchanged. The access token is still re-intersected with the client's current registered scope. Preserves the 30-day window; eliminates 400-on-reuse so concurrent connections / retries / stale copies all succeed.

**Trade-off:** drops rotation's stolen-token reuse-detection. Acceptable for a free service with PKCE, server-side revocation, and a 30-day TTL; matches typical MCP-server behaviour. A grace-window variant wouldn't cover tokens reused tens of minutes stale.

## Tests
- TDD: new `test_refresh_token_is_reusable_not_rotated` (redeems the same refresh token twice, asserts `200` + same `jti` echoed + record never revoked) — verified RED against the rotating code, then GREEN.
- New `test_create_access_token_persists_access_only`.
- `hive.auth.oauth` at 100% line coverage; full `inv pre-push` gate green.

## e2e note
Personal `jc` env e2e was blocked by **pre-existing, unrelated infra drift** in that stale environment (orphaned Lambda log groups, then a multi-GSI single-update limit) — neither relates to this application-only change (no infra touched). The `development` pipeline runs the full e2e suite on merge, which covers the live OAuth flow.