### PR TITLE
perf: query ApiKeyHashIndex GSI for API key hash lookups instead of scanning (#589)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,12 @@ hive/
     `GSI5SK=WORKSPACE#{workspace_id}` (workspaces a user belongs to).
     Unit/integration test fixtures that create the table must include this
     GSI — the auth flows now resolve Personal workspaces through it
+  - `ApiKeyHashIndex` — sparse GSI keyed directly on the top-level
+    `key_hash` attribute (only `APIKEY#` items carry it) — API key auth
+    lookups (#589). `get_api_key_by_hash` falls back to the legacy table
+    scan if the index is unavailable (e.g. still backfilling), so table
+    fixtures without this GSI still work — but include it to exercise
+    the fast path
 
 ## Management UI
 

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -140,6 +140,19 @@ class HiveStack(cdk.Stack):
             projection_type=dynamodb.ProjectionType.ALL,
         )
 
+        # GSI 6 — ApiKeyHashIndex: look up API keys by SHA-256 hash (#589).
+        # Sparse index keyed directly on the existing top-level ``key_hash``
+        # attribute (only APIKEY# items carry it) rather than a new GSI6PK
+        # composite — the asynchronous GSI backfill therefore projects every
+        # existing API key item automatically and no data migration is needed.
+        # storage.get_api_key_by_hash falls back to the legacy table scan
+        # while the index is still backfilling (or otherwise unavailable).
+        table.add_global_secondary_index(
+            index_name="ApiKeyHashIndex",
+            partition_key=dynamodb.Attribute(name="key_hash", type=dynamodb.AttributeType.STRING),
+            projection_type=dynamodb.ProjectionType.ALL,
+        )
+
         # ----------------------------------------------------------------
         # SSM Parameters
         # ----------------------------------------------------------------

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -6,8 +6,9 @@ Single-table design — all entities share one table.
 Table name is read from the HIVE_TABLE_NAME environment variable.
 
 GSIs:
-  TagIndex    — GSI2PK (TAG#{tag}), GSI2SK (memory_id)  → list_memories(tag)
-  ClientIndex — GSI3PK (CLIENT#{client_id})              → client lookups
+  TagIndex        — GSI2PK (TAG#{tag}), GSI2SK (memory_id) → list_memories(tag)
+  ClientIndex     — GSI3PK (CLIENT#{client_id})            → client lookups
+  ApiKeyHashIndex — key_hash (sparse, APIKEY# items only)  → API key auth lookups
 """
 
 from __future__ import annotations
@@ -1853,7 +1854,39 @@ class HiveStorage:
         return ApiKey.from_dynamo(item) if item else None
 
     def get_api_key_by_hash(self, key_hash: str) -> ApiKey | None:
-        """Look up an API key by its SHA-256 hash (full table scan — keys are rare)."""
+        """Look up an API key by its SHA-256 hash via the ApiKeyHashIndex GSI (#589).
+
+        The index is sparse — keyed directly on the top-level ``key_hash``
+        attribute, which only APIKEY# items carry — so a single-partition
+        query replaces the previous full table scan on every API-key-
+        authenticated request.
+
+        If the query fails because the index is unavailable (still
+        backfilling after deployment, or absent on a table that predates
+        it), the lookup degrades gracefully to the legacy scan. The
+        fallback is kept permanently as resilience, not as a transitional
+        shim — auth must not hard-fail on index availability.
+        """
+        try:
+            resp = self.table.query(
+                IndexName="ApiKeyHashIndex",
+                KeyConditionExpression=Key("key_hash").eq(key_hash),
+                FilterExpression=Attr("SK").eq("META") & Attr("PK").begins_with("APIKEY#"),
+            )
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code not in ("ValidationException", "ResourceNotFoundException"):
+                raise
+            logger.warning(
+                "ApiKeyHashIndex unavailable (%s) — falling back to table scan for API key lookup",
+                code,
+            )
+            return self._scan_api_key_by_hash(key_hash)
+        items = resp.get("Items", [])
+        return ApiKey.from_dynamo(items[0]) if items else None
+
+    def _scan_api_key_by_hash(self, key_hash: str) -> ApiKey | None:
+        """Legacy full-table-scan API key lookup — fallback for ApiKeyHashIndex."""
         resp = self.table.scan(
             FilterExpression="begins_with(PK, :prefix) AND SK = :sk AND key_hash = :hash",
             ExpressionAttributeValues={

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1895,9 +1895,17 @@ class HiveStorage:
             code = exc.response["Error"]["Code"]
             if code not in ("ValidationException", "ResourceNotFoundException"):
                 raise
+            # The full error message is logged so an unexpected fallback
+            # cause (e.g. a genuine query bug rather than a backfilling
+            # index) is immediately diagnosable. The code is deliberately
+            # not narrowed by message substring — DynamoDB, DynamoDB Local
+            # and moto phrase these messages differently, and the fallback
+            # direction is fail-safe (a scan, the pre-GSI behaviour).
             logger.warning(
-                "ApiKeyHashIndex unavailable (%s) — falling back to table scan for API key lookup",
+                "ApiKeyHashIndex unavailable (%s: %s) — falling back to table scan "
+                "for API key lookup",
                 code,
+                exc.response["Error"].get("Message", ""),
             )
             return self._scan_api_key_by_hash(key_hash)
 

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1902,28 +1902,47 @@ class HiveStorage:
             return self._scan_api_key_by_hash(key_hash)
 
     def _scan_api_key_by_hash(self, key_hash: str) -> ApiKey | None:
-        """Legacy full-table-scan API key lookup — fallback for ApiKeyHashIndex."""
-        resp = self.table.scan(
-            FilterExpression="begins_with(PK, :prefix) AND SK = :sk AND key_hash = :hash",
-            ExpressionAttributeValues={
+        """Legacy full-table-scan API key lookup — fallback for ApiKeyHashIndex.
+
+        Paginates on ``LastEvaluatedKey``: a filtered Scan can return an
+        empty page while matching items remain in later pages, and this is
+        the resilience path for API key auth — it must not false-negative.
+        """
+        scan_kwargs: dict[str, Any] = {
+            "FilterExpression": "begins_with(PK, :prefix) AND SK = :sk AND key_hash = :hash",
+            "ExpressionAttributeValues": {
                 _PK_PREFIX_KEY: _APIKEY_PK_PREFIX,
                 ":sk": "META",
                 ":hash": key_hash,
             },
-        )
-        items = resp.get("Items", [])
-        return ApiKey.from_dynamo(items[0]) if items else None
+        }
+        while True:
+            resp = self.table.scan(**scan_kwargs)
+            items = resp.get("Items", [])
+            if items:
+                return ApiKey.from_dynamo(items[0])
+            last_key = resp.get("LastEvaluatedKey")
+            if not last_key:
+                return None
+            scan_kwargs["ExclusiveStartKey"] = last_key
 
     def list_api_keys_for_user(self, owner_user_id: str) -> list[ApiKey]:
-        resp = self.table.scan(
-            FilterExpression="begins_with(PK, :prefix) AND SK = :sk AND owner_user_id = :uid",
-            ExpressionAttributeValues={
+        scan_kwargs: dict[str, Any] = {
+            "FilterExpression": "begins_with(PK, :prefix) AND SK = :sk AND owner_user_id = :uid",
+            "ExpressionAttributeValues": {
                 _PK_PREFIX_KEY: _APIKEY_PK_PREFIX,
                 ":sk": "META",
                 ":uid": owner_user_id,
             },
-        )
-        return [ApiKey.from_dynamo(item) for item in resp.get("Items", [])]
+        }
+        keys: list[ApiKey] = []
+        while True:
+            resp = self.table.scan(**scan_kwargs)
+            keys.extend(ApiKey.from_dynamo(item) for item in resp.get("Items", []))
+            last_key = resp.get("LastEvaluatedKey")
+            if not last_key:
+                return keys
+            scan_kwargs["ExclusiveStartKey"] = last_key
 
     def delete_api_key(self, key_id: str) -> bool:
         resp = self.table.get_item(Key={"PK": f"APIKEY#{key_id}", "SK": "META"})

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1867,16 +1867,29 @@ class HiveStorage:
         fallback is kept permanently as resilience, not as a transitional
         shim — auth must not hard-fail on index availability.
         """
+        # Limit=1 with a server-side shape filter, paginating on
+        # LastEvaluatedKey. DynamoDB applies Limit *before* the
+        # FilterExpression, so a single non-paginated call could
+        # false-negative if a foreign item ever carried the same key_hash
+        # (sparse-index invariant breach); paginating restores the exact
+        # legacy scan semantics. In the normal case — the partition holds
+        # exactly one API key item — this is a single 1-item read.
+        query_kwargs: dict[str, Any] = {
+            "IndexName": "ApiKeyHashIndex",
+            "KeyConditionExpression": Key("key_hash").eq(key_hash),
+            "FilterExpression": Attr("SK").eq("META") & Attr("PK").begins_with("APIKEY#"),
+            "Limit": 1,
+        }
         try:
-            # Limit=1: the partition holds at most one item (SHA-256 of a
-            # unique key). No server-side FilterExpression here — DynamoDB
-            # applies Limit *before* the filter, so combining them could
-            # false-negative; the item-shape check is done in Python below.
-            resp = self.table.query(
-                IndexName="ApiKeyHashIndex",
-                KeyConditionExpression=Key("key_hash").eq(key_hash),
-                Limit=1,
-            )
+            while True:
+                resp = self.table.query(**query_kwargs)
+                items = resp.get("Items", [])
+                if items:
+                    return ApiKey.from_dynamo(items[0])
+                last_key = resp.get("LastEvaluatedKey")
+                if not last_key:
+                    return None
+                query_kwargs["ExclusiveStartKey"] = last_key
         except ClientError as exc:
             code = exc.response["Error"]["Code"]
             if code not in ("ValidationException", "ResourceNotFoundException"):
@@ -1886,16 +1899,6 @@ class HiveStorage:
                 code,
             )
             return self._scan_api_key_by_hash(key_hash)
-        items = resp.get("Items", [])
-        if not items:
-            return None
-        item = items[0]
-        if not str(item.get("PK", "")).startswith("APIKEY#") or item.get("SK") != "META":
-            # Defensive: the sparse-index invariant (only APIKEY#/META items
-            # carry key_hash) was violated by some other item type — treat
-            # as a miss rather than mis-deserialising a foreign item.
-            return None
-        return ApiKey.from_dynamo(item)
 
     def _scan_api_key_by_hash(self, key_hash: str) -> ApiKey | None:
         """Legacy full-table-scan API key lookup — fallback for ApiKeyHashIndex."""

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1868,10 +1868,14 @@ class HiveStorage:
         shim — auth must not hard-fail on index availability.
         """
         try:
+            # Limit=1: the partition holds at most one item (SHA-256 of a
+            # unique key). No server-side FilterExpression here — DynamoDB
+            # applies Limit *before* the filter, so combining them could
+            # false-negative; the item-shape check is done in Python below.
             resp = self.table.query(
                 IndexName="ApiKeyHashIndex",
                 KeyConditionExpression=Key("key_hash").eq(key_hash),
-                FilterExpression=Attr("SK").eq("META") & Attr("PK").begins_with("APIKEY#"),
+                Limit=1,
             )
         except ClientError as exc:
             code = exc.response["Error"]["Code"]
@@ -1883,7 +1887,15 @@ class HiveStorage:
             )
             return self._scan_api_key_by_hash(key_hash)
         items = resp.get("Items", [])
-        return ApiKey.from_dynamo(items[0]) if items else None
+        if not items:
+            return None
+        item = items[0]
+        if not str(item.get("PK", "")).startswith("APIKEY#") or item.get("SK") != "META":
+            # Defensive: the sparse-index invariant (only APIKEY#/META items
+            # carry key_hash) was violated by some other item type — treat
+            # as a miss rather than mis-deserialising a foreign item.
+            return None
+        return ApiKey.from_dynamo(item)
 
     def _scan_api_key_by_hash(self, key_hash: str) -> ApiKey | None:
         """Legacy full-table-scan API key lookup — fallback for ApiKeyHashIndex."""

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -55,6 +55,7 @@ _UID_FILTER = " AND owner_user_id = :uid"
 _WSID_FILTER = " AND workspace_id = :wsid"
 _PK_PREFIX_KEY = ":prefix"
 _SK_PK_PREFIX_EXPR = "SK = :sk AND begins_with(PK, :prefix)"
+_APIKEY_PK_PREFIX = "APIKEY#"
 
 # Version retention
 _VERSION_RETENTION_DAYS = int(os.environ.get("HIVE_VERSION_RETENTION_DAYS", "30"))
@@ -1877,7 +1878,7 @@ class HiveStorage:
         query_kwargs: dict[str, Any] = {
             "IndexName": "ApiKeyHashIndex",
             "KeyConditionExpression": Key("key_hash").eq(key_hash),
-            "FilterExpression": Attr("SK").eq("META") & Attr("PK").begins_with("APIKEY#"),
+            "FilterExpression": Attr("SK").eq("META") & Attr("PK").begins_with(_APIKEY_PK_PREFIX),
             "Limit": 1,
         }
         try:
@@ -1905,7 +1906,7 @@ class HiveStorage:
         resp = self.table.scan(
             FilterExpression="begins_with(PK, :prefix) AND SK = :sk AND key_hash = :hash",
             ExpressionAttributeValues={
-                _PK_PREFIX_KEY: "APIKEY#",
+                _PK_PREFIX_KEY: _APIKEY_PK_PREFIX,
                 ":sk": "META",
                 ":hash": key_hash,
             },
@@ -1917,7 +1918,7 @@ class HiveStorage:
         resp = self.table.scan(
             FilterExpression="begins_with(PK, :prefix) AND SK = :sk AND owner_user_id = :uid",
             ExpressionAttributeValues={
-                _PK_PREFIX_KEY: "APIKEY#",
+                _PK_PREFIX_KEY: _APIKEY_PK_PREFIX,
                 ":sk": "META",
                 ":uid": owner_user_id,
             },

--- a/tests/integration/test_api_key_index.py
+++ b/tests/integration/test_api_key_index.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Integration tests for #589 — API key lookup via the ApiKeyHashIndex GSI.
+
+Runs against DynamoDB Local (Docker) — set DYNAMODB_ENDPOINT env var.
+
+Two tables are exercised:
+
+- one **with** ``ApiKeyHashIndex`` — proves ``get_api_key_by_hash`` resolves
+  keys through a single-partition GSI query (the fast path) against a real
+  DynamoDB query engine, not just moto;
+- one **without** the index — proves the graceful-degradation contract: a
+  real ``ValidationException`` from DynamoDB Local triggers the legacy
+  full-table-scan fallback, which is what production relies on while the
+  GSI is still backfilling after deployment.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+
+import pytest
+
+from hive.models import ApiKey
+
+DYNAMO_ENDPOINT = os.environ.get("DYNAMODB_ENDPOINT")
+
+pytestmark = pytest.mark.skipif(
+    not DYNAMO_ENDPOINT,
+    reason="DYNAMODB_ENDPOINT not set — skipping integration tests",
+)
+
+_BASE_TABLE_KWARGS = {
+    "KeySchema": [
+        {"AttributeName": "PK", "KeyType": "HASH"},
+        {"AttributeName": "SK", "KeyType": "RANGE"},
+    ],
+    "BillingMode": "PAY_PER_REQUEST",
+}
+
+
+def _ddb_client():
+    import boto3
+
+    return boto3.client(
+        "dynamodb",
+        endpoint_url=DYNAMO_ENDPOINT,
+        region_name="us-east-1",
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+    )
+
+
+def _storage_for(table_name: str):
+    from hive.storage import HiveStorage
+
+    return HiveStorage(
+        table_name=table_name,
+        region="us-east-1",
+        endpoint_url=DYNAMO_ENDPOINT,
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+    )
+
+
+@pytest.fixture(scope="module")
+def storage_with_index():
+    """HiveStorage on a table carrying ApiKeyHashIndex (production schema)."""
+    ddb = _ddb_client()
+    table_name = "hive-integration-apikey-idx"
+    with contextlib.suppress(Exception):
+        ddb.delete_table(TableName=table_name)
+    ddb.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "key_hash", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "ApiKeyHashIndex",
+                "KeySchema": [
+                    {"AttributeName": "key_hash", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        **_BASE_TABLE_KWARGS,
+    )
+    yield _storage_for(table_name)
+
+
+@pytest.fixture(scope="module")
+def storage_without_index():
+    """HiveStorage on a legacy-schema table lacking ApiKeyHashIndex."""
+    ddb = _ddb_client()
+    table_name = "hive-integration-apikey-noidx"
+    with contextlib.suppress(Exception):
+        ddb.delete_table(TableName=table_name)
+    ddb.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        **_BASE_TABLE_KWARGS,
+    )
+    yield _storage_for(table_name)
+
+
+def _make_key(name: str) -> ApiKey:
+    return ApiKey(owner_user_id="int-user", name=name, key_hash=f"int-hash-{name}")
+
+
+class TestApiKeyHashIndexQuery:
+    """Fast path — lookups resolve through the GSI on a real DynamoDB engine."""
+
+    def test_lookup_hits_gsi(self, storage_with_index):
+        from unittest.mock import patch
+
+        key = _make_key("gsi-hit")
+        storage_with_index.put_api_key(key)
+        # Block the scan path entirely — the GSI query alone must resolve it.
+        with patch.object(storage_with_index.table, "scan") as mock_scan:
+            found = storage_with_index.get_api_key_by_hash("int-hash-gsi-hit")
+        assert found is not None
+        assert found.key_id == key.key_id
+        assert found.owner_user_id == "int-user"
+        mock_scan.assert_not_called()
+
+    def test_lookup_miss_returns_none(self, storage_with_index):
+        assert storage_with_index.get_api_key_by_hash("int-hash-absent") is None
+
+
+class TestApiKeyHashIndexFallback:
+    """Degraded path — a table without the GSI still resolves keys via scan."""
+
+    def test_lookup_falls_back_to_scan(self, storage_without_index):
+        key = _make_key("legacy")
+        storage_without_index.put_api_key(key)
+        found = storage_without_index.get_api_key_by_hash("int-hash-legacy")
+        assert found is not None
+        assert found.key_id == key.key_id
+
+    def test_fallback_miss_returns_none(self, storage_without_index):
+        assert storage_without_index.get_api_key_by_hash("int-hash-nope") is None

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -61,6 +61,7 @@ def _create_table():
             {"AttributeName": "GSI4PK", "AttributeType": "S"},
             {"AttributeName": "GSI5PK", "AttributeType": "S"},
             {"AttributeName": "GSI5SK", "AttributeType": "S"},
+            {"AttributeName": "key_hash", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -91,6 +92,13 @@ def _create_table():
                 "KeySchema": [
                     {"AttributeName": "GSI5PK", "KeyType": "HASH"},
                     {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ApiKeyHashIndex",
+                "KeySchema": [
+                    {"AttributeName": "key_hash", "KeyType": "HASH"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
@@ -2494,6 +2502,31 @@ class TestHydrateMemoryIds:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture()
+def storage_no_apikey_index():
+    """HiveStorage on a table without ApiKeyHashIndex — legacy-schema table.
+
+    Exercises the graceful-degradation path of get_api_key_by_hash: the GSI
+    query fails with a real ValidationException and the lookup must fall
+    back to the legacy full-table scan.
+    """
+    with mock_aws():
+        ddb = boto3.client("dynamodb", region_name="us-east-1")
+        ddb.create_table(
+            TableName="hive-test-noidx",
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield HiveStorage(table_name="hive-test-noidx", region="us-east-1")
+
+
 class TestApiKeyStorage:
     def _key(self, owner_user_id: str = "u1", name: str = "test") -> ApiKey:
         return ApiKey(owner_user_id=owner_user_id, name=name, key_hash="hash-" + name)
@@ -2518,6 +2551,68 @@ class TestApiKeyStorage:
 
     def test_get_by_hash_not_found(self, storage):
         assert storage.get_api_key_by_hash("nonexistent-hash") is None
+
+    def test_get_by_hash_queries_gsi_not_scan(self, storage):
+        """The lookup must hit ApiKeyHashIndex — never scan when the GSI works."""
+        from unittest.mock import patch
+
+        k = self._key()
+        storage.put_api_key(k)
+        with patch.object(storage.table, "scan") as mock_scan:
+            found = storage.get_api_key_by_hash("hash-test")
+        assert found is not None
+        assert found.key_id == k.key_id
+        mock_scan.assert_not_called()
+
+    def test_get_by_hash_falls_back_when_index_missing(self, storage_no_apikey_index):
+        """A table without the GSI (legacy schema / backfilling) still resolves keys."""
+        k = self._key()
+        storage_no_apikey_index.put_api_key(k)
+        found = storage_no_apikey_index.get_api_key_by_hash("hash-test")
+        assert found is not None
+        assert found.key_id == k.key_id
+
+    def test_get_by_hash_fallback_not_found(self, storage_no_apikey_index):
+        assert storage_no_apikey_index.get_api_key_by_hash("nonexistent-hash") is None
+
+    def test_get_by_hash_falls_back_on_resource_not_found(self, storage):
+        """ResourceNotFoundException from the GSI query also triggers the scan."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        k = self._key()
+        storage.put_api_key(k)
+        with patch.object(
+            storage.table,
+            "query",
+            side_effect=ClientError(
+                {"Error": {"Code": "ResourceNotFoundException", "Message": "no index"}},
+                "Query",
+            ),
+        ):
+            found = storage.get_api_key_by_hash("hash-test")
+        assert found is not None
+        assert found.key_id == k.key_id
+
+    def test_get_by_hash_reraises_unrelated_errors(self, storage):
+        """Only index-unavailable errors degrade to a scan — others propagate."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        with (
+            patch.object(
+                storage.table,
+                "query",
+                side_effect=ClientError(
+                    {"Error": {"Code": "InternalServerError", "Message": "boom"}},
+                    "Query",
+                ),
+            ),
+            pytest.raises(ClientError),
+        ):
+            storage.get_api_key_by_hash("hash-test")
 
     def test_list_for_user(self, storage):
         k1 = self._key("u1", "key1")

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2564,6 +2564,11 @@ class TestApiKeyStorage:
         assert found.key_id == k.key_id
         mock_scan.assert_not_called()
 
+    def test_get_by_hash_ignores_non_apikey_items_in_index(self, storage):
+        """A foreign item carrying key_hash (invariant breach) is treated as a miss."""
+        storage.table.put_item(Item={"PK": "OTHER#rogue", "SK": "META", "key_hash": "hash-rogue"})
+        assert storage.get_api_key_by_hash("hash-rogue") is None
+
     def test_get_by_hash_falls_back_when_index_missing(self, storage_no_apikey_index):
         """A table without the GSI (legacy schema / backfilling) still resolves keys."""
         k = self._key()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2569,6 +2569,38 @@ class TestApiKeyStorage:
         storage.table.put_item(Item={"PK": "OTHER#rogue", "SK": "META", "key_hash": "hash-rogue"})
         assert storage.get_api_key_by_hash("hash-rogue") is None
 
+    def test_get_by_hash_paginates_past_foreign_items(self, storage):
+        """A real key sharing the partition with a foreign item is still found.
+
+        Limit=1 + FilterExpression means the first page can come back empty
+        (DynamoDB applies Limit before the filter); the pagination loop must
+        keep going until it reaches the genuine API key item.
+        """
+        storage.table.put_item(Item={"PK": "OTHER#rogue", "SK": "META", "key_hash": "hash-mixed"})
+        k = ApiKey(owner_user_id="u1", name="mixed", key_hash="hash-mixed")
+        storage.put_api_key(k)
+        found = storage.get_api_key_by_hash("hash-mixed")
+        assert found is not None
+        assert found.key_id == k.key_id
+
+    def test_get_by_hash_follows_last_evaluated_key(self, storage):
+        """An empty-but-truncated page (Limit applied before the filter) keeps paging."""
+        from unittest.mock import patch
+
+        k = self._key("u1", "paged")
+        pages = [
+            {"Items": [], "LastEvaluatedKey": {"key_hash": "hash-paged"}},
+            {"Items": [k.to_dynamo()]},
+        ]
+        with patch.object(storage.table, "query", side_effect=pages) as mock_query:
+            found = storage.get_api_key_by_hash("hash-paged")
+        assert found is not None
+        assert found.key_id == k.key_id
+        assert mock_query.call_count == 2
+        assert mock_query.call_args_list[1].kwargs["ExclusiveStartKey"] == {
+            "key_hash": "hash-paged"
+        }
+
     def test_get_by_hash_falls_back_when_index_missing(self, storage_no_apikey_index):
         """A table without the GSI (legacy schema / backfilling) still resolves keys."""
         k = self._key()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2632,6 +2632,37 @@ class TestApiKeyStorage:
         assert found is not None
         assert found.key_id == k.key_id
 
+    def test_scan_fallback_follows_last_evaluated_key(self, storage):
+        """The fallback scan pages past empty filtered pages — it must not false-negative."""
+        from unittest.mock import patch
+
+        k = self._key("u1", "scanpage")
+        pages = [
+            {"Items": [], "LastEvaluatedKey": {"PK": "x", "SK": "y"}},
+            {"Items": [k.to_dynamo()]},
+        ]
+        with patch.object(storage.table, "scan", side_effect=pages) as mock_scan:
+            found = storage._scan_api_key_by_hash("hash-scanpage")
+        assert found is not None
+        assert found.key_id == k.key_id
+        assert mock_scan.call_count == 2
+        assert mock_scan.call_args_list[1].kwargs["ExclusiveStartKey"] == {"PK": "x", "SK": "y"}
+
+    def test_list_for_user_follows_last_evaluated_key(self, storage):
+        """list_api_keys_for_user aggregates keys across scan pages."""
+        from unittest.mock import patch
+
+        k1 = self._key("u9", "page1")
+        k2 = self._key("u9", "page2")
+        pages = [
+            {"Items": [k1.to_dynamo()], "LastEvaluatedKey": {"PK": "x", "SK": "y"}},
+            {"Items": [k2.to_dynamo()]},
+        ]
+        with patch.object(storage.table, "scan", side_effect=pages) as mock_scan:
+            result = storage.list_api_keys_for_user("u9")
+        assert {k.name for k in result} == {"page1", "page2"}
+        assert mock_scan.call_count == 2
+
     def test_get_by_hash_reraises_unrelated_errors(self, storage):
         """Only index-unavailable errors degrade to a scan — others propagate."""
         from unittest.mock import patch


### PR DESCRIPTION
Closes #589

## Summary

`storage.get_api_key_by_hash` performed a full DynamoDB table scan with a `FilterExpression` on **every** API-key-authenticated request. This PR adds a new `ApiKeyHashIndex` GSI to the table and rewrites the lookup as a single-partition query, with a permanent graceful fallback to the legacy scan when the index is unavailable.

## Approach

- **Sparse GSI keyed directly on the existing top-level `key_hash` attribute** — not a new `GSI6PK` composite attribute. Only `APIKEY#` items carry `key_hash` (verified: `models.ApiKey.to_dynamo` is the sole writer of that attribute), so the index contains only API-key items.
- `get_api_key_by_hash` now queries `ApiKeyHashIndex` with a defensive `SK = META AND begins_with(PK, APIKEY#)` filter preserving the exact semantics of the old scan.
- The legacy scan lives on as `_scan_api_key_by_hash` and is invoked when the GSI query fails with `ValidationException` (index absent or still backfilling — DynamoDB rejects queries against a `CREATING` index with this code) or `ResourceNotFoundException`. A warning is logged on fallback (storage layer has no sync metrics counter pattern; `emit_metric` is async-only, so log-only here). Any other error re-raises. **The fallback is permanent resilience, not a transitional shim** — auth must never hard-fail on index availability.

## Migration / backfill story

Keying the GSI on the **existing** `key_hash` attribute means DynamoDB's asynchronous index backfill automatically projects **every existing API-key item** — they all already carry the attribute. No data migration, no dual-write stamping, no legacy-item gap. While the index is backfilling after deployment (Lambda code can go live before the GSI is ACTIVE), the scan fallback keeps API-key auth fully functional; once ACTIVE, all keys (old and new) resolve via the query path.

DynamoDB allows only one GSI creation per table update — this PR adds exactly one.

## Infra diff

Verified by synthesizing `HiveStack` at this branch and at the base commit (`4663e7a`) and structurally diffing the CloudFormation templates. The delta to `AWS::DynamoDB::Table` (`HiveTableA6FD3490`) is **exactly**:

- `AttributeDefinitions`: +1 entry — `{"AttributeName": "key_hash", "AttributeType": "S"}`
- `GlobalSecondaryIndexes`: +1 entry — `{"IndexName": "ApiKeyHashIndex", "KeySchema": [{"AttributeName": "key_hash", "KeyType": "HASH"}], "Projection": {"ProjectionType": "ALL"}}` (projection mirrors all existing GSIs)

No key-schema change, no table replacement, no modification or removal of existing GSIs, nothing else in the stack. The only other template diffs are Lambda code-asset hash rotations (and the derived `McpFunction` version/alias logical IDs), which accompany any `src/` change. Full `inv synth` (including the cdk-nag hard gate) passes.

## Not included: #596

`list_api_keys_for_user` (#596) needs a lookup keyed on `owner_user_id` — a different partition key that cannot share this GSI, and DynamoDB permits only one GSI creation per table update. #596 stays open for a separate PR.

## Testing

- Unit (moto): GSI-hit lookup asserting the scan path is never touched, miss returns `None`, fallback on a **real** `ValidationException` from an index-less table, fallback on `ResourceNotFoundException`, unrelated `ClientError` re-raises. Test-table fixture updated to carry the new GSI.
- Integration (DynamoDB Local, new `tests/e2e`-style skip guard): fast-path query and miss against a table **with** the index (scan blocked), fallback resolution and miss against a legacy-schema table **without** it — exercising the real DynamoDB error path, not just moto. All 4 pass locally against `amazon/dynamodb-local`.
- `uv run inv pre-push` passes (lint, mypy, copyright, unit, 905 frontend tests). `uv run inv synth` passes.

Local e2e not run — CI will cover this on the development branch deploy.

## Copilot review outcomes (5 iterations, all threads resolved)

1. **Add `Limit=1` to the GSI query** — applied (9d94b82), then hardened in 5b8b74f: `Limit=1` + server-side shape filter + `LastEvaluatedKey` pagination, because DynamoDB applies Limit *before* FilterExpression. Normal case remains a single 1-item read.
2. **Limit-without-filter could false-negative on an invariant breach** — applied (5b8b74f), as above.
3. **Use per-run unique integration table names** — declined; fixed-name + pre-delete guard is the repo's established integration-fixture convention (`test_api.py`, `test_oauth_user_binding.py`) and DynamoDB Local deletes tables synchronously.
4. **Scan paths don't paginate (pre-existing bug)** — applied (230c191): `_scan_api_key_by_hash` and `list_api_keys_for_user` now follow `LastEvaluatedKey`, fixing a pre-existing false-negative flaw the fallback had inherited from the original scan.
5. **Narrow the `ValidationException` fallback by message substring** — observability half applied (e3a2220: full error message now logged); substring gating declined as fragile (DynamoDB / DynamoDB Local / moto phrase these messages differently).

Also: extracted an `_APIKEY_PK_PREFIX` constant to clear the one SonarCloud S1192 flag (4567154).