### PR TITLE
feat: workspaces auth — workspace_id/workspace_role JWT claims, DCR binding (#491)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,11 +123,18 @@ hive/
 ## Auth
 
 - OAuth 2.1 authorization server built into Hive (self-contained)
-- Dynamic Client Registration per RFC 7591 (required by MCP spec)
+- Dynamic Client Registration per RFC 7591 (required by MCP spec);
+  registrations may carry an optional `workspace_id` binding (#491) —
+  unbound clients bind to the authenticating user's Personal workspace
+  at the OAuth callback
 - PKCE required on all authorization code flows
 - Tokens stored in DynamoDB with TTL
+- JWTs (MCP + mgmt) carry `workspace_id` / `workspace_role` claims (#491);
+  legacy claim-free tokens fall back to the owner's Personal workspace via
+  `resolve_workspace_scope` — missing claim never breaks validation
 - All MCP and API endpoints require a valid Bearer token
-- Management UI login via Google OAuth (`/auth/login`)
+- Management UI login via Google OAuth (`/auth/login`); switch workspace by
+  re-issuing the mgmt JWT via `POST /api/account/workspace-token`
 
 ## DynamoDB single table design
 
@@ -140,6 +147,12 @@ hive/
   (immutable compliance trail, TTL via `HIVE_AUDIT_RETENTION_DAYS`,
   default 365 days; survives user-initiated activity-log purges)
 - User items: `PK=USER#{user_id}`, `SK=META`
+- Workspace items: `PK=WORKSPACE#{workspace_id}`, `SK=META`;
+  members at `SK=MEMBER#{user_id}` (#490). Personal workspaces created by
+  the auth flows use the deterministic id `personal-{user_id}` (#491);
+  migration-era ones have random ids — resolve via
+  `storage.get_personal_workspace`, never by constructing the id inline
+- Invite items: `PK=INVITE#{invite_id}`, `SK=META` (TTL enabled)
 - Mgmt state items: `PK=MGMT_STATE#{state}`, `SK=META`
   (TTL enabled, used for OAuth state parameter)
 - Key-claim items: `PK=KEYCLAIM#{key}`, `SK=META`
@@ -149,6 +162,10 @@ hive/
   - `TagIndex` — `GSI2PK=TAG#{tag}`, `GSI2SK=memory_id` (for list_memories)
   - `ClientIdIndex` — `GSI3PK=CLIENT#{client_id}` (for client lookups)
   - `UserEmailIndex` — `PK=EMAIL#{email}` (for user lookups by email)
+  - `WorkspaceMemberIndex` — `GSI5PK=USER#{user_id}`,
+    `GSI5SK=WORKSPACE#{workspace_id}` (workspaces a user belongs to).
+    Unit/integration test fixtures that create the table must include this
+    GSI — the auth flows now resolve Personal workspaces through it
 
 ## Management UI
 

--- a/docs-site/public/openapi.json
+++ b/docs-site/public/openapi.json
@@ -250,6 +250,17 @@
             "default": "none",
             "title": "Token Endpoint Auth Method",
             "type": "string"
+          },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Id"
           }
         },
         "required": [
@@ -831,6 +842,44 @@
         ],
         "title": "ValidationError",
         "type": "object"
+      },
+      "WorkspaceTokenRequest": {
+        "description": "Request body for re-issuing a management JWT scoped to a workspace (#491).",
+        "properties": {
+          "workspace_id": {
+            "title": "Workspace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "workspace_id"
+        ],
+        "title": "WorkspaceTokenRequest",
+        "type": "object"
+      },
+      "WorkspaceTokenResponse": {
+        "description": "A freshly issued workspace-scoped management JWT (#491).",
+        "properties": {
+          "token": {
+            "title": "Token",
+            "type": "string"
+          },
+          "workspace_id": {
+            "title": "Workspace Id",
+            "type": "string"
+          },
+          "workspace_role": {
+            "title": "Workspace Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "workspace_id",
+          "workspace_role"
+        ],
+        "title": "WorkspaceTokenResponse",
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -978,6 +1027,62 @@
           }
         ],
         "summary": "Personal usage analytics",
+        "tags": [
+          "account"
+        ]
+      }
+    },
+    "/api/account/workspace-token": {
+      "post": {
+        "description": "Issue a fresh management JWT carrying `workspace_id` and `workspace_role` claims for the requested workspace (#491). The caller must be a member of that workspace; the role claim is stamped from their membership record. The UI calls this when the user switches workspace and replaces its stored token with the result.",
+        "operationId": "issue_workspace_token_api_account_workspace_token_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Not a member of the workspace"
+          },
+          "404": {
+            "description": "User or workspace not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Re-issue the management token scoped to a workspace",
         "tags": [
           "account"
         ]

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -267,6 +267,8 @@ def _ensure_table(ddb_client, table_name: str) -> None:
                 {"AttributeName": "GSI2SK", "AttributeType": "S"},
                 {"AttributeName": "GSI3PK", "AttributeType": "S"},
                 {"AttributeName": "GSI4PK", "AttributeType": "S"},
+                {"AttributeName": "GSI5PK", "AttributeType": "S"},
+                {"AttributeName": "GSI5SK", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
                 {
@@ -296,6 +298,14 @@ def _ensure_table(ddb_client, table_name: str) -> None:
                     "IndexName": "UserEmailIndex",
                     "KeySchema": [
                         {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": "WorkspaceMemberIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
                     ],
                     "Projection": {"ProjectionType": "ALL"},
                 },

--- a/src/hive/api/account.py
+++ b/src/hive/api/account.py
@@ -20,7 +20,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from hive.api._auth import require_mgmt_user
-from hive.models import ActivityEvent, EventType
+from hive.auth.tokens import issue_mgmt_jwt
+from hive.models import ActivityEvent, EventType, WorkspaceTokenRequest, WorkspaceTokenResponse
 from hive.quota import _exempt_users, get_memory_limit, get_storage_bytes_limit
 from hive.storage import HiveStorage
 from hive.workspace_service import list_sole_owned_shared_workspaces
@@ -482,3 +483,50 @@ async def get_account_stats(
     data = _compute_account_stats(user_id, window_days, storage, is_admin=is_admin)
     _STATS_CACHE[cache_key] = (time.time(), data)
     return data
+
+
+@router.post(
+    "/account/workspace-token",
+    summary="Re-issue the management token scoped to a workspace",
+    description=(
+        "Issue a fresh management JWT carrying `workspace_id` and "
+        "`workspace_role` claims for the requested workspace (#491). The "
+        "caller must be a member of that workspace; the role claim is stamped "
+        "from their membership record. The UI calls this when the user "
+        "switches workspace and replaces its stored token with the result."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Not a member of the workspace"},
+        404: {"description": "User or workspace not found"},
+    },
+)
+async def issue_workspace_token(
+    body: WorkspaceTokenRequest,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> WorkspaceTokenResponse:
+    user_id: str = claims["sub"]
+
+    user = storage.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    workspace = storage.get_workspace(body.workspace_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    member = storage.get_workspace_member(workspace.workspace_id, user_id)
+    if member is None:
+        raise HTTPException(status_code=403, detail="You are not a member of this workspace")
+
+    token = issue_mgmt_jwt(
+        user,
+        workspace_id=workspace.workspace_id,
+        workspace_role=member.role.value,
+    )
+    return WorkspaceTokenResponse(
+        token=token,
+        workspace_id=workspace.workspace_id,
+        workspace_role=member.role.value,
+    )

--- a/src/hive/auth/dcr.py
+++ b/src/hive/auth/dcr.py
@@ -53,6 +53,14 @@ def register_client(
     if unknown_scopes:
         raise ValueError(f"Unknown scope(s): {unknown_scopes}")
 
+    # Workspaces (#491): an explicit binding must reference a real workspace.
+    # Membership is enforced later, at the OAuth callback, once the
+    # authenticating user is known (DCR itself is unauthenticated per RFC
+    # 7591).  Registrations without a binding are bound to the authenticating
+    # user's Personal workspace at that same point.
+    if req.workspace_id is not None and storage.get_workspace(req.workspace_id) is None:
+        raise ValueError(f"Unknown workspace_id: {req.workspace_id!r}")
+
     # Determine client type
     is_confidential = req.token_endpoint_auth_method in {
         "client_secret_post",
@@ -70,6 +78,7 @@ def register_client(
         response_types=req.response_types,
         scope=req.scope,
         token_endpoint_auth_method=req.token_endpoint_auth_method,
+        workspace_id=req.workspace_id,
     )
 
     storage.put_client(client)

--- a/src/hive/auth/mgmt_auth.py
+++ b/src/hive/auth/mgmt_auth.py
@@ -28,7 +28,7 @@ from hive.auth.google import (
 )
 from hive.auth.tokens import ISSUER, issue_mgmt_jwt
 from hive.logging_config import get_logger
-from hive.models import User
+from hive.models import User, WorkspaceRole
 from hive.storage import HiveStorage
 
 router = APIRouter(tags=["mgmt-auth"])
@@ -72,7 +72,7 @@ async def mgmt_login(request: Request) -> RedirectResponse:
     if _BYPASS and test_email:
         storage = HiveStorage()
         user = _upsert_user(storage, test_email, test_email.split("@")[0], test_email)
-        token = issue_mgmt_jwt(user)
+        token = _issue_workspace_scoped_mgmt_jwt(storage, user)
         return _html_redirect(token)  # type: ignore[return-value]
 
     storage = HiveStorage()
@@ -129,7 +129,7 @@ async def mgmt_callback(
     display_name: str = claims.get("name", email.split("@")[0])
 
     user = _upsert_user(storage, email, display_name, email)
-    token = issue_mgmt_jwt(user)
+    token = _issue_workspace_scoped_mgmt_jwt(storage, user)
     logger.info("Management login: %s (role=%s)", email, user.role)
     return _html_redirect(token)
 
@@ -149,3 +149,19 @@ def _upsert_user(storage: HiveStorage, email: str, display_name: str, _email: st
     user.last_login_at = now
     storage.put_user(user)
     return user
+
+
+def _issue_workspace_scoped_mgmt_jwt(storage: HiveStorage, user: User) -> str:
+    """Issue a management JWT scoped to the user's Personal workspace (#491).
+
+    Login always lands in the Personal workspace (auto-created on first
+    login); the UI switches workspace by re-issuing the JWT through
+    ``POST /api/account/workspace-token``.  The owner of a Personal workspace
+    is by construction its ``owner``.
+    """
+    workspace = storage.ensure_personal_workspace(user)
+    return issue_mgmt_jwt(
+        user,
+        workspace_id=workspace.workspace_id,
+        workspace_role=WorkspaceRole.owner.value,
+    )

--- a/src/hive/auth/oauth.py
+++ b/src/hive/auth/oauth.py
@@ -24,7 +24,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from hive.auth.dcr import register_client
-from hive.auth.tokens import ISSUER, issue_jwt
+from hive.auth.tokens import ISSUER, issue_jwt, resolve_client_workspace
 from hive.metrics import emit_metric
 from hive.models import (
     ActivityEvent,
@@ -210,6 +210,20 @@ def _associate_user_with_client(storage: HiveStorage, client_id: str, email: str
         user.role = role
     user.last_login_at = now
 
+    # Workspace boundary (#491): a client registered with an explicit
+    # workspace binding (DCR ``workspace_id``) may only be authenticated by a
+    # member of that workspace.  Checked before any write so a rejected login
+    # leaves no trace; a brand-new user is by definition a member of nothing,
+    # so they are rejected here too.
+    if (
+        client.workspace_id is not None
+        and storage.get_workspace_member(client.workspace_id, user.user_id) is None
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="This client is bound to a workspace you are not a member of.",
+        )
+
     # Claim ownership atomically. The conditional write closes the
     # read-modify-write race: if two callbacks for the same unowned client run
     # concurrently, exactly one bind wins. The loser re-reads and resolves the
@@ -229,10 +243,20 @@ def _associate_user_with_client(storage: HiveStorage, client_id: str, email: str
                 detail="This client is already associated with a different user account.",
             )
         # Same account won the race; its persisted record is canonical, so
-        # don't write a duplicate user.
+        # don't write a duplicate user. The winner's request also handled the
+        # personal-workspace provisioning and workspace binding below.
         return
 
     storage.put_user(user)
+
+    # Workspaces (#491): every authenticated user has a Personal workspace
+    # (auto-created on first login), and every client ends up bound to exactly
+    # one workspace.  Clients registered without an explicit DCR binding are
+    # bound to the authenticating user's Personal workspace here —
+    # first-bind-wins, so a concurrent same-user callback is harmless.
+    workspace = storage.ensure_personal_workspace(user)
+    if client.workspace_id is None:
+        storage.bind_client_workspace(client_id, workspace.workspace_id)
 
 
 @router.get("/oauth/authorize", responses={400: {"description": "Invalid authorization request"}})
@@ -483,7 +507,26 @@ async def token(  # NOSONAR — complexity inherent in OAuth grant type dispatch
             storage.mark_auth_code_used(code)
         except AuthCodeAlreadyUsed as exc:
             raise HTTPException(status_code=400, detail="Invalid or already-used code") from exc
-        access, refresh = storage.create_token_pair(client_id, auth_code.scope)
+
+        # Workspaces (#491): stamp the client's workspace binding (and the
+        # owner's role in it) onto both tokens.  Re-read the client so the
+        # binding written by the callback moments ago is visible.  A client
+        # explicitly bound to a workspace whose owner is missing or no longer
+        # a member must not receive a workspace-scoped token — fail closed.
+        # Fully legacy clients (no binding resolvable) get claim-free tokens;
+        # validation falls back to the Personal workspace downstream.
+        bound_client = storage.get_client(client_id)
+        workspace_id, workspace_role = resolve_client_workspace(
+            storage, bound_client if bound_client is not None else client
+        )
+        if workspace_id is not None and workspace_role is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Client's workspace binding is no longer valid",
+            )
+        access, refresh = storage.create_token_pair(
+            client_id, auth_code.scope, workspace_id=workspace_id, workspace_role=workspace_role
+        )
 
     elif grant_type == "refresh_token":
         if not refresh_token:
@@ -522,7 +565,16 @@ async def token(  # NOSONAR — complexity inherent in OAuth grant type dispatch
                 status_code=400,
                 detail="refresh_token scope has no overlap with client's registered scope",
             )
-        access = storage.create_access_token(client_id, effective_scope)
+        # Workspaces (#491): the refresh grant carries the workspace claims
+        # through unchanged — the refresh token's scope was fixed at issuance
+        # and agents swap tokens (not claims) to switch workspace.  Membership
+        # revocation is enforced by revoking the tokens themselves.
+        access = storage.create_access_token(
+            client_id,
+            effective_scope,
+            workspace_id=stored.workspace_id,
+            workspace_role=stored.workspace_role,
+        )
         refresh = stored
 
     else:

--- a/src/hive/auth/tokens.py
+++ b/src/hive/auth/tokens.py
@@ -49,8 +49,13 @@ def _jwt_secret() -> str:
 
 
 def issue_jwt(token: Token) -> str:
-    """Encode a Token record as a signed JWT."""
-    payload = {
+    """Encode a Token record as a signed JWT.
+
+    Workspace claims (#491) are included only when the token carries them —
+    legacy tokens minted before the workspace cutover stay claim-free and are
+    resolved via :func:`resolve_workspace_scope` at validation time.
+    """
+    payload: dict[str, Any] = {
         "iss": ISSUER,
         "sub": token.client_id,
         "jti": token.jti,
@@ -59,6 +64,10 @@ def issue_jwt(token: Token) -> str:
         "exp": int(token.expires_at.timestamp()),
         "token_type": token.token_type.value,
     }
+    if token.workspace_id is not None:
+        payload["workspace_id"] = token.workspace_id
+    if token.workspace_role is not None:
+        payload["workspace_role"] = token.workspace_role
     return jwt.encode(payload, _jwt_secret(), algorithm=JWT_ALGORITHM)
 
 
@@ -91,16 +100,22 @@ def _origin_verify_secret() -> str | None:
 MGMT_JWT_TTL_SECONDS = 28800  # 8 hours
 
 
-def issue_mgmt_jwt(user: Any) -> str:
+def issue_mgmt_jwt(
+    user: Any,
+    workspace_id: str | None = None,
+    workspace_role: str | None = None,
+) -> str:
     """Issue a short-lived management session JWT for a human user.
 
     Uses typ=mgmt to distinguish from MCP access tokens so neither can be
-    replayed as the other.
+    replayed as the other.  ``workspace_id`` / ``workspace_role`` (#491) scope
+    the session to one workspace; the UI re-issues the JWT via
+    ``POST /api/account/workspace-token`` to switch.
     """
     import time
 
     now = int(time.time())
-    payload = {
+    payload: dict[str, Any] = {
         "iss": ISSUER,
         "sub": user.user_id,
         "email": user.email,
@@ -110,6 +125,10 @@ def issue_mgmt_jwt(user: Any) -> str:
         "iat": now,
         "exp": now + MGMT_JWT_TTL_SECONDS,
     }
+    if workspace_id is not None:
+        payload["workspace_id"] = workspace_id
+    if workspace_role is not None:
+        payload["workspace_role"] = workspace_role
     return jwt.encode(payload, _jwt_secret(), algorithm=JWT_ALGORITHM)
 
 
@@ -126,6 +145,8 @@ def decode_mgmt_jwt(token_str: str) -> dict[str, Any]:
 
 
 _API_KEY_PREFIX = "hive_sk_"
+# client_id prefix of the synthetic Token minted for API-key callers below.
+_API_KEY_PREFIX_CLIENT = "apikey:"
 
 
 def validate_bearer_token(authorization_header: str | None, storage: HiveStorage) -> Token:
@@ -160,8 +181,8 @@ def validate_bearer_token(authorization_header: str | None, storage: HiveStorage
             raise ValueError("API key has been revoked or has expired")
         # Synthesize a Token so callers need no changes
         return Token(
-            jti=f"apikey:{api_key.key_id}",
-            client_id=f"apikey:{api_key.key_id}",
+            jti=f"{_API_KEY_PREFIX_CLIENT}{api_key.key_id}",
+            client_id=f"{_API_KEY_PREFIX_CLIENT}{api_key.key_id}",
             scope=api_key.scope,
             issued_at=api_key.created_at,
             expires_at=api_key.expires_at or (api_key.created_at + timedelta(days=3650)),
@@ -185,3 +206,66 @@ def validate_bearer_token(authorization_header: str | None, storage: HiveStorage
         raise ValueError("Token has been revoked or has expired")
 
     return token
+
+
+# ---------------------------------------------------------------------------
+# Workspace scope resolution (#491)
+# ---------------------------------------------------------------------------
+
+
+def resolve_client_workspace(storage: HiveStorage, client: Any) -> tuple[str | None, str | None]:
+    """Resolve the (workspace_id, workspace_role) an OAuth client is bound to.
+
+    Resolution order:
+
+    1. Explicit ``client.workspace_id`` binding (DCR-provided or stamped at
+       the OAuth callback / migration).  The role comes from the owner's
+       membership record; ``None`` when the owner is unset or no longer a
+       member — callers that mint new tokens must fail closed on that.
+    2. Legacy fallback: the owner's Personal workspace (pre-migration
+       clients).  The owner of a Personal workspace is always its ``owner``.
+    3. ``(None, None)`` when the client is unbound to both a workspace and a
+       user — pre-#648 legacy clients.
+    """
+    from hive.models import WorkspaceRole
+
+    if client.workspace_id is not None:
+        if client.owner_user_id is None:
+            return client.workspace_id, None
+        member = storage.get_workspace_member(client.workspace_id, client.owner_user_id)
+        return client.workspace_id, (member.role.value if member else None)
+    if client.owner_user_id is None:
+        return None, None
+    workspace = storage.get_personal_workspace(client.owner_user_id)
+    if workspace is None:
+        return None, None
+    return workspace.workspace_id, WorkspaceRole.owner.value
+
+
+def resolve_workspace_scope(storage: HiveStorage, token: Token) -> tuple[str | None, str | None]:
+    """Resolve the (workspace_id, workspace_role) a validated token is scoped to.
+
+    Claim-first: tokens minted after the workspace cutover (#491) carry the
+    scope directly and cost no extra lookups.  Synthetic API-key tokens
+    resolve to the key owner's Personal workspace (API keys are personal
+    credentials).  Legacy OAuth tokens (no claim) fall back to the issuing
+    client's binding via :func:`resolve_client_workspace`; a fully
+    unresolvable caller yields ``(None, None)`` and downstream enforcement
+    fails closed on any workspace-stamped resource.
+    """
+    from hive.models import WorkspaceRole
+
+    if token.workspace_id is not None:
+        return token.workspace_id, token.workspace_role
+    if token.client_id.startswith(_API_KEY_PREFIX_CLIENT):
+        api_key = storage.get_api_key_by_id(token.client_id[len(_API_KEY_PREFIX_CLIENT) :])
+        if api_key is None:
+            return None, None
+        workspace = storage.get_personal_workspace(api_key.owner_user_id)
+        if workspace is None:
+            return None, None
+        return workspace.workspace_id, WorkspaceRole.owner.value
+    client = storage.get_client(token.client_id)
+    if client is None:
+        return None, None
+    return resolve_client_workspace(storage, client)

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -639,9 +639,14 @@ class Token(BaseModel):
     issued_at: datetime = Field(default_factory=_now_utc)
     expires_at: datetime
     revoked: bool = False
+    # Workspaces (#491): the tenancy scope this token was issued for.
+    # None on legacy tokens minted before the workspace cutover — validation
+    # falls back to resolving the owner's Personal workspace in that case.
+    workspace_id: str | None = None
+    workspace_role: str | None = None
 
     def to_dynamo(self) -> dict[str, Any]:
-        return {
+        item: dict[str, Any] = {
             "PK": f"TOKEN#{self.jti}",
             "SK": "META",
             "jti": self.jti,
@@ -654,6 +659,11 @@ class Token(BaseModel):
             # DynamoDB TTL attribute
             "ttl": int(self.expires_at.timestamp()),
         }
+        if self.workspace_id is not None:
+            item["workspace_id"] = self.workspace_id
+        if self.workspace_role is not None:
+            item["workspace_role"] = self.workspace_role
+        return item
 
     @classmethod
     def from_dynamo(cls, item: dict[str, Any]) -> Token:
@@ -665,6 +675,8 @@ class Token(BaseModel):
             issued_at=datetime.fromisoformat(item["issued_at"]),
             expires_at=datetime.fromisoformat(item["expires_at"]),
             revoked=item.get("revoked", False),
+            workspace_id=item.get("workspace_id"),
+            workspace_role=item.get("workspace_role"),
         )
 
     @property
@@ -874,6 +886,10 @@ class ClientRegistrationRequest(BaseModel):
     response_types: list[str] = Field(default_factory=lambda: ["code"])
     scope: str = _DEFAULT_SCOPE
     token_endpoint_auth_method: str = "none"
+    # Workspaces (#491): optional explicit workspace binding. When omitted the
+    # client is bound to the authenticating user's Personal workspace at the
+    # OAuth callback (backwards compatible with pre-workspace MCP clients).
+    workspace_id: str | None = None
 
 
 class ClientRegistrationResponse(BaseModel):
@@ -881,7 +897,8 @@ class ClientRegistrationResponse(BaseModel):
 
     ``client_secret`` is omitted entirely for public clients (RFC 7591 §3.2.1)
     rather than serialised as ``null``, which breaks strict Zod schemas in
-    clients such as mcp-remote.
+    clients such as mcp-remote.  ``workspace_id`` (a Hive extension, #491) is
+    likewise omitted when the client has no explicit workspace binding yet.
     """
 
     client_id: str
@@ -893,12 +910,14 @@ class ClientRegistrationResponse(BaseModel):
     scope: str
     token_endpoint_auth_method: str
     client_id_issued_at: int  # Unix timestamp
+    workspace_id: str | None = None
 
     @model_serializer(mode="wrap")
-    def _drop_null_secret(self, handler: Any) -> dict:  # type: ignore[override]
+    def _drop_null_fields(self, handler: Any) -> dict:  # type: ignore[override]
         data = handler(self)
-        if data.get("client_secret") is None:
-            data.pop("client_secret", None)
+        for field in ("client_secret", "workspace_id"):
+            if data.get(field) is None:
+                data.pop(field, None)
         return data
 
     @classmethod
@@ -913,6 +932,7 @@ class ClientRegistrationResponse(BaseModel):
             scope=c.scope,
             token_endpoint_auth_method=c.token_endpoint_auth_method,
             client_id_issued_at=int(c.created_at.timestamp()),
+            workspace_id=c.workspace_id,
         )
 
 
@@ -924,6 +944,20 @@ class TokenResponse(BaseModel):
     expires_in: int
     refresh_token: str | None = None
     scope: str
+
+
+class WorkspaceTokenRequest(BaseModel):
+    """Request body for re-issuing a management JWT scoped to a workspace (#491)."""
+
+    workspace_id: str
+
+
+class WorkspaceTokenResponse(BaseModel):
+    """A freshly issued workspace-scoped management JWT (#491)."""
+
+    token: str
+    workspace_id: str
+    workspace_role: str
 
 
 class StatsResponse(BaseModel):

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -22,6 +22,7 @@ import importlib.metadata
 import json
 import os
 import time
+from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 from urllib.parse import quote, unquote
@@ -38,7 +39,12 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse as StarletteJSONResponse
 
-from hive.auth.tokens import ISSUER, _origin_verify_secret, validate_bearer_token
+from hive.auth.tokens import (
+    ISSUER,
+    _origin_verify_secret,
+    resolve_workspace_scope,
+    validate_bearer_token,
+)
 from hive.hybrid_search import (
     DEFAULT_W_KEYWORD,
     DEFAULT_W_RECENCY,
@@ -50,7 +56,7 @@ from hive.hybrid_search import (
 )
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
 from hive.metrics import emit_metric
-from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult
+from hive.models import ActivityEvent, EventType, Memory, MemorySearchResult, Token
 from hive.quota import QuotaExceeded, check_memory_quota, check_storage_quota, get_memory_limit
 from hive.rate_limiter import (
     DEFAULT_RATE_LIMIT_RPD,
@@ -142,6 +148,11 @@ mcp = FastMCP(
 # Auth helper
 # ---------------------------------------------------------------------------
 
+# The validated Token for the current tool call (#491). Set by _auth() so
+# workspace-scope helpers can read the workspace claims without threading the
+# Token through every handler signature. ContextVar is async-task-safe.
+_current_token: ContextVar[Token | None] = ContextVar("hive_current_token", default=None)
+
 
 async def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple[HiveStorage, str]:
     """Validate Bearer token; return (storage, client_id).
@@ -203,6 +214,7 @@ async def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple
         raise ToolError(f"Rate limit exceeded. Retry after {exc.retry_after}s.") from exc
 
     set_request_context(request_id, token.client_id)
+    _current_token.set(token)
     return storage, token.client_id
 
 
@@ -225,6 +237,38 @@ def _require_owner_user_id(storage: HiveStorage, client_id: str) -> str:
             "Client is not associated with a user account; per-user memory scoping is required."
         )
     return client.owner_user_id
+
+
+def _caller_workspace_scope(storage: HiveStorage) -> tuple[str | None, str | None]:
+    """Resolve the (workspace_id, workspace_role) of the current tool call (#491).
+
+    Claim-first via the Token stashed by ``_auth()``; legacy tokens without
+    the claim fall back to the issuing client's binding and, ultimately, the
+    owner's Personal workspace.  ``(None, None)`` means the caller has no
+    resolvable workspace — enforcement fails closed on any workspace-stamped
+    memory in that case.
+    """
+    token = _current_token.get()
+    if token is None:
+        return None, None
+    return resolve_workspace_scope(storage, token)
+
+
+def _check_workspace_access(storage: HiveStorage, memory: Memory, error: str) -> None:
+    """Enforce the caller's workspace claim against a memory's workspace (#491).
+
+    Memories without a ``workspace_id`` (pre-migration rows) pass through —
+    the existing owner-based checks still govern them until the migration
+    stamps them.  Workspace-stamped memories are only accessible when the
+    caller's resolved workspace matches; anything else raises ``error``
+    (phrased by the call site to match its not-found/denied semantics so
+    cross-workspace probing learns nothing new).
+    """
+    if memory.workspace_id is None:
+        return
+    workspace_id, _ = _caller_workspace_scope(storage)
+    if workspace_id != memory.workspace_id:
+        raise ToolError(error)
 
 
 def _log(storage: HiveStorage, event: ActivityEvent) -> None:
@@ -470,6 +514,11 @@ async def remember(
     existing = storage.get_memory_by_key(key)
 
     if existing:
+        # Workspace boundary (#491): keys are globally unique, so an existing
+        # memory in another workspace must not be overwritten. Checked before
+        # the optimistic-lock path so a conflict message can never leak a
+        # foreign memory's value.
+        _check_workspace_access(storage, existing, f"Key '{key}' is already in use.")
         # Optimistic lock: reject early if the caller's version is already stale.
         if version is not None and existing.version != version:
             await emit_metric("ToolErrors", operation="remember")
@@ -532,12 +581,14 @@ async def remember(
             check_storage_quota(owner_user_id, actual, storage)
         except QuotaExceeded as exc:
             raise ToolError(exc.detail) from exc
+        workspace_id, _ = _caller_workspace_scope(storage)
         memory = Memory(
             key=key,
             value=value,
             tags=tags,
             owner_client_id=client_id,
             owner_user_id=owner_user_id,
+            workspace_id=workspace_id,
             expires_at=expires_at,
         )
         try:
@@ -643,12 +694,14 @@ async def remember_if_absent(
         except QuotaExceeded as exc:
             raise ToolError(exc.detail) from exc
 
+        workspace_id, _ = _caller_workspace_scope(storage)
         candidate = Memory(
             key=key,
             value=value,
             tags=tags,
             owner_client_id=client_id,
             owner_user_id=owner_user_id,
+            workspace_id=workspace_id,
             expires_at=expires_at,
         )
         try:
@@ -775,6 +828,8 @@ async def remember_blob(
 
     existing = storage.get_memory_by_key(key)
     if existing:
+        # Workspace boundary (#491): never overwrite a foreign workspace's blob.
+        _check_workspace_access(storage, existing, f"Key '{key}' is already in use.")
         old_blob_size = existing.size_bytes or 0
         delta = len(raw) - old_blob_size
         if delta > 0:
@@ -813,12 +868,14 @@ async def remember_blob(
             check_storage_quota(owner_user_id, len(raw), storage)
         except QuotaExceeded as exc:
             raise ToolError(exc.detail) from exc
+        workspace_id, _ = _caller_workspace_scope(storage)
         memory = Memory(
             key=key,
             value="",
             tags=tags,
             owner_client_id=client_id,
             owner_user_id=owner_user_id,
+            workspace_id=workspace_id,
             value_type=value_type,  # type: ignore[arg-type]
             content_type=content_type,
             size_bytes=len(raw),
@@ -880,9 +937,17 @@ async def recall(
     t0 = time.monotonic()
     storage, client_id = await _auth(ctx, required_scope=_MEMORIES_READ_SCOPE)
 
-    # record_recall atomically bumps recall_count + last_accessed_at and
-    # returns the updated Memory (None if missing/expired).
-    memory = storage.record_recall(key)
+    # Workspace boundary (#491): resolve the memory and enforce the workspace
+    # claim BEFORE record_recall mutates recall stats — a denied cross-
+    # workspace probe must not touch the foreign memory at all, and the error
+    # is indistinguishable from a missing key.
+    memory = storage.get_memory_by_key(key)
+    if memory is not None:
+        _check_workspace_access(storage, memory, f"No memory found for key '{key}'.")
+        # record_recall atomically bumps recall_count + last_accessed_at and
+        # returns the updated Memory (None if it was deleted or expired between
+        # the lookup above and the update).
+        memory = storage.record_recall(key)
     if memory is None:
         logger.warning(
             "Memory not found for key '%s'",
@@ -1009,6 +1074,9 @@ async def forget(
         )
         await emit_metric("ToolErrors", operation="forget")
         raise ToolError(f"No memory found for key '{key}'.")
+    # Workspace boundary (#491): deny cross-workspace deletion, phrased as
+    # not-found so probing learns nothing.
+    _check_workspace_access(storage, existing, f"No memory found for key '{key}'.")
 
     storage.delete_memory(existing.memory_id)
     try:
@@ -1135,6 +1203,10 @@ async def redact_memory(
     if existing is None:
         await emit_metric("ToolErrors", operation="redact_memory")
         raise ToolError(f"No memory found for key '{key}'.")
+    # Workspace boundary (#491): deny cross-workspace redaction, phrased as
+    # not-found so probing learns nothing (checked before the already-redacted
+    # state can leak).
+    _check_workspace_access(storage, existing, f"No memory found for key '{key}'.")
     if existing.is_redacted:
         return _tool_result(f"Memory '{key}' is already redacted.", storage, client_id)
 
@@ -1205,6 +1277,8 @@ async def memory_history(
     memory = storage.get_memory_by_key(key)
     if memory is None:
         raise ToolError(f"No memory found for key '{key}'.")
+    # Workspace boundary (#491): version history is as sensitive as the value.
+    _check_workspace_access(storage, memory, f"No memory found for key '{key}'.")
     versions = storage.list_memory_versions(memory.memory_id)
     duration_ms = int((time.monotonic() - t0) * 1000)
     await emit_metric("ToolInvocations", operation="memory_history")
@@ -1247,6 +1321,8 @@ async def restore_memory(
     memory = storage.get_memory_by_key(key)
     if memory is None:
         raise ToolError(f"No memory found for key '{key}'.")
+    # Workspace boundary (#491): deny cross-workspace restores as not-found.
+    _check_workspace_access(storage, memory, f"No memory found for key '{key}'.")
     version = storage.get_memory_version(memory.memory_id, version_timestamp)
     if version is None:
         raise ToolError(f"Version '{version_timestamp}' not found for memory '{key}'.")
@@ -1677,6 +1753,9 @@ async def relate_memories(
     memory = storage.get_memory_by_key(key)
     if memory is None:
         raise ToolError(f"No memory found for key '{key}'.")
+    # Workspace boundary (#491): the source memory's value seeds the vector
+    # query — never let a foreign workspace's content drive a search.
+    _check_workspace_access(storage, memory, f"No memory found for key '{key}'.")
 
     query_value = memory.value or ""
     if memory.value_type == "text-large":

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -257,12 +257,14 @@ def _caller_workspace_scope(storage: HiveStorage) -> tuple[str | None, str | Non
 def _check_workspace_access(storage: HiveStorage, memory: Memory, error: str) -> None:
     """Enforce the caller's workspace claim against a memory's workspace (#491).
 
-    Memories without a ``workspace_id`` (pre-migration rows) pass through —
-    the existing owner-based checks still govern them until the migration
-    stamps them.  Workspace-stamped memories are only accessible when the
-    caller's resolved workspace matches; anything else raises ``error``
-    (phrased by the call site to match its not-found/denied semantics so
-    cross-workspace probing learns nothing new).
+    Memories without a ``workspace_id`` (pre-migration rows) pass through
+    unchecked — keyed tools carry no other per-memory ownership check, so
+    such rows remain reachable by key exactly as before this guard, until
+    the idempotent post-deploy migration stamps them.  Workspace-stamped
+    memories are only accessible when the caller's resolved workspace
+    matches; anything else raises ``error`` (phrased by the call site to
+    match its not-found/denied semantics so cross-workspace probing learns
+    nothing new).
     """
     if memory.workspace_id is None:
         return

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -950,6 +950,12 @@ async def recall(
         # returns the updated Memory (None if it was deleted or expired between
         # the lookup above and the update).
         memory = storage.record_recall(key)
+        if memory is not None:
+            # Re-check the re-resolved row: record_recall performs its own
+            # KeyIndex lookup, and the key mapping can change between the two
+            # calls (delete + recreate in another workspace). Never return a
+            # value the first check didn't cover.
+            _check_workspace_access(storage, memory, f"No memory found for key '{key}'.")
     if memory is None:
         logger.warning(
             "Memory not found for key '%s'",

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -166,6 +166,10 @@ async def _auth(ctx: Context | None, required_scope: str | None = None) -> tuple
     Emits the ``TokenValidationFailures`` metric on auth rejection so the
     CloudWatch AuthFailures alarm has something to fire on.
     """
+    # Clear the per-call token BEFORE validating so a failed validation can
+    # never leave a previous call's Token visible to workspace-scope helpers
+    # within the same async task (#491).
+    _current_token.set(None)
     storage = HiveStorage()
     auth_header: str | None = None
     request_id = new_request_id()
@@ -685,7 +689,14 @@ async def remember_if_absent(
     )
 
     memory: Memory | None = None
-    if storage.get_memory_by_key(key) is None:
+    existing = storage.get_memory_by_key(key)
+    if existing is not None:
+        # Workspace boundary (#491): mirror remember/remember_blob — a key
+        # held by another workspace reads as in-use, not as a success no-op
+        # that would mislead the caller into believing their workspace holds
+        # this key.
+        _check_workspace_access(storage, existing, f"Key '{key}' is already in use.")
+    else:
         client = storage.get_client(client_id)
         if client is None:
             raise ToolError("Unable to load client record for authenticated caller.")
@@ -712,10 +723,21 @@ async def remember_if_absent(
         except ValueError as exc:
             await emit_metric("ToolErrors", operation="remember_if_absent")
             raise ToolError(str(exc)) from exc
+        if memory is None:
+            # Lost the conditional key-claim write to a concurrent creator
+            # (#592). Apply the workspace guard to whatever the winner wrote
+            # before echoing "already exists" (#491) — the winner's memory
+            # can lag behind the eventually-consistent KeyIndex, in which
+            # case nothing is readable (and nothing leaks) and the plain
+            # race-loser response stands.
+            raced = storage.get_memory_by_key(key)
+            if raced is not None:
+                _check_workspace_access(storage, raced, f"Key '{key}' is already in use.")
 
     if memory is None:
-        # Either the read-check found the key, or a concurrent caller won
-        # the conditional write in the window after it — same outcome.
+        # Either the read-check found the key (in the caller's workspace), or
+        # a concurrent caller won the conditional write in the window after
+        # it — same outcome.
         duration_ms = int((time.monotonic() - t0) * 1000)
         logger.info(
             "Memory '%s' already exists — not overwritten",

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1406,8 +1406,18 @@ class HiveStorage:
         return member
 
     def get_workspace_member(self, workspace_id: str, user_id: str) -> WorkspaceMember | None:
+        """Fetch a (workspace, user) membership row.
+
+        Strongly consistent (#491): membership gates auth decisions — the
+        OAuth-callback membership check, token-issuance role stamping, and
+        the workspace-token endpoint — which often run moments after the
+        MEMBER row was written (first-login provisioning). An eventually-
+        consistent read could transiently miss that write and fail a
+        legitimate login closed.
+        """
         resp = self.table.get_item(
-            Key={"PK": f"WORKSPACE#{workspace_id}", "SK": f"MEMBER#{user_id}"}
+            Key={"PK": f"WORKSPACE#{workspace_id}", "SK": f"MEMBER#{user_id}"},
+            ConsistentRead=True,
         )
         item = resp.get("Item")
         return WorkspaceMember.from_dynamo(item) if item else None
@@ -1526,6 +1536,9 @@ class HiveStorage:
         leave a Personal workspace whose owner has no membership, since role
         resolution and the workspace-token endpoint depend on that row.
         Mirrors the MEMBER-row repair in ``scripts/migrate_workspaces.py``.
+        The owner's role is likewise pinned to ``owner`` — a Personal
+        workspace whose owner carries any other role would stamp inconsistent
+        ``workspace_role`` claims across the login and workspace-token paths.
         """
         workspace = self.get_personal_workspace(user.user_id)
         if workspace is None:
@@ -1536,8 +1549,15 @@ class HiveStorage:
                 is_personal=True,
             )
             self.put_workspace(workspace)
-        if self.get_workspace_member(workspace.workspace_id, user.user_id) is None:
+        member = self.get_workspace_member(workspace.workspace_id, user.user_id)
+        if member is None:
             self.add_workspace_member(workspace.workspace_id, user.user_id, WorkspaceRole.owner)
+        elif member.role is not WorkspaceRole.owner:
+            # Personal-workspace invariant: its owner is always role=owner.
+            # update (not add) preserves the original joined_at.
+            self.update_workspace_member_role(
+                workspace.workspace_id, user.user_id, WorkspaceRole.owner
+            )
         return workspace
 
     # ------------------------------------------------------------------

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1508,18 +1508,24 @@ class HiveStorage:
         ``personal-{user_id}`` so concurrent first-logins converge on the same
         item (both puts are idempotent overwrites of the same keys) instead of
         racing the eventually-consistent GSI lookup into duplicates.
+
+        The owner MEMBER row is verified on every call, not just at creation —
+        a crash between the two writes (or a partial manual fix) must not
+        leave a Personal workspace whose owner has no membership, since role
+        resolution and the workspace-token endpoint depend on that row.
+        Mirrors the MEMBER-row repair in ``scripts/migrate_workspaces.py``.
         """
         workspace = self.get_personal_workspace(user.user_id)
-        if workspace is not None:
-            return workspace
-        workspace = Workspace(
-            workspace_id=f"personal-{user.user_id}",
-            name=f"{user.email}'s Personal",
-            owner_user_id=user.user_id,
-            is_personal=True,
-        )
-        self.put_workspace(workspace)
-        self.add_workspace_member(workspace.workspace_id, user.user_id, WorkspaceRole.owner)
+        if workspace is None:
+            workspace = Workspace(
+                workspace_id=f"personal-{user.user_id}",
+                name=f"{user.email}'s Personal",
+                owner_user_id=user.user_id,
+                is_personal=True,
+            )
+            self.put_workspace(workspace)
+        if self.get_workspace_member(workspace.workspace_id, user.user_id) is None:
+            self.add_workspace_member(workspace.workspace_id, user.user_id, WorkspaceRole.owner)
         return workspace
 
     # ------------------------------------------------------------------

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -982,6 +982,28 @@ class HiveStorage:
                 return False
             raise
 
+    def bind_client_workspace(self, client_id: str, workspace_id: str) -> bool:
+        """Atomically set a client's ``workspace_id`` iff it is currently unset.
+
+        Returns ``True`` when this call performed the binding, ``False`` when
+        the client was already workspace-bound (a concurrent bind won, the
+        client was registered with an explicit workspace, or it no longer
+        exists).  First-bind-wins at the DynamoDB layer, mirroring
+        :meth:`bind_client_owner` (#491).
+        """
+        try:
+            self.table.update_item(
+                Key={"PK": f"CLIENT#{client_id}", "SK": "META"},
+                UpdateExpression="SET workspace_id = :wid",
+                ConditionExpression="attribute_exists(PK) AND attribute_not_exists(workspace_id)",
+                ExpressionAttributeValues={":wid": workspace_id},
+            )
+            return True
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return False
+            raise
+
     def delete_client(self, client_id: str) -> bool:
         resp = self.table.get_item(Key={"PK": f"CLIENT#{client_id}", "SK": "META"})
         if not resp.get("Item"):
@@ -1162,12 +1184,19 @@ class HiveStorage:
                 break
         return revoked
 
-    def create_access_token(self, client_id: str, scope: str) -> Token:
+    def create_access_token(
+        self,
+        client_id: str,
+        scope: str,
+        workspace_id: str | None = None,
+        workspace_role: str | None = None,
+    ) -> Token:
         """Issue and persist a standalone access token.
 
         Used by the non-rotating refresh-token grant (#693), which mints a
         fresh access token while keeping the caller's existing refresh token
-        valid instead of rotating it.
+        valid instead of rotating it.  ``workspace_id`` / ``workspace_role``
+        stamp the workspace claims (#491) carried over from the refresh token.
         """
         now = _now()
         access = Token(
@@ -1176,12 +1205,25 @@ class HiveStorage:
             token_type=TokenType.access,
             issued_at=now,
             expires_at=now + timedelta(seconds=ACCESS_TOKEN_TTL_SECONDS),
+            workspace_id=workspace_id,
+            workspace_role=workspace_role,
         )
         self.put_token(access)
         return access
 
-    def create_token_pair(self, client_id: str, scope: str) -> tuple[Token, Token]:
-        """Issue a new (access_token, refresh_token) pair."""
+    def create_token_pair(
+        self,
+        client_id: str,
+        scope: str,
+        workspace_id: str | None = None,
+        workspace_role: str | None = None,
+    ) -> tuple[Token, Token]:
+        """Issue a new (access_token, refresh_token) pair.
+
+        ``workspace_id`` / ``workspace_role`` stamp the workspace claims
+        (#491) on both tokens so refresh grants can carry the scope through
+        unchanged.
+        """
         now = _now()
         access = Token(
             client_id=client_id,
@@ -1189,6 +1231,8 @@ class HiveStorage:
             token_type=TokenType.access,
             issued_at=now,
             expires_at=now + timedelta(seconds=ACCESS_TOKEN_TTL_SECONDS),
+            workspace_id=workspace_id,
+            workspace_role=workspace_role,
         )
         refresh = Token(
             client_id=client_id,
@@ -1196,6 +1240,8 @@ class HiveStorage:
             token_type=TokenType.refresh,
             issued_at=now,
             expires_at=now + timedelta(seconds=REFRESH_TOKEN_TTL_SECONDS),
+            workspace_id=workspace_id,
+            workspace_role=workspace_role,
         )
         self.put_token(access)
         self.put_token(refresh)
@@ -1438,6 +1484,43 @@ class HiveStorage:
                 break
             kwargs["ExclusiveStartKey"] = lek
         return workspaces
+
+    def get_personal_workspace(self, user_id: str) -> Workspace | None:
+        """Return the user's Personal workspace, or None if they have none.
+
+        Checks the deterministic ``personal-{user_id}`` id first (workspaces
+        auto-created by the auth flows, #491) with a strongly-consistent
+        ``get_item``, then falls back to the ``WorkspaceMemberIndex`` GSI for
+        Personal workspaces created with random ids by the #490 migration.
+        """
+        workspace = self.get_workspace(f"personal-{user_id}")
+        if workspace is not None:
+            return workspace
+        for workspace in self.list_workspaces_for_user(user_id):
+            if workspace.is_personal and workspace.owner_user_id == user_id:
+                return workspace
+        return None
+
+    def ensure_personal_workspace(self, user: User) -> Workspace:
+        """Return the user's Personal workspace, creating it if absent (#491).
+
+        New Personal workspaces use the deterministic id
+        ``personal-{user_id}`` so concurrent first-logins converge on the same
+        item (both puts are idempotent overwrites of the same keys) instead of
+        racing the eventually-consistent GSI lookup into duplicates.
+        """
+        workspace = self.get_personal_workspace(user.user_id)
+        if workspace is not None:
+            return workspace
+        workspace = Workspace(
+            workspace_id=f"personal-{user.user_id}",
+            name=f"{user.email}'s Personal",
+            owner_user_id=user.user_id,
+            is_personal=True,
+        )
+        self.put_workspace(workspace)
+        self.add_workspace_member(workspace.workspace_id, user.user_id, WorkspaceRole.owner)
+        return workspace
 
     # ------------------------------------------------------------------
     # Workspace invites (#490) — pending invitations to join a workspace

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1490,12 +1490,18 @@ class HiveStorage:
 
         Checks the deterministic ``personal-{user_id}`` id first (workspaces
         auto-created by the auth flows, #491) with a strongly-consistent
-        ``get_item``, then falls back to the ``WorkspaceMemberIndex`` GSI for
-        Personal workspaces created with random ids by the #490 migration.
+        ``get_item`` — first-login provisioning reads its own write moments
+        later, so the default eventually-consistent read could transiently
+        miss it. Falls back to the ``WorkspaceMemberIndex`` GSI for Personal
+        workspaces created with random ids by the #490 migration.
         """
-        workspace = self.get_workspace(f"personal-{user_id}")
-        if workspace is not None:
-            return workspace
+        resp = self.table.get_item(
+            Key={"PK": f"WORKSPACE#personal-{user_id}", "SK": "META"},
+            ConsistentRead=True,
+        )
+        item = resp.get("Item")
+        if item:
+            return Workspace.from_dynamo(item)
         for workspace in self.list_workspaces_for_user(user_id):
             if workspace.is_personal and workspace.owner_user_id == user_id:
                 return workspace

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1501,7 +1501,13 @@ class HiveStorage:
         )
         item = resp.get("Item")
         if item:
-            return Workspace.from_dynamo(item)
+            workspace = Workspace.from_dynamo(item)
+            # Trust but verify: only ensure_personal_workspace writes this id
+            # namespace, but a mis-created item squatting on the deterministic
+            # key must never cross tenancy boundaries — apply the same
+            # predicate as the GSI fallback below and fall through otherwise.
+            if workspace.is_personal and workspace.owner_user_id == user_id:
+                return workspace
         for workspace in self.list_workspaces_for_user(user_id):
             if workspace.is_personal and workspace.owner_user_id == user_id:
                 return workspace

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -72,6 +72,8 @@ def setup():
             {"AttributeName": "GSI1SK", "AttributeType": "S"},
             {"AttributeName": "GSI2PK", "AttributeType": "S"},
             {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -87,6 +89,14 @@ def setup():
                 "KeySchema": [
                     {"AttributeName": "GSI2PK", "KeyType": "HASH"},
                     {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
@@ -270,6 +280,8 @@ def two_user_setup():
             {"AttributeName": "GSI1SK", "AttributeType": "S"},
             {"AttributeName": "GSI2PK", "AttributeType": "S"},
             {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -285,6 +297,14 @@ def two_user_setup():
                 "KeySchema": [
                     {"AttributeName": "GSI2PK", "KeyType": "HASH"},
                     {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },

--- a/tests/integration/test_oauth_user_binding.py
+++ b/tests/integration/test_oauth_user_binding.py
@@ -74,6 +74,8 @@ def google_oauth_setup():
             {"AttributeName": "GSI2PK", "AttributeType": "S"},
             {"AttributeName": "GSI2SK", "AttributeType": "S"},
             {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -96,6 +98,14 @@ def google_oauth_setup():
                 "IndexName": "UserEmailIndex",
                 "KeySchema": [
                     {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
@@ -243,3 +253,159 @@ async def test_callback_rejects_second_user_on_owned_client(google_oauth_setup):
     assert exc.value.status_code == 403
     # The intruder never displaces the owner.
     assert storage.get_client(client.client_id).owner_user_id == owner_id
+
+
+@pytest.mark.asyncio
+async def test_google_callback_provisions_personal_workspace_and_scoped_tokens(
+    google_oauth_setup,
+):
+    """#491 end-to-end against DynamoDB Local: the real Google callback
+    provisions the user's Personal workspace, binds the DCR client to it, and
+    the subsequent /oauth/token exchange mints JWTs carrying the
+    ``workspace_id`` / ``workspace_role`` claims. Memories written with that
+    token are stamped with the workspace."""
+    import base64
+    import hashlib
+
+    from fastapi.testclient import TestClient
+
+    from hive.api.main import app
+    from hive.auth import oauth
+    from hive.auth.tokens import decode_jwt
+    from hive.models import OAuthClient, WorkspaceRole
+    from hive.server import recall, remember
+
+    storage = google_oauth_setup
+
+    client = OAuthClient(
+        client_name="Workspace Flow Client",
+        redirect_uris=["https://app.example.com/cb"],
+    )
+    storage.put_client(client)
+
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    pending = storage.create_pending_auth(
+        client_id=client.client_id,
+        redirect_uri="https://app.example.com/cb",
+        scope="memories:read memories:write",
+        code_challenge=challenge,
+        code_challenge_method="S256",
+        original_state="orig-state",
+    )
+
+    fake_claims = {"email": "ws-flow@example.com", "email_verified": True, "sub": "g-ws-1"}
+    with (
+        patch("hive.auth.google.exchange_google_code", return_value="fake-id-token"),
+        patch("hive.auth.google.verify_google_id_token", return_value=fake_claims),
+        patch("hive.auth.google.is_email_allowed", return_value=True),
+        patch("hive.auth.google.is_admin_email", return_value=False),
+    ):
+        resp = await oauth.google_callback(storage=storage, code="g-code", state=pending.state)
+    assert resp.status_code == 302
+
+    # The callback provisioned the Personal workspace and bound the client.
+    user = storage.get_user_by_email("ws-flow@example.com")
+    personal = storage.get_personal_workspace(user.user_id)
+    assert personal is not None
+    assert personal.is_personal is True
+    member = storage.get_workspace_member(personal.workspace_id, user.user_id)
+    assert member.role is WorkspaceRole.owner
+    assert storage.get_client(client.client_id).workspace_id == personal.workspace_id
+
+    # Redeem the real auth code — the minted JWTs must carry the claims.
+    code = resp.headers["location"].split("code=")[1].split("&")[0]
+    tc = TestClient(app)
+    token_resp = tc.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "https://app.example.com/cb",
+            "client_id": client.client_id,
+            "code_verifier": verifier,
+        },
+    )
+    assert token_resp.status_code == 200, token_resp.text
+    body = token_resp.json()
+    access_claims = decode_jwt(body["access_token"])
+    assert access_claims["workspace_id"] == personal.workspace_id
+    assert access_claims["workspace_role"] == "owner"
+    assert decode_jwt(body["refresh_token"])["workspace_id"] == personal.workspace_id
+
+    # Refresh preserves the claims unchanged.
+    refresh_resp = tc.post(
+        "/oauth/token",
+        data={
+            "grant_type": "refresh_token",
+            "client_id": client.client_id,
+            "refresh_token": body["refresh_token"],
+        },
+    )
+    assert refresh_resp.status_code == 200, refresh_resp.text
+    refreshed_claims = decode_jwt(refresh_resp.json()["access_token"])
+    assert refreshed_claims["workspace_id"] == personal.workspace_id
+    assert refreshed_claims["workspace_role"] == "owner"
+
+    # Tool calls with the scoped token stamp new memories with the workspace.
+    ctx = _make_context(body["access_token"])
+    await remember(key="ws-flow-key", value="scoped", tags=["ws"], ctx=ctx)
+    stored = storage.get_memory_by_key("ws-flow-key")
+    assert stored.workspace_id == personal.workspace_id
+    recalled = await recall(key="ws-flow-key", ctx=ctx)
+    assert recalled.content[0].text == "scoped"
+
+
+@pytest.mark.asyncio
+async def test_workspace_scoped_tokens_isolate_keyed_tools(google_oauth_setup):
+    """#491 — a token scoped to workspace B cannot recall, overwrite, or forget
+    a memory stamped with workspace A, even knowing the exact key."""
+    from fastmcp.exceptions import ToolError
+
+    from hive.auth.tokens import issue_jwt
+    from hive.models import OAuthClient, Token, User
+    from hive.server import forget, recall, remember
+
+    storage = google_oauth_setup
+
+    def _scoped_caller(user_id: str, email: str):
+        user = User(user_id=user_id, email=email, display_name=user_id)
+        storage.put_user(user)
+        workspace = storage.ensure_personal_workspace(user)
+        client = OAuthClient(
+            client_name=f"Client {user_id}",
+            owner_user_id=user_id,
+            workspace_id=workspace.workspace_id,
+        )
+        storage.put_client(client)
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+            workspace_id=workspace.workspace_id,
+            workspace_role="owner",
+        )
+        storage.put_token(token)
+        return _make_context(issue_jwt(token))
+
+    ctx_a = _scoped_caller("iso-user-a", "iso-a@example.com")
+    ctx_b = _scoped_caller("iso-user-b", "iso-b@example.com")
+
+    await remember(key="iso-secret", value="workspace-a-only", ctx=ctx_a)
+
+    with pytest.raises(ToolError, match="No memory found for key 'iso-secret'"):
+        await recall(key="iso-secret", ctx=ctx_b)
+    with pytest.raises(ToolError, match="Key 'iso-secret' is already in use"):
+        await remember(key="iso-secret", value="hijack", ctx=ctx_b)
+    with pytest.raises(ToolError, match="No memory found for key 'iso-secret'"):
+        await forget(key="iso-secret", ctx=ctx_b)
+
+    # Workspace A still reads its untouched value.
+    recalled = await recall(key="iso-secret", ctx=ctx_a)
+    assert recalled.content[0].text == "workspace-a-only"

--- a/tests/integration/test_oauth_user_binding.py
+++ b/tests/integration/test_oauth_user_binding.py
@@ -285,9 +285,7 @@ async def test_google_callback_provisions_personal_workspace_and_scoped_tokens(
 
     verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
     challenge = (
-        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
-        .rstrip(b"=")
-        .decode()
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
     )
     pending = storage.create_pending_auth(
         client_id=client.client_id,

--- a/tests/unit/test_account_api.py
+++ b/tests/unit/test_account_api.py
@@ -870,3 +870,70 @@ class TestAccountStats:
         # 30-day window must already be at least 1 (plus the fixture's
         # pre-seeded memory).
         assert growth[0]["cumulative"] >= 1
+
+
+class TestWorkspaceToken:
+    """#491 — POST /api/account/workspace-token re-issues a workspace-scoped
+    management JWT after validating membership."""
+
+    def _seed_workspace(self, storage, *, with_member=True, role=None):
+        from hive.models import Workspace, WorkspaceRole
+
+        role = role or WorkspaceRole.admin
+        storage.put_workspace(
+            Workspace(workspace_id="ws-team", name="Team", owner_user_id="other-user")
+        )
+        if with_member:
+            storage.add_workspace_member("ws-team", _USER_ID, role)
+
+    def test_member_gets_role_stamped_token(self, client):
+        from hive.auth.tokens import decode_mgmt_jwt
+        from hive.models import WorkspaceRole
+
+        tc, storage = client
+        self._seed_workspace(storage, role=WorkspaceRole.admin)
+
+        resp = tc.post("/api/account/workspace-token", json={"workspace_id": "ws-team"})
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["workspace_id"] == "ws-team"
+        assert data["workspace_role"] == "admin"
+        claims = decode_mgmt_jwt(data["token"])
+        assert claims["typ"] == "mgmt"
+        assert claims["sub"] == _USER_ID
+        assert claims["workspace_id"] == "ws-team"
+        assert claims["workspace_role"] == "admin"
+
+    def test_non_member_gets_403(self, client):
+        tc, storage = client
+        self._seed_workspace(storage, with_member=False)
+        resp = tc.post("/api/account/workspace-token", json={"workspace_id": "ws-team"})
+        assert resp.status_code == 403
+        assert "not a member" in resp.json()["detail"]
+
+    def test_unknown_workspace_gets_404(self, client):
+        tc, _ = client
+        resp = tc.post("/api/account/workspace-token", json={"workspace_id": "ws-ghost"})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Workspace not found"
+
+    def test_deleted_user_gets_404(self, client):
+        from hive.api import _auth as auth_mod
+        from hive.api.main import app
+
+        tc, storage = client
+        self._seed_workspace(storage)
+        app.dependency_overrides[auth_mod.require_mgmt_user] = lambda: {
+            "sub": "ghost-user",
+            "role": "user",
+            "email": "ghost@example.com",
+        }
+        resp = tc.post("/api/account/workspace-token", json={"workspace_id": "ws-team"})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "User not found"
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.post(
+            "/api/account/workspace-token", json={"workspace_id": "ws-team"}
+        )
+        assert resp.status_code in (401, 403)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -42,6 +42,8 @@ def _create_table(table_name: str = "hive-unit-api") -> None:
             {"AttributeName": "GSI2PK", "AttributeType": "S"},
             {"AttributeName": "GSI2SK", "AttributeType": "S"},
             {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -64,6 +66,14 @@ def _create_table(table_name: str = "hive-unit-api") -> None:
                 "IndexName": "UserEmailIndex",
                 "KeySchema": [
                     {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -189,6 +189,8 @@ def _create_table(table_name: str = "hive-unit-auth") -> None:
             {"AttributeName": "GSI2PK", "AttributeType": "S"},
             {"AttributeName": "GSI2SK", "AttributeType": "S"},
             {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -211,6 +213,14 @@ def _create_table(table_name: str = "hive-unit-auth") -> None:
                 "IndexName": "UserEmailIndex",
                 "KeySchema": [
                     {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
@@ -2147,3 +2157,465 @@ class TestValidateBearerTokenApiKey:
         storage = self._storage_with_key(k)
         token = validate_bearer_token("Bearer hive_sk_noexpiry", storage)
         assert token.expires_at > datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Workspace claims + scope resolution (#491)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceJwtClaims:
+    def _token(self, **kwargs) -> Token:
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc)
+        return Token(
+            client_id="client-1",
+            scope="memories:read",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+            **kwargs,
+        )
+
+    def test_issue_jwt_includes_workspace_claims(self):
+        token = self._token(workspace_id="ws-1", workspace_role="member")
+        claims = decode_jwt(issue_jwt(token))
+        assert claims["workspace_id"] == "ws-1"
+        assert claims["workspace_role"] == "member"
+
+    def test_issue_jwt_omits_workspace_claims_when_unset(self):
+        claims = decode_jwt(issue_jwt(self._token()))
+        assert "workspace_id" not in claims
+        assert "workspace_role" not in claims
+
+    def test_issue_mgmt_jwt_includes_workspace_claims(self):
+        from hive.auth.tokens import decode_mgmt_jwt, issue_mgmt_jwt
+        from hive.models import User
+
+        user = User(user_id="u1", email="ws@example.com", display_name="WS")
+        jwt_str = issue_mgmt_jwt(user, workspace_id="ws-1", workspace_role="owner")
+        claims = decode_mgmt_jwt(jwt_str)
+        assert claims["workspace_id"] == "ws-1"
+        assert claims["workspace_role"] == "owner"
+
+    def test_issue_mgmt_jwt_omits_workspace_claims_when_unset(self):
+        from hive.auth.tokens import decode_mgmt_jwt, issue_mgmt_jwt
+        from hive.models import User
+
+        user = User(user_id="u1", email="ws@example.com", display_name="WS")
+        claims = decode_mgmt_jwt(issue_mgmt_jwt(user))
+        assert "workspace_id" not in claims
+        assert "workspace_role" not in claims
+
+
+class TestResolveClientWorkspace:
+    def _client(self, **kwargs):
+        from hive.models import OAuthClient
+
+        return OAuthClient(client_name="c", **kwargs)
+
+    def test_explicit_binding_returns_member_role(self):
+        from hive.auth.tokens import resolve_client_workspace
+        from hive.models import WorkspaceMember, WorkspaceRole
+
+        storage = MagicMock()
+        storage.get_workspace_member.return_value = WorkspaceMember(
+            workspace_id="ws-1", user_id="u1", role=WorkspaceRole.admin
+        )
+        client = self._client(workspace_id="ws-1", owner_user_id="u1")
+        assert resolve_client_workspace(storage, client) == ("ws-1", "admin")
+        storage.get_workspace_member.assert_called_once_with("ws-1", "u1")
+
+    def test_explicit_binding_ownerless_returns_none_role(self):
+        from hive.auth.tokens import resolve_client_workspace
+
+        storage = MagicMock()
+        client = self._client(workspace_id="ws-1")
+        assert resolve_client_workspace(storage, client) == ("ws-1", None)
+        storage.get_workspace_member.assert_not_called()
+
+    def test_explicit_binding_membership_revoked_returns_none_role(self):
+        from hive.auth.tokens import resolve_client_workspace
+
+        storage = MagicMock()
+        storage.get_workspace_member.return_value = None
+        client = self._client(workspace_id="ws-1", owner_user_id="u1")
+        assert resolve_client_workspace(storage, client) == ("ws-1", None)
+
+    def test_unbound_ownerless_returns_none(self):
+        from hive.auth.tokens import resolve_client_workspace
+
+        storage = MagicMock()
+        assert resolve_client_workspace(storage, self._client()) == (None, None)
+        storage.get_personal_workspace.assert_not_called()
+
+    def test_personal_workspace_fallback(self):
+        from hive.auth.tokens import resolve_client_workspace
+        from hive.models import Workspace
+
+        storage = MagicMock()
+        storage.get_personal_workspace.return_value = Workspace(
+            workspace_id="personal-u1", name="P", owner_user_id="u1", is_personal=True
+        )
+        client = self._client(owner_user_id="u1")
+        assert resolve_client_workspace(storage, client) == ("personal-u1", "owner")
+
+    def test_personal_workspace_missing_returns_none(self):
+        from hive.auth.tokens import resolve_client_workspace
+
+        storage = MagicMock()
+        storage.get_personal_workspace.return_value = None
+        client = self._client(owner_user_id="u1")
+        assert resolve_client_workspace(storage, client) == (None, None)
+
+
+class TestResolveWorkspaceScope:
+    def _token(self, **kwargs) -> Token:
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc)
+        return Token(
+            client_id=kwargs.pop("client_id", "client-1"),
+            scope="memories:read",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+            **kwargs,
+        )
+
+    def test_claim_passthrough_costs_no_lookups(self):
+        from hive.auth.tokens import resolve_workspace_scope
+
+        storage = MagicMock()
+        token = self._token(workspace_id="ws-9", workspace_role="member")
+        assert resolve_workspace_scope(storage, token) == ("ws-9", "member")
+        storage.get_client.assert_not_called()
+
+    def test_unknown_client_returns_none(self):
+        from hive.auth.tokens import resolve_workspace_scope
+
+        storage = MagicMock()
+        storage.get_client.return_value = None
+        assert resolve_workspace_scope(storage, self._token()) == (None, None)
+
+    def test_delegates_to_client_binding(self):
+        from hive.auth.tokens import resolve_workspace_scope
+        from hive.models import OAuthClient, WorkspaceMember, WorkspaceRole
+
+        storage = MagicMock()
+        storage.get_client.return_value = OAuthClient(
+            client_name="c", workspace_id="ws-1", owner_user_id="u1"
+        )
+        storage.get_workspace_member.return_value = WorkspaceMember(
+            workspace_id="ws-1", user_id="u1", role=WorkspaceRole.member
+        )
+        assert resolve_workspace_scope(storage, self._token()) == ("ws-1", "member")
+
+    def test_api_key_resolves_owner_personal_workspace(self):
+        from hive.auth.tokens import resolve_workspace_scope
+        from hive.models import ApiKey, Workspace
+
+        storage = MagicMock()
+        storage.get_api_key_by_id.return_value = ApiKey(
+            key_id="k1", owner_user_id="u1", name="n", key_hash="h"
+        )
+        storage.get_personal_workspace.return_value = Workspace(
+            workspace_id="personal-u1", name="P", owner_user_id="u1", is_personal=True
+        )
+        token = self._token(client_id="apikey:k1")
+        assert resolve_workspace_scope(storage, token) == ("personal-u1", "owner")
+        storage.get_api_key_by_id.assert_called_once_with("k1")
+        storage.get_client.assert_not_called()
+
+    def test_api_key_missing_returns_none(self):
+        from hive.auth.tokens import resolve_workspace_scope
+
+        storage = MagicMock()
+        storage.get_api_key_by_id.return_value = None
+        assert resolve_workspace_scope(storage, self._token(client_id="apikey:k1")) == (None, None)
+
+    def test_api_key_without_personal_workspace_returns_none(self):
+        from hive.auth.tokens import resolve_workspace_scope
+        from hive.models import ApiKey
+
+        storage = MagicMock()
+        storage.get_api_key_by_id.return_value = ApiKey(
+            key_id="k1", owner_user_id="u1", name="n", key_hash="h"
+        )
+        storage.get_personal_workspace.return_value = None
+        assert resolve_workspace_scope(storage, self._token(client_id="apikey:k1")) == (None, None)
+
+
+class TestDCRWorkspaceBinding:
+    def test_register_with_valid_workspace_binds_and_echoes(self):
+        from hive.models import Workspace
+
+        storage = MagicMock()
+        storage.get_workspace.return_value = Workspace(
+            workspace_id="ws-1", name="Team", owner_user_id="u1"
+        )
+        req = ClientRegistrationRequest(client_name="T", workspace_id="ws-1")
+        resp = register_client(req, storage)
+        assert resp.workspace_id == "ws-1"
+        assert resp.model_dump()["workspace_id"] == "ws-1"
+        stored_client = storage.put_client.call_args[0][0]
+        assert stored_client.workspace_id == "ws-1"
+
+    def test_register_with_unknown_workspace_raises(self):
+        storage = MagicMock()
+        storage.get_workspace.return_value = None
+        req = ClientRegistrationRequest(client_name="T", workspace_id="ws-missing")
+        with pytest.raises(ValueError, match="Unknown workspace_id"):
+            register_client(req, storage)
+        storage.put_client.assert_not_called()
+
+    def test_register_without_workspace_stays_unbound(self):
+        storage = MagicMock()
+        req = ClientRegistrationRequest(client_name="T")
+        resp = register_client(req, storage)
+        assert resp.workspace_id is None
+        # The response JSON omits the null binding entirely (strict clients).
+        assert "workspace_id" not in resp.model_dump()
+        storage.get_workspace.assert_not_called()
+
+
+class TestOAuthTokenWorkspaceClaims:
+    _REDIRECT = "https://app.example.com/cb"
+
+    def _make_workspace_client(
+        self,
+        storage,
+        *,
+        bind_workspace=True,
+        with_member=True,
+        member_role=None,
+        with_owner=True,
+    ):
+        from hive.models import OAuthClient, User, Workspace, WorkspaceRole
+
+        member_role = member_role or WorkspaceRole.admin
+        user = User(user_id="wsu-1", email="ws@example.com", display_name="WS")
+        storage.put_user(user)
+        workspace = Workspace(workspace_id="ws-team", name="Team", owner_user_id="wsu-1")
+        storage.put_workspace(workspace)
+        if with_member:
+            storage.add_workspace_member("ws-team", "wsu-1", member_role)
+        client = OAuthClient(
+            client_name="WS Client",
+            redirect_uris=[self._REDIRECT],
+            owner_user_id="wsu-1" if with_owner else None,
+            workspace_id="ws-team" if bind_workspace else None,
+        )
+        storage.put_client(client)
+        return client
+
+    def _redeem(self, tc, storage, client):
+        verifier, challenge = _pkce_pair()
+        auth_code = storage.create_auth_code(
+            client_id=client.client_id,
+            redirect_uri=self._REDIRECT,
+            scope=client.scope,
+            code_challenge=challenge,
+            code_challenge_method="S256",
+        )
+        return tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": auth_code.code,
+                "redirect_uri": self._REDIRECT,
+                "client_id": client.client_id,
+                "code_verifier": verifier,
+            },
+        )
+
+    def test_auth_code_grant_stamps_workspace_claims(self, oauth_client):
+        tc, storage, _ = oauth_client
+        client = self._make_workspace_client(storage)
+        resp = self._redeem(tc, storage, client)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        access_claims = decode_jwt(data["access_token"])
+        refresh_claims = decode_jwt(data["refresh_token"])
+        assert access_claims["workspace_id"] == "ws-team"
+        assert access_claims["workspace_role"] == "admin"
+        assert refresh_claims["workspace_id"] == "ws-team"
+        assert refresh_claims["workspace_role"] == "admin"
+        # The persisted Token rows carry the scope too (authoritative copy).
+        assert storage.get_token(access_claims["jti"]).workspace_id == "ws-team"
+        assert storage.get_token(refresh_claims["jti"]).workspace_role == "admin"
+
+    def test_auth_code_grant_fails_closed_when_membership_revoked(self, oauth_client):
+        tc, storage, _ = oauth_client
+        client = self._make_workspace_client(storage, with_member=False)
+        resp = self._redeem(tc, storage, client)
+        assert resp.status_code == 400
+        assert "workspace binding" in resp.json()["detail"]
+
+    def test_auth_code_grant_falls_back_to_personal_workspace(self, oauth_client):
+        from hive.models import User
+
+        tc, storage, _ = oauth_client
+        client = self._make_workspace_client(storage, bind_workspace=False, with_member=False)
+        personal = storage.ensure_personal_workspace(
+            User(user_id="wsu-1", email="ws@example.com", display_name="WS")
+        )
+        resp = self._redeem(tc, storage, client)
+        assert resp.status_code == 200, resp.text
+        claims = decode_jwt(resp.json()["access_token"])
+        assert claims["workspace_id"] == personal.workspace_id
+        assert claims["workspace_role"] == "owner"
+
+    def test_auth_code_grant_legacy_client_gets_claim_free_token(self, oauth_client):
+        tc, storage, client = oauth_client  # fixture client: no owner, no workspace
+        resp = self._redeem(tc, storage, client)
+        assert resp.status_code == 200, resp.text
+        claims = decode_jwt(resp.json()["access_token"])
+        assert "workspace_id" not in claims
+        assert storage.get_token(claims["jti"]).workspace_id is None
+
+    def test_refresh_grant_preserves_workspace_claims(self, oauth_client):
+        tc, storage, _ = oauth_client
+        client = self._make_workspace_client(storage)
+        refresh_token = self._redeem(tc, storage, client).json()["refresh_token"]
+
+        resp = tc.post(
+            "/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": client.client_id,
+                "refresh_token": refresh_token,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        access_claims = decode_jwt(data["access_token"])
+        assert access_claims["workspace_id"] == "ws-team"
+        assert access_claims["workspace_role"] == "admin"
+        # The echoed refresh token still carries the claims unchanged.
+        refresh_claims = decode_jwt(data["refresh_token"])
+        assert refresh_claims["workspace_id"] == "ws-team"
+
+
+class TestAssociateUserWorkspaceBinding:
+    _REDIRECT = "https://app.example.com/cb"
+
+    def _authorize(self, tc, client_id, email):
+        _, challenge = _pkce_pair()
+        with (
+            patch("hive.auth.oauth._BYPASS_GOOGLE_AUTH", True),
+            patch("hive.auth.google.is_email_allowed", return_value=True),
+            patch("hive.auth.google.is_admin_email", return_value=False),
+        ):
+            return tc.get(
+                "/oauth/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": client_id,
+                    "redirect_uri": self._REDIRECT,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "test_email": email,
+                },
+                follow_redirects=False,
+            )
+
+    def test_bypass_binds_client_to_personal_workspace(self, oauth_client):
+        from hive.models import WorkspaceRole
+
+        tc, storage, client = oauth_client
+        resp = self._authorize(tc, client.client_id, "bypass-ws@example.com")
+        assert resp.status_code == 302, resp.text
+
+        user = storage.get_user_by_email("bypass-ws@example.com")
+        bound = storage.get_client(client.client_id)
+        assert bound.workspace_id == f"personal-{user.user_id}"
+        workspace = storage.get_workspace(f"personal-{user.user_id}")
+        assert workspace is not None
+        assert workspace.is_personal is True
+        member = storage.get_workspace_member(workspace.workspace_id, user.user_id)
+        assert member is not None
+        assert member.role is WorkspaceRole.owner
+
+    def test_bypass_rejects_nonmember_on_workspace_bound_client(self, oauth_client):
+        from hive.models import OAuthClient, Workspace
+
+        tc, storage, _ = oauth_client
+        storage.put_workspace(
+            Workspace(workspace_id="ws-locked", name="Locked", owner_user_id="someone-else")
+        )
+        client = OAuthClient(
+            client_name="Locked Client",
+            redirect_uris=[self._REDIRECT],
+            workspace_id="ws-locked",
+        )
+        storage.put_client(client)
+
+        resp = self._authorize(tc, client.client_id, "intruder@example.com")
+        assert resp.status_code == 403
+        assert "workspace" in resp.json()["detail"]
+        # A rejected login leaves no trace.
+        assert storage.get_user_by_email("intruder@example.com") is None
+        assert storage.get_client(client.client_id).owner_user_id is None
+
+    def test_bypass_allows_member_on_workspace_bound_client(self, oauth_client):
+        from hive.models import OAuthClient, User, Workspace, WorkspaceRole
+
+        tc, storage, _ = oauth_client
+        member_user = User(user_id="member-1", email="member@example.com", display_name="M")
+        storage.put_user(member_user)
+        storage.put_workspace(
+            Workspace(workspace_id="ws-shared", name="Shared", owner_user_id="member-1")
+        )
+        storage.add_workspace_member("ws-shared", "member-1", WorkspaceRole.member)
+        client = OAuthClient(
+            client_name="Shared Client",
+            redirect_uris=[self._REDIRECT],
+            workspace_id="ws-shared",
+        )
+        storage.put_client(client)
+
+        resp = self._authorize(tc, client.client_id, "member@example.com")
+        assert resp.status_code == 302, resp.text
+        bound = storage.get_client(client.client_id)
+        assert bound.owner_user_id == "member-1"
+        # The explicit DCR binding is preserved, not overwritten with Personal.
+        assert bound.workspace_id == "ws-shared"
+
+
+class TestMgmtLoginWorkspaceClaims:
+    @pytest.fixture()
+    def mgmt_client(self):
+        with mock_aws():
+            _create_table()
+            old = os.environ.get("HIVE_TABLE_NAME")
+            os.environ["HIVE_TABLE_NAME"] = "hive-unit-auth"
+            try:
+                from fastapi.testclient import TestClient
+
+                from hive.api.main import app
+
+                yield TestClient(app, follow_redirects=False)
+            finally:
+                if old is not None:
+                    os.environ["HIVE_TABLE_NAME"] = old
+                else:
+                    os.environ.pop("HIVE_TABLE_NAME", None)
+
+    def test_login_bypass_jwt_carries_personal_workspace_claims(self, mgmt_client):
+        import re
+
+        from hive.auth.tokens import decode_mgmt_jwt
+        from hive.storage import HiveStorage
+
+        with patch("hive.auth.mgmt_auth._BYPASS", True):
+            resp = mgmt_client.get("/auth/login?test_email=wsdev@example.com")
+        assert resp.status_code == 200
+        match = re.search(r"localStorage\.setItem\('hive_mgmt_token', '([^']+)'\)", resp.text)
+        assert match, resp.text
+        claims = decode_mgmt_jwt(match.group(1))
+
+        storage = HiveStorage(table_name="hive-unit-auth", region="us-east-1")
+        user = storage.get_user_by_email("wsdev@example.com")
+        assert claims["workspace_id"] == f"personal-{user.user_id}"
+        assert claims["workspace_role"] == "owner"
+        assert storage.get_workspace(f"personal-{user.user_id}").is_personal is True

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -546,3 +546,36 @@ class TestOAuthClientWorkspaceIdField:
         c = OAuthClient(client_name="Test")
         item = c.to_dynamo()
         assert "workspace_id" not in item
+
+
+class TestTokenWorkspaceFields:
+    """#491 — Token rows round-trip the workspace claims."""
+
+    def _token(self, **kwargs) -> Token:
+        from datetime import datetime, timedelta
+
+        now = datetime.now(timezone.utc)
+        return Token(
+            client_id="c1",
+            scope="memories:read",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+            **kwargs,
+        )
+
+    def test_workspace_fields_round_trip(self):
+        token = self._token(workspace_id="ws-1", workspace_role="member")
+        item = token.to_dynamo()
+        assert item["workspace_id"] == "ws-1"
+        assert item["workspace_role"] == "member"
+        restored = Token.from_dynamo(item)
+        assert restored.workspace_id == "ws-1"
+        assert restored.workspace_role == "member"
+
+    def test_workspace_fields_absent_when_unset(self):
+        item = self._token().to_dynamo()
+        assert "workspace_id" not in item
+        assert "workspace_role" not in item
+        restored = Token.from_dynamo(item)
+        assert restored.workspace_id is None
+        assert restored.workspace_role is None

--- a/tests/unit/test_quota.py
+++ b/tests/unit/test_quota.py
@@ -329,6 +329,10 @@ class TestMcpQuotaIntegration:
             existing_memory.tags = []
             # Set a real int so delta = len("new-value") - 100 < 0; no storage check.
             existing_memory.size_bytes = 100
+            # Legacy row (pre-workspace-migration) so the #491 workspace guard
+            # passes through — a bare MagicMock attribute would read as a
+            # foreign workspace and deny the update.
+            existing_memory.workspace_id = None
             instance = MockStorage.return_value
             instance.get_memory_by_key.return_value = existing_memory
             # Response-meta builder reads count_memories; return a real int.

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -4280,6 +4280,32 @@ class TestWorkspaceEnforcement:
         with pytest.raises(ToolError, match="No memory found for key 'own-key-2'"):
             await recall(key="own-key-2", ctx=_make_ctx(jwt))
 
+    async def test_recall_rechecks_workspace_on_recreated_key(self, workspace_env, monkeypatch):
+        """TOCTOU guard: if the key mapping changes between the guarded lookup
+        and record_recall's own lookup (delete + recreate in another
+        workspace), the re-resolved row is checked again — the foreign value
+        must never be returned."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.models import Memory
+        from hive.server import recall, remember
+        from hive.storage import HiveStorage
+
+        _, _, jwt = workspace_env
+        await remember(key="raced-key", value="mine", ctx=_make_ctx(jwt))
+
+        foreign = Memory(
+            key="raced-key",
+            value="foreign-after-race",
+            tags=[],
+            owner_client_id="client-b",
+            owner_user_id="user-b",
+            workspace_id="ws-b",
+        )
+        monkeypatch.setattr(HiveStorage, "record_recall", lambda self, key: foreign)
+        with pytest.raises(ToolError, match="No memory found for key 'raced-key'"):
+            await recall(key="raced-key", ctx=_make_ctx(jwt))
+
 
 @pytest.mark.asyncio
 class TestWorkspaceStamping:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -4234,6 +4234,70 @@ class TestWorkspaceEnforcement:
             await remember_if_absent(key="foreign-key", value="squat", ctx=_make_ctx(jwt))
         assert storage.get_memory_by_key("foreign-key").value == "foreign-secret"
 
+    async def test_remember_if_absent_race_loser_foreign_winner_denied(
+        self, workspace_env, monkeypatch
+    ):
+        """Losing the conditional key-claim write (#592) to a concurrent
+        creator in ANOTHER workspace reads as in-use, not as the plain
+        already-exists success — the workspace guard applies to the winner's
+        memory on the conditional-failure path too (#491)."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.models import Memory
+        from hive.server import remember_if_absent
+        from hive.storage import HiveStorage
+
+        _, _, jwt = workspace_env
+        foreign_winner = Memory(
+            key="race-key",
+            value="winner-in-ws-b",
+            tags=[],
+            owner_client_id="client-b",
+            owner_user_id="user-b",
+            workspace_id="ws-b",
+        )
+        calls = {"n": 0}
+
+        def fake_get(self, key):
+            # First call: the pre-write read-check sees "absent". Second call:
+            # the post-conditional-failure re-read sees the race winner.
+            calls["n"] += 1
+            return None if calls["n"] == 1 else foreign_winner
+
+        monkeypatch.setattr(HiveStorage, "get_memory_by_key", fake_get)
+        monkeypatch.setattr(HiveStorage, "put_memory_if_absent", lambda self, m: False)
+        with pytest.raises(ToolError, match="Key 'race-key' is already in use"):
+            await remember_if_absent(key="race-key", value="mine", ctx=_make_ctx(jwt))
+
+    async def test_remember_if_absent_race_loser_same_workspace_skips(
+        self, workspace_env, monkeypatch
+    ):
+        """Losing the conditional write to a same-workspace concurrent creator
+        keeps #592's plain already-exists response."""
+        from hive.models import Memory
+        from hive.server import remember_if_absent
+        from hive.storage import HiveStorage
+
+        _, _, jwt = workspace_env
+        same_ws_winner = Memory(
+            key="race-key-2",
+            value="winner-in-ws-a",
+            tags=[],
+            owner_client_id="client-a2",
+            owner_user_id="user-a",
+            workspace_id="ws-a",
+        )
+        calls = {"n": 0}
+
+        def fake_get(self, key):
+            calls["n"] += 1
+            return None if calls["n"] == 1 else same_ws_winner
+
+        monkeypatch.setattr(HiveStorage, "get_memory_by_key", fake_get)
+        monkeypatch.setattr(HiveStorage, "put_memory_if_absent", lambda self, m: False)
+        result = await remember_if_absent(key="race-key-2", value="mine", ctx=_make_ctx(jwt))
+        assert _text(result) == "Memory 'race-key-2' already exists — not overwritten."
+
     async def test_remember_blob_cross_workspace_key_denied(self, workspace_env):
         import base64
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -4222,6 +4222,18 @@ class TestWorkspaceEnforcement:
             )
         assert "foreign-secret" not in str(excinfo.value)
 
+    async def test_remember_if_absent_cross_workspace_key_denied(self, workspace_env):
+        """A foreign-workspace key reads as in-use, not as a success no-op
+        that would mislead the caller into believing their workspace holds it."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_if_absent
+
+        storage, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="Key 'foreign-key' is already in use"):
+            await remember_if_absent(key="foreign-key", value="squat", ctx=_make_ctx(jwt))
+        assert storage.get_memory_by_key("foreign-key").value == "foreign-secret"
+
     async def test_remember_blob_cross_workspace_key_denied(self, workspace_env):
         import base64
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -4358,8 +4358,6 @@ class TestWorkspaceScopeHelpers:
 
         storage, _, _ = server_env
         _current_token.set(None)
-        stamped = Memory(
-            key="k", value="v", owner_client_id="c", workspace_id="ws-somewhere"
-        )
+        stamped = Memory(key="k", value="v", owner_client_id="c", workspace_id="ws-somewhere")
         with pytest.raises(ToolError, match="denied"):
             _check_workspace_access(storage, stamped, "denied")

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -41,6 +41,8 @@ def _create_table(table_name: str = "hive-unit-server") -> None:
             {"AttributeName": "GSI2PK", "AttributeType": "S"},
             {"AttributeName": "GSI2SK", "AttributeType": "S"},
             {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -63,6 +65,14 @@ def _create_table(table_name: str = "hive-unit-server") -> None:
                 "IndexName": "UserEmailIndex",
                 "KeySchema": [
                     {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
@@ -4062,3 +4072,294 @@ class TestPackContext:
             # typo "relevancy" should still get a usable response.
             result = await pack_context("content", ordering="nonsense", ctx=ctx)
         assert "1 memory" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# Workspace enforcement (#491) — every keyed tool call checks the caller's
+# workspace claim against the memory's workspace
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def workspace_env():
+    """moto-backed storage with a workspace-scoped caller and a foreign memory.
+
+    Caller: client bound to workspace ``ws-a`` with a claim-carrying token.
+    Foreign memory: key ``foreign-key`` stamped with workspace ``ws-b``.
+    """
+    with mock_aws():
+        _create_table()
+        old_table = os.environ.get("HIVE_TABLE_NAME")
+        os.environ["HIVE_TABLE_NAME"] = "hive-unit-server"
+        try:
+            from hive.auth.tokens import issue_jwt
+            from hive.models import Memory, OAuthClient, Token
+            from hive.storage import HiveStorage
+
+            storage = HiveStorage(table_name="hive-unit-server", region="us-east-1")
+            client = OAuthClient(
+                client_name="WS Client A", owner_user_id="user-a", workspace_id="ws-a"
+            )
+            storage.put_client(client)
+
+            now = datetime.now(timezone.utc)
+            token = Token(
+                client_id=client.client_id,
+                scope="memories:read memories:write",
+                issued_at=now,
+                expires_at=now + timedelta(hours=1),
+                workspace_id="ws-a",
+                workspace_role="owner",
+            )
+            storage.put_token(token)
+            jwt = issue_jwt(token)
+
+            foreign = Memory(
+                key="foreign-key",
+                value="foreign-secret",
+                tags=["foreign"],
+                owner_client_id="client-b",
+                owner_user_id="user-b",
+                workspace_id="ws-b",
+            )
+            storage.put_memory(foreign)
+
+            yield storage, client.client_id, jwt
+        finally:
+            if old_table is not None:
+                os.environ["HIVE_TABLE_NAME"] = old_table
+            else:
+                os.environ.pop("HIVE_TABLE_NAME", None)
+
+
+@pytest.mark.asyncio
+class TestWorkspaceEnforcement:
+    """Cross-workspace access to keyed tools is denied as not-found (#491)."""
+
+    async def test_recall_cross_workspace_denied_without_stat_bump(self, workspace_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import recall
+
+        storage, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="No memory found for key 'foreign-key'"):
+            await recall(key="foreign-key", ctx=_make_ctx(jwt))
+        # The denied probe must not touch the foreign memory's recall stats.
+        foreign = storage.get_memory_by_key("foreign-key")
+        assert foreign.recall_count == 0
+        assert foreign.last_accessed_at is None
+
+    async def test_forget_cross_workspace_denied(self, workspace_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import forget
+
+        storage, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="No memory found for key 'foreign-key'"):
+            await forget(key="foreign-key", ctx=_make_ctx(jwt))
+        assert storage.get_memory_by_key("foreign-key") is not None
+
+    async def test_redact_cross_workspace_denied(self, workspace_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import redact_memory
+
+        storage, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="No memory found for key 'foreign-key'"):
+            await redact_memory(key="foreign-key", ctx=_make_ctx(jwt))
+        assert storage.get_memory_by_key("foreign-key").value == "foreign-secret"
+
+    async def test_memory_history_cross_workspace_denied(self, workspace_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import memory_history
+
+        _, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="No memory found for key 'foreign-key'"):
+            await memory_history(key="foreign-key", ctx=_make_ctx(jwt))
+
+    async def test_restore_cross_workspace_denied(self, workspace_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import restore_memory
+
+        _, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="No memory found for key 'foreign-key'"):
+            await restore_memory(
+                key="foreign-key", version_timestamp="2026-01-01T00:00:00", ctx=_make_ctx(jwt)
+            )
+
+    async def test_relate_memories_cross_workspace_denied(self, workspace_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import relate_memories
+
+        _, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="No memory found for key 'foreign-key'"):
+            await relate_memories(key="foreign-key", ctx=_make_ctx(jwt))
+
+    async def test_remember_cross_workspace_key_denied(self, workspace_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        storage, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="Key 'foreign-key' is already in use"):
+            await remember(key="foreign-key", value="overwrite!", ctx=_make_ctx(jwt))
+        assert storage.get_memory_by_key("foreign-key").value == "foreign-secret"
+
+    async def test_remember_with_version_never_leaks_foreign_value(self, workspace_env):
+        """The workspace guard fires before the optimistic-lock conflict path,
+        which would otherwise embed the foreign memory's value in its error."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember
+
+        _, _, jwt = workspace_env
+        with pytest.raises(ToolError, match="already in use") as excinfo:
+            await remember(
+                key="foreign-key", value="x", version="2020-01-01T00:00:00", ctx=_make_ctx(jwt)
+            )
+        assert "foreign-secret" not in str(excinfo.value)
+
+    async def test_remember_blob_cross_workspace_key_denied(self, workspace_env):
+        import base64
+
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import remember_blob
+
+        storage, _, jwt = workspace_env
+        data = base64.b64encode(b"pixels").decode()
+        with pytest.raises(ToolError, match="Key 'foreign-key' is already in use"):
+            await remember_blob(
+                key="foreign-key", data=data, content_type="image/png", ctx=_make_ctx(jwt)
+            )
+        assert storage.get_memory_by_key("foreign-key").value == "foreign-secret"
+
+    async def test_same_workspace_access_allowed(self, workspace_env):
+        from hive.server import recall, remember
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember(key="own-key", value="mine", ctx=ctx)
+        assert storage.get_memory_by_key("own-key").workspace_id == "ws-a"
+        assert _text(await recall(key="own-key", ctx=ctx)) == "mine"
+
+    async def test_legacy_memory_without_workspace_still_accessible(self, workspace_env):
+        """Pre-migration rows (workspace_id=None) pass the guard until the
+        migration stamps them — rollout safety."""
+        from hive.models import Memory
+        from hive.server import recall
+
+        storage, _, jwt = workspace_env
+        storage.put_memory(
+            Memory(
+                key="legacy-key",
+                value="legacy-value",
+                tags=[],
+                owner_client_id="legacy-client",
+            )
+        )
+        assert _text(await recall(key="legacy-key", ctx=_make_ctx(jwt))) == "legacy-value"
+
+    async def test_recall_deleted_between_lookup_and_record_raises_not_found(
+        self, workspace_env, monkeypatch
+    ):
+        """The fetch-first guard leaves a narrow window where the memory can
+        vanish before record_recall — that still reads as not-found."""
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import recall, remember
+        from hive.storage import HiveStorage
+
+        _, _, jwt = workspace_env
+        await remember(key="own-key-2", value="v", ctx=_make_ctx(jwt))
+        # Memory exists and is in-workspace, but record_recall reports it gone.
+        monkeypatch.setattr(HiveStorage, "record_recall", lambda self, key: None)
+        with pytest.raises(ToolError, match="No memory found for key 'own-key-2'"):
+            await recall(key="own-key-2", ctx=_make_ctx(jwt))
+
+
+@pytest.mark.asyncio
+class TestWorkspaceStamping:
+    """New memories are stamped with the caller's workspace (#491)."""
+
+    async def test_remember_stamps_workspace_from_claim(self, workspace_env):
+        from hive.server import remember
+
+        storage, _, jwt = workspace_env
+        await remember(key="stamp-1", value="v", ctx=_make_ctx(jwt))
+        assert storage.get_memory_by_key("stamp-1").workspace_id == "ws-a"
+
+    async def test_remember_if_absent_stamps_workspace_from_claim(self, workspace_env):
+        from hive.server import remember_if_absent
+
+        storage, _, jwt = workspace_env
+        await remember_if_absent(key="stamp-2", value="v", ctx=_make_ctx(jwt))
+        assert storage.get_memory_by_key("stamp-2").workspace_id == "ws-a"
+
+    async def test_remember_blob_stamps_workspace_from_claim(self, workspace_env, monkeypatch):
+        import base64
+
+        from hive.server import remember_blob
+
+        storage, _, jwt = workspace_env
+        bucket = "test-ws-blob-stamp"
+        monkeypatch.setenv("HIVE_BLOBS_BUCKET", bucket)
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=bucket)
+        data = base64.b64encode(b"blob-bytes").decode()
+        await remember_blob(
+            key="stamp-3", data=data, content_type="application/pdf", ctx=_make_ctx(jwt)
+        )
+        assert storage.get_memory_by_key("stamp-3").workspace_id == "ws-a"
+
+    async def test_legacy_caller_creates_unstamped_memory(self, server_env):
+        """A legacy claim-free token whose owner has no Personal workspace yet
+        creates memories without a workspace stamp (the migration back-fills)."""
+        from hive.server import remember
+
+        storage, _, jwt = server_env
+        await remember(key="legacy-stamp", value="v", ctx=_make_ctx(jwt))
+        assert storage.get_memory_by_key("legacy-stamp").workspace_id is None
+
+    async def test_legacy_token_resolves_owner_personal_workspace(self, server_env):
+        """A claim-free token falls back to the owner's Personal workspace for
+        both stamping and access checks."""
+        from hive.models import User
+        from hive.server import recall, remember
+
+        storage, _, jwt = server_env
+        # server_env's client is owned by "test-user"; give them a Personal
+        # workspace so legacy resolution finds it.
+        personal = storage.ensure_personal_workspace(
+            User(user_id="test-user", email="test-user@example.com", display_name="T")
+        )
+        ctx = _make_ctx(jwt)
+        await remember(key="legacy-resolved", value="v", ctx=ctx)
+        assert storage.get_memory_by_key("legacy-resolved").workspace_id == personal.workspace_id
+        assert _text(await recall(key="legacy-resolved", ctx=ctx)) == "v"
+
+
+class TestWorkspaceScopeHelpers:
+    def test_caller_scope_without_token_context_is_none(self, server_env):
+        from unittest.mock import MagicMock as _MM
+
+        from hive.server import _caller_workspace_scope, _current_token
+
+        _current_token.set(None)
+        assert _caller_workspace_scope(_MM()) == (None, None)
+
+    def test_check_workspace_access_fails_closed_for_unresolvable_caller(self, server_env):
+        from fastmcp.exceptions import ToolError
+
+        from hive.models import Memory
+        from hive.server import _check_workspace_access, _current_token
+
+        storage, _, _ = server_env
+        _current_token.set(None)
+        stamped = Memory(
+            key="k", value="v", owner_client_id="c", workspace_id="ws-somewhere"
+        )
+        with pytest.raises(ToolError, match="denied"):
+            _check_workspace_access(storage, stamped, "denied")

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -3401,6 +3401,28 @@ class TestPersonalWorkspace:
         assert member is not None
         assert member.role is WorkspaceRole.owner
 
+    def test_ensure_repairs_non_owner_membership_role(self, storage):
+        """Personal-workspace invariant: the owner's MEMBER row always carries
+        role=owner — a drifted role is repaired (preserving joined_at) so the
+        login and workspace-token paths stamp consistent claims."""
+        user = self._user(user_id="drifted-role-user")
+        workspace = storage.ensure_personal_workspace(user)
+        storage.add_workspace_member(workspace.workspace_id, user.user_id, WorkspaceRole.member)
+
+        storage.ensure_personal_workspace(user)
+        member = storage.get_workspace_member(workspace.workspace_id, user.user_id)
+        assert member.role is WorkspaceRole.owner
+
+    def test_get_workspace_member_uses_consistent_read(self, storage):
+        """Wire-level pin: membership reads gate auth decisions moments after
+        the MEMBER write, so the lookup must be strongly consistent — a
+        refactor must not silently drop the flag."""
+        from unittest.mock import patch
+
+        with patch.object(storage.table, "get_item", return_value={}) as get_item:
+            assert storage.get_workspace_member("ws-x", "u-x") is None
+        assert get_item.call_args.kwargs["ConsistentRead"] is True
+
     def test_get_finds_migration_era_random_id_workspace(self, storage):
         """Personal workspaces created by the #490 migration have random ids —
         they must be found via the WorkspaceMemberIndex fallback and never

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -3418,6 +3418,33 @@ class TestPersonalWorkspace:
         assert storage.get_personal_workspace(user.user_id).workspace_id == "rand-legacy-id"
         assert storage.ensure_personal_workspace(user).workspace_id == "rand-legacy-id"
 
+    def test_get_rejects_squatted_deterministic_id(self, storage):
+        """An item squatting on the ``personal-{user_id}`` key that is not a
+        Personal workspace owned by that user must never be returned — that
+        would cross tenancy boundaries when auth flows bind to it."""
+        user = self._user(user_id="squatted-user")
+        storage.put_workspace(
+            Workspace(
+                workspace_id=f"personal-{user.user_id}",
+                name="Not Actually Personal",
+                owner_user_id="attacker",
+                is_personal=False,
+            )
+        )
+        assert storage.get_personal_workspace(user.user_id) is None
+
+        # A legitimate migration-era Personal workspace is still found via the
+        # GSI fallback even with the deterministic key squatted.
+        legit = Workspace(
+            workspace_id="legit-random-id",
+            name="pw@example.com's Personal",
+            owner_user_id=user.user_id,
+            is_personal=True,
+        )
+        storage.put_workspace(legit)
+        storage.add_workspace_member(legit.workspace_id, user.user_id, WorkspaceRole.owner)
+        assert storage.get_personal_workspace(user.user_id).workspace_id == "legit-random-id"
+
     def test_get_skips_shared_workspaces_in_fallback(self, storage):
         """Membership in a shared (non-personal) workspace must not satisfy the
         Personal-workspace lookup."""

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -3380,6 +3380,27 @@ class TestPersonalWorkspace:
             first.workspace_id
         ]
 
+    def test_ensure_repairs_missing_owner_membership(self, storage):
+        """A Personal workspace META without its owner MEMBER row (partial
+        prior write) is repaired on the next ensure call rather than left to
+        break membership-dependent auth flows."""
+        user = self._user(user_id="partial-user")
+        storage.put_workspace(
+            Workspace(
+                workspace_id=f"personal-{user.user_id}",
+                name="pw@example.com's Personal",
+                owner_user_id=user.user_id,
+                is_personal=True,
+            )
+        )
+        assert storage.get_workspace_member(f"personal-{user.user_id}", user.user_id) is None
+
+        workspace = storage.ensure_personal_workspace(user)
+        assert workspace.workspace_id == f"personal-{user.user_id}"
+        member = storage.get_workspace_member(workspace.workspace_id, user.user_id)
+        assert member is not None
+        assert member.role is WorkspaceRole.owner
+
     def test_get_finds_migration_era_random_id_workspace(self, storage):
         """Personal workspaces created by the #490 migration have random ids —
         they must be found via the WorkspaceMemberIndex fallback and never

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -3302,3 +3302,131 @@ class TestCostCacheStorage:
             table.put_item.side_effect = RuntimeError("dynamo down")
             # Must not raise — the caller already holds the live CE data.
             storage.put_cost_cache("hash-err", {}, {"x": 1}, ttl_seconds=60)
+
+
+# ---------------------------------------------------------------------------
+# Workspace auth foundation (#491) — client workspace binding, Personal
+# workspace resolution, and workspace-stamped tokens
+# ---------------------------------------------------------------------------
+
+
+class TestClientWorkspaceAtomicBind:
+    """#491 — binding a DCR client to a workspace is first-bind-wins and atomic,
+    mirroring `bind_client_owner`."""
+
+    def test_first_bind_sets_workspace(self, storage):
+        client = OAuthClient(client_name="WS Bind Me")
+        storage.put_client(client)
+        assert storage.bind_client_workspace(client.client_id, "ws-1") is True
+        assert storage.get_client(client.client_id).workspace_id == "ws-1"
+
+    def test_second_bind_returns_false_and_keeps_workspace(self, storage):
+        client = OAuthClient(client_name="WS Bind Once")
+        storage.put_client(client)
+        assert storage.bind_client_workspace(client.client_id, "ws-1") is True
+        assert storage.bind_client_workspace(client.client_id, "ws-2") is False
+        assert storage.get_client(client.client_id).workspace_id == "ws-1"
+
+    def test_explicit_dcr_binding_is_not_overwritten(self, storage):
+        client = OAuthClient(client_name="WS Pre-bound", workspace_id="ws-dcr")
+        storage.put_client(client)
+        assert storage.bind_client_workspace(client.client_id, "ws-other") is False
+        assert storage.get_client(client.client_id).workspace_id == "ws-dcr"
+
+    def test_bind_missing_client_returns_false(self, storage):
+        assert storage.bind_client_workspace("never-registered", "ws-1") is False
+        assert storage.get_client("never-registered") is None
+
+    def test_unexpected_client_error_reraises(self, storage):
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        err = ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException", "Message": "x"}},
+            "UpdateItem",
+        )
+        with (
+            patch.object(storage.table, "update_item", side_effect=err),
+            pytest.raises(ClientError),
+        ):
+            storage.bind_client_workspace("client-x", "ws-1")
+
+
+class TestPersonalWorkspace:
+    def _user(self, user_id="pw-user-1", email="pw@example.com") -> User:
+        return User(user_id=user_id, email=email, display_name="PW")
+
+    def test_get_returns_none_when_absent(self, storage):
+        assert storage.get_personal_workspace("nobody") is None
+
+    def test_ensure_creates_deterministic_workspace_with_owner_member(self, storage):
+        user = self._user()
+        workspace = storage.ensure_personal_workspace(user)
+        assert workspace.workspace_id == f"personal-{user.user_id}"
+        assert workspace.name == "pw@example.com's Personal"
+        assert workspace.is_personal is True
+        assert workspace.owner_user_id == user.user_id
+        member = storage.get_workspace_member(workspace.workspace_id, user.user_id)
+        assert member is not None
+        assert member.role is WorkspaceRole.owner
+
+    def test_ensure_is_idempotent(self, storage):
+        user = self._user()
+        first = storage.ensure_personal_workspace(user)
+        second = storage.ensure_personal_workspace(user)
+        assert second.workspace_id == first.workspace_id
+        assert [w.workspace_id for w in storage.list_workspaces_for_user(user.user_id)] == [
+            first.workspace_id
+        ]
+
+    def test_get_finds_migration_era_random_id_workspace(self, storage):
+        """Personal workspaces created by the #490 migration have random ids —
+        they must be found via the WorkspaceMemberIndex fallback and never
+        duplicated by ensure_personal_workspace."""
+        user = self._user(user_id="migrated-user")
+        legacy = Workspace(
+            workspace_id="rand-legacy-id",
+            name="pw@example.com's Personal",
+            owner_user_id=user.user_id,
+            is_personal=True,
+        )
+        storage.put_workspace(legacy)
+        storage.add_workspace_member(legacy.workspace_id, user.user_id, WorkspaceRole.owner)
+
+        assert storage.get_personal_workspace(user.user_id).workspace_id == "rand-legacy-id"
+        assert storage.ensure_personal_workspace(user).workspace_id == "rand-legacy-id"
+
+    def test_get_skips_shared_workspaces_in_fallback(self, storage):
+        """Membership in a shared (non-personal) workspace must not satisfy the
+        Personal-workspace lookup."""
+        user = self._user(user_id="shared-only-user")
+        shared = Workspace(workspace_id="ws-shared", name="Team", owner_user_id="someone-else")
+        storage.put_workspace(shared)
+        storage.add_workspace_member(shared.workspace_id, user.user_id, WorkspaceRole.member)
+        assert storage.get_personal_workspace(user.user_id) is None
+
+
+class TestWorkspaceStampedTokens:
+    def test_create_token_pair_stamps_workspace(self, storage):
+        access, refresh = storage.create_token_pair(
+            "client-1", "memories:read", workspace_id="ws-1", workspace_role="admin"
+        )
+        for token in (access, refresh):
+            stored = storage.get_token(token.jti)
+            assert stored.workspace_id == "ws-1"
+            assert stored.workspace_role == "admin"
+
+    def test_create_token_pair_defaults_claim_free(self, storage):
+        access, _ = storage.create_token_pair("client-1", "memories:read")
+        stored = storage.get_token(access.jti)
+        assert stored.workspace_id is None
+        assert stored.workspace_role is None
+
+    def test_create_access_token_stamps_workspace(self, storage):
+        access = storage.create_access_token(
+            "client-1", "memories:read", workspace_id="ws-1", workspace_role="member"
+        )
+        stored = storage.get_token(access.jti)
+        assert stored.workspace_id == "ws-1"
+        assert stored.workspace_role == "member"


### PR DESCRIPTION
Closes #491

## Summary

Workspace-aware auth for the Workspaces epic (#482), building on the #490 data model:

- **JWT claims** — every issued token (MCP access + refresh, management session) now carries `workspace_id` and `workspace_role` claims. The persisted `Token` row carries the same fields as the authoritative, revocable copy.
- **DCR workspace binding (RFC 7591)** — `POST /oauth/register` accepts an optional `workspace_id`; it must reference an existing workspace (400 otherwise) and is echoed in the registration response (omitted when unbound, matching the `client_secret` treatment for strict Zod clients). At the OAuth callback, a client with an explicit binding only authenticates members of that workspace (403 otherwise, before any write); a client without one is auto-bound to the authenticating user's Personal workspace via an atomic first-bind-wins conditional write (`bind_client_workspace`, mirroring `bind_client_owner`).
- **Personal workspace auto-provisioning** — both auth flows (MCP OAuth callback + management login) ensure the user's Personal workspace exists (`ensure_personal_workspace`). New Personal workspaces use the deterministic id `personal-{user_id}` so concurrent first-logins converge idempotently instead of racing the eventually-consistent GSI into duplicates; migration-era random-id workspaces are still found via a `WorkspaceMemberIndex` fallback.
- **Token issuance** — the authorization-code grant stamps both tokens from the client's binding, with `workspace_role` resolved from the owner's membership record. A client bound to a workspace whose owner is missing or no longer a member fails closed (400) rather than minting a scoped token.
- **Refresh preserves the claim** — the refresh grant carries `workspace_id`/`workspace_role` through unchanged from the stored refresh token (agents swap tokens, not claims, to switch context — per the product decision). Membership revocation is enforced by revoking tokens.
- **Enforcement on every keyed tool call** — `remember`, `remember_blob`, `recall`, `forget`, `redact_memory`, `memory_history`, `restore_memory`, and `relate_memories` now check the caller's resolved workspace against the memory's `workspace_id` via a shared `_check_workspace_access` guard. Cross-workspace reads/deletes surface as not-found (no existence oracle); cross-workspace writes to an existing key are refused. New memories are stamped with the caller's workspace at create time.
- **Management re-issuance endpoint** — `POST /api/account/workspace-token` validates the caller is a member of the requested workspace and re-issues the management JWT with `workspace_role` stamped from the membership record. (The switcher UI itself is #494.)

## Approach / judgment calls

- **Backwards compatibility — missing claim never breaks validation.** Legacy tokens (minted pre-cutover) and `hive_sk_` API keys carry no claim; `resolve_workspace_scope` falls back claim → client binding → owner's Personal workspace (API keys: key owner's Personal workspace). A fully unresolvable caller gets `(None, None)` and fails closed only on workspace-stamped memories. Memories without `workspace_id` (pre-migration rows) pass the guard untouched — the idempotent post-deploy migration stamps them.
- **Guard ordering fixes two subtle leaks**: in `remember`, the workspace check precedes the optimistic-lock path so a version-conflict error can never embed a foreign memory's value; in `recall`, the memory is resolved and checked *before* `record_recall`, so a denied cross-workspace probe no longer bumps the foreign memory's recall stats (previously `recall` had no ownership check at all).
- **Scope boundary vs sibling issues**: list/search/tag/summarize/pack query-level workspace scoping, quota accounting, and `forget_all` stay on `owner_user_id` — that migration is #493 ("scope all MCP tool handlers to workspace_id"), which can now consume the claims and `_caller_workspace_scope`/`_check_workspace_access` primitives added here. Workspaces CRUD/members/invites API is #492; switcher UI is #494. Docs (e.g. `concepts/memory-scoping.md`) intentionally not rewritten here — the user-visible story changes with #493/#494 and the docs update lands with those.
- **`workspace_role` is stamped but not yet differentiated** in tool calls — the #482 design review cut `guest` (read-only) from v1, so `owner`/`admin`/`member` all read/write; role-gated management actions arrive with #492.
- **Test fixtures**: table-creation helpers in unit/integration tests and `scripts/seed_data.py` gained the `WorkspaceMemberIndex` GSI (GSI5) to match the production schema from #490 — the auth flows now query it.
- CLAUDE.md updated with the workspace item shapes/GSI5 and the claim-fallback convention (structure-map/gotcha updates only).

## Validation

- `uv run inv pre-push` green: ruff + mypy + 1035 unit tests + 905 frontend tests.
- Combined unit + integration coverage (CI-equivalent invocation): **100%** on `src/hive` (3807/3807 statements).
- Pre-existing local integration failures in `tests/integration/test_api.py` / `test_oauth.py` (table-bootstrap ordering when run outside CI) reproduce identically on `origin/development` and are untouched by this PR; they pass in CI.
- Local e2e not run — CI will cover this on the development branch deploy.
