### PR TITLE
release: v0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,35 @@ See the [GitHub releases page](https://github.com/warlordofmars/hive/releases) f
 
 ## [Unreleased]
 
-_Changes accumulated on `development` since v0.28.1. Will be rolled into the next release._
+_Changes accumulated on `development` since v0.28.2. Will be rolled into the next release._
+
+## v0.28.2 — 2026-06-15
+
+A patch release that stops the Hive MCP server from forcing frequent full
+re-authentication.
+
+### Fixed
+
+#### Auth
+
+- **Refresh tokens are no longer rotated on use, ending frequent re-auth.** The
+  `/oauth/token` refresh grant revoked the presented refresh token and issued a
+  new pair on every use, so only the single newest token stayed valid. Any reuse
+  of a prior token — by a concurrent MCP connection, a retry, or a stale
+  persisted copy — returned a 400, and the MCP client fell back to a full browser
+  re-authorization (observed as roughly hourly re-auths despite a 30-day
+  refresh-token lifetime). The grant now mints a fresh access token while keeping
+  the presented refresh token valid, and rejects a refresh whose scope no longer
+  overlaps the client's current registered scope rather than silently falling
+  back to the token's original scope. (#694)
+
+### Meta
+
+- **`inv e2e` forwards the caller's environment to pytest.** The task built its
+  env from scratch with only the deployed-stack URLs, dropping `HIVE_E2E_EMAIL` /
+  `HIVE_ADMIN_EMAIL`; local runs against a deployed env then registered an OAuth
+  client with no user-account association and the account-scoped MCP tools failed
+  closed. It now merges `os.environ` first, mirroring `inv e2e-local`. (#695, #696)
 
 ## v0.28.1 — 2026-06-14
 

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -506,14 +506,24 @@ async def token(  # NOSONAR — complexity inherent in OAuth grant type dispatch
         if stored.client_id != client_id:
             raise HTTPException(status_code=400, detail="refresh_token not issued to this client")
 
-        # Rotate: revoke old refresh token, issue new pair
-        # Re-intersect scope in case client's registered scope was narrowed since issuance
-        effective_scope = (
-            " ".join(sorted(set(stored.scope.split()) & set(client.scope.split()))) or stored.scope
-        )
-        assert jti is not None
-        storage.revoke_token(jti)
-        access, refresh = storage.create_token_pair(client_id, effective_scope)
+        # Non-rotating refresh tokens (#693): mint a fresh access token but keep
+        # the presented refresh token valid and echo it back unchanged. Rotation
+        # (revoke-on-use) forced a full browser re-auth whenever a still-good
+        # refresh token was reused — by a concurrent MCP connection, a retry, or
+        # a stale persisted copy — because only the single newest token stayed
+        # valid. Reusing the token makes the silent-refresh path tolerant of all
+        # three. The access token is still re-intersected with the client's
+        # current registered scope in case it was narrowed since issuance — and,
+        # mirroring /oauth/authorize, a now-disjoint scope fails rather than
+        # falling back to the token's original (now-unauthorized) scope.
+        effective_scope = " ".join(sorted(set(stored.scope.split()) & set(client.scope.split())))
+        if not effective_scope:
+            raise HTTPException(
+                status_code=400,
+                detail="refresh_token scope has no overlap with client's registered scope",
+            )
+        access = storage.create_access_token(client_id, effective_scope)
+        refresh = stored
 
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported grant_type: {grant_type}")

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -938,6 +938,24 @@ class HiveStorage:
                 break
         return revoked
 
+    def create_access_token(self, client_id: str, scope: str) -> Token:
+        """Issue and persist a standalone access token.
+
+        Used by the non-rotating refresh-token grant (#693), which mints a
+        fresh access token while keeping the caller's existing refresh token
+        valid instead of rotating it.
+        """
+        now = _now()
+        access = Token(
+            client_id=client_id,
+            scope=scope,
+            token_type=TokenType.access,
+            issued_at=now,
+            expires_at=now + timedelta(seconds=ACCESS_TOKEN_TTL_SECONDS),
+        )
+        self.put_token(access)
+        return access
+
     def create_token_pair(self, client_id: str, scope: str) -> tuple[Token, Token]:
         """Issue a new (access_token, refresh_token) pair."""
         now = _now()

--- a/tasks.py
+++ b/tasks.py
@@ -264,7 +264,13 @@ def e2e(ctx, env="prod"):
     api_url = _cfn_output(ctx, "ApiFunctionUrl", env=env)
     mcp_url = _cfn_output(ctx, "McpFunctionUrl", env=env)
     ui_url = _cfn_output(ctx, "UiUrl", env=env)
+    # Inherit the caller's environment so HIVE_E2E_EMAIL / HIVE_ADMIN_EMAIL (and
+    # AWS creds) reach pytest — without them the bypass flow registers a client
+    # with no user association and the account-scoped MCP tools (#666) fail
+    # closed. CI sets these as repo vars; local runs rely on this passthrough.
+    # Explicit URL keys come last so they win over any stale values in os.environ.
     extra_env = {
+        **os.environ,
         "HIVE_API_URL": api_url,
         "HIVE_MCP_URL": mcp_url,
         "HIVE_UI_URL": ui_url,

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -948,6 +948,49 @@ class TestOAuthToken:
         assert resp.status_code == 200
         assert resp.json()["access_token"]
 
+    def test_refresh_token_is_reusable_not_rotated(self, oauth_client):
+        """Refresh tokens are non-rotating (#693): the same refresh token can be
+        redeemed more than once.
+
+        Rotation (revoke-on-use) forced a full browser re-auth whenever a
+        still-good refresh token was reused — by a concurrent MCP connection, a
+        retry, or a stale persisted copy — because only the single newest token
+        stayed valid. The grant must instead mint a fresh access token while
+        leaving the presented refresh token valid and echoing it back unchanged.
+        """
+        tc, storage, client = oauth_client
+        code, verifier = self._get_auth_code(tc, storage, client)
+        refresh_token = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": "https://app.example.com/cb",
+                "client_id": client.client_id,
+                "code_verifier": verifier,
+            },
+        ).json()["refresh_token"]
+        original_jti = decode_jwt(refresh_token)["jti"]
+
+        # Redeem the refresh token twice with the exact same token value.
+        for _ in range(2):
+            resp = tc.post(
+                "/oauth/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "client_id": client.client_id,
+                    "refresh_token": refresh_token,
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["access_token"]
+            # Same refresh token comes back — not a rotated replacement.
+            assert decode_jwt(body["refresh_token"])["jti"] == original_jti
+
+        # The underlying refresh-token record was never revoked.
+        assert storage.get_token(original_jti).is_valid
+
     def test_missing_client_id_returns_400(self, oauth_client):
         tc, *_ = oauth_client
         resp = tc.post(
@@ -1590,6 +1633,57 @@ class TestRefreshTokenScopeNarrowing:
         claims = decode_jwt(resp.json()["access_token"])
         assert "memories:write" not in claims["scope"]
         assert "memories:read" in claims["scope"]
+
+    def test_refresh_with_disjoint_client_scope_returns_400(self, oauth_client):
+        """If the client's registered scope no longer overlaps the refresh
+        token's scope, the grant must fail — not fall back to the token's
+        original (now-unauthorized) scope and mint a privileged access token.
+        Mirrors /oauth/authorize's no-overlap handling.
+        """
+        from hive.models import OAuthClient
+
+        tc, storage, _ = oauth_client
+
+        wide_client = OAuthClient(
+            client_name="Disjoint Scope Client",
+            redirect_uris=["https://app.example.com/cb"],
+            scope="memories:read memories:write",
+        )
+        storage.put_client(wide_client)
+
+        verifier, challenge = _pkce_pair()
+        auth_code = storage.create_auth_code(
+            client_id=wide_client.client_id,
+            redirect_uri="https://app.example.com/cb",
+            scope="memories:read memories:write",
+            code_challenge=challenge,
+            code_challenge_method="S256",
+        )
+        refresh_token = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": auth_code.code,
+                "redirect_uri": "https://app.example.com/cb",
+                "client_id": wide_client.client_id,
+                "code_verifier": verifier,
+            },
+        ).json()["refresh_token"]
+
+        # Narrow the client to a scope disjoint from the refresh token's scope.
+        wide_client.scope = "admin:console"
+        storage.put_client(wide_client)
+
+        resp = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": wide_client.client_id,
+                "refresh_token": refresh_token,
+            },
+        )
+        assert resp.status_code == 400
+        assert "overlap" in resp.json()["detail"].lower()
 
 
 class TestTokenScopeIntersection:

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -822,6 +822,17 @@ class TestTokenStorage:
         assert fetched.client_id == "c1"
         assert fetched.token_type == TokenType.access
 
+    def test_create_access_token_persists_access_only(self, storage):
+        # The non-rotating refresh grant (#693) mints a lone access token and
+        # leaves the refresh token untouched.
+        access = storage.create_access_token("c1", "memories:read")
+        assert access.token_type == TokenType.access
+        fetched = storage.get_token(access.jti)
+        assert fetched is not None
+        assert fetched.client_id == "c1"
+        assert fetched.scope == "memories:read"
+        assert fetched.is_valid
+
     def test_revoke(self, storage):
         access, _ = storage.create_token_pair("c1", "s")
         storage.revoke_token(access.jti)


### PR DESCRIPTION
Release v0.28.2 — stops the Hive MCP server from forcing frequent full re-authentication (non-rotating refresh tokens, #694) plus an `inv e2e` env-passthrough fix (#695/#696). See CHANGELOG for details.