### PR TITLE
fix(security): revoke a client's active tokens when it is deleted

### DIFF
--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -46,7 +46,7 @@ Access tokens are valid for **1 hour** and refresh automatically in supported cl
 
 ### How do I revoke access from a specific client?
 
-Go to the **Clients** tab in the management UI and click **Delete** on the client you want to revoke. The token is immediately invalidated. See [OAuth clients](/ui-guide/oauth-clients) for details.
+Go to the **Clients** tab in the management UI and click **Delete** on the client you want to revoke. The client's access and refresh tokens are immediately invalidated. See [OAuth clients](/ui-guide/oauth-clients) for details.
 
 ### How do I delete my account?
 

--- a/docs-site/public/openapi.json
+++ b/docs-site/public/openapi.json
@@ -1627,7 +1627,7 @@
     },
     "/api/clients/{client_id}": {
       "delete": {
-        "description": "Permanently delete an OAuth client by its client ID. Non-admins can only delete their own clients.",
+        "description": "Permanently delete an OAuth client by its client ID and immediately revoke every access and refresh token issued to it. Non-admins can only delete their own clients.",
         "operationId": "delete_client_api_clients__client_id__delete",
         "parameters": [
           {

--- a/docs-site/ui-guide/oauth-clients.md
+++ b/docs-site/ui-guide/oauth-clients.md
@@ -20,6 +20,6 @@ You can see all your memories across all clients in the [Memory Browser](/ui-gui
 
 ## Revoking access
 
-To revoke a client's access, click **Delete** on its card. The client's token is immediately invalidated and any future requests using that token will be rejected. The memories created by that client are not deleted — they remain accessible via the management UI and other clients.
+To revoke a client's access, click **Delete** on its card. The client's access and refresh tokens are immediately invalidated and any future requests using those tokens will be rejected. The memories created by that client are not deleted — they remain accessible via the management UI and other clients.
 
 To reconnect after deletion, simply use a Hive tool from that client again — it will re-register and prompt for re-authorisation.

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -130,7 +130,11 @@ async def get_client(
 @router.delete(
     "/clients/{client_id}",
     summary="Delete an OAuth client",
-    description="Permanently delete an OAuth client by its client ID. Non-admins can only delete their own clients.",
+    description=(
+        "Permanently delete an OAuth client by its client ID and immediately "
+        "revoke every access and refresh token issued to it. Non-admins can "
+        "only delete their own clients."
+    ),
     status_code=204,
     responses={
         401: {"description": "Unauthorized"},
@@ -149,11 +153,25 @@ async def delete_client(
     if owner_user_id and client.owner_user_id != owner_user_id:
         raise HTTPException(status_code=404, detail=_CLIENT_NOT_FOUND)
 
+    # First sweep: revoke the client's outstanding tokens while its record
+    # still exists — if anything below fails, a retry can rediscover the
+    # client and finish the job (#711, mirroring #588's ordering).
+    revoked_tokens = storage.delete_tokens_for_clients({client_id})
+
+    # Close the mint path: /oauth/token authenticates the client via
+    # get_client, so removing the record stops a concurrent refresh grant
+    # from issuing new tokens.
     storage.delete_client(client_id)
+
+    # Second sweep: catch tokens minted by grants in flight during the
+    # first scan. With the client gone nothing new can be minted, so this
+    # sweep is final.
+    revoked_tokens += storage.delete_tokens_for_clients({client_id})
+
     storage.log_event(
         ActivityEvent(
             event_type=EventType.client_deleted,
             client_id=claims["sub"],
-            metadata={"deleted_client_id": client_id},
+            metadata={"deleted_client_id": client_id, "revoked_tokens": revoked_tokens},
         )
     )

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -164,8 +164,10 @@ async def delete_client(
     storage.delete_client(client_id)
 
     # Second sweep: catch tokens minted by grants in flight during the
-    # first scan. With the client gone nothing new can be minted, so this
-    # sweep is final.
+    # first scan. Deleting the record stops new grants from
+    # authenticating, so this narrows the race window to a grant that
+    # loaded the client before the delete and persists its token after
+    # this scan — such stragglers still expire via their short TTLs.
     revoked_tokens += storage.delete_tokens_for_clients({client_id})
 
     storage.log_event(

--- a/src/hive/api/clients.py
+++ b/src/hive/api/clients.py
@@ -165,9 +165,11 @@ async def delete_client(
 
     # Second sweep: catch tokens minted by grants in flight during the
     # first scan. Deleting the record stops new grants from
-    # authenticating, so this narrows the race window to a grant that
-    # loaded the client before the delete and persists its token after
-    # this scan — such stragglers still expire via their short TTLs.
+    # authenticating, so the residual race is a grant that loaded the
+    # client before the delete and persists its token after this scan.
+    # A straggler access token lives at most its 1-hour TTL; a straggler
+    # refresh token cannot be redeemed at all — /oauth/token re-resolves
+    # the client record, which is gone.
     revoked_tokens += storage.delete_tokens_for_clients({client_id})
 
     storage.log_event(

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1190,9 +1190,10 @@ class HiveStorage:
         """Hard-delete every outstanding token issued to the given clients.
 
         Used by account deletion (#588) and individual client deletion
-        (#711) — tokens carry short TTLs, but a still-live access or
-        refresh token must not keep working after its owner's account or
-        client registration is gone. Token items are not projected into
+        (#711) — tokens do expire via their TTLs (1 hour access, 30 days
+        refresh), but a still-live access or refresh token must not keep
+        working after its owner's account or client registration is gone.
+        Token items are not projected into
         ClientIndex, so this walks the same ``TOKEN#`` scan as
         ``revoke_all_tokens`` and deletes matches outright: validation
         fails immediately on the missing item, and DynamoDB TTL has

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1189,9 +1189,10 @@ class HiveStorage:
     def delete_tokens_for_clients(self, client_ids: set[str]) -> int:
         """Hard-delete every outstanding token issued to the given clients.
 
-        Used by account deletion (#588) — tokens carry short TTLs, but a
-        still-live access or refresh token must not keep working after its
-        owner's account is gone. Token items are not projected into
+        Used by account deletion (#588) and individual client deletion
+        (#711) — tokens carry short TTLs, but a still-live access or
+        refresh token must not keep working after its owner's account or
+        client registration is gone. Token items are not projected into
         ClientIndex, so this walks the same ``TOKEN#`` scan as
         ``revoke_all_tokens`` and deletes matches outright: validation
         fails immediately on the missing item, and DynamoDB TTL has

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -297,3 +297,74 @@ class TestAccountDeletionRevokesTokens:
         assert storage.get_token(b_access.jti) is not None
         assert storage.get_client(client_b.client_id) is not None
         assert storage.get_user_by_id("itest-588-user-b") is not None
+
+
+class TestClientDeletionRevokesTokens:
+    """#711 — DELETE /api/clients/{id} must revoke the client's tokens."""
+
+    @pytest.fixture()
+    def storage(self, client):
+        from hive.storage import HiveStorage
+
+        # `client` guarantees the table exists before storage is used.
+        return HiveStorage(
+            table_name="hive-integration-test",
+            region="us-east-1",
+            endpoint_url=DYNAMO_ENDPOINT,
+            aws_access_key_id="local",
+            aws_secret_access_key="local",
+        )
+
+    @staticmethod
+    def _issue_token(storage, client_id: str, token_type=None, ttl_seconds: int = 3600):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import Token, TokenType
+
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client_id,
+            scope="memories:read",
+            token_type=token_type or TokenType.access,
+            issued_at=now,
+            expires_at=now + timedelta(seconds=ttl_seconds),
+        )
+        storage.put_token(token)
+        return token
+
+    def test_deleted_clients_tokens_are_gone_other_clients_survive(self, storage):
+        from hive.api.main import app
+        from hive.auth.tokens import issue_mgmt_jwt
+        from hive.models import OAuthClient, TokenType, User
+
+        user = User(
+            user_id="itest-711-owner",
+            email="itest-711-owner@example.com",
+            display_name="Owner 711",
+        )
+        storage.put_user(user)
+
+        doomed = OAuthClient(client_name="itest-711-doomed", owner_user_id=user.user_id)
+        bystander = OAuthClient(client_name="itest-711-bystander", owner_user_id=user.user_id)
+        storage.put_client(doomed)
+        storage.put_client(bystander)
+
+        doomed_access = self._issue_token(storage, doomed.client_id)
+        doomed_refresh = self._issue_token(
+            storage, doomed.client_id, token_type=TokenType.refresh, ttl_seconds=86400 * 30
+        )
+        bystander_access = self._issue_token(storage, bystander.client_id)
+
+        mgmt_tc = TestClient(app)
+        mgmt_tc.headers.update({"Authorization": f"Bearer {issue_mgmt_jwt(user)}"})
+
+        resp = mgmt_tc.delete(f"/api/clients/{doomed.client_id}")
+
+        assert resp.status_code == 204
+        # The deleted client's access and refresh tokens are gone
+        assert storage.get_client(doomed.client_id) is None
+        assert storage.get_token(doomed_access.jti) is None
+        assert storage.get_token(doomed_refresh.jti) is None
+        # The other client's registration and token survive
+        assert storage.get_client(bystander.client_id) is not None
+        assert storage.get_token(bystander_access.jti) is not None

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -820,6 +820,89 @@ class TestClients:
         resp = tc.delete("/api/clients/no-such-id")
         assert resp.status_code == 404
 
+    @staticmethod
+    def _issue_token(storage, client_id, token_type=None):
+        from datetime import datetime, timedelta, timezone
+
+        from hive.models import Token, TokenType
+
+        now = datetime.now(timezone.utc)
+        token = Token(
+            client_id=client_id,
+            scope="memories:read",
+            token_type=token_type or TokenType.access,
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+        )
+        storage.put_token(token)
+        return token
+
+    def test_delete_revokes_clients_tokens(self, client):
+        """#711 — deleting a client hard-deletes its access + refresh tokens."""
+        from hive.models import TokenType
+
+        tc, storage, _ = client
+        cid = tc.post("/api/clients", json={"client_name": "RevokeMe"}).json()["client_id"]
+        other_cid = tc.post("/api/clients", json={"client_name": "Bystander"}).json()["client_id"]
+
+        access = self._issue_token(storage, cid)
+        refresh = self._issue_token(storage, cid, token_type=TokenType.refresh)
+        other = self._issue_token(storage, other_cid)
+
+        resp = tc.delete(f"/api/clients/{cid}")
+
+        assert resp.status_code == 204
+        assert storage.get_client(cid) is None
+        assert storage.get_token(access.jti) is None
+        assert storage.get_token(refresh.jti) is None
+        # Another client's registration and token must survive
+        assert storage.get_client(other_cid) is not None
+        assert storage.get_token(other.jti) is not None
+
+    def test_delete_logs_revoked_token_count(self, client):
+        """#711 — the client_deleted activity event reports revoked_tokens."""
+        from datetime import datetime, timezone
+
+        tc, storage, _ = client
+        cid = tc.post("/api/clients", json={"client_name": "Counted"}).json()["client_id"]
+        self._issue_token(storage, cid)
+        self._issue_token(storage, cid)
+
+        assert tc.delete(f"/api/clients/{cid}").status_code == 204
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        events = [
+            e
+            for e in storage.get_events_for_date(today)
+            if e.event_type.value == "client_deleted" and e.metadata.get("deleted_client_id") == cid
+        ]
+        assert len(events) == 1
+        assert events[0].metadata["revoked_tokens"] == 2
+
+    def test_delete_second_sweep_catches_token_minted_mid_delete(self, client):
+        """#711 — a token minted after the first sweep but before the client
+        record is deleted (a refresh grant in flight) is caught by the
+        second sweep."""
+        from unittest.mock import patch
+
+        tc, storage, _ = client
+        cid = tc.post("/api/clients", json={"client_name": "Race"}).json()["client_id"]
+        self._issue_token(storage, cid)
+
+        real_delete_client = storage.delete_client
+        late_tokens = []
+
+        def _delete_client_with_race(client_id):
+            # Simulate a concurrent refresh grant minting a token after the
+            # first sweep has already run but before the client is deleted.
+            late_tokens.append(self._issue_token(storage, client_id))
+            return real_delete_client(client_id)
+
+        with patch.object(storage, "delete_client", side_effect=_delete_client_with_race):
+            assert tc.delete(f"/api/clients/{cid}").status_code == 204
+
+        assert storage.get_token(late_tokens[0].jti) is None
+
     def test_create_returns_429_when_client_quota_exceeded(self, client):
         import os
         from unittest.mock import patch

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -868,12 +868,15 @@ class TestClients:
         self._issue_token(storage, cid)
         self._issue_token(storage, cid)
 
+        # Bracket the delete with both candidate dates so the assertion
+        # cannot flake if the event lands across a UTC midnight boundary.
+        date_before = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         assert tc.delete(f"/api/clients/{cid}").status_code == 204
+        date_after = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         events = [
             e
-            for e in storage.get_events_for_date(today)
+            for e in storage.get_events_for_dates(sorted({date_before, date_after}))
             if e.event_type.value == "client_deleted" and e.metadata.get("deleted_client_id") == cid
         ]
         assert len(events) == 1


### PR DESCRIPTION
Closes #711

## Summary

`DELETE /api/clients/{id}` deleted the OAuth client record but left the client's active access and refresh tokens in DynamoDB with their original TTLs — an access token with up to 1 hour remaining (and refresh tokens with up to 30 days) kept working after the client was "revoked", while the docs FAQ claimed deletion invalidates the token immediately. Same class of gap as #588 (account deletion, fixed in PR #708); the per-client path was explicitly out of scope there.

The endpoint now reuses `storage.delete_tokens_for_clients` (added in #708) with the single client ID, mirroring #708's ordering rationale:

1. **First sweep** — revoke outstanding tokens while the client record still exists, so a partial failure leaves the client discoverable and a retry can finish the job
2. **Delete the client record** — `/oauth/token` authenticates the client via `get_client`, so this closes the mint path for concurrent refresh grants
3. **Second sweep** — catch tokens minted by grants in flight during the first scan; with the client gone this sweep is final

The `client_deleted` activity event now carries a `revoked_tokens` count in its metadata (additive — the endpoint's 204 No Content response contract is unchanged, and no new event type was invented).

## Approach

- **Reuse, not rewrite**: no new storage logic — `delete_tokens_for_clients` already handles the strongly-consistent `TOKEN#` scan, batch deletes, and pagination. `storage.py` only gets a docstring update noting the second caller.
- **Ownership checks unchanged**: the 404-for-foreign-clients behaviour runs before any deletion, so a non-admin cannot trigger token sweeps on clients they don't own.

## Docs

- `docs-site/faq.md` ("How do I revoke access from a specific client?") and `docs-site/ui-guide/oauth-clients.md` ("Revoking access") claimed immediate invalidation — true only after this fix. Both now say access **and refresh** tokens are immediately invalidated, matching actual behaviour.
- `ui/src/components/FaqPage.jsx` was checked and carries no client-revocation claim — no UI change needed.

## Testing

- Unit (moto, `tests/unit/test_api.py`): deleting a client removes its access + refresh tokens while another client's registration and tokens survive; the `client_deleted` activity event reports `revoked_tokens`; a token minted between the first sweep and the client delete (simulated in-flight refresh grant) is caught by the second sweep. `hive/api/clients.py` at 100% coverage.
- Integration (DynamoDB Local, `tests/integration/test_api.py`): end-to-end `DELETE /api/clients/{id}` with a real management JWT — deleted client's access + refresh tokens gone, bystander client and its token survive. Verified locally against DynamoDB Local in Docker.
- `uv run inv pre-push` green: 1178 unit + 905 frontend tests.

Local e2e not run — CI will cover this on the development branch deploy.