### PR TITLE
fix(auth): TTL-cache secrets so SSM rotations apply without a Lambda restart

### DIFF
--- a/src/hive/auth/google.py
+++ b/src/hive/auth/google.py
@@ -26,7 +26,7 @@ from urllib.parse import urlencode
 import httpx
 from jose import jwt as jose_jwt
 
-from hive.auth.secret_cache import ttl_cached
+from hive.auth.secret_cache import SecretConfigError, ttl_cached
 
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
@@ -61,18 +61,31 @@ def _no_allowed_emails() -> frozenset[str]:
     return frozenset()
 
 
+def _parse_allowlist(raw: str, source: str) -> frozenset[str]:
+    """Parse an allowlist JSON array, failing closed on malformed input.
+
+    A config typo must raise (SecretConfigError propagates through the TTL
+    cache untouched) rather than silently degrade to an empty allow-all list.
+    """
+    try:
+        return frozenset(json.loads(raw))
+    except (ValueError, TypeError) as exc:
+        raise SecretConfigError(f"Malformed allowlist JSON in {source}: {exc}") from exc
+
+
 @ttl_cached(fallback=_no_allowed_emails)
 def _allowed_emails() -> frozenset[str]:
     """Return the email allowlist (empty = allow all).
 
     TTL-cached (#585) so SSM rotations take effect in a warm Lambda; a failed
     refresh serves the previous allowlist (fail-static) rather than silently
-    falling open on an SSM blip.
+    falling open on an SSM blip.  Only *transient* fetch failures use the
+    fallback / stale value — malformed allowlist JSON fails closed.
     """
     if val := os.environ.get("ALLOWED_EMAILS"):
-        return frozenset(json.loads(val))
+        return _parse_allowlist(val, source="ALLOWED_EMAILS env var")
     raw = _ssm_param(os.environ.get("ALLOWED_EMAILS_PARAM", "/hive/allowed-emails"))
-    return frozenset(json.loads(raw))
+    return _parse_allowlist(raw, source="allowed-emails SSM parameter")
 
 
 def google_authorization_url(state: str, callback_uri: str) -> str:

--- a/src/hive/auth/google.py
+++ b/src/hive/auth/google.py
@@ -18,7 +18,6 @@ Configuration (env vars or SSM parameters):
 
 from __future__ import annotations
 
-import functools
 import json
 import os
 from typing import Any
@@ -26,6 +25,8 @@ from urllib.parse import urlencode
 
 import httpx
 from jose import jwt as jose_jwt
+
+from hive.auth.secret_cache import ttl_cached
 
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
@@ -41,29 +42,37 @@ def _ssm_param(name: str) -> str:
     return resp["Parameter"]["Value"]
 
 
-@functools.lru_cache(maxsize=1)
+@ttl_cached()
 def _google_client_id() -> str:
     if val := os.environ.get("GOOGLE_CLIENT_ID"):
         return val
     return _ssm_param(os.environ.get("GOOGLE_CLIENT_ID_PARAM", "/hive/google-client-id"))
 
 
-@functools.lru_cache(maxsize=1)
+@ttl_cached()
 def _google_client_secret() -> str:
     if val := os.environ.get("GOOGLE_CLIENT_SECRET"):
         return val
     return _ssm_param(os.environ.get("GOOGLE_CLIENT_SECRET_PARAM", "/hive/google-client-secret"))
 
 
-@functools.lru_cache(maxsize=1)
+def _no_allowed_emails() -> frozenset[str]:
+    """First-fetch fallback: empty allowlist = allow all (open)."""
+    return frozenset()
+
+
+@ttl_cached(fallback=_no_allowed_emails)
 def _allowed_emails() -> frozenset[str]:
+    """Return the email allowlist (empty = allow all).
+
+    TTL-cached (#585) so SSM rotations take effect in a warm Lambda; a failed
+    refresh serves the previous allowlist (fail-static) rather than silently
+    falling open on an SSM blip.
+    """
     if val := os.environ.get("ALLOWED_EMAILS"):
         return frozenset(json.loads(val))
-    try:
-        raw = _ssm_param(os.environ.get("ALLOWED_EMAILS_PARAM", "/hive/allowed-emails"))
-        return frozenset(json.loads(raw))
-    except Exception:
-        return frozenset()  # empty = allow all (open)
+    raw = _ssm_param(os.environ.get("ALLOWED_EMAILS_PARAM", "/hive/allowed-emails"))
+    return frozenset(json.loads(raw))
 
 
 def google_authorization_url(state: str, callback_uri: str) -> str:

--- a/src/hive/auth/secret_cache.py
+++ b/src/hive/auth/secret_cache.py
@@ -14,6 +14,11 @@ logged — an SSM blip must never take down token issuance or validation.
 The optional ``fallback`` is used only when the *first* fetch fails (no
 cached value exists yet); without a fallback the exception propagates.
 This preserves each call site's original first-fetch failure behaviour.
+
+:class:`SecretConfigError` is the exception to fail-static: it marks a
+non-transient misconfiguration (e.g. malformed allowlist JSON) and always
+propagates — a config typo must fail closed, never be silently masked by a
+fallback or a stale value.
 """
 
 from __future__ import annotations
@@ -35,13 +40,29 @@ TTL_ENV_VAR = "HIVE_SECRET_CACHE_TTL_SECONDS"
 T = TypeVar("T")
 
 
+class SecretConfigError(Exception):
+    """A non-transient secret misconfiguration (e.g. malformed JSON).
+
+    Never masked by the cache's fallback or stale-serving — always
+    propagates so a config typo fails closed instead of silently falling
+    open.
+    """
+
+
+# Last invalid TTL value already warned about — dedupes the warning so a
+# misconfigured env var doesn't spam the log on every cached secret access.
+_last_invalid_ttl: str | None = None
+
+
 def _ttl_seconds() -> float:
     """Return the cache TTL, honouring the env override (default 300s).
 
     Only finite, non-negative values are accepted — NaN would disable
     caching entirely (comparisons are always False) and negative or
     non-numeric values are misconfigurations; all fall back to the default.
+    Each distinct invalid value is warned about once, not on every call.
     """
+    global _last_invalid_ttl
     raw = os.environ.get(TTL_ENV_VAR)
     if not raw:
         return DEFAULT_TTL_SECONDS
@@ -50,7 +71,11 @@ def _ttl_seconds() -> float:
     except ValueError:
         ttl = math.nan
     if not (math.isfinite(ttl) and ttl >= 0):
-        logger.warning("Invalid %s=%r; using default %ss", TTL_ENV_VAR, raw, DEFAULT_TTL_SECONDS)
+        if raw != _last_invalid_ttl:
+            _last_invalid_ttl = raw
+            logger.warning(
+                "Invalid %s=%r; using default %ss", TTL_ENV_VAR, raw, DEFAULT_TTL_SECONDS
+            )
         return DEFAULT_TTL_SECONDS
     return ttl
 
@@ -81,6 +106,10 @@ class _TtlCache(Generic[T]):
                 return self._value
             try:
                 value = self._fetch()
+            except SecretConfigError:
+                # Non-transient misconfiguration: fail closed — never mask
+                # with the fallback or a stale value.
+                raise
             except Exception:
                 if self._has_value:
                     # Fail-static: serve the previous value rather than let an

--- a/src/hive/auth/secret_cache.py
+++ b/src/hive/auth/secret_cache.py
@@ -3,10 +3,10 @@
 Time-based (TTL) caching for auth secrets.
 
 Replaces the previous ``functools.lru_cache(maxsize=1)`` on the secret
-fetchers (#585): an unbounded cache meant SSM parameter rotations never took
-effect in a warm Lambda without a cold start.  Cached values are re-fetched
-once the TTL expires — default 300 seconds, overridable via the
-``HIVE_SECRET_CACHE_TTL_SECONDS`` environment variable.
+fetchers (#585): those cache entries never expired, so SSM parameter
+rotations never took effect in a warm Lambda without a cold start.  Cached
+values are now re-fetched once the TTL expires — default 300 seconds,
+overridable via the ``HIVE_SECRET_CACHE_TTL_SECONDS`` environment variable.
 
 Failure semantics are fail-static: when a *refresh* fetch fails but a
 previously fetched value exists, the stale value is served and a warning is
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import math
 import os
 import threading
 import time
@@ -35,15 +36,23 @@ T = TypeVar("T")
 
 
 def _ttl_seconds() -> float:
-    """Return the cache TTL, honouring the env override (default 300s)."""
+    """Return the cache TTL, honouring the env override (default 300s).
+
+    Only finite, non-negative values are accepted — NaN would disable
+    caching entirely (comparisons are always False) and negative or
+    non-numeric values are misconfigurations; all fall back to the default.
+    """
     raw = os.environ.get(TTL_ENV_VAR)
     if not raw:
         return DEFAULT_TTL_SECONDS
     try:
-        return float(raw)
+        ttl = float(raw)
     except ValueError:
+        ttl = math.nan
+    if not (math.isfinite(ttl) and ttl >= 0):
         logger.warning("Invalid %s=%r; using default %ss", TTL_ENV_VAR, raw, DEFAULT_TTL_SECONDS)
         return DEFAULT_TTL_SECONDS
+    return ttl
 
 
 class _TtlCache(Generic[T]):

--- a/src/hive/auth/secret_cache.py
+++ b/src/hive/auth/secret_cache.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Time-based (TTL) caching for auth secrets.
+
+Replaces the previous ``functools.lru_cache(maxsize=1)`` on the secret
+fetchers (#585): an unbounded cache meant SSM parameter rotations never took
+effect in a warm Lambda without a cold start.  Cached values are re-fetched
+once the TTL expires — default 300 seconds, overridable via the
+``HIVE_SECRET_CACHE_TTL_SECONDS`` environment variable.
+
+Failure semantics are fail-static: when a *refresh* fetch fails but a
+previously fetched value exists, the stale value is served and a warning is
+logged — an SSM blip must never take down token issuance or validation.
+The optional ``fallback`` is used only when the *first* fetch fails (no
+cached value exists yet); without a fallback the exception propagates.
+This preserves each call site's original first-fetch failure behaviour.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable
+from typing import Any, Generic, Protocol, TypeVar
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 300.0
+TTL_ENV_VAR = "HIVE_SECRET_CACHE_TTL_SECONDS"
+
+T = TypeVar("T")
+
+
+def _ttl_seconds() -> float:
+    """Return the cache TTL, honouring the env override (default 300s)."""
+    raw = os.environ.get(TTL_ENV_VAR)
+    if not raw:
+        return DEFAULT_TTL_SECONDS
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %ss", TTL_ENV_VAR, raw, DEFAULT_TTL_SECONDS)
+        return DEFAULT_TTL_SECONDS
+
+
+class _TtlCache(Generic[T]):
+    """A zero-argument fetch function wrapped in a time-based cache.
+
+    Exposes ``cache_clear()`` mirroring ``functools.lru_cache`` so existing
+    test hooks keep working unchanged.
+    """
+
+    __name__: str  # set by functools.update_wrapper
+
+    def __init__(self, fetch: Callable[[], T], fallback: Callable[[], T] | None) -> None:
+        self._fetch = fetch
+        self._fallback = fallback
+        self._name = getattr(fetch, "__name__", repr(fetch))
+        self._lock = threading.Lock()
+        self._has_value = False
+        self._value: T  # guarded by _has_value; assigned on first successful fetch
+        self._fetched_at = 0.0
+        functools.update_wrapper(self, fetch)
+
+    def __call__(self) -> T:
+        with self._lock:
+            now = time.monotonic()
+            if self._has_value and (now - self._fetched_at) < _ttl_seconds():
+                return self._value
+            try:
+                value = self._fetch()
+            except Exception:
+                if self._has_value:
+                    # Fail-static: serve the previous value rather than let an
+                    # SSM blip break token issuance/validation.  Resetting the
+                    # timestamp backs off retries by one TTL window.
+                    logger.warning(
+                        "Refresh of %s failed; serving previously cached value",
+                        self._name,
+                        exc_info=True,
+                    )
+                    self._fetched_at = now
+                    return self._value
+                if self._fallback is None:
+                    raise
+                logger.warning(
+                    "Initial fetch of %s failed; using fallback value",
+                    self._name,
+                    exc_info=True,
+                )
+                value = self._fallback()
+            self._value = value
+            self._has_value = True
+            self._fetched_at = now
+            return value
+
+    def cache_clear(self) -> None:
+        """Drop the cached value so the next call re-fetches (test hook)."""
+        with self._lock:
+            self._has_value = False
+            self._fetched_at = 0.0
+
+
+class _Decorator(Protocol):
+    """A decorator whose value type binds at application time."""
+
+    def __call__(self, fetch: Callable[[], T]) -> _TtlCache[T]: ...
+
+
+def ttl_cached(fallback: Callable[[], Any] | None = None) -> _Decorator:
+    """Decorate a zero-argument secret fetcher with a TTL cache.
+
+    ``fallback`` is invoked only when the very first fetch fails; its result
+    is cached like a normal value so the process stays consistent until the
+    next refresh window.  Refresh failures after a successful fetch always
+    serve the stale value instead (fail-static).
+    """
+
+    def decorator(fetch: Callable[[], T]) -> _TtlCache[T]:
+        return _TtlCache(fetch, fallback)
+
+    return decorator

--- a/src/hive/auth/tokens.py
+++ b/src/hive/auth/tokens.py
@@ -9,13 +9,13 @@ every request — but we still persist tokens for revocation support.
 
 from __future__ import annotations
 
-import functools
 import os
 import secrets
 from typing import Any
 
 from jose import JWTError, jwt
 
+from hive.auth.secret_cache import ttl_cached
 from hive.models import Token
 from hive.storage import HiveStorage
 
@@ -26,7 +26,12 @@ JWT_ALGORITHM = "HS256"
 ISSUER = os.environ.get("HIVE_ISSUER", "https://hive.example.com").rstrip("/")
 
 
-@functools.lru_cache(maxsize=1)
+def _random_jwt_secret() -> str:
+    """First-fetch fallback: a random secret (single-process local dev only)."""
+    return secrets.token_hex(32)
+
+
+@ttl_cached(fallback=_random_jwt_secret)
 def _jwt_secret() -> str:
     """Return the JWT signing secret.
 
@@ -34,18 +39,19 @@ def _jwt_secret() -> str:
     1. HIVE_JWT_SECRET env var (tests / local dev)
     2. SSM Parameter /hive/jwt-secret (Lambda runtime)
     3. Random fallback (single-process local dev only)
+
+    TTL-cached (#585) so SSM rotations take effect in a warm Lambda; a failed
+    refresh serves the previous value (fail-static) rather than minting a
+    random secret that would invalidate every outstanding token.
     """
     if secret := os.environ.get("HIVE_JWT_SECRET"):
         return secret
-    try:
-        import boto3
+    import boto3
 
-        param_name = os.environ.get("HIVE_JWT_SECRET_PARAM", "/hive/jwt-secret")
-        ssm = boto3.client("ssm")
-        resp = ssm.get_parameter(Name=param_name, WithDecryption=True)
-        return resp["Parameter"]["Value"]
-    except Exception:
-        return secrets.token_hex(32)
+    param_name = os.environ.get("HIVE_JWT_SECRET_PARAM", "/hive/jwt-secret")
+    ssm = boto3.client("ssm")
+    resp = ssm.get_parameter(Name=param_name, WithDecryption=True)
+    return str(resp["Parameter"]["Value"])
 
 
 def issue_jwt(token: Token) -> str:
@@ -76,25 +82,30 @@ def decode_jwt(token_str: str) -> dict[str, Any]:
     return jwt.decode(token_str, _jwt_secret(), algorithms=[JWT_ALGORITHM], issuer=ISSUER)
 
 
-@functools.lru_cache(maxsize=1)
+def _origin_verify_unavailable() -> str | None:
+    """First-fetch fallback: disable the origin check when SSM is unreachable."""
+    return None
+
+
+@ttl_cached(fallback=_origin_verify_unavailable)
 def _origin_verify_secret() -> str | None:
     """Return the expected X-Origin-Verify header value, or None if not configured.
 
     None disables the check (local dev / non-prod without WAF).
+
+    TTL-cached (#585) so SSM rotations take effect in a warm Lambda; a failed
+    refresh serves the previous value (fail-static).
     """
     if secret := os.environ.get("HIVE_ORIGIN_VERIFY_SECRET"):
         return secret
     param_name = os.environ.get("HIVE_ORIGIN_VERIFY_PARAM")
     if not param_name:
         return None
-    try:
-        import boto3
+    import boto3
 
-        ssm = boto3.client("ssm")
-        resp = ssm.get_parameter(Name=param_name, WithDecryption=False)
-        return resp["Parameter"]["Value"]
-    except Exception:
-        return None
+    ssm = boto3.client("ssm")
+    resp = ssm.get_parameter(Name=param_name, WithDecryption=False)
+    return str(resp["Parameter"]["Value"])
 
 
 MGMT_JWT_TTL_SECONDS = 28800  # 8 hours

--- a/tests/unit/test_secret_cache.py
+++ b/tests/unit/test_secret_cache.py
@@ -49,12 +49,17 @@ class TestTtlSeconds:
         monkeypatch.setenv(TTL_ENV_VAR, "42.5")
         assert _ttl_seconds() == 42.5
 
-    def test_invalid_env_falls_back_to_default(self, monkeypatch):
-        monkeypatch.setenv(TTL_ENV_VAR, "not-a-number")
+    @pytest.mark.parametrize("raw", ["not-a-number", "nan", "inf", "-inf", "-5"])
+    def test_invalid_env_falls_back_to_default(self, monkeypatch, raw):
+        monkeypatch.setenv(TTL_ENV_VAR, raw)
         with patch("hive.auth.secret_cache.logger") as mock_logger:
             assert _ttl_seconds() == DEFAULT_TTL_SECONDS
         mock_logger.warning.assert_called_once()
         assert "Invalid" in mock_logger.warning.call_args[0][0]
+
+    def test_zero_is_a_valid_ttl(self, monkeypatch):
+        monkeypatch.setenv(TTL_ENV_VAR, "0")
+        assert _ttl_seconds() == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_secret_cache.py
+++ b/tests/unit/test_secret_cache.py
@@ -11,6 +11,7 @@ import pytest
 from hive.auth.secret_cache import (
     DEFAULT_TTL_SECONDS,
     TTL_ENV_VAR,
+    SecretConfigError,
     _ttl_seconds,
     ttl_cached,
 )
@@ -51,11 +52,28 @@ class TestTtlSeconds:
 
     @pytest.mark.parametrize("raw", ["not-a-number", "nan", "inf", "-inf", "-5"])
     def test_invalid_env_falls_back_to_default(self, monkeypatch, raw):
+        from hive.auth import secret_cache
+
+        monkeypatch.setattr(secret_cache, "_last_invalid_ttl", None)
         monkeypatch.setenv(TTL_ENV_VAR, raw)
         with patch("hive.auth.secret_cache.logger") as mock_logger:
             assert _ttl_seconds() == DEFAULT_TTL_SECONDS
         mock_logger.warning.assert_called_once()
         assert "Invalid" in mock_logger.warning.call_args[0][0]
+
+    def test_invalid_env_warns_once_per_distinct_value(self, monkeypatch):
+        """A misconfigured TTL must not spam the log on every secret access."""
+        from hive.auth import secret_cache
+
+        monkeypatch.setattr(secret_cache, "_last_invalid_ttl", None)
+        monkeypatch.setenv(TTL_ENV_VAR, "bogus")
+        with patch("hive.auth.secret_cache.logger") as mock_logger:
+            assert _ttl_seconds() == DEFAULT_TTL_SECONDS
+            assert _ttl_seconds() == DEFAULT_TTL_SECONDS
+            assert mock_logger.warning.call_count == 1
+            monkeypatch.setenv(TTL_ENV_VAR, "-1")  # a *new* invalid value warns again
+            assert _ttl_seconds() == DEFAULT_TTL_SECONDS
+            assert mock_logger.warning.call_count == 2
 
     def test_zero_is_a_valid_ttl(self, monkeypatch):
         monkeypatch.setenv(TTL_ENV_VAR, "0")
@@ -142,6 +160,27 @@ class TestTtlCached:
         cached.cache_clear()
         assert cached() == "v2"
         assert fetch.call_count == 2
+
+    def test_config_error_bypasses_fallback(self, monkeypatch):
+        """SecretConfigError fails closed: never masked by the fallback."""
+        monkeypatch.delenv(TTL_ENV_VAR, raising=False)
+        fetch = MagicMock(side_effect=SecretConfigError("bad config"))
+        fallback = MagicMock(return_value="open")
+        cached = ttl_cached(fallback=fallback)(fetch)
+
+        with pytest.raises(SecretConfigError, match="bad config"):
+            cached()
+        fallback.assert_not_called()
+
+    def test_config_error_bypasses_stale_serve(self, monkeypatch):
+        """SecretConfigError fails closed even when a stale value exists."""
+        monkeypatch.setenv(TTL_ENV_VAR, "0")
+        fetch = MagicMock(side_effect=["v1", SecretConfigError("bad config")])
+        cached = ttl_cached()(fetch)
+
+        assert cached() == "v1"
+        with pytest.raises(SecretConfigError, match="bad config"):
+            cached()
 
     def test_wrapper_preserves_function_metadata(self):
         def my_secret() -> str:
@@ -273,3 +312,23 @@ class TestAllowedEmailsRotation:
         ):
             assert g._allowed_emails() == frozenset({"kept@example.com"})
             assert g._allowed_emails() == frozenset({"kept@example.com"})
+
+    def test_malformed_env_json_fails_closed(self, monkeypatch):
+        """A typo in ALLOWED_EMAILS must raise, not silently allow all."""
+        from hive.auth import google as g
+
+        monkeypatch.setenv("ALLOWED_EMAILS", "not-json[")
+        with pytest.raises(SecretConfigError, match="ALLOWED_EMAILS env var"):
+            g._allowed_emails()
+
+    def test_malformed_ssm_json_fails_closed(self):
+        """Malformed allowlist JSON in SSM must raise, not silently allow all."""
+        from hive.auth import google as g
+
+        env = {k: v for k, v in os.environ.items() if k != "ALLOWED_EMAILS"}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("boto3.client", return_value=_ssm_mock("{broken")),
+            pytest.raises(SecretConfigError, match="SSM parameter"),
+        ):
+            g._allowed_emails()

--- a/tests/unit/test_secret_cache.py
+++ b/tests/unit/test_secret_cache.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for the TTL secret cache (auth/secret_cache.py) — #585."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hive.auth.secret_cache import (
+    DEFAULT_TTL_SECONDS,
+    TTL_ENV_VAR,
+    _ttl_seconds,
+    ttl_cached,
+)
+
+
+def _clear_secret_caches():
+    from hive.auth import google as g
+    from hive.auth import tokens as t
+
+    t._jwt_secret.cache_clear()
+    t._origin_verify_secret.cache_clear()
+    g._google_client_id.cache_clear()
+    g._google_client_secret.cache_clear()
+    g._allowed_emails.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_caches():
+    """Clear every secret cache before and after each test in this module."""
+    _clear_secret_caches()
+    yield
+    _clear_secret_caches()
+
+
+# ---------------------------------------------------------------------------
+# _ttl_seconds
+# ---------------------------------------------------------------------------
+
+
+class TestTtlSeconds:
+    def test_default_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv(TTL_ENV_VAR, raising=False)
+        assert _ttl_seconds() == DEFAULT_TTL_SECONDS
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv(TTL_ENV_VAR, "42.5")
+        assert _ttl_seconds() == 42.5
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(TTL_ENV_VAR, "not-a-number")
+        with patch("hive.auth.secret_cache.logger") as mock_logger:
+            assert _ttl_seconds() == DEFAULT_TTL_SECONDS
+        mock_logger.warning.assert_called_once()
+        assert "Invalid" in mock_logger.warning.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# ttl_cached decorator
+# ---------------------------------------------------------------------------
+
+
+class TestTtlCached:
+    def test_serves_cached_value_within_ttl(self, monkeypatch):
+        monkeypatch.delenv(TTL_ENV_VAR, raising=False)
+        fetch = MagicMock(return_value="v1")
+        cached = ttl_cached()(fetch)
+
+        assert cached() == "v1"
+        assert cached() == "v1"
+        assert fetch.call_count == 1
+
+    def test_refetches_after_ttl_expiry(self, monkeypatch):
+        """Rotation takes effect once the TTL lapses."""
+        monkeypatch.setenv(TTL_ENV_VAR, "0")
+        fetch = MagicMock(side_effect=["v1", "v2"])
+        cached = ttl_cached()(fetch)
+
+        assert cached() == "v1"
+        assert cached() == "v2"
+        assert fetch.call_count == 2
+
+    def test_refresh_failure_serves_stale_value(self, monkeypatch):
+        """Fail-static: a failed refresh serves the previous value + warns."""
+        monkeypatch.setenv(TTL_ENV_VAR, "0")
+        fetch = MagicMock(side_effect=["v1", RuntimeError("ssm blip")])
+        cached = ttl_cached()(fetch)
+
+        assert cached() == "v1"
+        with patch("hive.auth.secret_cache.logger") as mock_logger:
+            assert cached() == "v1"
+        mock_logger.warning.assert_called_once()
+        assert "serving previously cached value" in mock_logger.warning.call_args[0][0]
+
+    def test_refresh_failure_backs_off_one_ttl(self, monkeypatch):
+        """After a failed refresh the cache waits a full TTL before retrying."""
+        monkeypatch.delenv(TTL_ENV_VAR, raising=False)
+        fetch = MagicMock(side_effect=["v1", RuntimeError("ssm blip"), "v2"])
+        cached = ttl_cached()(fetch)
+
+        assert cached() == "v1"
+        cached._fetched_at -= DEFAULT_TTL_SECONDS + 1  # expire the entry
+        assert cached() == "v1"  # refresh fails -> stale served, clock reset
+        assert cached() == "v1"  # within the reset TTL -> no fetch attempt
+        assert fetch.call_count == 2
+
+    def test_first_fetch_failure_without_fallback_raises(self, monkeypatch):
+        monkeypatch.delenv(TTL_ENV_VAR, raising=False)
+        fetch = MagicMock(side_effect=RuntimeError("ssm down"))
+        cached = ttl_cached()(fetch)
+
+        with pytest.raises(RuntimeError, match="ssm down"):
+            cached()
+
+    def test_first_fetch_failure_uses_fallback_and_caches_it(self, monkeypatch):
+        monkeypatch.delenv(TTL_ENV_VAR, raising=False)
+        fetch = MagicMock(side_effect=RuntimeError("ssm down"))
+        fallback = MagicMock(return_value="fallback-value")
+        cached = ttl_cached(fallback=fallback)(fetch)
+
+        with patch("hive.auth.secret_cache.logger") as mock_logger:
+            assert cached() == "fallback-value"
+        mock_logger.warning.assert_called_once()
+        assert "using fallback value" in mock_logger.warning.call_args[0][0]
+        assert cached() == "fallback-value"  # cached; no second fetch/fallback
+        assert fetch.call_count == 1
+        assert fallback.call_count == 1
+
+    def test_cache_clear_forces_refetch(self, monkeypatch):
+        monkeypatch.delenv(TTL_ENV_VAR, raising=False)
+        fetch = MagicMock(side_effect=["v1", "v2"])
+        cached = ttl_cached()(fetch)
+
+        assert cached() == "v1"
+        cached.cache_clear()
+        assert cached() == "v2"
+        assert fetch.call_count == 2
+
+    def test_wrapper_preserves_function_metadata(self):
+        def my_secret() -> str:
+            """Docstring."""
+            return "s"
+
+        cached = ttl_cached()(my_secret)
+        assert cached.__name__ == "my_secret"
+        assert cached.__doc__ == "Docstring."
+
+
+# ---------------------------------------------------------------------------
+# Cached secret functions — rotation + fail-static per call site
+# ---------------------------------------------------------------------------
+
+
+def _ssm_mock(*values):
+    """An SSM client mock whose get_parameter yields each value in turn."""
+    mock_ssm = MagicMock()
+    mock_ssm.get_parameter.side_effect = [
+        v if isinstance(v, Exception) else {"Parameter": {"Value": v}} for v in values
+    ]
+    return mock_ssm
+
+
+class TestJwtSecretRotation:
+    def test_rotation_applies_after_ttl(self):
+        from hive.auth import tokens
+
+        env = {k: v for k, v in os.environ.items() if k != "HIVE_JWT_SECRET"}
+        env[TTL_ENV_VAR] = "0"
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("boto3.client", return_value=_ssm_mock("old-secret", "new-secret")),
+        ):
+            assert tokens._jwt_secret() == "old-secret"
+            assert tokens._jwt_secret() == "new-secret"
+
+    def test_refresh_failure_serves_stale_not_random(self):
+        """An SSM blip must not mint a random secret (would invalidate tokens)."""
+        from hive.auth import tokens
+
+        env = {k: v for k, v in os.environ.items() if k != "HIVE_JWT_SECRET"}
+        env[TTL_ENV_VAR] = "0"
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("boto3.client", return_value=_ssm_mock("old-secret", RuntimeError("blip"))),
+        ):
+            assert tokens._jwt_secret() == "old-secret"
+            assert tokens._jwt_secret() == "old-secret"
+
+
+class TestOriginVerifySecretRotation:
+    def test_rotation_applies_after_ttl(self, monkeypatch):
+        from hive.auth import tokens
+
+        monkeypatch.delenv("HIVE_ORIGIN_VERIFY_SECRET", raising=False)
+        monkeypatch.setenv("HIVE_ORIGIN_VERIFY_PARAM", "/hive/origin-verify-secret")
+        monkeypatch.setenv(TTL_ENV_VAR, "0")
+        with patch("boto3.client", return_value=_ssm_mock("old-ov", "new-ov")):
+            assert tokens._origin_verify_secret() == "old-ov"
+            assert tokens._origin_verify_secret() == "new-ov"
+
+    def test_refresh_failure_serves_stale(self, monkeypatch):
+        from hive.auth import tokens
+
+        monkeypatch.delenv("HIVE_ORIGIN_VERIFY_SECRET", raising=False)
+        monkeypatch.setenv("HIVE_ORIGIN_VERIFY_PARAM", "/hive/origin-verify-secret")
+        monkeypatch.setenv(TTL_ENV_VAR, "0")
+        with patch("boto3.client", return_value=_ssm_mock("old-ov", RuntimeError("blip"))):
+            assert tokens._origin_verify_secret() == "old-ov"
+            assert tokens._origin_verify_secret() == "old-ov"
+
+
+class TestGoogleCredentialRotation:
+    def test_client_id_rotation_applies_after_ttl(self):
+        from hive.auth import google as g
+
+        env = {k: v for k, v in os.environ.items() if k != "GOOGLE_CLIENT_ID"}
+        env[TTL_ENV_VAR] = "0"
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("boto3.client", return_value=_ssm_mock("old-id", "new-id")),
+        ):
+            assert g._google_client_id() == "old-id"
+            assert g._google_client_id() == "new-id"
+
+    def test_client_secret_refresh_failure_serves_stale(self):
+        from hive.auth import google as g
+
+        env = {k: v for k, v in os.environ.items() if k != "GOOGLE_CLIENT_SECRET"}
+        env[TTL_ENV_VAR] = "0"
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("boto3.client", return_value=_ssm_mock("old-cs", RuntimeError("blip"))),
+        ):
+            assert g._google_client_secret() == "old-cs"
+            assert g._google_client_secret() == "old-cs"
+
+
+class TestAllowedEmailsRotation:
+    def test_rotation_applies_after_ttl(self):
+        from hive.auth import google as g
+
+        env = {k: v for k, v in os.environ.items() if k != "ALLOWED_EMAILS"}
+        env[TTL_ENV_VAR] = "0"
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch(
+                "boto3.client",
+                return_value=_ssm_mock('["old@example.com"]', '["new@example.com"]'),
+            ),
+        ):
+            assert g._allowed_emails() == frozenset({"old@example.com"})
+            assert g._allowed_emails() == frozenset({"new@example.com"})
+
+    def test_refresh_failure_serves_stale_allowlist(self):
+        """An SSM blip must not drop the allowlist to empty (= allow all)."""
+        from hive.auth import google as g
+
+        env = {k: v for k, v in os.environ.items() if k != "ALLOWED_EMAILS"}
+        env[TTL_ENV_VAR] = "0"
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch(
+                "boto3.client",
+                return_value=_ssm_mock('["kept@example.com"]', RuntimeError("blip")),
+            ),
+        ):
+            assert g._allowed_emails() == frozenset({"kept@example.com"})
+            assert g._allowed_emails() == frozenset({"kept@example.com"})


### PR DESCRIPTION
Closes #585

## Summary

`src/hive/auth/tokens.py` and `src/hive/auth/google.py` cached their secrets (`_jwt_secret`, `_origin_verify_secret`, `_google_client_id`, `_google_client_secret`, `_allowed_emails`) with `functools.lru_cache(maxsize=1)`, so an SSM parameter rotation never took effect in a warm Lambda without a cold start. This PR replaces the lru_cache with a small shared time-based cache: `ttl_cached` in the new `src/hive/auth/secret_cache.py`, holding `(value, fetched_at)` and re-fetching once the TTL lapses. Default TTL is 300 seconds, overridable via `HIVE_SECRET_CACHE_TTL_SECONDS`.

## Approach

- **One reusable helper, not five hand-rolled copies** — a module-private-to-auth `ttl_cached(fallback=...)` decorator wrapping a `_TtlCache` class. It exposes `cache_clear()` mirroring `lru_cache`, so all existing test hooks (`_jwt_secret.cache_clear()` etc.) keep working unchanged — zero churn in the existing suites.
- **Fail-static on refresh failure (deliberate security decision)** — if a re-fetch fails after TTL expiry but a previously fetched value exists, the stale value is served and a warning is logged. An SSM blip must not take down token issuance/validation. This is a strict improvement over the old behaviour in two spots: a failed `_jwt_secret` refresh no longer mints a random secret (which would have invalidated every outstanding token), and a failed `_allowed_emails` refresh no longer falls open to an empty allow-all list — both now serve the last known-good value. Retries back off one full TTL window after a failure so a hard SSM outage isn't hammered on every request.
- **First-fetch failure behaviour preserved** — each call site's original no-cached-value fallback is kept via the decorator's `fallback` hook: random secret for `_jwt_secret` (local dev), `None` for `_origin_verify_secret` (check disabled), empty frozenset for `_allowed_emails` (allow all). `_google_client_id`/`_google_client_secret` had no fallback before and still raise.
- **TTL read per call** from the env var; an unparsable value logs a warning and uses the 300s default rather than breaking auth.
- **Malformed allowlist JSON fails closed** (added in round-2 review): a `SecretConfigError` propagates through the TTL cache untouched — no fallback, no stale-serve — so a typo in `ALLOWED_EMAILS` (env or SSM) raises instead of silently degrading to an empty allow-all list. Invalid `HIVE_SECRET_CACHE_TTL_SECONDS` values (non-numeric, NaN, inf, negative) warn once per distinct value and use the 300s default.

Tests: new `tests/unit/test_secret_cache.py` covers within-TTL caching, expiry-triggered refetch, stale-serve on refresh failure (+ backoff), first-fetch fallback vs raise, `cache_clear`, env TTL override (valid + invalid), and rotation + fail-static behaviour for each of the five cached secret functions. Python coverage on the touched modules is 100%.

Local e2e not run — CI will cover this on the development branch deploy.
