### PR TITLE
fix(security): revoke active tokens on account deletion

### DIFF
--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -2114,17 +2114,23 @@ class HiveStorage:
             if cursor is None:
                 break
 
-        # Delete the client records BEFORE sweeping tokens: /oauth/token
-        # authenticates the client via get_client, so removing the client
-        # first closes the mint path — a concurrent refresh grant can no
-        # longer issue a fresh access token after the token sweep has
-        # passed it.
+        # First sweep: revoke everything outstanding while the client
+        # records still exist — if anything below fails, a retry can
+        # rediscover the clients via list_clients and finish the job.
+        deleted_tokens = self.delete_tokens_for_clients(set(client_ids))
+
+        # Close the mint path: /oauth/token authenticates the client via
+        # get_client, so removing the client records stops a concurrent
+        # refresh grant from issuing new tokens.
         deleted_clients = 0
         for client_id in client_ids:
             self.delete_client(client_id)
             deleted_clients += 1
 
-        deleted_tokens = self.delete_tokens_for_clients(set(client_ids))
+        # Second sweep: catch tokens minted by grants in flight during
+        # the first scan. With the clients gone nothing new can be
+        # minted, so this sweep is final.
+        deleted_tokens += self.delete_tokens_for_clients(set(client_ids))
 
         self.delete_user(user_id)
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1184,6 +1184,42 @@ class HiveStorage:
                 break
         return revoked
 
+    def delete_tokens_for_clients(self, client_ids: set[str]) -> int:
+        """Hard-delete every outstanding token issued to the given clients.
+
+        Used by account deletion (#588) — tokens carry short TTLs, but a
+        still-live access or refresh token must not keep working after its
+        owner's account is gone. Token items are not projected into
+        ClientIndex, so this walks the same ``TOKEN#`` scan as
+        ``revoke_all_tokens`` and deletes matches outright: validation
+        fails immediately on the missing item, and DynamoDB TTL has
+        nothing left to clean up. The batch writer transparently chunks
+        deletes to BatchWriteItem's 25-item limit and retries unprocessed
+        items. Returns the number of tokens deleted.
+        """
+        if not client_ids:
+            return 0
+        deleted = 0
+        start_key: dict[str, Any] | None = None
+        with self.table.batch_writer() as batch:
+            while True:
+                kwargs: dict[str, Any] = {
+                    "FilterExpression": _SK_PK_PREFIX_EXPR,
+                    "ExpressionAttributeValues": {":sk": "META", _PK_PREFIX_KEY: "TOKEN#"},
+                    "ProjectionExpression": "jti, client_id",
+                }
+                if start_key:
+                    kwargs["ExclusiveStartKey"] = start_key
+                resp = self.table.scan(**kwargs)
+                for item in resp.get("Items", []):
+                    if item.get("client_id") in client_ids:
+                        batch.delete_item(Key={"PK": f"TOKEN#{item['jti']}", "SK": "META"})
+                        deleted += 1
+                start_key = resp.get("LastEvaluatedKey")
+                if start_key is None:
+                    break
+        return deleted
+
     def create_access_token(
         self,
         client_id: str,
@@ -2046,9 +2082,11 @@ class HiveStorage:
     def delete_user_data(self, user_id: str) -> dict[str, int]:
         """Delete all data owned by a user.
 
-        Deletes all memories, OAuth clients, and the user record.
-        Tokens are not explicitly revoked — they carry short TTLs and
-        will expire naturally. Returns counts of deleted items.
+        Deletes all memories, OAuth clients, every outstanding token
+        issued to those clients, and the user record. Tokens are
+        hard-deleted rather than left to expire via their TTLs — a
+        still-live access token must not outlive its owner's account
+        (#588). Returns counts of deleted items.
         """
         deleted_memories = 0
         cursor: str | None = None
@@ -2062,19 +2100,31 @@ class HiveStorage:
             if cursor is None:
                 break
 
-        deleted_clients = 0
+        # Collect the user's clients before deleting them: tokens are
+        # found by client_id, and revoking first means a partial failure
+        # leaves the clients discoverable so a retry can finish the job.
+        client_ids: list[str] = []
         cursor = None
         while True:
             clients, cursor = self.list_clients(owner_user_id=user_id, limit=200, cursor=cursor)
-            for client in clients:
-                self.delete_client(client.client_id)
-                deleted_clients += 1
+            client_ids.extend(client.client_id for client in clients)
             if cursor is None:
                 break
 
+        deleted_tokens = self.delete_tokens_for_clients(set(client_ids))
+
+        deleted_clients = 0
+        for client_id in client_ids:
+            self.delete_client(client_id)
+            deleted_clients += 1
+
         self.delete_user(user_id)
 
-        return {"deleted_memories": deleted_memories, "deleted_clients": deleted_clients}
+        return {
+            "deleted_memories": deleted_memories,
+            "deleted_clients": deleted_clients,
+            "deleted_tokens": deleted_tokens,
+        }
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1193,9 +1193,13 @@ class HiveStorage:
         ClientIndex, so this walks the same ``TOKEN#`` scan as
         ``revoke_all_tokens`` and deletes matches outright: validation
         fails immediately on the missing item, and DynamoDB TTL has
-        nothing left to clean up. The batch writer transparently chunks
-        deletes to BatchWriteItem's 25-item limit and retries unprocessed
-        items. Returns the number of tokens deleted.
+        nothing left to clean up. The scan is strongly consistent so
+        tokens minted just before the call cannot be missed, and matches
+        are deleted by their scanned ``PK`` so a malformed row without a
+        ``jti`` attribute cannot abort the sweep. The batch writer
+        transparently chunks deletes to BatchWriteItem's 25-item limit
+        and retries unprocessed items. Returns the number of tokens
+        deleted.
         """
         if not client_ids:
             return 0
@@ -1205,15 +1209,17 @@ class HiveStorage:
             while True:
                 kwargs: dict[str, Any] = {
                     "FilterExpression": _SK_PK_PREFIX_EXPR,
+                    "ExpressionAttributeNames": {"#pk": "PK"},
                     "ExpressionAttributeValues": {":sk": "META", _PK_PREFIX_KEY: "TOKEN#"},
-                    "ProjectionExpression": "jti, client_id",
+                    "ProjectionExpression": "#pk, client_id",
+                    "ConsistentRead": True,
                 }
                 if start_key:
                     kwargs["ExclusiveStartKey"] = start_key
                 resp = self.table.scan(**kwargs)
                 for item in resp.get("Items", []):
                     if item.get("client_id") in client_ids:
-                        batch.delete_item(Key={"PK": f"TOKEN#{item['jti']}", "SK": "META"})
+                        batch.delete_item(Key={"PK": item["PK"], "SK": "META"})
                         deleted += 1
                 start_key = resp.get("LastEvaluatedKey")
                 if start_key is None:
@@ -2100,9 +2106,6 @@ class HiveStorage:
             if cursor is None:
                 break
 
-        # Collect the user's clients before deleting them: tokens are
-        # found by client_id, and revoking first means a partial failure
-        # leaves the clients discoverable so a retry can finish the job.
         client_ids: list[str] = []
         cursor = None
         while True:
@@ -2111,12 +2114,17 @@ class HiveStorage:
             if cursor is None:
                 break
 
-        deleted_tokens = self.delete_tokens_for_clients(set(client_ids))
-
+        # Delete the client records BEFORE sweeping tokens: /oauth/token
+        # authenticates the client via get_client, so removing the client
+        # first closes the mint path — a concurrent refresh grant can no
+        # longer issue a fresh access token after the token sweep has
+        # passed it.
         deleted_clients = 0
         for client_id in client_ids:
             self.delete_client(client_id)
             deleted_clients += 1
+
+        deleted_tokens = self.delete_tokens_for_clients(set(client_ids))
 
         self.delete_user(user_id)
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -226,3 +226,74 @@ class TestCostCache:
         storage.put_cost_cache("itest-overwrite", {}, {"v": 2}, ttl_seconds=300)
 
         assert storage.get_cost_cache("itest-overwrite") == {"v": 2}
+
+
+class TestAccountDeletionRevokesTokens:
+    """#588 — delete_user_data must revoke every token issued to the user's clients."""
+
+    @pytest.fixture()
+    def storage(self, client):
+        from hive.storage import HiveStorage
+
+        # `client` guarantees the table exists before storage is used.
+        return HiveStorage(
+            table_name="hive-integration-test",
+            region="us-east-1",
+            endpoint_url=DYNAMO_ENDPOINT,
+            aws_access_key_id="local",
+            aws_secret_access_key="local",
+        )
+
+    @staticmethod
+    def _make_user_with_client(storage, user_id: str):
+        from hive.models import OAuthClient, User
+
+        storage.put_user(
+            User(user_id=user_id, email=f"{user_id}@example.com", display_name=user_id)
+        )
+        oauth_client = OAuthClient(client_name=f"{user_id}-client", owner_user_id=user_id)
+        storage.put_client(oauth_client)
+        return oauth_client
+
+    @staticmethod
+    def _issue_token(storage, client_id: str, token_type=None, ttl_seconds: int = 3600):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import Token, TokenType
+
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client_id,
+            scope="memories:read",
+            token_type=token_type or TokenType.access,
+            issued_at=now,
+            expires_at=now + timedelta(seconds=ttl_seconds),
+        )
+        storage.put_token(token)
+        return token
+
+    def test_deleted_users_tokens_are_gone_other_users_survive(self, storage):
+        from hive.models import TokenType
+
+        client_a = self._make_user_with_client(storage, "itest-588-user-a")
+        client_b = self._make_user_with_client(storage, "itest-588-user-b")
+
+        a_access = self._issue_token(storage, client_a.client_id)
+        a_refresh = self._issue_token(
+            storage, client_a.client_id, token_type=TokenType.refresh, ttl_seconds=86400 * 30
+        )
+        b_access = self._issue_token(storage, client_b.client_id)
+
+        counts = storage.delete_user_data("itest-588-user-a")
+
+        assert counts["deleted_clients"] == 1
+        assert counts["deleted_tokens"] == 2
+        # Both the access and refresh tokens for the deleted user are gone
+        assert storage.get_token(a_access.jti) is None
+        assert storage.get_token(a_refresh.jti) is None
+        assert storage.get_client(client_a.client_id) is None
+        assert storage.get_user_by_id("itest-588-user-a") is None
+        # The other user's client and token survive
+        assert storage.get_token(b_access.jti) is not None
+        assert storage.get_client(client_b.client_id) is not None
+        assert storage.get_user_by_id("itest-588-user-b") is not None

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -3325,6 +3325,27 @@ class TestDeleteUserDataRevokesTokens:
         assert counts == {"deleted_memories": 0, "deleted_clients": 0, "deleted_tokens": 0}
         assert storage.get_token(stray.jti) is not None
 
+    def test_token_minted_during_deletion_is_caught_by_second_sweep(self, storage):
+        from unittest.mock import patch
+
+        client = self._make_user_with_client(storage, "user-r")
+        _issue_token(storage, client.client_id)
+
+        real_delete_client = storage.delete_client
+        late_tokens = []
+
+        def _delete_client_with_race(client_id):
+            # Simulate a concurrent refresh grant minting a token after the
+            # first sweep has already run but before the client is deleted.
+            late_tokens.append(_issue_token(storage, client_id))
+            return real_delete_client(client_id)
+
+        with patch.object(storage, "delete_client", side_effect=_delete_client_with_race):
+            counts = storage.delete_user_data("user-r")
+
+        assert counts["deleted_tokens"] == 2
+        assert storage.get_token(late_tokens[0].jti) is None
+
 
 class TestCostCacheStorage:
     """COST_CACHE# read/write for the Cost Explorer cache (#578)."""

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -3222,6 +3222,100 @@ class TestRevokeAllTokens:
         assert upd.call_count == 2
 
 
+def _issue_token(storage, client_id: str, token_type=TokenType.access):
+    from datetime import datetime, timedelta, timezone
+
+    from hive.models import Token
+
+    now = datetime.now(timezone.utc)
+    token = Token(
+        client_id=client_id,
+        scope="memories:read",
+        token_type=token_type,
+        issued_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    storage.put_token(token)
+    return token
+
+
+class TestDeleteTokensForClients:
+    """Bulk token deletion used by account deletion (#588)."""
+
+    def test_deletes_access_and_refresh_tokens_for_given_clients(self, storage):
+        access = _issue_token(storage, "c1")
+        refresh = _issue_token(storage, "c1", token_type=TokenType.refresh)
+        other = _issue_token(storage, "c2")
+
+        assert storage.delete_tokens_for_clients({"c1"}) == 2
+        assert storage.get_token(access.jti) is None
+        assert storage.get_token(refresh.jti) is None
+        # Another client's token must survive
+        assert storage.get_token(other.jti) is not None
+
+    def test_empty_client_set_is_a_noop(self, storage):
+        token = _issue_token(storage, "c1")
+        assert storage.delete_tokens_for_clients(set()) == 0
+        assert storage.get_token(token.jti) is not None
+
+    def test_paginates(self, storage):
+        from unittest.mock import patch
+
+        page1 = {
+            "Items": [{"jti": "t1", "client_id": "c1"}],
+            "LastEvaluatedKey": {"PK": "TOKEN#t1", "SK": "META"},
+        }
+        page2 = {
+            "Items": [
+                {"jti": "t2", "client_id": "c1"},
+                {"jti": "t3", "client_id": "someone-else"},
+            ]
+        }
+        with patch.object(storage.table, "scan", side_effect=[page1, page2]) as scan:
+            assert storage.delete_tokens_for_clients({"c1"}) == 2
+        assert "ExclusiveStartKey" in scan.call_args_list[1].kwargs
+
+
+class TestDeleteUserDataRevokesTokens:
+    """Account deletion must revoke the user's outstanding tokens (#588)."""
+
+    @staticmethod
+    def _make_user_with_client(storage, user_id: str):
+        storage.put_user(
+            User(user_id=user_id, email=f"{user_id}@example.com", display_name=user_id)
+        )
+        client = OAuthClient(client_name=f"{user_id}-client", owner_user_id=user_id)
+        storage.put_client(client)
+        return client
+
+    def test_deletes_tokens_for_the_users_clients_only(self, storage):
+        client_a = self._make_user_with_client(storage, "user-a")
+        client_b = self._make_user_with_client(storage, "user-b")
+
+        a_access = _issue_token(storage, client_a.client_id)
+        a_refresh = _issue_token(storage, client_a.client_id, token_type=TokenType.refresh)
+        b_access = _issue_token(storage, client_b.client_id)
+
+        counts = storage.delete_user_data("user-a")
+
+        assert counts["deleted_clients"] == 1
+        assert counts["deleted_tokens"] == 2
+        assert storage.get_token(a_access.jti) is None
+        assert storage.get_token(a_refresh.jti) is None
+        # The other user's client and token are untouched
+        assert storage.get_token(b_access.jti) is not None
+        assert storage.get_client(client_b.client_id) is not None
+
+    def test_user_without_clients_reports_zero_tokens(self, storage):
+        storage.put_user(User(user_id="user-c", email="c@example.com", display_name="C"))
+        stray = _issue_token(storage, "unrelated-client")
+
+        counts = storage.delete_user_data("user-c")
+
+        assert counts == {"deleted_memories": 0, "deleted_clients": 0, "deleted_tokens": 0}
+        assert storage.get_token(stray.jti) is not None
+
+
 class TestCostCacheStorage:
     """COST_CACHE# read/write for the Cost Explorer cache (#578)."""
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -3262,18 +3262,28 @@ class TestDeleteTokensForClients:
         from unittest.mock import patch
 
         page1 = {
-            "Items": [{"jti": "t1", "client_id": "c1"}],
+            "Items": [{"PK": "TOKEN#t1", "client_id": "c1"}],
             "LastEvaluatedKey": {"PK": "TOKEN#t1", "SK": "META"},
         }
         page2 = {
             "Items": [
-                {"jti": "t2", "client_id": "c1"},
-                {"jti": "t3", "client_id": "someone-else"},
+                {"PK": "TOKEN#t2", "client_id": "c1"},
+                {"PK": "TOKEN#t3", "client_id": "someone-else"},
             ]
         }
         with patch.object(storage.table, "scan", side_effect=[page1, page2]) as scan:
             assert storage.delete_tokens_for_clients({"c1"}) == 2
         assert "ExclusiveStartKey" in scan.call_args_list[1].kwargs
+        # Security-critical sweep must be strongly consistent — an
+        # eventually-consistent scan could miss just-minted tokens
+        assert scan.call_args_list[0].kwargs["ConsistentRead"] is True
+
+    def test_row_without_client_id_is_skipped(self, storage):
+        from unittest.mock import patch
+
+        page = {"Items": [{"PK": "TOKEN#orphan"}, {"PK": "TOKEN#t1", "client_id": "c1"}]}
+        with patch.object(storage.table, "scan", side_effect=[page]):
+            assert storage.delete_tokens_for_clients({"c1"}) == 1
 
 
 class TestDeleteUserDataRevokesTokens:


### PR DESCRIPTION
Closes #588

## Summary

`storage.delete_user_data` deleted a user's memories, OAuth clients, and user record but left active `TOKEN#` items in DynamoDB with their original TTLs — an access token with up to 1 hour remaining (and refresh tokens with up to 30 days) kept working after account deletion. Bearer validation resolves tokens via `storage.get_token(jti)`, so hard-deleting the items invalidates them immediately.

`delete_user_data` now:
1. Collects the user's client IDs **before** deleting the client records (so a partial failure leaves the clients discoverable and a retry can finish the job)
2. Deletes every outstanding token (access **and** refresh) issued to those clients via a new `delete_tokens_for_clients` storage helper
3. Deletes the clients and user record as before, and reports a new `deleted_tokens` count

## Approach

- **Scan, not GSI**: token items are not projected into `ClientIdIndex` (only `CLIENT#` items carry `GSI3PK`), so the helper follows the existing `TOKEN#` scan pattern from `revoke_all_tokens` with a paginated scan projecting `jti, client_id`.
- **Hard-delete, not revocation flag**: per the issue, tokens are short-TTL so batch delete is sufficient — validation fails immediately on the missing item and TTL has nothing left to clean up. Deletes go through `table.batch_writer()`, which chunks to BatchWriteItem's 25-item limit and retries unprocessed items (same pattern as `_delete_tag_items`).
- **Minimal surface**: only `storage.py` + tests. The #495 sole-owner guard in `api/account.py` is untouched; the audit event there keeps its existing explicit keys. KEYCLAIM release (#704) already happens inside `delete_memory`, so nothing was duplicated.
- **Observation (out of scope)**: deleting an individual OAuth client via `DELETE /api/clients/{id}` has the same gap — its tokens are not revoked either (the docs FAQ claims otherwise). That path is not part of #588; happy to file a follow-up issue.

## Testing

- Unit (moto): `delete_tokens_for_clients` deletes access + refresh tokens for the given clients while another client's tokens survive; empty-set no-op; scan pagination. `delete_user_data` deletes only the target user's tokens and reports `deleted_tokens` (including the zero-clients case).
- Integration (DynamoDB Local): end-to-end `delete_user_data` — deleted user's access + refresh tokens gone, other user's client/token/user record survive. Verified locally against DynamoDB Local in Docker.
- `uv run inv pre-push` green after rebasing onto the just-merged #705 (workspace claims): 1134 unit + 905 frontend tests; `storage.py` at 100% coverage.

Local e2e not run — CI will cover this on the development branch deploy.