### PR TITLE
fix(e2e): skip synthetic-traffic metrics assertion while the schedule is disabled

### DIFF
--- a/tests/e2e/test_admin_e2e.py
+++ b/tests/e2e/test_admin_e2e.py
@@ -101,6 +101,14 @@ class TestAdminMetricsE2E:
             )
             assert resp.status_code == 401
 
+    @pytest.mark.skipif(
+        os.environ.get("HIVE_SYNTHETIC_TRAFFIC_ENABLED") != "1",
+        reason=(
+            "synthetic-traffic schedule is disabled until prod release (#641); "
+            "the 7d window is legitimately empty — set HIVE_SYNTHETIC_TRAFFIC_ENABLED=1 "
+            "in the e2e CI step when re-enabling the cron (#706)"
+        ),
+    )
     async def test_metrics_has_data_after_synthetic_traffic(self, live_admin_token):
         """After synthetic traffic has run, the 7d window should have invocation data."""
         async with httpx.AsyncClient(base_url=API_URL, timeout=30.0) as http:

--- a/tests/e2e/test_admin_e2e.py
+++ b/tests/e2e/test_admin_e2e.py
@@ -104,9 +104,10 @@ class TestAdminMetricsE2E:
     @pytest.mark.skipif(
         os.environ.get("HIVE_SYNTHETIC_TRAFFIC_ENABLED") != "1",
         reason=(
-            "synthetic-traffic schedule is disabled until prod release (#641); "
-            "the 7d window is legitimately empty — set HIVE_SYNTHETIC_TRAFFIC_ENABLED=1 "
-            "in the e2e CI step when re-enabling the cron (#706)"
+            "#641 disabled the synthetic-traffic cron until prod release, so the 7d "
+            "window is legitimately empty (skip added by #706); the future PR that "
+            "re-enables the cron must also set HIVE_SYNTHETIC_TRAFFIC_ENABLED=1 in "
+            "the e2e CI step"
         ),
     )
     async def test_metrics_has_data_after_synthetic_traffic(self, live_admin_token):


### PR DESCRIPTION
Closes #706

## Summary
`test_metrics_has_data_after_synthetic_traffic` fails on the first push to `development` after any >7-day quiet period (the e2e suite's own MCP traffic then refills the 7-day CloudWatch window until the next quiet spell — see the corrected failure model in #706): #641 deliberately disabled the synthetic-traffic cron until prod release, but the test still asserts traffic-generated data exists. First observed on the pipeline run for the #703 merge (run 29670165370).

## Approach
Gate the single assertion-bearing test behind `HIVE_SYNTHETIC_TRAFFIC_ENABLED=1` with a skip reason that references #641 and #706 — the PR that re-enables the cron after prod release should flip the env var in the e2e CI step. The structure-only metrics tests still run unconditionally. No workflow files touched.

Local e2e not run — the change is itself an e2e skip marker; CI will cover this on the development branch deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7D3HqD2QPs6DvtnVaRbzF