### PR TITLE
chore(dx): forward caller env to pytest in the inv e2e task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -264,7 +264,13 @@ def e2e(ctx, env="prod"):
     api_url = _cfn_output(ctx, "ApiFunctionUrl", env=env)
     mcp_url = _cfn_output(ctx, "McpFunctionUrl", env=env)
     ui_url = _cfn_output(ctx, "UiUrl", env=env)
+    # Inherit the caller's environment so HIVE_E2E_EMAIL / HIVE_ADMIN_EMAIL (and
+    # AWS creds) reach pytest — without them the bypass flow registers a client
+    # with no user association and the account-scoped MCP tools (#666) fail
+    # closed. CI sets these as repo vars; local runs rely on this passthrough.
+    # Explicit URL keys come last so they win over any stale values in os.environ.
     extra_env = {
+        **os.environ,
         "HIVE_API_URL": api_url,
         "HIVE_MCP_URL": mcp_url,
         "HIVE_UI_URL": ui_url,


### PR DESCRIPTION
Closes #695

## Summary
`inv e2e` built `extra_env` as a fresh dict containing only the three URL vars, so it didn't inherit the caller's environment. Running it locally dropped `HIVE_E2E_EMAIL` / `HIVE_ADMIN_EMAIL`, so the deployed-env bypass flow registered an OAuth client with no user-account association and the account-scoped MCP tools (`list_memories`, `search_memories`, `summarize_context`) failed closed with *"Client is not associated with a user account"* (#666). CI passed only because it injects those vars as repo `vars`.

## Fix
Build `extra_env` as `{**os.environ, <explicit URL overrides>}` — mirroring the existing `e2e-local` task — so the emails and AWS creds reach pytest, with the explicit URL keys still winning over any stale values.

## Verification
Discovered while running the auth/MCP e2e against a freshly-recreated personal env: 6 MCP tests failed with the account-scoping error until `HIVE_E2E_EMAIL` was exported manually, after which all 14 passed. `tasks.py` is outside the coverage scope (`source = ["src/hive"]`); `inv pre-push` gate is green.