### PR TITLE
fix(mcp): close remember_if_absent race with conditional key-claim writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ hive/
   (TTL enabled, used for OAuth state parameter)
 - Key-claim items: `PK=KEYCLAIM#{key}`, `SK=META`
   (uniqueness anchor for `remember_if_absent` conditional writes;
-  released on memory delete, mirrors the memory's TTL when set)
+  released on memory delete, stale claims reclaimed at conflict time)
 - GSIs:
   - `TagIndex` — `GSI2PK=TAG#{tag}`, `GSI2SK=memory_id` (for list_memories)
   - `ClientIdIndex` — `GSI3PK=CLIENT#{client_id}` (for client lookups)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,9 @@ hive/
 - User items: `PK=USER#{user_id}`, `SK=META`
 - Mgmt state items: `PK=MGMT_STATE#{state}`, `SK=META`
   (TTL enabled, used for OAuth state parameter)
+- Key-claim items: `PK=KEYCLAIM#{key}`, `SK=META`
+  (uniqueness anchor for `remember_if_absent` conditional writes;
+  released on memory delete, mirrors the memory's TTL when set)
 - GSIs:
   - `TagIndex` — `GSI2PK=TAG#{tag}`, `GSI2SK=memory_id` (for list_memories)
   - `ClientIdIndex` — `GSI3PK=CLIENT#{client_id}` (for client lookups)

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -14,6 +14,9 @@ DynamoDB single-table design:
   Invite items:     PK=INVITE#{invite_id}   SK=META          (TTL enabled)
   Mgmt state:       PK=MGMT_STATE#{state}   SK=META          (TTL enabled)
   API key items:    PK=APIKEY#{key_id}      SK=META
+  Key-claim items:  PK=KEYCLAIM#{key}       SK=META          (uniqueness anchor
+                    for remember_if_absent conditional writes; mirrors the
+                    memory's TTL when one is set)
 
 GSIs:
   TagIndex:              PK=TAG#{tag}, SK=memory_id   — list_memories(tag)

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -15,8 +15,8 @@ DynamoDB single-table design:
   Mgmt state:       PK=MGMT_STATE#{state}   SK=META          (TTL enabled)
   API key items:    PK=APIKEY#{key_id}      SK=META
   Key-claim items:  PK=KEYCLAIM#{key}       SK=META          (uniqueness anchor
-                    for remember_if_absent conditional writes; mirrors the
-                    memory's TTL when one is set)
+                    for remember_if_absent conditional writes; released on
+                    memory delete, reclaimed at conflict time when stale)
 
 GSIs:
   TagIndex:              PK=TAG#{tag}, SK=memory_id   — list_memories(tag)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -609,9 +609,11 @@ async def remember_if_absent(
     Returns "Stored memory '{key}'." on write, or
     "Memory '{key}' already exists — not overwritten." on skip.
 
-    Uses a read-then-write check. Two concurrent callers with the same key
-    can still race in the narrow window between the read and the write;
-    strict DynamoDB-level atomicity is tracked in #391.
+    Existence is enforced in two layers: a fast read via the key index,
+    then a DynamoDB conditional write (``attribute_not_exists``) on a
+    per-key claim item. The conditional write is atomic server-side, so
+    two concurrent callers with the same key can never both create the
+    memory — the loser gets the "already exists" response (#592).
     """
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope="memories:write")
@@ -629,8 +631,36 @@ async def remember_if_absent(
         else None
     )
 
-    existing = storage.get_memory_by_key(key)
-    if existing:
+    memory: Memory | None = None
+    if storage.get_memory_by_key(key) is None:
+        client = storage.get_client(client_id)
+        if client is None:
+            raise ToolError("Unable to load client record for authenticated caller.")
+        owner_user_id = client.owner_user_id
+        try:
+            check_memory_quota(owner_user_id, storage)
+            check_storage_quota(owner_user_id, actual, storage)
+        except QuotaExceeded as exc:
+            raise ToolError(exc.detail) from exc
+
+        candidate = Memory(
+            key=key,
+            value=value,
+            tags=tags,
+            owner_client_id=client_id,
+            owner_user_id=owner_user_id,
+            expires_at=expires_at,
+        )
+        try:
+            if storage.put_memory_if_absent(candidate):
+                memory = candidate
+        except ValueError as exc:
+            await emit_metric("ToolErrors", operation="remember_if_absent")
+            raise ToolError(str(exc)) from exc
+
+    if memory is None:
+        # Either the read-check found the key, or a concurrent caller won
+        # the conditional write in the window after it — same outcome.
         duration_ms = int((time.monotonic() - t0) * 1000)
         logger.info(
             "Memory '%s' already exists — not overwritten",
@@ -644,29 +674,6 @@ async def remember_if_absent(
         await emit_metric("ToolInvocations", operation="remember_if_absent")
         return _tool_result(f"Memory '{key}' already exists — not overwritten.", storage, client_id)
 
-    client = storage.get_client(client_id)
-    if client is None:
-        raise ToolError("Unable to load client record for authenticated caller.")
-    owner_user_id = client.owner_user_id
-    try:
-        check_memory_quota(owner_user_id, storage)
-        check_storage_quota(owner_user_id, actual, storage)
-    except QuotaExceeded as exc:
-        raise ToolError(exc.detail) from exc
-
-    memory = Memory(
-        key=key,
-        value=value,
-        tags=tags,
-        owner_client_id=client_id,
-        owner_user_id=owner_user_id,
-        expires_at=expires_at,
-    )
-    try:
-        storage.put_memory(memory)
-    except ValueError as exc:
-        await emit_metric("ToolErrors", operation="remember_if_absent")
-        raise ToolError(str(exc)) from exc
     try:
         _vector_store().upsert_memory(
             memory.model_copy(update={"value": value})

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -429,12 +429,17 @@ class HiveStorage:
             )
         ).get("Item")
         if holder is not None:
-            meta = (
-                self.table.get_item(
-                    Key={"PK": f"MEMORY#{holder['memory_id']}", "SK": "META"},
-                    ConsistentRead=True,
-                )
-            ).get("Item")
+            # Defensive .get — a malformed claim (no memory_id) must degrade
+            # to "stale" rather than crash and leave its key blocked.
+            holder_memory_id = holder.get("memory_id")
+            meta = None
+            if holder_memory_id is not None:
+                meta = (
+                    self.table.get_item(
+                        Key={"PK": f"MEMORY#{holder_memory_id}", "SK": "META"},
+                        ConsistentRead=True,
+                    )
+                ).get("Item")
             if meta is not None and not Memory.from_dynamo(meta).is_expired:
                 return False  # a live memory holds the key
             if meta is None:
@@ -444,7 +449,14 @@ class HiveStorage:
             try:
                 self.table.delete_item(
                     Key={"PK": f"KEYCLAIM#{memory.key}", "SK": "META"},
-                    ConditionExpression=Attr("memory_id").eq(holder["memory_id"]),
+                    # Delete only the claim we observed: match its memory_id,
+                    # or require the attribute still absent for a malformed
+                    # claim, so one that changed hands is never cleared.
+                    ConditionExpression=(
+                        Attr("memory_id").eq(holder_memory_id)
+                        if holder_memory_id is not None
+                        else Attr("memory_id").not_exists()
+                    ),
                 )
             except ClientError as exc:
                 if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -467,16 +467,26 @@ class HiveStorage:
         return self._try_claim_key(memory)
 
     def _release_key_claim(self, key: str) -> None:
-        """Delete the key-claim item for ``key`` (no-op if none exists).
+        """Best-effort delete of the key-claim item for ``key``.
 
         Deliberately unconditional: deleting a claim for a key whose memory
         still exists merely degrades remember_if_absent back to its
         read-check for that key, whereas a conditional delete could leave an
         orphaned claim permanently blocking if-absent creates after a
-        mid-write crash. An orphaned claim is self-healing — any delete of a
-        same-key memory (e.g. remember then forget) clears it.
+        mid-write crash.
+
+        Failures are logged and swallowed (mirroring
+        ``_delete_blob_if_needed``): by the time this runs the memory
+        delete has already happened, so a throttled claim cleanup must not
+        turn an otherwise-successful delete into an API/tool error. A
+        claim that survives is self-healing — the next same-key delete
+        clears it, and the grace-based reclaim in ``_reclaim_stale_key``
+        takes it over on the next if-absent create.
         """
-        self.table.delete_item(Key={"PK": f"KEYCLAIM#{key}", "SK": "META"})
+        try:
+            self.table.delete_item(Key={"PK": f"KEYCLAIM#{key}", "SK": "META"})
+        except ClientError:
+            logger.warning("Failed to release key claim for %r (non-fatal)", key, exc_info=True)
 
     def get_memory_by_id(self, memory_id: str) -> Memory | None:
         item = self._get_memory_meta(memory_id)

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -58,6 +58,12 @@ _SK_PK_PREFIX_EXPR = "SK = :sk AND begins_with(PK, :prefix)"
 # Version retention
 _VERSION_RETENTION_DAYS = int(os.environ.get("HIVE_VERSION_RETENTION_DAYS", "30"))
 
+# How old a KEYCLAIM item with no backing memory must be before an if-absent
+# create may treat it as a crashed-create orphan and take it over (#592).
+# Generous enough to cover the slowest legitimate create (S3 routing of a
+# large value + batched DynamoDB writes) plus cross-Lambda clock skew.
+_KEYCLAIM_GRACE_SECONDS = int(os.environ.get("HIVE_KEYCLAIM_GRACE_SECONDS", "60"))
+
 # Token lifetimes
 ACCESS_TOKEN_TTL_SECONDS = 3600  # 1 hour
 REFRESH_TOKEN_TTL_SECONDS = 86400 * 30  # 30 days
@@ -319,22 +325,24 @@ class HiveStorage:
         neither a GSI nor a condition on the META item (whose PK is a fresh
         surrogate UUID) can enforce it. The atomic unit is therefore a
         dedicated key-claim item (``PK=KEYCLAIM#{key}``, ``SK=META``) written
-        with a conditional ``PutItem``::
-
-            attribute_not_exists(PK) OR expires_at <= :now
-
+        with a conditional ``PutItem`` (``attribute_not_exists(PK)``).
         DynamoDB serialises conditional writes on the same item, so exactly
-        one of any number of concurrent callers wins the claim (#592). The
-        ``OR`` arm lets a claim whose memory has expired be taken over
-        atomically — expired memories read as absent everywhere else — and
-        is itself race-safe: the winner's put replaces ``expires_at`` with
-        its own future value (or removes it), so every other taker's
-        condition evaluates false.
+        one of any number of concurrent callers wins the claim (#592).
+
+        A lost conditional write is not automatically "exists": the holder
+        is resolved via ``_reclaim_stale_key``, which distinguishes a claim
+        backed by a live memory (return ``False``) from a stale one — a
+        crashed create that never wrote its memory, or a memory that has
+        since expired — which is cleared and re-claimed atomically. Claim
+        lifetime is deliberately decoupled from the memory's TTL: liveness
+        is decided at conflict time against the memory item itself, so a
+        TTL later added, extended, or removed via ``remember``/the API can
+        never strand or prematurely free the claim.
 
         Returns ``True`` when the claim and the memory write both succeed,
-        ``False`` when the key is already claimed by a live memory. If the
-        memory write fails after a successful claim, the claim is rolled
-        back and the error re-raised.
+        ``False`` when the key is already claimed by a live (or in-flight)
+        memory. If the memory write fails after a successful claim, the
+        claim is rolled back and the error re-raised.
 
         Claims are released by ``delete_memory`` / ``delete_memories_by_tag``
         so a forgotten key can be re-created. Memories created through other
@@ -342,28 +350,8 @@ class HiveStorage:
         claim; callers must pair this method with a ``get_memory_by_key``
         pre-check to preserve if-absent semantics against those.
         """
-        now_iso = _now().isoformat()
-        claim: dict[str, Any] = {
-            "PK": f"KEYCLAIM#{memory.key}",
-            "SK": "META",
-            "key": memory.key,
-            "memory_id": memory.memory_id,
-            "created_at": now_iso,
-        }
-        if memory.expires_at is not None:
-            claim["expires_at"] = memory.expires_at.isoformat()
-            # Mirror the memory's DynamoDB TTL so the reaper prunes the claim
-            # alongside the memory item itself.
-            claim["ttl"] = int(memory.expires_at.timestamp())
-        try:
-            self.table.put_item(
-                Item=claim,
-                ConditionExpression=(Attr("PK").not_exists() | Attr("expires_at").lte(now_iso)),
-            )
-        except ClientError as exc:
-            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                return False
-            raise
+        if not self._try_claim_key(memory) and not self._reclaim_stale_key(memory):
+            return False
         try:
             self.put_memory(memory)
         except Exception:
@@ -371,6 +359,84 @@ class HiveStorage:
             self._release_key_claim(memory.key)
             raise
         return True
+
+    def _try_claim_key(self, memory: Memory) -> bool:
+        """Conditionally write the key-claim item for ``memory``.
+
+        Returns ``True`` when the claim was won, ``False`` when another
+        claim already holds the key. Any other DynamoDB error re-raises.
+        """
+        claim: dict[str, Any] = {
+            "PK": f"KEYCLAIM#{memory.key}",
+            "SK": "META",
+            "key": memory.key,
+            "memory_id": memory.memory_id,
+            "created_at": _now().isoformat(),
+        }
+        try:
+            self.table.put_item(
+                Item=claim,
+                ConditionExpression=Attr("PK").not_exists(),
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return False
+            raise
+        return True
+
+    def _reclaim_stale_key(self, memory: Memory) -> bool:
+        """After a lost claim, decide live-vs-stale and re-claim if stale.
+
+        A claim is *stale* when its ``memory_id`` no longer resolves to a
+        live memory: either the memory expired, or a previous create
+        crashed between writing the claim and writing the memory. The
+        latter is indistinguishable from an in-flight create, so a claim
+        with no memory is only treated as stale once it is older than
+        ``_KEYCLAIM_GRACE_SECONDS`` — younger claims are reported as
+        "exists" to protect a concurrent creator mid-write.
+
+        Both reads use ``ConsistentRead`` — deciding staleness from an
+        eventually-consistent replica could miss a just-committed memory
+        and clear a live claim. The stale claim is deleted *conditionally*
+        on its observed ``memory_id`` so a claim that changed hands in the
+        meantime is never cleared out from under its new owner; the
+        conditional put is then retried exactly once. At most one of any
+        number of concurrent reclaimers can pass the conditional delete,
+        so single-create is preserved.
+        """
+        holder = (
+            self.table.get_item(
+                Key={"PK": f"KEYCLAIM#{memory.key}", "SK": "META"},
+                ConsistentRead=True,
+            )
+        ).get("Item")
+        if holder is not None:
+            meta = (
+                self.table.get_item(
+                    Key={"PK": f"MEMORY#{holder['memory_id']}", "SK": "META"},
+                    ConsistentRead=True,
+                )
+            ).get("Item")
+            if meta is not None and not Memory.from_dynamo(meta).is_expired:
+                return False  # a live memory holds the key
+            if meta is None:
+                claimed_at = datetime.fromisoformat(
+                    str(holder.get("created_at", "1970-01-01T00:00:00+00:00"))
+                )
+                if (_now() - claimed_at).total_seconds() < _KEYCLAIM_GRACE_SECONDS:
+                    return False  # likely an in-flight create — don't steal it
+            try:
+                self.table.delete_item(
+                    Key={"PK": f"KEYCLAIM#{memory.key}", "SK": "META"},
+                    ConditionExpression=Attr("memory_id").eq(holder["memory_id"]),
+                )
+            except ClientError as exc:
+                if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                    return False  # another caller re-claimed the key first
+                raise
+        # Claim cleared (or vanished between the lost put and the read) —
+        # retry the conditional write exactly once.
+        return self._try_claim_key(memory)
 
     def _release_key_claim(self, key: str) -> None:
         """Delete the key-claim item for ``key`` (no-op if none exists).

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -374,7 +374,7 @@ class HiveStorage:
             self.put_memory(memory)
         except Exception:
             # Roll back the claim so a failed create doesn't poison the key.
-            self._release_key_claim(memory.key)
+            self._release_key_claim(memory.key, memory.memory_id)
             raise
         return True
 
@@ -466,26 +466,33 @@ class HiveStorage:
         # retry the conditional write exactly once.
         return self._try_claim_key(memory)
 
-    def _release_key_claim(self, key: str) -> None:
-        """Best-effort delete of the key-claim item for ``key``.
+    def _release_key_claim(self, key: str, memory_id: str) -> None:
+        """Best-effort delete of ``key``'s claim, only if ``memory_id`` owns it.
 
-        Deliberately unconditional: deleting a claim for a key whose memory
-        still exists merely degrades remember_if_absent back to its
-        read-check for that key, whereas a conditional delete could leave an
-        orphaned claim permanently blocking if-absent creates after a
-        mid-write crash.
+        The delete is conditional on the claim's ``memory_id`` matching the
+        memory being deleted: if duplicate same-key memories exist (possible
+        via the non-if-absent create paths, or historically from the
+        pre-#592 race), deleting one of them must not clear the claim that
+        belongs to the other, still-live memory. A failed condition is the
+        expected no-op for memories that never held a claim.
 
-        Failures are logged and swallowed (mirroring
+        This conditionality cannot strand an orphaned claim: a claim whose
+        memory is gone is reclaimed by ``_reclaim_stale_key`` on the next
+        if-absent create once the grace period passes.
+
+        Other failures are logged and swallowed (mirroring
         ``_delete_blob_if_needed``): by the time this runs the memory
         delete has already happened, so a throttled claim cleanup must not
-        turn an otherwise-successful delete into an API/tool error. A
-        claim that survives is self-healing — the next same-key delete
-        clears it, and the grace-based reclaim in ``_reclaim_stale_key``
-        takes it over on the next if-absent create.
+        turn an otherwise-successful delete into an API/tool error.
         """
         try:
-            self.table.delete_item(Key={"PK": f"KEYCLAIM#{key}", "SK": "META"})
-        except ClientError:
+            self.table.delete_item(
+                Key={"PK": f"KEYCLAIM#{key}", "SK": "META"},
+                ConditionExpression=Attr("memory_id").eq(memory_id),
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return  # no claim, or the claim belongs to another memory
             logger.warning("Failed to release key claim for %r (non-fatal)", key, exc_info=True)
 
     def get_memory_by_id(self, memory_id: str) -> Memory | None:
@@ -551,7 +558,7 @@ class HiveStorage:
         self._delete_tag_items(memory)
         self.table.delete_item(Key={"PK": f"MEMORY#{memory_id}", "SK": "META"})
         self._delete_blob_if_needed(memory)
-        self._release_key_claim(memory.key)
+        self._release_key_claim(memory.key, memory.memory_id)
         return True
 
     # ------------------------------------------------------------------
@@ -846,7 +853,7 @@ class HiveStorage:
                 self._delete_tag_items(memory)
                 self.table.delete_item(Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"})
                 self._delete_blob_if_needed(memory)
-                self._release_key_claim(memory.key)
+                self._release_key_claim(memory.key, memory.memory_id)
                 deleted += 1
             if cursor is None:
                 break

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -115,6 +115,24 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _parse_claim_timestamp(raw: Any) -> datetime:
+    """Parse a KEYCLAIM item's ``created_at`` defensively.
+
+    Claims are only ever written with an aware-UTC isoformat, but a
+    malformed item must degrade to "reclaimable" (epoch — maximally old)
+    rather than crash the reclaim path and leave its key permanently
+    blocked by an unreclaimable claim. Naive datetimes are assumed UTC so
+    the subtraction against the aware ``_now()`` can never raise.
+    """
+    try:
+        parsed = datetime.fromisoformat(str(raw))
+    except (TypeError, ValueError):
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def _encode_cursor(last_evaluated_key: dict[str, Any]) -> str:
     """Encode a DynamoDB LastEvaluatedKey as an opaque base64 cursor."""
     return base64.urlsafe_b64encode(json.dumps(last_evaluated_key).encode()).decode()
@@ -420,9 +438,7 @@ class HiveStorage:
             if meta is not None and not Memory.from_dynamo(meta).is_expired:
                 return False  # a live memory holds the key
             if meta is None:
-                claimed_at = datetime.fromisoformat(
-                    str(holder.get("created_at", "1970-01-01T00:00:00+00:00"))
-                )
+                claimed_at = _parse_claim_timestamp(holder.get("created_at"))
                 if (_now() - claimed_at).total_seconds() < _KEYCLAIM_GRACE_SECONDS:
                     return False  # likely an in-flight create — don't steal it
             try:

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -312,6 +312,78 @@ class HiveStorage:
         # Drop the inline value — DynamoDB only keeps the pointer.
         memory.value = ""
 
+    def put_memory_if_absent(self, memory: Memory) -> bool:
+        """Atomically create a memory only if its key is not already claimed.
+
+        Key uniqueness lives on the KeyIndex GSI (``GSI1PK=KEY#{key}``), and
+        neither a GSI nor a condition on the META item (whose PK is a fresh
+        surrogate UUID) can enforce it. The atomic unit is therefore a
+        dedicated key-claim item (``PK=KEYCLAIM#{key}``, ``SK=META``) written
+        with a conditional ``PutItem``::
+
+            attribute_not_exists(PK) OR expires_at <= :now
+
+        DynamoDB serialises conditional writes on the same item, so exactly
+        one of any number of concurrent callers wins the claim (#592). The
+        ``OR`` arm lets a claim whose memory has expired be taken over
+        atomically — expired memories read as absent everywhere else — and
+        is itself race-safe: the winner's put replaces ``expires_at`` with
+        its own future value (or removes it), so every other taker's
+        condition evaluates false.
+
+        Returns ``True`` when the claim and the memory write both succeed,
+        ``False`` when the key is already claimed by a live memory. If the
+        memory write fails after a successful claim, the claim is rolled
+        back and the error re-raised.
+
+        Claims are released by ``delete_memory`` / ``delete_memories_by_tag``
+        so a forgotten key can be re-created. Memories created through other
+        paths (``remember``'s create branch, the management API) carry no
+        claim; callers must pair this method with a ``get_memory_by_key``
+        pre-check to preserve if-absent semantics against those.
+        """
+        now_iso = _now().isoformat()
+        claim: dict[str, Any] = {
+            "PK": f"KEYCLAIM#{memory.key}",
+            "SK": "META",
+            "key": memory.key,
+            "memory_id": memory.memory_id,
+            "created_at": now_iso,
+        }
+        if memory.expires_at is not None:
+            claim["expires_at"] = memory.expires_at.isoformat()
+            # Mirror the memory's DynamoDB TTL so the reaper prunes the claim
+            # alongside the memory item itself.
+            claim["ttl"] = int(memory.expires_at.timestamp())
+        try:
+            self.table.put_item(
+                Item=claim,
+                ConditionExpression=(Attr("PK").not_exists() | Attr("expires_at").lte(now_iso)),
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return False
+            raise
+        try:
+            self.put_memory(memory)
+        except Exception:
+            # Roll back the claim so a failed create doesn't poison the key.
+            self._release_key_claim(memory.key)
+            raise
+        return True
+
+    def _release_key_claim(self, key: str) -> None:
+        """Delete the key-claim item for ``key`` (no-op if none exists).
+
+        Deliberately unconditional: deleting a claim for a key whose memory
+        still exists merely degrades remember_if_absent back to its
+        read-check for that key, whereas a conditional delete could leave an
+        orphaned claim permanently blocking if-absent creates after a
+        mid-write crash. An orphaned claim is self-healing — any delete of a
+        same-key memory (e.g. remember then forget) clears it.
+        """
+        self.table.delete_item(Key={"PK": f"KEYCLAIM#{key}", "SK": "META"})
+
     def get_memory_by_id(self, memory_id: str) -> Memory | None:
         item = self._get_memory_meta(memory_id)
         if item is None:
@@ -375,6 +447,7 @@ class HiveStorage:
         self._delete_tag_items(memory)
         self.table.delete_item(Key={"PK": f"MEMORY#{memory_id}", "SK": "META"})
         self._delete_blob_if_needed(memory)
+        self._release_key_claim(memory.key)
         return True
 
     # ------------------------------------------------------------------
@@ -669,6 +742,7 @@ class HiveStorage:
                 self._delete_tag_items(memory)
                 self.table.delete_item(Key={"PK": f"MEMORY#{memory.memory_id}", "SK": "META"})
                 self._delete_blob_if_needed(memory)
+                self._release_key_claim(memory.key)
                 deleted += 1
             if cursor is None:
                 break

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -173,6 +173,49 @@ class TestMCPTools:
         assert "summary" in text.lower()
         assert "s1" in text or "s2" in text
 
+    async def test_remember_if_absent_second_call_does_not_overwrite(self, setup):
+        from hive.server import recall, remember_if_absent
+
+        jwt = setup
+        ctx = _make_context(jwt)
+        first = await remember_if_absent(key="ifa-int", value="original", ctx=ctx)
+        assert _text(first) == "Stored memory 'ifa-int'."
+
+        second = await remember_if_absent(key="ifa-int", value="usurper", ctx=ctx)
+        assert _text(second) == "Memory 'ifa-int' already exists — not overwritten."
+        assert _text(await recall(key="ifa-int", ctx=ctx)) == "original"
+
+    async def test_remember_if_absent_conditional_write_blocks_race(self, setup):
+        """Deterministically exercise the #592 race window against real
+        DynamoDB conditional-write semantics: bypass the read-check (as if
+        both callers read 'absent' simultaneously) and prove the second
+        writer loses the conditional claim instead of double-creating."""
+        from unittest.mock import patch
+
+        from hive.server import recall, remember_if_absent
+        from hive.storage import HiveStorage
+
+        jwt = setup
+        ctx = _make_context(jwt)
+        with patch.object(HiveStorage, "get_memory_by_key", return_value=None):
+            first = await remember_if_absent(key="ifa-race-int", value="winner", ctx=ctx)
+            second = await remember_if_absent(key="ifa-race-int", value="loser", ctx=ctx)
+
+        assert _text(first) == "Stored memory 'ifa-race-int'."
+        assert _text(second) == "Memory 'ifa-race-int' already exists — not overwritten."
+        assert _text(await recall(key="ifa-race-int", ctx=ctx)) == "winner"
+
+    async def test_remember_if_absent_key_reusable_after_forget(self, setup):
+        from hive.server import forget, recall, remember_if_absent
+
+        jwt = setup
+        ctx = _make_context(jwt)
+        await remember_if_absent(key="ifa-reuse", value="v1", ctx=ctx)
+        await forget(key="ifa-reuse", ctx=ctx)
+        result = await remember_if_absent(key="ifa-reuse", value="v2", ctx=ctx)
+        assert _text(result) == "Stored memory 'ifa-reuse'."
+        assert _text(await recall(key="ifa-reuse", ctx=ctx)) == "v2"
+
 
 def _make_user_token(storage, owner_user_id: str) -> str:
     """Create an OAuth client + token for ``owner_user_id`` and return a JWT."""

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -531,6 +531,34 @@ class TestRememberIfAbsent:
         with pytest.raises(ToolError, match="Insufficient scope"):
             await remember_if_absent("ifa-scope", "v", ctx=_make_ctx(read_only_jwt))
 
+    async def test_lost_conditional_write_returns_already_exists(self, server_env):
+        """A concurrent caller winning the conditional claim between the
+        read-check and the write yields the already-exists response (#592)."""
+        from unittest.mock import patch
+
+        from hive.server import remember_if_absent
+
+        storage, _, jwt = server_env
+        with (
+            patch.object(storage.__class__, "get_memory_by_key", return_value=None),
+            patch.object(storage.__class__, "put_memory_if_absent", return_value=False) as mock_put,
+        ):
+            result = await remember_if_absent("ifa-race", "v", ctx=_make_ctx(jwt))
+        assert _text(result) == "Memory 'ifa-race' already exists — not overwritten."
+        mock_put.assert_called_once()
+
+    async def test_forgotten_key_can_be_recreated(self, server_env):
+        """forget releases the key claim, so a later if-absent create works."""
+        storage, _, jwt = server_env
+        from hive.server import forget, remember_if_absent
+
+        await remember_if_absent("ifa-cycle", "v1", ctx=_make_ctx(jwt))
+        await forget("ifa-cycle", ctx=_make_ctx(jwt))
+        result = await remember_if_absent("ifa-cycle", "v2", ctx=_make_ctx(jwt))
+        assert _text(result) == "Stored memory 'ifa-cycle'."
+        m = storage.get_memory_by_key("ifa-cycle")
+        assert m.value == "v2"
+
 
 # ---------------------------------------------------------------------------
 # recall

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -612,6 +612,43 @@ class TestPutMemoryIfAbsent:
         m = Memory(key="ifa-nodate", value="v", owner_client_id="c1")
         assert storage.put_memory_if_absent(m) is True
 
+    def test_orphaned_claim_with_invalid_created_at_is_reclaimed(self, storage):
+        """A claim whose created_at is not parseable ISO-8601 degrades to
+        maximally old (reclaimable) instead of crashing the reclaim path and
+        leaving the key permanently blocked."""
+        storage.table.put_item(
+            Item={
+                "PK": "KEYCLAIM#ifa-badts",
+                "SK": "META",
+                "key": "ifa-badts",
+                "memory_id": "gone",
+                "created_at": "not-a-timestamp",
+            }
+        )
+        m = Memory(key="ifa-badts", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+
+    def test_orphaned_claim_with_naive_created_at_is_assumed_utc(self, storage):
+        """A timezone-naive created_at is assumed UTC — the aware-vs-naive
+        subtraction must never raise, and a recent naive timestamp still
+        counts as within the in-flight grace period."""
+        from datetime import datetime, timedelta, timezone
+
+        naive_recent = (
+            (datetime.now(timezone.utc) - timedelta(seconds=5)).replace(tzinfo=None).isoformat()
+        )
+        storage.table.put_item(
+            Item={
+                "PK": "KEYCLAIM#ifa-naive",
+                "SK": "META",
+                "key": "ifa-naive",
+                "memory_id": "being-written",
+                "created_at": naive_recent,
+            }
+        )
+        m = Memory(key="ifa-naive", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is False
+
     def test_reclaim_reads_are_strongly_consistent(self, storage):
         """Staleness must never be decided from an eventually-consistent
         replica — a lagging read could miss a just-committed memory and

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -466,6 +466,164 @@ class TestMemoryStorage:
 
 
 # ---------------------------------------------------------------------------
+# Atomic if-absent creation via key-claim items (#592)
+# ---------------------------------------------------------------------------
+
+
+class TestPutMemoryIfAbsent:
+    """put_memory_if_absent arbitrates concurrent same-key creates with a
+    conditional write on a KEYCLAIM item — the KeyIndex GSI can't enforce
+    uniqueness, and the META item's PK is a fresh surrogate UUID."""
+
+    @staticmethod
+    def _claim_item(storage, key):
+        resp = storage.table.get_item(Key={"PK": f"KEYCLAIM#{key}", "SK": "META"})
+        return resp.get("Item")
+
+    def test_creates_memory_and_claim_when_key_unclaimed(self, storage):
+        m = Memory(key="ifa", value="v1", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+        stored = storage.get_memory_by_key("ifa")
+        assert stored is not None
+        assert stored.value == "v1"
+        claim = self._claim_item(storage, "ifa")
+        assert claim is not None
+        assert claim["memory_id"] == m.memory_id
+        # No TTL on the memory → no TTL on the claim
+        assert "ttl" not in claim
+        assert "expires_at" not in claim
+
+    def test_second_call_returns_false_and_does_not_overwrite(self, storage):
+        first = Memory(key="ifa-dupe", value="original", owner_client_id="c1")
+        assert storage.put_memory_if_absent(first) is True
+        second = Memory(key="ifa-dupe", value="usurper", owner_client_id="c2")
+        assert storage.put_memory_if_absent(second) is False
+        stored = storage.get_memory_by_key("ifa-dupe")
+        assert stored.value == "original"
+        assert stored.memory_id == first.memory_id
+        # The loser's memory was never written
+        assert storage.get_memory_by_id(second.memory_id) is None
+
+    def test_claim_write_is_conditional(self, storage):
+        """Pin the wire-level contract: the claim put carries
+        ``attribute_not_exists(PK) OR expires_at <= :now`` so a refactor
+        can't silently drop the atomicity (#592). DynamoDB's server-side
+        serialisation of conditional writes is what enforces single-create."""
+        from unittest.mock import MagicMock
+
+        captured: dict[str, object] = {}
+        original = storage.table.put_item
+
+        def _spy(**kwargs: object) -> object:
+            if "ConditionExpression" in kwargs and not captured:
+                captured.update(kwargs)
+            return original(**kwargs)
+
+        storage.table = MagicMock(wraps=storage.table)
+        storage.table.put_item.side_effect = _spy
+
+        m = Memory(key="ifa-cond", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+
+        assert captured["Item"]["PK"] == "KEYCLAIM#ifa-cond"
+        assert captured["Item"]["SK"] == "META"
+        expr = captured["ConditionExpression"].get_expression()
+        assert expr["operator"] == "OR"
+        not_exists, expired = expr["values"]
+        assert not_exists.get_expression()["operator"] == "attribute_not_exists"
+        assert not_exists.get_expression()["values"][0].name == "PK"
+        assert expired.get_expression()["operator"] == "<="
+        assert expired.get_expression()["values"][0].name == "expires_at"
+
+    def test_claim_mirrors_memory_ttl(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        m = Memory(key="ifa-ttl", value="v", owner_client_id="c1", expires_at=expires)
+        assert storage.put_memory_if_absent(m) is True
+        claim = self._claim_item(storage, "ifa-ttl")
+        assert claim["expires_at"] == expires.isoformat()
+        assert claim["ttl"] == int(expires.timestamp())
+
+    def test_expired_claim_is_taken_over(self, storage):
+        """A claim whose memory has expired reads as absent everywhere else,
+        so the ``expires_at <= :now`` arm lets a new create take it over."""
+        from datetime import datetime, timedelta, timezone
+
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        stale = Memory(key="ifa-exp", value="old", owner_client_id="c1", expires_at=past)
+        assert storage.put_memory_if_absent(stale) is True
+        fresh = Memory(key="ifa-exp", value="new", owner_client_id="c1")
+        assert storage.put_memory_if_absent(fresh) is True
+        claim = self._claim_item(storage, "ifa-exp")
+        assert claim["memory_id"] == fresh.memory_id
+        # The takeover rewrites the claim wholesale — no stale expiry left
+        assert "expires_at" not in claim
+
+    def test_live_ttl_claim_still_blocks(self, storage):
+        from datetime import datetime, timedelta, timezone
+
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        live = Memory(key="ifa-live", value="v", owner_client_id="c1", expires_at=future)
+        assert storage.put_memory_if_absent(live) is True
+        rival = Memory(key="ifa-live", value="x", owner_client_id="c1")
+        assert storage.put_memory_if_absent(rival) is False
+
+    def test_failed_memory_write_rolls_back_claim(self, storage):
+        from unittest.mock import patch
+
+        m = Memory(key="ifa-rollback", value="v", owner_client_id="c1")
+        with (
+            patch.object(storage.__class__, "put_memory", side_effect=ValueError("too big")),
+            pytest.raises(ValueError, match="too big"),
+        ):
+            storage.put_memory_if_absent(m)
+        assert self._claim_item(storage, "ifa-rollback") is None
+        # The key is not poisoned — a subsequent create succeeds
+        retry = Memory(key="ifa-rollback", value="v2", owner_client_id="c1")
+        assert storage.put_memory_if_absent(retry) is True
+
+    def test_unexpected_client_error_reraises(self, storage):
+        """Only ConditionalCheckFailedException maps to False — anything else
+        bubbles up so genuine AWS failures aren't masked as 'exists'."""
+        from unittest.mock import MagicMock
+
+        from botocore.exceptions import ClientError
+
+        throttled = ClientError(
+            error_response={"Error": {"Code": "ProvisionedThroughputExceededException"}},
+            operation_name="PutItem",
+        )
+        storage.table = MagicMock(wraps=storage.table)
+        storage.table.put_item.side_effect = throttled
+        m = Memory(key="ifa-throttle", value="v", owner_client_id="c1")
+        with pytest.raises(ClientError):
+            storage.put_memory_if_absent(m)
+
+    def test_delete_memory_releases_claim(self, storage):
+        m = Memory(key="ifa-del", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+        assert storage.delete_memory(m.memory_id) is True
+        assert self._claim_item(storage, "ifa-del") is None
+        recreated = Memory(key="ifa-del", value="v2", owner_client_id="c1")
+        assert storage.put_memory_if_absent(recreated) is True
+
+    def test_delete_memory_without_claim_is_a_noop_release(self, storage):
+        m = Memory(key="ifa-noclaim", value="v", owner_client_id="c1")
+        storage.put_memory(m)  # plain create path — no claim written
+        assert self._claim_item(storage, "ifa-noclaim") is None
+        assert storage.delete_memory(m.memory_id) is True
+
+    def test_delete_memories_by_tag_releases_claims(self, storage):
+        m = Memory(key="ifa-tagged", value="v", tags=["t592"], owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+        assert storage.delete_memories_by_tag("t592", owner_client_id="c1") == 1
+        assert self._claim_item(storage, "ifa-tagged") is None
+        recreated = Memory(key="ifa-tagged", value="v2", tags=["t592"], owner_client_id="c1")
+        assert storage.put_memory_if_absent(recreated) is True
+
+
+# ---------------------------------------------------------------------------
 # Large-memory routing tests (#497)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -489,7 +489,7 @@ class TestPutMemoryIfAbsent:
         claim = self._claim_item(storage, "ifa")
         assert claim is not None
         assert claim["memory_id"] == m.memory_id
-        # No TTL on the memory → no TTL on the claim
+        # Claims never carry TTL attributes — lifetime is decoupled
         assert "ttl" not in claim
         assert "expires_at" not in claim
 
@@ -506,9 +506,9 @@ class TestPutMemoryIfAbsent:
 
     def test_claim_write_is_conditional(self, storage):
         """Pin the wire-level contract: the claim put carries
-        ``attribute_not_exists(PK) OR expires_at <= :now`` so a refactor
-        can't silently drop the atomicity (#592). DynamoDB's server-side
-        serialisation of conditional writes is what enforces single-create."""
+        ``attribute_not_exists(PK)`` so a refactor can't silently drop the
+        atomicity (#592). DynamoDB's server-side serialisation of
+        conditional writes is what enforces single-create."""
         from unittest.mock import MagicMock
 
         captured: dict[str, object] = {}
@@ -528,26 +528,25 @@ class TestPutMemoryIfAbsent:
         assert captured["Item"]["PK"] == "KEYCLAIM#ifa-cond"
         assert captured["Item"]["SK"] == "META"
         expr = captured["ConditionExpression"].get_expression()
-        assert expr["operator"] == "OR"
-        not_exists, expired = expr["values"]
-        assert not_exists.get_expression()["operator"] == "attribute_not_exists"
-        assert not_exists.get_expression()["values"][0].name == "PK"
-        assert expired.get_expression()["operator"] == "<="
-        assert expired.get_expression()["values"][0].name == "expires_at"
+        assert expr["operator"] == "attribute_not_exists"
+        assert expr["values"][0].name == "PK"
 
-    def test_claim_mirrors_memory_ttl(self, storage):
+    def test_claim_lifetime_is_decoupled_from_memory_ttl(self, storage):
+        """Claims never carry expires_at/ttl — liveness is resolved against
+        the memory item at conflict time, so a TTL later added, extended,
+        or removed via remember/the API can't strand or free the claim."""
         from datetime import datetime, timedelta, timezone
 
         expires = datetime.now(timezone.utc) + timedelta(hours=1)
         m = Memory(key="ifa-ttl", value="v", owner_client_id="c1", expires_at=expires)
         assert storage.put_memory_if_absent(m) is True
         claim = self._claim_item(storage, "ifa-ttl")
-        assert claim["expires_at"] == expires.isoformat()
-        assert claim["ttl"] == int(expires.timestamp())
+        assert "expires_at" not in claim
+        assert "ttl" not in claim
 
     def test_expired_claim_is_taken_over(self, storage):
         """A claim whose memory has expired reads as absent everywhere else,
-        so the ``expires_at <= :now`` arm lets a new create take it over."""
+        so the stale-claim reclaim path lets a new create take it over."""
         from datetime import datetime, timedelta, timezone
 
         past = datetime.now(timezone.utc) - timedelta(hours=1)
@@ -557,8 +556,152 @@ class TestPutMemoryIfAbsent:
         assert storage.put_memory_if_absent(fresh) is True
         claim = self._claim_item(storage, "ifa-exp")
         assert claim["memory_id"] == fresh.memory_id
-        # The takeover rewrites the claim wholesale — no stale expiry left
-        assert "expires_at" not in claim
+
+    def test_orphaned_claim_past_grace_is_reclaimed(self, storage):
+        """A claim with no backing memory older than the grace period is a
+        crashed-create orphan — the key self-heals on the next create."""
+        from datetime import timedelta
+
+        from hive.storage import _now
+
+        storage.table.put_item(
+            Item={
+                "PK": "KEYCLAIM#ifa-orphan",
+                "SK": "META",
+                "key": "ifa-orphan",
+                "memory_id": "gone-forever",
+                "created_at": (_now() - timedelta(seconds=120)).isoformat(),
+            }
+        )
+        m = Memory(key="ifa-orphan", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+        assert self._claim_item(storage, "ifa-orphan")["memory_id"] == m.memory_id
+        assert storage.get_memory_by_key("ifa-orphan").value == "v"
+
+    def test_orphaned_claim_within_grace_blocks(self, storage):
+        """A claim with no backing memory younger than the grace period may
+        belong to an in-flight create — it must not be stolen."""
+        from datetime import timedelta
+
+        from hive.storage import _now
+
+        storage.table.put_item(
+            Item={
+                "PK": "KEYCLAIM#ifa-inflight",
+                "SK": "META",
+                "key": "ifa-inflight",
+                "memory_id": "being-written",
+                "created_at": (_now() - timedelta(seconds=5)).isoformat(),
+            }
+        )
+        m = Memory(key="ifa-inflight", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is False
+        assert self._claim_item(storage, "ifa-inflight")["memory_id"] == "being-written"
+
+    def test_orphaned_claim_without_created_at_is_reclaimed(self, storage):
+        """A malformed claim missing created_at defaults to epoch age and is
+        immediately reclaimable rather than blocking the key forever."""
+        storage.table.put_item(
+            Item={
+                "PK": "KEYCLAIM#ifa-nodate",
+                "SK": "META",
+                "key": "ifa-nodate",
+                "memory_id": "gone",
+            }
+        )
+        m = Memory(key="ifa-nodate", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+
+    def test_reclaim_reads_are_strongly_consistent(self, storage):
+        """Staleness must never be decided from an eventually-consistent
+        replica — a lagging read could miss a just-committed memory and
+        clear a live claim."""
+        from unittest.mock import MagicMock
+
+        first = Memory(key="ifa-consist", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(first) is True
+
+        calls: list[dict[str, object]] = []
+        original = storage.table.get_item
+
+        def _spy(**kwargs: object) -> object:
+            calls.append(kwargs)
+            return original(**kwargs)
+
+        storage.table = MagicMock(wraps=storage.table)
+        storage.table.get_item.side_effect = _spy
+
+        rival = Memory(key="ifa-consist", value="x", owner_client_id="c1")
+        assert storage.put_memory_if_absent(rival) is False
+        reclaim_reads = [
+            c for c in calls if str(c["Key"]["PK"]).startswith(("KEYCLAIM#", "MEMORY#"))
+        ]
+        assert len(reclaim_reads) >= 2
+        assert all(c.get("ConsistentRead") is True for c in reclaim_reads)
+
+    def test_reclaim_lost_conditional_delete_returns_false(self, storage):
+        """If the stale claim changes hands between the read and the
+        conditional delete, the reclaim backs off instead of clearing the
+        new owner's claim."""
+        from datetime import timedelta
+        from unittest.mock import MagicMock
+
+        from botocore.exceptions import ClientError
+
+        from hive.storage import _now
+
+        storage.table.put_item(
+            Item={
+                "PK": "KEYCLAIM#ifa-handoff",
+                "SK": "META",
+                "key": "ifa-handoff",
+                "memory_id": "gone",
+                "created_at": (_now() - timedelta(seconds=120)).isoformat(),
+            }
+        )
+        lost = ClientError(
+            error_response={"Error": {"Code": "ConditionalCheckFailedException"}},
+            operation_name="DeleteItem",
+        )
+        storage.table = MagicMock(wraps=storage.table)
+        storage.table.delete_item.side_effect = lost
+        m = Memory(key="ifa-handoff", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is False
+
+    def test_reclaim_unexpected_delete_error_reraises(self, storage):
+        from datetime import timedelta
+        from unittest.mock import MagicMock
+
+        from botocore.exceptions import ClientError
+
+        from hive.storage import _now
+
+        storage.table.put_item(
+            Item={
+                "PK": "KEYCLAIM#ifa-delerr",
+                "SK": "META",
+                "key": "ifa-delerr",
+                "memory_id": "gone",
+                "created_at": (_now() - timedelta(seconds=120)).isoformat(),
+            }
+        )
+        throttled = ClientError(
+            error_response={"Error": {"Code": "ProvisionedThroughputExceededException"}},
+            operation_name="DeleteItem",
+        )
+        storage.table = MagicMock(wraps=storage.table)
+        storage.table.delete_item.side_effect = throttled
+        m = Memory(key="ifa-delerr", value="v", owner_client_id="c1")
+        with pytest.raises(ClientError):
+            storage.put_memory_if_absent(m)
+
+    def test_reclaim_vanished_claim_retries_put(self, storage):
+        """If the claim disappears between the lost put and the resolution
+        read (e.g. a concurrent forget released it), the conditional put is
+        retried once and wins."""
+        m = Memory(key="ifa-vanished", value="v", owner_client_id="c1")
+        assert storage._reclaim_stale_key(m) is True
+        assert self._claim_item(storage, "ifa-vanished")["memory_id"] == m.memory_id
 
     def test_live_ttl_claim_still_blocks(self, storage):
         from datetime import datetime, timedelta, timezone

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -815,6 +815,34 @@ class TestPutMemoryIfAbsent:
         assert self._claim_item(storage, "ifa-noclaim") is None
         assert storage.delete_memory(m.memory_id) is True
 
+    def test_release_key_claim_failure_does_not_fail_delete(self, storage):
+        """Claim cleanup is best-effort: a throttled release must not turn a
+        successful memory delete into an error — the surviving claim
+        self-heals via the next delete or the grace-based reclaim."""
+        from unittest.mock import MagicMock
+
+        from botocore.exceptions import ClientError
+
+        m = Memory(key="ifa-relerr", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+
+        throttled = ClientError(
+            error_response={"Error": {"Code": "ProvisionedThroughputExceededException"}},
+            operation_name="DeleteItem",
+        )
+        original = storage.table.delete_item
+
+        def _fail_claim_delete(**kwargs: object) -> object:
+            if str(kwargs["Key"]["PK"]).startswith("KEYCLAIM#"):
+                raise throttled
+            return original(**kwargs)
+
+        storage.table = MagicMock(wraps=storage.table)
+        storage.table.delete_item.side_effect = _fail_claim_delete
+
+        assert storage.delete_memory(m.memory_id) is True
+        assert storage.get_memory_by_key("ifa-relerr") is None
+
     def test_delete_memories_by_tag_releases_claims(self, storage):
         m = Memory(key="ifa-tagged", value="v", tags=["t592"], owner_client_id="c1")
         assert storage.put_memory_if_absent(m) is True

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -815,6 +815,24 @@ class TestPutMemoryIfAbsent:
         assert self._claim_item(storage, "ifa-noclaim") is None
         assert storage.delete_memory(m.memory_id) is True
 
+    def test_delete_of_duplicate_key_memory_preserves_other_claim(self, storage):
+        """Claim release is conditional on the owning memory_id: with
+        duplicate same-key memories (possible via non-if-absent paths or the
+        pre-#592 race), deleting one must not clear the claim that protects
+        the other, still-live memory."""
+        claimed = Memory(key="ifa-dupe-del", value="claimed", owner_client_id="c1")
+        assert storage.put_memory_if_absent(claimed) is True
+        # Simulate a duplicate created through a claim-less path
+        rogue = Memory(key="ifa-dupe-del", value="rogue", owner_client_id="c1")
+        storage.put_memory(rogue)
+
+        assert storage.delete_memory(rogue.memory_id) is True
+        # The claim still belongs to the if-absent memory
+        assert self._claim_item(storage, "ifa-dupe-del")["memory_id"] == claimed.memory_id
+
+        assert storage.delete_memory(claimed.memory_id) is True
+        assert self._claim_item(storage, "ifa-dupe-del") is None
+
     def test_release_key_claim_failure_does_not_fail_delete(self, storage):
         """Claim cleanup is best-effort: a throttled release must not turn a
         successful memory delete into an error — the surviving claim

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -612,6 +612,27 @@ class TestPutMemoryIfAbsent:
         m = Memory(key="ifa-nodate", value="v", owner_client_id="c1")
         assert storage.put_memory_if_absent(m) is True
 
+    def test_orphaned_claim_without_memory_id_is_reclaimed(self, storage):
+        """A malformed claim missing memory_id degrades to stale (its key
+        self-heals) instead of raising KeyError in the reclaim path; the
+        conditional delete requires the attribute still absent so a claim
+        that changed hands is never cleared."""
+        from datetime import timedelta
+
+        from hive.storage import _now
+
+        storage.table.put_item(
+            Item={
+                "PK": "KEYCLAIM#ifa-noid",
+                "SK": "META",
+                "key": "ifa-noid",
+                "created_at": (_now() - timedelta(seconds=120)).isoformat(),
+            }
+        )
+        m = Memory(key="ifa-noid", value="v", owner_client_id="c1")
+        assert storage.put_memory_if_absent(m) is True
+        assert self._claim_item(storage, "ifa-noid")["memory_id"] == m.memory_id
+
     def test_orphaned_claim_with_invalid_created_at_is_reclaimed(self, storage):
         """A claim whose created_at is not parseable ISO-8601 degrades to
         maximally old (reclaimable) instead of crashing the reclaim path and


### PR DESCRIPTION
Closes #592

## Summary

`remember_if_absent` used a read-then-write existence check, and its docstring openly acknowledged that two concurrent callers with the same key could race in the window between the read and the write — each seeing "absent" and both creating the memory (two META items sharing one key, with `get_memory_by_key`'s `Limit=1` returning an arbitrary winner and the other orphaned).

The fix replaces the raw `put_memory` call with a new `HiveStorage.put_memory_if_absent`, whose claim write is a DynamoDB `PutItem` with `ConditionExpression=Attr("PK").not_exists()`. DynamoDB serialises conditional writes on the same item, so exactly one of any number of concurrent creators wins; the loser receives the exact same external response as before (`"Memory '{key}' already exists — not overwritten."` — same message, log shape, and metrics as the read-check skip path). The race-acknowledging docstring is replaced with a description of the conditional-write behaviour.

## Approach

**Uniqueness-axis decision (why the condition isn't on the memory item itself):** the issue prescribes `ConditionExpression=Attr("PK").not_exists()`, but the memory META item's PK is `MEMORY#{memory_id}` with a *freshly generated UUID* — a not-exists condition there would always pass and protect nothing. The uniqueness the old read-check actually enforced is **by key**, which lives only on the eventually-consistent `KeyIndex` GSI (`GSI1PK=KEY#{key}`), and DynamoDB cannot condition on a GSI. The conditional write is therefore anchored on a new item that *represents* key uniqueness: a **key-claim item** (`PK=KEYCLAIM#{key}`, `SK=META`, carrying `memory_id` + `created_at`). This follows the repo's existing precedent for atomicity fixes (`mark_auth_code_used`, `bind_client_owner`), which condition on the item keyed by the natural key. `KEYCLAIM#` was chosen over `MEMORYKEY#` because unfiltered scans use `begins_with(PK, "MEMORY#")` and would have falsely matched the latter.

Details of the final design (evolved through the Copilot review loop — see resolved threads):

- **Two-layer existence check preserved:** the fast `get_memory_by_key` read stays (it covers keys created via `remember`/the management API, which carry no claim, and keeps the common already-exists path cheap); the conditional claim write closes the concurrent window between if-absent creators. As a bonus it also closes the sequential read-your-writes gap where GSI propagation lag could let two quick back-to-back `remember_if_absent` calls double-create.
- **Claim condition is pure `attribute_not_exists(PK)`; staleness is resolved at conflict time.** A lost conditional write is not automatically "exists": `_reclaim_stale_key` resolves the holder with **strongly-consistent reads** (deciding staleness from an eventually-consistent replica could miss a just-committed memory and clear a live claim). A claim backed by a live memory → "already exists". A stale claim — its memory expired, or a crashed create that never wrote its memory — is deleted *conditionally on the observed `memory_id`* (so a claim that changed hands is never cleared from under its new owner) and the conditional put is retried exactly once; at most one concurrent reclaimer can pass that conditional delete, preserving single-create.
- **Crashed-create orphans self-heal, in-flight creates are protected:** a claim with no backing memory is only reclaimable once older than `HIVE_KEYCLAIM_GRACE_SECONDS` (default 60s) — younger claims are indistinguishable from an in-flight create and are reported as "exists".
- **Claim lifetime is decoupled from the memory's TTL** (no `expires_at`/`ttl` attributes on claims): liveness is decided against the memory item at conflict time, so a TTL later added, extended, or removed via `remember`/the API can neither strand a reaped key nor permit takeover of a live one. Expired memories still read as absent — their claims resolve as stale through the same path.
- **Lifecycle:** claims are released in `delete_memory` and `delete_memories_by_tag` (all delete paths — `forget`, `forget_all`, the management API, and user-data purge — funnel through these), so a forgotten key is immediately re-creatable. The release is **conditional on the owning `memory_id`** (so deleting one of two duplicate same-key memories never clears the claim protecting the other) and **best-effort** (failures logged and swallowed, mirroring `_delete_blob_if_needed`) so a throttled cleanup can't fail an otherwise-successful delete; a claim whose memory is gone self-heals via the grace-based reclaim. If the memory write fails after a successful claim, the claim is rolled back and the error re-raised.
- **Malformed claims degrade to reclaimable, never crash:** `created_at` is parsed defensively (invalid → epoch, naive → assumed UTC) and a claim missing `memory_id` resolves as stale with a matching `attribute_not_exists(memory_id)` delete condition.
- **Out of scope (unchanged behaviour):** a concurrent `remember`/API create racing an if-absent create can still double-create, exactly as today — those paths are upsert/last-write-wins by design and carry no if-absent contract; extending claims to them would require a backfill migration and is not needed for #592.
- No schema/infra changes — the claim is just another item in the single table (no new GSI, no CDK change).

## Testing

- **Unit (moto):** new `TestPutMemoryIfAbsent` storage suite — claim creation, second-writer rejection without overwrite, wire-level pin of the `attribute_not_exists(PK)` condition (so a refactor can't silently drop it), TTL decoupling, expired-claim takeover, live-TTL blocking, orphan reclaim past/within grace, malformed-claim tolerance (missing/invalid/naive `created_at`, missing `memory_id`), strongly-consistent reclaim reads, conditional-delete hand-off backoff, rollback on failed memory write, best-effort release, non-conditional `ClientError` re-raise, and claim release via both delete paths. New server tests cover the lost-conditional-write already-exists response and forget-then-recreate.
- **Integration (DynamoDB Local, run locally, all passing):** second `remember_if_absent` returns already-exists and does not overwrite; a deterministic race-window test bypasses the read-check (as if both callers read "absent" simultaneously) and proves against real DynamoDB conditional-write semantics that the second writer loses and the winner's value survives; forget-then-recreate works.
- Full gate green locally: ruff + mypy + copyright, 992 unit tests, 905 frontend tests. Coverage on both touched modules verified with no missed lines in the changed code.
- Local e2e not run — CI will cover this on the development branch deploy.
