### PR TITLE
feat: workspaces API — CRUD, members, invites endpoints

### DIFF
--- a/docs-site/public/openapi.json
+++ b/docs-site/public/openapi.json
@@ -1,6 +1,29 @@
 {
   "components": {
     "schemas": {
+      "AcceptInviteResponse": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "workspace_id": {
+            "title": "Workspace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "workspace_id",
+          "name",
+          "role"
+        ],
+        "title": "AcceptInviteResponse",
+        "type": "object"
+      },
       "AccountDeleteRequest": {
         "properties": {
           "confirm": {
@@ -302,6 +325,133 @@
           }
         },
         "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "InviteCreateRequest": {
+        "properties": {
+          "email": {
+            "maxLength": 320,
+            "pattern": "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
+            "title": "Email",
+            "type": "string"
+          },
+          "role": {
+            "default": "member",
+            "enum": [
+              "admin",
+              "member"
+            ],
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "title": "InviteCreateRequest",
+        "type": "object"
+      },
+      "InviteResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          },
+          "invite_id": {
+            "title": "Invite Id",
+            "type": "string"
+          },
+          "invited_by_user_id": {
+            "title": "Invited By User Id",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "workspace_id": {
+            "title": "Workspace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "invite_id",
+          "workspace_id",
+          "email",
+          "role",
+          "invited_by_user_id",
+          "created_at",
+          "expires_at"
+        ],
+        "title": "InviteResponse",
+        "type": "object"
+      },
+      "MemberResponse": {
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "joined_at": {
+            "format": "date-time",
+            "title": "Joined At",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "role",
+          "joined_at"
+        ],
+        "title": "MemberResponse",
+        "type": "object"
+      },
+      "MemberRoleUpdateRequest": {
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/WorkspaceRole"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "MemberRoleUpdateRequest",
         "type": "object"
       },
       "MemoryCreate": {
@@ -843,6 +993,94 @@
         "title": "ValidationError",
         "type": "object"
       },
+      "WorkspaceCreateRequest": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "WorkspaceCreateRequest",
+        "type": "object"
+      },
+      "WorkspaceResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_personal": {
+            "title": "Is Personal",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner_user_id": {
+            "title": "Owner User Id",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "workspace_id": {
+            "title": "Workspace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "workspace_id",
+          "name",
+          "description",
+          "is_personal",
+          "owner_user_id",
+          "created_at",
+          "role"
+        ],
+        "title": "WorkspaceResponse",
+        "type": "object"
+      },
+      "WorkspaceRole": {
+        "description": "Membership roles inside a workspace.\n\n`guest` (read-only) was cut from v1 per the #482 design review \u2014\nship `owner` / `admin` / `member` and revisit once there is demand.",
+        "enum": [
+          "owner",
+          "admin",
+          "member"
+        ],
+        "title": "WorkspaceRole",
+        "type": "string"
+      },
       "WorkspaceTokenRequest": {
         "description": "Request body for re-issuing a management JWT scoped to a workspace (#491).",
         "properties": {
@@ -879,6 +1117,21 @@
           "workspace_role"
         ],
         "title": "WorkspaceTokenResponse",
+        "type": "object"
+      },
+      "WorkspaceUpdateRequest": {
+        "properties": {
+          "name": {
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "WorkspaceUpdateRequest",
         "type": "object"
       }
     },
@@ -1721,6 +1974,66 @@
         "summary": "Get an OAuth client",
         "tags": [
           "clients"
+        ]
+      }
+    },
+    "/api/invites/{invite_id}/accept": {
+      "post": {
+        "description": "Redeem a pending invite: the authenticated user joins the workspace with the invited role and the invite is consumed (single-use). The caller's login email must match the invited address. Expired or already-redeemed invites return 404.",
+        "operationId": "accept_invite_api_invites__invite_id__accept_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "invite_id",
+            "required": true,
+            "schema": {
+              "title": "Invite Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptInviteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Invite was issued for a different email address"
+          },
+          "404": {
+            "description": "Invite not found or expired, or workspace deleted"
+          },
+          "409": {
+            "description": "Already a member of the workspace"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Accept a workspace invite",
+        "tags": [
+          "workspaces"
         ]
       }
     },
@@ -2956,6 +3269,482 @@
         "summary": "Get per-user statistics",
         "tags": [
           "users"
+        ]
+      }
+    },
+    "/api/workspaces": {
+      "get": {
+        "description": "Return every workspace the authenticated user belongs to, each with the caller's role in it.",
+        "operationId": "list_workspaces_api_workspaces_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceResponse"
+                  },
+                  "title": "Response List Workspaces Api Workspaces Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List my workspaces",
+        "tags": [
+          "workspaces"
+        ]
+      },
+      "post": {
+        "description": "Create a shared workspace. The caller becomes its owner. Workspace names are display-only and per-user unique \u2014 creating a second workspace with a name you already use fails with 409.",
+        "operationId": "create_workspace_api_workspaces_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "409": {
+            "description": "You already have a workspace with this name"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create a workspace",
+        "tags": [
+          "workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{workspace_id}": {
+      "delete": {
+        "description": "Delete a workspace and its memberships. Owner only. Personal workspaces cannot be deleted \u2014 they are removed with the account. Fails with 409 while other members remain (consistent with the account-deletion sole-owner guard, #495): remove them or transfer ownership so the new owner can decide.",
+        "operationId": "delete_workspace_api_workspaces__workspace_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Not a member, or not an owner"
+          },
+          "404": {
+            "description": "Workspace not found"
+          },
+          "409": {
+            "description": "Workspace is Personal, or still has other members"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete a workspace",
+        "tags": [
+          "workspaces"
+        ]
+      },
+      "patch": {
+        "description": "Update a workspace's display name. Requires the owner or admin role.",
+        "operationId": "update_workspace_api_workspaces__workspace_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Not a member, or insufficient role"
+          },
+          "404": {
+            "description": "Workspace not found"
+          },
+          "409": {
+            "description": "You already have a workspace with this name"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Rename a workspace",
+        "tags": [
+          "workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{workspace_id}/invites": {
+      "post": {
+        "description": "Create a pending invite for an email address with a `member` or `admin` role (owner is granted post-join via the role endpoint). Requires the owner or admin role. Invites expire after `HIVE_INVITE_TTL_DAYS` days (default 7) via DynamoDB TTL.",
+        "operationId": "create_invite_api_workspaces__workspace_id__invites_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Not a member, or insufficient role"
+          },
+          "404": {
+            "description": "Workspace not found"
+          },
+          "409": {
+            "description": "Workspace is Personal, the email is already a member, or an invite for it is already pending"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Invite a user to the workspace",
+        "tags": [
+          "workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{workspace_id}/members": {
+      "get": {
+        "description": "Return every member of the workspace with their role, join date, and profile (email / display name) where the user record still exists. Any member can list members.",
+        "operationId": "list_members_api_workspaces__workspace_id__members_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MemberResponse"
+                  },
+                  "title": "Response List Members Api Workspaces  Workspace Id  Members Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Not a member of the workspace"
+          },
+          "404": {
+            "description": "Workspace not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List workspace members",
+        "tags": [
+          "workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{workspace_id}/members/{user_id}": {
+      "delete": {
+        "description": "Remove a member from the workspace. Any member may remove themself (leave) \u2014 except the only owner, who must transfer ownership or delete the workspace instead (409). Owners can remove anyone; admins can remove non-owners; members can only remove themselves.",
+        "operationId": "remove_member_api_workspaces__workspace_id__members__user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Not a member, or insufficient role"
+          },
+          "404": {
+            "description": "Workspace or member not found"
+          },
+          "409": {
+            "description": "The only owner cannot leave"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Remove a member (or leave)",
+        "tags": [
+          "workspaces"
+        ]
+      },
+      "put": {
+        "description": "Set a member's role. Owners can set any role; admins can move non-owner members between `member` and `admin` but cannot grant or revoke the owner role. Demoting the only owner fails with 409 \u2014 promote another owner first.",
+        "operationId": "update_member_role_api_workspaces__workspace_id__members__user_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberRoleUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Not a member, or insufficient role for this transition"
+          },
+          "404": {
+            "description": "Workspace or member not found"
+          },
+          "409": {
+            "description": "Cannot demote the only owner"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Change a member's role",
+        "tags": [
+          "workspaces"
         ]
       }
     },

--- a/src/hive/api/main.py
+++ b/src/hive/api/main.py
@@ -30,6 +30,7 @@ from hive.api.memories import router as memories_router
 from hive.api.stats import router as stats_router
 from hive.api.users import router as users_router
 from hive.api.versions import router as versions_router
+from hive.api.workspaces import router as workspaces_router
 from hive.auth.mgmt_auth import router as mgmt_auth_router
 from hive.auth.oauth import router as oauth_router
 from hive.logging_config import configure_logging, get_logger, new_request_id, set_request_context
@@ -135,6 +136,7 @@ app.include_router(versions_router, prefix="/api")
 app.include_router(clients_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
+app.include_router(workspaces_router, prefix="/api")
 app.include_router(keys_router, prefix="/api")
 app.include_router(account_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")

--- a/src/hive/api/workspaces.py
+++ b/src/hive/api/workspaces.py
@@ -38,6 +38,8 @@ from hive.workspace_service import AlreadyMemberError, InviteError, WorkspaceNot
 
 router = APIRouter(tags=["workspaces"])
 
+_WORKSPACE_NOT_FOUND = "Workspace not found"
+_MEMBER_NOT_FOUND = "Member not found"
 _DEFAULT_INVITE_TTL_DAYS = 7
 _NAME_MAX = 100
 _DESCRIPTION_MAX = 500
@@ -172,7 +174,7 @@ def _require_workspace_member(
     """
     workspace = storage.get_workspace(workspace_id)
     if workspace is None:
-        raise HTTPException(status_code=404, detail="Workspace not found")
+        raise HTTPException(status_code=404, detail=_WORKSPACE_NOT_FOUND)
     member = storage.get_workspace_member(workspace_id, user_id)
     if member is None:
         raise HTTPException(status_code=403, detail="You are not a member of this workspace")
@@ -277,7 +279,7 @@ async def list_workspaces(
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Not a member, or insufficient role"},
-        404: {"description": "Workspace not found"},
+        404: {"description": _WORKSPACE_NOT_FOUND},
         409: {"description": "You already have a workspace with this name"},
     },
 )
@@ -299,7 +301,7 @@ async def update_workspace(
         )
     if not storage.rename_workspace(workspace_id, body.name):
         # Deleted between the membership check and the conditional update.
-        raise HTTPException(status_code=404, detail="Workspace not found")
+        raise HTTPException(status_code=404, detail=_WORKSPACE_NOT_FOUND)
     workspace.name = body.name
     return WorkspaceResponse.from_workspace(workspace, member.role.value)
 
@@ -318,7 +320,7 @@ async def update_workspace(
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Not a member, or not an owner"},
-        404: {"description": "Workspace not found"},
+        404: {"description": _WORKSPACE_NOT_FOUND},
         409: {"description": "Workspace is Personal, or still has other members"},
     },
 )
@@ -352,7 +354,7 @@ async def delete_workspace(
         storage, workspace_id=workspace_id, actor_user_id=user_id
     ):
         # Deleted between the membership check and the delete.
-        raise HTTPException(status_code=404, detail="Workspace not found")
+        raise HTTPException(status_code=404, detail=_WORKSPACE_NOT_FOUND)
 
 
 # ---------------------------------------------------------------------------
@@ -371,7 +373,7 @@ async def delete_workspace(
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Not a member of the workspace"},
-        404: {"description": "Workspace not found"},
+        404: {"description": _WORKSPACE_NOT_FOUND},
     },
 )
 async def list_members(
@@ -421,7 +423,7 @@ async def update_member_role(
         )
     target = storage.get_workspace_member(workspace_id, user_id)
     if target is None:
-        raise HTTPException(status_code=404, detail="Member not found")
+        raise HTTPException(status_code=404, detail=_MEMBER_NOT_FOUND)
     new_role = body.role
     if actor.role is WorkspaceRole.admin and WorkspaceRole.owner in (target.role, new_role):
         raise HTTPException(
@@ -449,7 +451,7 @@ async def update_member_role(
         actor_user_id=actor_user_id,
     ):
         # Membership vanished between the read and the conditional update.
-        raise HTTPException(status_code=404, detail="Member not found")
+        raise HTTPException(status_code=404, detail=_MEMBER_NOT_FOUND)
     target.role = new_role
     return _member_response(storage, target)
 
@@ -481,7 +483,7 @@ async def remove_member(
     _, actor = _require_workspace_member(storage, workspace_id, actor_user_id)
     target = storage.get_workspace_member(workspace_id, user_id)
     if target is None:
-        raise HTTPException(status_code=404, detail="Member not found")
+        raise HTTPException(status_code=404, detail=_MEMBER_NOT_FOUND)
     if user_id == actor_user_id:
         if actor.role is WorkspaceRole.owner:
             owners = {
@@ -505,7 +507,7 @@ async def remove_member(
         storage, workspace_id=workspace_id, user_id=user_id, actor_user_id=actor_user_id
     ):
         # Membership vanished between the read and the delete.
-        raise HTTPException(status_code=404, detail="Member not found")
+        raise HTTPException(status_code=404, detail=_MEMBER_NOT_FOUND)
 
 
 # ---------------------------------------------------------------------------
@@ -526,7 +528,7 @@ async def remove_member(
     responses={
         401: {"description": "Unauthorized"},
         403: {"description": "Not a member, or insufficient role"},
-        404: {"description": "Workspace not found"},
+        404: {"description": _WORKSPACE_NOT_FOUND},
         409: {
             "description": (
                 "Workspace is Personal, the email is already a member, or an "
@@ -588,7 +590,7 @@ async def create_invite(
         )
     except WorkspaceNotFoundError as exc:
         # Deleted between the membership check and the invite write.
-        raise HTTPException(status_code=404, detail="Workspace not found") from exc
+        raise HTTPException(status_code=404, detail=_WORKSPACE_NOT_FOUND) from exc
     return InviteResponse(
         invite_id=invite.invite_id,
         workspace_id=invite.workspace_id,

--- a/src/hive/api/workspaces.py
+++ b/src/hive/api/workspaces.py
@@ -1,0 +1,629 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Workspace management endpoints (#492).
+
+- ``POST   /api/workspaces``                        — create (caller becomes owner)
+- ``GET    /api/workspaces``                        — list caller's workspaces + roles
+- ``PATCH  /api/workspaces/{id}``                   — rename (owner/admin)
+- ``DELETE /api/workspaces/{id}``                   — delete (owner only; 409 while
+  other members remain or the workspace is Personal)
+- ``GET    /api/workspaces/{id}/members``           — list members (any member)
+- ``PUT    /api/workspaces/{id}/members/{user_id}`` — change role (owner/admin)
+- ``DELETE /api/workspaces/{id}/members/{user_id}`` — remove member / leave
+- ``POST   /api/workspaces/{id}/invites``           — create invite (owner/admin)
+- ``POST   /api/invites/{id}/accept``               — accept invite (email must match)
+
+Authorization is resolved per-request from the caller's membership row
+(``storage.get_workspace_member``), not from the JWT's ``workspace_role``
+claim — the management token may be scoped to a different workspace than
+the one being managed, and membership rows are the source of truth (#491).
+Every membership mutation goes through :mod:`hive.workspace_service` so the
+compliance audit trail (#495) stays paired with the mutation.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+
+from hive import workspace_service
+from hive.api._auth import require_mgmt_user
+from hive.models import Workspace, WorkspaceMember, WorkspaceRole
+from hive.storage import HiveStorage
+from hive.workspace_service import InviteError, WorkspaceNotFoundError
+
+router = APIRouter(tags=["workspaces"])
+
+_DEFAULT_INVITE_TTL_DAYS = 7
+_NAME_MAX = 100
+_DESCRIPTION_MAX = 500
+# Deliberately loose — rejects whitespace and missing @/dot without trying to
+# fully validate RFC 5322. The invite is only redeemable by a user whose
+# Google-verified login email matches, so a typo'd address simply expires.
+_EMAIL_PATTERN = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+
+
+def _invite_ttl_days() -> int:
+    return int(os.environ.get("HIVE_INVITE_TTL_DAYS", _DEFAULT_INVITE_TTL_DAYS))
+
+
+def _storage() -> HiveStorage:
+    return HiveStorage()
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class _WorkspaceNameRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=_NAME_MAX)
+
+    @field_validator("name")
+    @classmethod
+    def _strip_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("name must not be blank")
+        return value
+
+
+class WorkspaceCreateRequest(_WorkspaceNameRequest):
+    description: str | None = Field(default=None, max_length=_DESCRIPTION_MAX)
+
+
+class WorkspaceUpdateRequest(_WorkspaceNameRequest):
+    pass
+
+
+class WorkspaceResponse(BaseModel):
+    workspace_id: str
+    name: str
+    description: str | None
+    is_personal: bool
+    owner_user_id: str
+    created_at: datetime
+    role: str
+
+    @classmethod
+    def from_workspace(cls, workspace: Workspace, role: str) -> WorkspaceResponse:
+        return cls(
+            workspace_id=workspace.workspace_id,
+            name=workspace.name,
+            description=workspace.description,
+            is_personal=workspace.is_personal,
+            owner_user_id=workspace.owner_user_id,
+            created_at=workspace.created_at,
+            role=role,
+        )
+
+
+class MemberResponse(BaseModel):
+    user_id: str
+    role: str
+    joined_at: datetime
+    email: str | None = None
+    display_name: str | None = None
+
+
+class MemberRoleUpdateRequest(BaseModel):
+    role: WorkspaceRole
+
+
+class InviteCreateRequest(BaseModel):
+    email: str = Field(max_length=320, pattern=_EMAIL_PATTERN)
+    # ``owner`` is deliberately not invitable — the owner role is granted by
+    # an existing owner via the role endpoint after the invitee has joined.
+    role: Literal["admin", "member"] = "member"
+
+    @field_validator("email")
+    @classmethod
+    def _normalize_email(cls, value: str) -> str:
+        return value.strip().lower()
+
+
+class InviteResponse(BaseModel):
+    invite_id: str
+    workspace_id: str
+    email: str
+    role: str
+    invited_by_user_id: str
+    created_at: datetime
+    expires_at: datetime
+
+
+class AcceptInviteResponse(BaseModel):
+    workspace_id: str
+    name: str
+    role: str
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_workspace_member(
+    storage: HiveStorage, workspace_id: str, user_id: str
+) -> tuple[Workspace, WorkspaceMember]:
+    """Resolve (workspace, caller-membership) or raise 404 / 403.
+
+    Matches the status-code convention of ``POST /api/account/workspace-token``
+    (#491): 404 when the workspace does not exist, 403 when it exists but the
+    caller is not a member.
+    """
+    workspace = storage.get_workspace(workspace_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    member = storage.get_workspace_member(workspace_id, user_id)
+    if member is None:
+        raise HTTPException(status_code=403, detail="You are not a member of this workspace")
+    return workspace, member
+
+
+def _name_taken(
+    storage: HiveStorage,
+    user_id: str,
+    name: str,
+    exclude_workspace_id: str | None = None,
+) -> bool:
+    """Best-effort per-user name uniqueness (#482 design decision 2).
+
+    Workspace names are display-only and per-user unique; only the caller's
+    own workspace list is checked — global uniqueness is intentionally not
+    enforced.
+    """
+    normalized = name.lower()
+    for workspace in storage.list_workspaces_for_user(user_id):
+        if workspace.workspace_id == exclude_workspace_id:
+            continue
+        if workspace.name.strip().lower() == normalized:
+            return True
+    return False
+
+
+def _member_response(storage: HiveStorage, member: WorkspaceMember) -> MemberResponse:
+    user = storage.get_user_by_id(member.user_id)
+    return MemberResponse(
+        user_id=member.user_id,
+        role=member.role.value,
+        joined_at=member.joined_at,
+        email=user.email if user else None,
+        display_name=user.display_name if user else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Workspace CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/workspaces",
+    status_code=201,
+    summary="Create a workspace",
+    description=(
+        "Create a shared workspace. The caller becomes its owner. Workspace "
+        "names are display-only and per-user unique — creating a second "
+        "workspace with a name you already use fails with 409."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        409: {"description": "You already have a workspace with this name"},
+    },
+)
+async def create_workspace(
+    body: WorkspaceCreateRequest,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> WorkspaceResponse:
+    user_id: str = claims["sub"]
+    if _name_taken(storage, user_id, body.name):
+        raise HTTPException(
+            status_code=409, detail=f"You already have a workspace named '{body.name}'"
+        )
+    workspace = workspace_service.create_workspace(
+        storage, name=body.name, owner_user_id=user_id, description=body.description
+    )
+    return WorkspaceResponse.from_workspace(workspace, WorkspaceRole.owner.value)
+
+
+@router.get(
+    "/workspaces",
+    summary="List my workspaces",
+    description=(
+        "Return every workspace the authenticated user belongs to, each with "
+        "the caller's role in it."
+    ),
+    responses={401: {"description": "Unauthorized"}},
+)
+async def list_workspaces(
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> list[WorkspaceResponse]:
+    user_id: str = claims["sub"]
+    workspaces: list[WorkspaceResponse] = []
+    for workspace in storage.list_workspaces_for_user(user_id):
+        member = storage.get_workspace_member(workspace.workspace_id, user_id)
+        if member is None:
+            # Membership vanished between the GSI listing and this read.
+            continue
+        workspaces.append(WorkspaceResponse.from_workspace(workspace, member.role.value))
+    return workspaces
+
+
+@router.patch(
+    "/workspaces/{workspace_id}",
+    summary="Rename a workspace",
+    description="Update a workspace's display name. Requires the owner or admin role.",
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Not a member, or insufficient role"},
+        404: {"description": "Workspace not found"},
+        409: {"description": "You already have a workspace with this name"},
+    },
+)
+async def update_workspace(
+    workspace_id: str,
+    body: WorkspaceUpdateRequest,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> WorkspaceResponse:
+    user_id: str = claims["sub"]
+    workspace, member = _require_workspace_member(storage, workspace_id, user_id)
+    if member.role not in (WorkspaceRole.owner, WorkspaceRole.admin):
+        raise HTTPException(
+            status_code=403, detail="Owner or admin role required to rename this workspace"
+        )
+    if _name_taken(storage, user_id, body.name, exclude_workspace_id=workspace_id):
+        raise HTTPException(
+            status_code=409, detail=f"You already have a workspace named '{body.name}'"
+        )
+    if not storage.rename_workspace(workspace_id, body.name):
+        # Deleted between the membership check and the conditional update.
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    workspace.name = body.name
+    return WorkspaceResponse.from_workspace(workspace, member.role.value)
+
+
+@router.delete(
+    "/workspaces/{workspace_id}",
+    status_code=204,
+    summary="Delete a workspace",
+    description=(
+        "Delete a workspace and its memberships. Owner only. Personal "
+        "workspaces cannot be deleted — they are removed with the account. "
+        "Fails with 409 while other members remain (consistent with the "
+        "account-deletion sole-owner guard, #495): remove them or transfer "
+        "ownership so the new owner can decide."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Not a member, or not an owner"},
+        404: {"description": "Workspace not found"},
+        409: {"description": "Workspace is Personal, or still has other members"},
+    },
+)
+async def delete_workspace(
+    workspace_id: str,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> None:
+    user_id: str = claims["sub"]
+    workspace, member = _require_workspace_member(storage, workspace_id, user_id)
+    if member.role is not WorkspaceRole.owner:
+        raise HTTPException(status_code=403, detail="Only an owner can delete a workspace")
+    if workspace.is_personal:
+        raise HTTPException(
+            status_code=409,
+            detail="Personal workspaces cannot be deleted; they are removed with your account",
+        )
+    others = [m for m in storage.list_workspace_members(workspace_id) if m.user_id != user_id]
+    if others:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": (
+                    "This workspace still has other members. Remove them or "
+                    "transfer ownership before deleting it."
+                ),
+                "members": [{"user_id": m.user_id, "role": m.role.value} for m in others],
+            },
+        )
+    if not workspace_service.delete_workspace(
+        storage, workspace_id=workspace_id, actor_user_id=user_id
+    ):
+        # Deleted between the membership check and the delete.
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+
+# ---------------------------------------------------------------------------
+# Members
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/workspaces/{workspace_id}/members",
+    summary="List workspace members",
+    description=(
+        "Return every member of the workspace with their role, join date, and "
+        "profile (email / display name) where the user record still exists. "
+        "Any member can list members."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Not a member of the workspace"},
+        404: {"description": "Workspace not found"},
+    },
+)
+async def list_members(
+    workspace_id: str,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> list[MemberResponse]:
+    user_id: str = claims["sub"]
+    _require_workspace_member(storage, workspace_id, user_id)
+    return [
+        _member_response(storage, member) for member in storage.list_workspace_members(workspace_id)
+    ]
+
+
+@router.put(
+    "/workspaces/{workspace_id}/members/{user_id}",
+    summary="Change a member's role",
+    description=(
+        "Set a member's role. Owners can set any role; admins can move "
+        "non-owner members between `member` and `admin` but cannot grant or "
+        "revoke the owner role. Demoting the only owner fails with 409 — "
+        "promote another owner first."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Not a member, or insufficient role for this transition"},
+        404: {"description": "Workspace or member not found"},
+        409: {"description": "Cannot demote the only owner"},
+    },
+)
+async def update_member_role(
+    workspace_id: str,
+    user_id: str,
+    body: MemberRoleUpdateRequest,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> MemberResponse:
+    actor_user_id: str = claims["sub"]
+    _, actor = _require_workspace_member(storage, workspace_id, actor_user_id)
+    if actor.role not in (WorkspaceRole.owner, WorkspaceRole.admin):
+        raise HTTPException(
+            status_code=403, detail="Owner or admin role required to change member roles"
+        )
+    target = storage.get_workspace_member(workspace_id, user_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Member not found")
+    new_role = body.role
+    if actor.role is WorkspaceRole.admin and WorkspaceRole.owner in (target.role, new_role):
+        raise HTTPException(
+            status_code=403, detail="Only an owner can grant or revoke the owner role"
+        )
+    if target.role is WorkspaceRole.owner and new_role is not WorkspaceRole.owner:
+        owners = {
+            m.user_id
+            for m in storage.list_workspace_members(workspace_id)
+            if m.role is WorkspaceRole.owner
+        }
+        if owners == {user_id}:
+            raise HTTPException(
+                status_code=409,
+                detail="Cannot demote the only owner. Promote another owner first.",
+            )
+    if target.role is new_role:
+        # No-op — skip the mutation so the audit trail records real changes only.
+        return _member_response(storage, target)
+    if not workspace_service.change_member_role(
+        storage,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        role=new_role,
+        actor_user_id=actor_user_id,
+    ):
+        # Membership vanished between the read and the conditional update.
+        raise HTTPException(status_code=404, detail="Member not found")
+    target.role = new_role
+    return _member_response(storage, target)
+
+
+@router.delete(
+    "/workspaces/{workspace_id}/members/{user_id}",
+    status_code=204,
+    summary="Remove a member (or leave)",
+    description=(
+        "Remove a member from the workspace. Any member may remove themself "
+        "(leave) — except the only owner, who must transfer ownership or "
+        "delete the workspace instead (409). Owners can remove anyone; admins "
+        "can remove non-owners; members can only remove themselves."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Not a member, or insufficient role"},
+        404: {"description": "Workspace or member not found"},
+        409: {"description": "The only owner cannot leave"},
+    },
+)
+async def remove_member(
+    workspace_id: str,
+    user_id: str,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> None:
+    actor_user_id: str = claims["sub"]
+    _, actor = _require_workspace_member(storage, workspace_id, actor_user_id)
+    target = storage.get_workspace_member(workspace_id, user_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Member not found")
+    if user_id == actor_user_id:
+        if actor.role is WorkspaceRole.owner:
+            owners = {
+                m.user_id
+                for m in storage.list_workspace_members(workspace_id)
+                if m.role is WorkspaceRole.owner
+            }
+            if owners == {actor_user_id}:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "You are the only owner of this workspace. Transfer "
+                        "ownership or delete the workspace instead."
+                    ),
+                )
+    elif actor.role is WorkspaceRole.member:
+        raise HTTPException(status_code=403, detail="Members can only remove themselves")
+    elif actor.role is WorkspaceRole.admin and target.role is WorkspaceRole.owner:
+        raise HTTPException(status_code=403, detail="Admins cannot remove owners")
+    if not workspace_service.remove_member(
+        storage, workspace_id=workspace_id, user_id=user_id, actor_user_id=actor_user_id
+    ):
+        # Membership vanished between the read and the delete.
+        raise HTTPException(status_code=404, detail="Member not found")
+
+
+# ---------------------------------------------------------------------------
+# Invites
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/workspaces/{workspace_id}/invites",
+    status_code=201,
+    summary="Invite a user to the workspace",
+    description=(
+        "Create a pending invite for an email address with a `member` or "
+        "`admin` role (owner is granted post-join via the role endpoint). "
+        "Requires the owner or admin role. Invites expire after "
+        "`HIVE_INVITE_TTL_DAYS` days (default 7) via DynamoDB TTL."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Not a member, or insufficient role"},
+        404: {"description": "Workspace not found"},
+        409: {
+            "description": (
+                "Workspace is Personal, the email is already a member, or an "
+                "invite for it is already pending"
+            )
+        },
+    },
+)
+async def create_invite(
+    workspace_id: str,
+    body: InviteCreateRequest,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> InviteResponse:
+    actor_user_id: str = claims["sub"]
+    workspace, actor = _require_workspace_member(storage, workspace_id, actor_user_id)
+    if actor.role not in (WorkspaceRole.owner, WorkspaceRole.admin):
+        raise HTTPException(
+            status_code=403, detail="Owner or admin role required to invite members"
+        )
+    if workspace.is_personal:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Personal workspaces cannot have additional members. "
+                "Create a shared workspace instead."
+            ),
+        )
+    existing_user = storage.get_user_by_email(body.email)
+    if (
+        existing_user is not None
+        and storage.get_workspace_member(workspace_id, existing_user.user_id) is not None
+    ):
+        raise HTTPException(
+            status_code=409, detail=f"'{body.email}' is already a member of this workspace"
+        )
+    if any(
+        invite.email.lower() == body.email
+        for invite in storage.list_pending_invites_for_workspace(workspace_id)
+    ):
+        raise HTTPException(
+            status_code=409, detail=f"An invite for '{body.email}' is already pending"
+        )
+    expires_at = datetime.now(timezone.utc) + timedelta(days=_invite_ttl_days())
+    try:
+        invite = workspace_service.send_invite(
+            storage,
+            workspace_id=workspace_id,
+            email=body.email,
+            role=WorkspaceRole(body.role),
+            invited_by_user_id=actor_user_id,
+            expires_at=expires_at,
+        )
+    except WorkspaceNotFoundError as exc:
+        # Deleted between the membership check and the invite write.
+        raise HTTPException(status_code=404, detail="Workspace not found") from exc
+    return InviteResponse(
+        invite_id=invite.invite_id,
+        workspace_id=invite.workspace_id,
+        email=invite.email,
+        role=invite.role.value,
+        invited_by_user_id=invite.invited_by_user_id,
+        created_at=invite.created_at,
+        expires_at=invite.expires_at,
+    )
+
+
+@router.post(
+    "/invites/{invite_id}/accept",
+    summary="Accept a workspace invite",
+    description=(
+        "Redeem a pending invite: the authenticated user joins the workspace "
+        "with the invited role and the invite is consumed (single-use). The "
+        "caller's login email must match the invited address. Expired or "
+        "already-redeemed invites return 404."
+    ),
+    responses={
+        401: {"description": "Unauthorized"},
+        403: {"description": "Invite was issued for a different email address"},
+        404: {"description": "Invite not found or expired, or workspace deleted"},
+        409: {"description": "Already a member of the workspace"},
+    },
+)
+async def accept_invite(
+    invite_id: str,
+    claims: Annotated[dict[str, Any], Depends(require_mgmt_user)],
+    storage: Annotated[HiveStorage, Depends(_storage)],
+) -> AcceptInviteResponse:
+    user_id: str = claims["sub"]
+    email = str(claims.get("email") or "").strip().lower()
+    invite = storage.get_invite(invite_id)
+    if invite is None or invite.is_expired:
+        raise HTTPException(status_code=404, detail="Invite not found or expired")
+    if not email or invite.email.lower() != email:
+        raise HTTPException(
+            status_code=403, detail="This invite was issued for a different email address"
+        )
+    workspace = storage.get_workspace(invite.workspace_id)
+    if workspace is None:
+        raise HTTPException(
+            status_code=404, detail="The workspace for this invite no longer exists"
+        )
+    if storage.get_workspace_member(invite.workspace_id, user_id) is not None:
+        # Leave the invite unconsumed — accepting would overwrite the caller's
+        # existing (possibly higher) role via the membership put.
+        raise HTTPException(status_code=409, detail="You are already a member of this workspace")
+    try:
+        joined = workspace_service.accept_invite(storage, invite_id=invite_id, user_id=user_id)
+    except InviteError as exc:
+        # Consumed or TTL-expired between the read and the atomic claim.
+        raise HTTPException(status_code=404, detail="Invite not found or expired") from exc
+    except WorkspaceNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail="The workspace for this invite no longer exists"
+        ) from exc
+    return AcceptInviteResponse(
+        workspace_id=workspace.workspace_id, name=workspace.name, role=joined.role.value
+    )

--- a/src/hive/api/workspaces.py
+++ b/src/hive/api/workspaces.py
@@ -130,10 +130,14 @@ class InviteCreateRequest(BaseModel):
     # an existing owner via the role endpoint after the invitee has joined.
     role: Literal["admin", "member"] = "member"
 
-    @field_validator("email")
+    @field_validator("email", mode="before")
     @classmethod
-    def _normalize_email(cls, value: str) -> str:
-        return value.strip().lower()
+    def _normalize_email(cls, value: Any) -> Any:
+        # mode="before" so trimming/lowercasing happens ahead of the Field
+        # pattern check — a pasted " User@Example.com " normalizes instead
+        # of tripping the whitespace-rejecting regex. Non-strings pass
+        # through for pydantic's own type validation to reject.
+        return value.strip().lower() if isinstance(value, str) else value
 
 
 class InviteResponse(BaseModel):

--- a/src/hive/api/workspaces.py
+++ b/src/hive/api/workspaces.py
@@ -48,7 +48,17 @@ _EMAIL_PATTERN = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
 
 
 def _invite_ttl_days() -> int:
-    return int(os.environ.get("HIVE_INVITE_TTL_DAYS", _DEFAULT_INVITE_TTL_DAYS))
+    """Invite lifetime in days (``HIVE_INVITE_TTL_DAYS``, default 7).
+
+    Falls back to the default when the value is unset, non-numeric, or
+    non-positive — a zero/negative TTL would mint already-expired invites,
+    and a parse error would 500 every invite creation.
+    """
+    try:
+        days = int(os.environ.get("HIVE_INVITE_TTL_DAYS", ""))
+    except ValueError:
+        return _DEFAULT_INVITE_TTL_DAYS
+    return days if days > 0 else _DEFAULT_INVITE_TTL_DAYS
 
 
 def _storage() -> HiveStorage:
@@ -367,6 +377,10 @@ async def list_members(
 ) -> list[MemberResponse]:
     user_id: str = claims["sub"]
     _require_workspace_member(storage, workspace_id, user_id)
+    # Per-member get_user_by_id is an accepted N+1 at workspace scale —
+    # membership is invite-only and human-sized, matching the per-item read
+    # patterns elsewhere (e.g. list_workspaces_for_user). Swap to a
+    # BatchGetItem-backed lookup if workspaces ever grow beyond that.
     return [
         _member_response(storage, member) for member in storage.list_workspace_members(workspace_id)
     ]

--- a/src/hive/api/workspaces.py
+++ b/src/hive/api/workspaces.py
@@ -34,7 +34,7 @@ from hive import workspace_service
 from hive.api._auth import require_mgmt_user
 from hive.models import Workspace, WorkspaceMember, WorkspaceRole
 from hive.storage import HiveStorage
-from hive.workspace_service import InviteError, WorkspaceNotFoundError
+from hive.workspace_service import AlreadyMemberError, InviteError, WorkspaceNotFoundError
 
 router = APIRouter(tags=["workspaces"])
 
@@ -545,6 +545,12 @@ async def create_invite(
         raise HTTPException(
             status_code=409, detail=f"'{body.email}' is already a member of this workspace"
         )
+    # Best-effort duplicate suppression: the pending-invite listing is a
+    # filtered scan (acceptable at invite volume — see the storage-layer
+    # docstring) and the check-then-write is not atomic. A duplicate that
+    # slips through a concurrent race is harmless: invites are single-use
+    # and TTL out, and redemption's conditional membership write means a
+    # second accept cannot alter an existing member's role.
     if any(
         invite.email.lower() == body.email
         for invite in storage.list_pending_invites_for_workspace(workspace_id)
@@ -612,14 +618,22 @@ async def accept_invite(
             status_code=404, detail="The workspace for this invite no longer exists"
         )
     if storage.get_workspace_member(invite.workspace_id, user_id) is not None:
-        # Leave the invite unconsumed — accepting would overwrite the caller's
-        # existing (possibly higher) role via the membership put.
+        # Friendly pre-check: reject without consuming the invite. The
+        # atomic backstop is the service's conditional membership write —
+        # a membership appearing after this check raises AlreadyMemberError
+        # below rather than being overwritten with the invited role.
         raise HTTPException(status_code=409, detail="You are already a member of this workspace")
     try:
         joined = workspace_service.accept_invite(storage, invite_id=invite_id, user_id=user_id)
     except InviteError as exc:
         # Consumed or TTL-expired between the read and the atomic claim.
         raise HTTPException(status_code=404, detail="Invite not found or expired") from exc
+    except AlreadyMemberError as exc:
+        # Membership appeared between the pre-check and the claim; the
+        # existing row (and role) is untouched.
+        raise HTTPException(
+            status_code=409, detail="You are already a member of this workspace"
+        ) from exc
     except WorkspaceNotFoundError as exc:
         raise HTTPException(
             status_code=404, detail="The workspace for this invite no longer exists"

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -1443,10 +1443,29 @@ class HiveStorage:
         workspace_id: str,
         user_id: str,
         role: WorkspaceRole = WorkspaceRole.member,
-    ) -> WorkspaceMember:
-        """Insert a (workspace, user, role) binding. Overwrites if it exists."""
+        overwrite: bool = True,
+    ) -> WorkspaceMember | None:
+        """Insert a (workspace, user, role) binding.
+
+        Overwrites an existing binding by default. With ``overwrite=False``
+        the put is conditional on the membership not already existing and
+        returns None when it does — invite redemption (#492) uses this so a
+        concurrently-created membership is never clobbered with the invited
+        role.
+        """
         member = WorkspaceMember(workspace_id=workspace_id, user_id=user_id, role=role)
-        self.table.put_item(Item=member.to_dynamo())
+        if overwrite:
+            self.table.put_item(Item=member.to_dynamo())
+            return member
+        try:
+            self.table.put_item(
+                Item=member.to_dynamo(),
+                ConditionExpression="attribute_not_exists(PK)",
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return None
+            raise
         return member
 
     def get_workspace_member(self, workspace_id: str, user_id: str) -> WorkspaceMember | None:

--- a/src/hive/workspace_service.py
+++ b/src/hive/workspace_service.py
@@ -43,6 +43,10 @@ class InviteError(Exception):
     """Raised when accepting an invite that is missing or expired."""
 
 
+class AlreadyMemberError(Exception):
+    """Raised when an invite is redeemed by someone who is already a member."""
+
+
 class WorkspaceNotFoundError(Exception):
     """Raised when an invite targets a workspace that does not exist."""
 
@@ -184,6 +188,12 @@ def accept_invite(storage: HiveStorage, *, invite_id: str, user_id: str) -> Work
     conditional delete (``claim_invite``) *before* the membership is
     written, so of N concurrent acceptors exactly one adds the member and
     emits the audit event — the rest get :class:`InviteError`.
+
+    The membership write is likewise conditional (``overwrite=False``): if
+    the user gained a membership through another path after the claim, the
+    existing row — and whatever role it carries — is left untouched and
+    :class:`AlreadyMemberError` is raised (the invite stays consumed, and
+    no audit event is written since no mutation happened).
     """
     invite = storage.get_invite(invite_id)
     if invite is None or invite.is_expired:
@@ -200,7 +210,12 @@ def accept_invite(storage: HiveStorage, *, invite_id: str, user_id: str) -> Work
         workspace_id=invite.workspace_id,
         user_id=user_id,
         role=invite.role,
+        overwrite=False,
     )
+    if member is None:
+        raise AlreadyMemberError(
+            f"User '{user_id}' is already a member of workspace '{invite.workspace_id}'."
+        )
     _audit(
         storage,
         EventType.workspace_invite_accepted,

--- a/src/hive/workspace_service.py
+++ b/src/hive/workspace_service.py
@@ -206,6 +206,10 @@ def accept_invite(storage: HiveStorage, *, invite_id: str, user_id: str) -> Work
         # Lost the race with a concurrent acceptor — the invite was
         # consumed between the read and the claim.
         raise InviteError(f"Invite '{invite_id}' not found or expired.")
+    if invite.is_expired:
+        # Crossed expires_at between the read and the claim — enforce
+        # expiry strictly. The consumed invite is moot: it is expired.
+        raise InviteError(f"Invite '{invite_id}' not found or expired.")
     if storage.get_workspace(invite.workspace_id) is None:
         # Workspace deleted between the claim and the membership write —
         # re-check so no MEMBER row is created for a dead workspace (it

--- a/src/hive/workspace_service.py
+++ b/src/hive/workspace_service.py
@@ -26,7 +26,7 @@ orphaned with members but no owner.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from hive.models import (
     ActivityEvent,
@@ -206,9 +206,11 @@ def accept_invite(storage: HiveStorage, *, invite_id: str, user_id: str) -> Work
         # Lost the race with a concurrent acceptor — the invite was
         # consumed between the read and the claim.
         raise InviteError(f"Invite '{invite_id}' not found or expired.")
-    if invite.is_expired:
+    if datetime.now(timezone.utc) >= invite.expires_at:
         # Crossed expires_at between the read and the claim — enforce
-        # expiry strictly. The consumed invite is moot: it is expired.
+        # expiry strictly with a fresh clock read (deliberately not
+        # ``invite.is_expired`` again: the point is that time moved on
+        # since the first check). The consumed invite is moot: expired.
         raise InviteError(f"Invite '{invite_id}' not found or expired.")
     if storage.get_workspace(invite.workspace_id) is None:
         # Workspace deleted between the claim and the membership write —

--- a/src/hive/workspace_service.py
+++ b/src/hive/workspace_service.py
@@ -206,6 +206,15 @@ def accept_invite(storage: HiveStorage, *, invite_id: str, user_id: str) -> Work
         # Lost the race with a concurrent acceptor — the invite was
         # consumed between the read and the claim.
         raise InviteError(f"Invite '{invite_id}' not found or expired.")
+    if storage.get_workspace(invite.workspace_id) is None:
+        # Workspace deleted between the claim and the membership write —
+        # re-check so no MEMBER row is created for a dead workspace (it
+        # would orphan a WorkspaceMemberIndex entry). Best-effort per this
+        # module's non-transactional design; the invite stays consumed,
+        # which is fine — there is nothing left to redeem into.
+        raise WorkspaceNotFoundError(
+            f"Workspace '{invite.workspace_id}' no longer exists; invite cannot be accepted."
+        )
     member = storage.add_workspace_member(
         workspace_id=invite.workspace_id,
         user_id=user_id,

--- a/tests/integration/test_workspaces_api.py
+++ b/tests/integration/test_workspaces_api.py
@@ -124,8 +124,11 @@ def env():
 
 
 def _audit_events(storage: Any, workspace_id: str, event_type: str) -> list[Any]:
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    events = storage.get_audit_events_for_dates([today], event_type=event_type)
+    # Query today and yesterday so a test spanning midnight UTC cannot miss
+    # an event written just before the day boundary.
+    now = datetime.now(timezone.utc)
+    dates = [(now - timedelta(days=1)).strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d")]
+    events = storage.get_audit_events_for_dates(dates, event_type=event_type)
     return [e for e in events if e.metadata.get("workspace_id") == workspace_id]
 
 

--- a/tests/integration/test_workspaces_api.py
+++ b/tests/integration/test_workspaces_api.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Integration tests for the workspaces API (#492) against DynamoDB Local.
+
+Drives the full invite lifecycle end-to-end through the FastAPI endpoints:
+create workspace -> invite -> accept -> role change -> leave -> delete,
+asserting the membership state, the single-use invite semantics, invite
+expiry, and the compliance audit trail (#495) written by every mutation.
+
+Usage:
+  docker run -p 8080:8000 amazon/dynamodb-local
+  DYNAMODB_ENDPOINT=http://localhost:8080 pytest tests/integration/
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+DYNAMO_ENDPOINT = os.environ.get("DYNAMODB_ENDPOINT")
+
+pytestmark = pytest.mark.skipif(
+    not DYNAMO_ENDPOINT,
+    reason="DYNAMODB_ENDPOINT not set — skipping integration tests",
+)
+
+_TABLE = "hive-integration-workspaces-api"
+
+_ALICE = "ws-api-alice"
+_BOB = "ws-api-bob"
+_EMAILS = {_ALICE: "alice@example.com", _BOB: "bob@example.com"}
+
+
+@pytest.fixture(scope="module")
+def env():
+    """(client, storage, login) against a fresh DynamoDB Local table."""
+    import contextlib
+
+    import boto3
+
+    ddb = boto3.client(
+        "dynamodb",
+        endpoint_url=DYNAMO_ENDPOINT,
+        region_name="us-east-1",
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+    )
+    with contextlib.suppress(Exception):
+        ddb.delete_table(TableName=_TABLE)
+
+    ddb.create_table(
+        TableName=_TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "UserEmailIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    from hive.api import _auth as auth_mod
+    from hive.api import workspaces as workspaces_mod
+    from hive.api.main import app
+    from hive.models import User
+    from hive.storage import HiveStorage
+
+    storage = HiveStorage(
+        table_name=_TABLE,
+        region="us-east-1",
+        endpoint_url=DYNAMO_ENDPOINT,
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+    )
+    for user_id, email in _EMAILS.items():
+        storage.put_user(User(user_id=user_id, email=email, display_name=user_id, role="user"))
+
+    claims: dict[str, Any] = {}
+
+    def _override_mgmt_user() -> dict[str, Any]:
+        return dict(claims)
+
+    def _override_storage() -> HiveStorage:
+        return storage
+
+    def login(user_id: str) -> None:
+        claims.clear()
+        claims.update({"sub": user_id, "role": "user", "email": _EMAILS[user_id]})
+
+    app.dependency_overrides[auth_mod.require_mgmt_user] = _override_mgmt_user
+    app.dependency_overrides[workspaces_mod._storage] = _override_storage
+
+    yield TestClient(app), storage, login
+
+    app.dependency_overrides.clear()
+    with contextlib.suppress(Exception):
+        ddb.delete_table(TableName=_TABLE)
+
+
+def _audit_events(storage: Any, workspace_id: str, event_type: str) -> list[Any]:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    events = storage.get_audit_events_for_dates([today], event_type=event_type)
+    return [e for e in events if e.metadata.get("workspace_id") == workspace_id]
+
+
+class TestInviteLifecycle:
+    def test_full_lifecycle_create_invite_accept_promote_leave_delete(self, env):
+        client, storage, login = env
+
+        # Alice creates a workspace and becomes its owner.
+        login(_ALICE)
+        resp = client.post("/api/workspaces", json={"name": "Lifecycle Team", "description": "e2e"})
+        assert resp.status_code == 201
+        ws_id = resp.json()["workspace_id"]
+        assert resp.json()["role"] == "owner"
+        assert len(_audit_events(storage, ws_id, "workspace_created")) == 1
+
+        # Alice invites Bob as admin.
+        resp = client.post(
+            f"/api/workspaces/{ws_id}/invites",
+            json={"email": _EMAILS[_BOB], "role": "admin"},
+        )
+        assert resp.status_code == 201
+        invite_id = resp.json()["invite_id"]
+        assert len(_audit_events(storage, ws_id, "workspace_invite_sent")) == 1
+
+        # A second identical invite is rejected while one is pending.
+        resp = client.post(
+            f"/api/workspaces/{ws_id}/invites",
+            json={"email": _EMAILS[_BOB], "role": "member"},
+        )
+        assert resp.status_code == 409
+
+        # Bob cannot see the workspace before accepting.
+        login(_BOB)
+        assert client.get("/api/workspaces").json() == []
+
+        # Bob accepts the invite and joins with the invited role.
+        resp = client.post(f"/api/invites/{invite_id}/accept")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "workspace_id": ws_id,
+            "name": "Lifecycle Team",
+            "role": "admin",
+        }
+        assert len(_audit_events(storage, ws_id, "workspace_invite_accepted")) == 1
+
+        # Single-use: the invite is consumed.
+        assert client.post(f"/api/invites/{invite_id}/accept").status_code == 404
+
+        # Both members now appear in the member list.
+        resp = client.get(f"/api/workspaces/{ws_id}/members")
+        assert resp.status_code == 200
+        roles = {m["user_id"]: m["role"] for m in resp.json()}
+        assert roles == {_ALICE: "owner", _BOB: "admin"}
+        emails = {m["user_id"]: m["email"] for m in resp.json()}
+        assert emails[_BOB] == _EMAILS[_BOB]
+
+        # Bob (admin) cannot delete the workspace; Alice (owner) is blocked
+        # by the remaining-members guard.
+        assert client.delete(f"/api/workspaces/{ws_id}").status_code == 403
+        login(_ALICE)
+        resp = client.delete(f"/api/workspaces/{ws_id}")
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["members"] == [{"user_id": _BOB, "role": "admin"}]
+
+        # Alice promotes Bob to owner, then leaves.
+        resp = client.put(f"/api/workspaces/{ws_id}/members/{_BOB}", json={"role": "owner"})
+        assert resp.status_code == 200
+        events = _audit_events(storage, ws_id, "workspace_member_role_changed")
+        assert len(events) == 1
+        assert events[0].metadata["previous_role"] == "admin"
+        assert events[0].metadata["new_role"] == "owner"
+
+        assert client.delete(f"/api/workspaces/{ws_id}/members/{_ALICE}").status_code == 204
+        removed = _audit_events(storage, ws_id, "workspace_member_removed")
+        assert len(removed) == 1
+        assert removed[0].client_id == _ALICE  # self-removal: actor == target
+        assert client.get("/api/workspaces").json() == []
+
+        # Bob — now the sole owner and sole member — deletes the workspace.
+        login(_BOB)
+        assert client.delete(f"/api/workspaces/{ws_id}").status_code == 204
+        assert len(_audit_events(storage, ws_id, "workspace_deleted")) == 1
+        assert client.get("/api/workspaces").json() == []
+        assert storage.get_workspace(ws_id) is None
+
+    def test_expired_invite_is_rejected_and_membership_untouched(self, env):
+        client, storage, login = env
+        from hive.models import Invite, WorkspaceRole
+
+        login(_ALICE)
+        resp = client.post("/api/workspaces", json={"name": "Expiry Team"})
+        assert resp.status_code == 201
+        ws_id = resp.json()["workspace_id"]
+
+        invite = Invite(
+            workspace_id=ws_id,
+            email=_EMAILS[_BOB],
+            role=WorkspaceRole.member,
+            invited_by_user_id=_ALICE,
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+        storage.put_invite(invite)
+
+        login(_BOB)
+        resp = client.post(f"/api/invites/{invite.invite_id}/accept")
+        assert resp.status_code == 404
+        assert storage.get_workspace_member(ws_id, _BOB) is None
+        assert _audit_events(storage, ws_id, "workspace_invite_accepted") == []
+
+    def test_sole_owner_demotion_and_leave_are_blocked(self, env):
+        client, storage, login = env
+
+        login(_ALICE)
+        resp = client.post("/api/workspaces", json={"name": "Guard Team"})
+        assert resp.status_code == 201
+        ws_id = resp.json()["workspace_id"]
+
+        resp = client.put(f"/api/workspaces/{ws_id}/members/{_ALICE}", json={"role": "member"})
+        assert resp.status_code == 409
+        resp = client.delete(f"/api/workspaces/{ws_id}/members/{_ALICE}")
+        assert resp.status_code == 409
+        member = storage.get_workspace_member(ws_id, _ALICE)
+        assert member is not None
+        assert member.role.value == "owner"

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2932,6 +2932,34 @@ class TestWorkspaceMemberStorage:
         member = storage.add_workspace_member("ws-1", "u1")
         assert member.role is WorkspaceRole.member
 
+    def test_add_member_no_overwrite_inserts_when_absent(self, storage):
+        member = storage.add_workspace_member("ws-1", "u1", WorkspaceRole.admin, overwrite=False)
+        assert member is not None
+        assert member.role is WorkspaceRole.admin
+        assert storage.get_workspace_member("ws-1", "u1").role is WorkspaceRole.admin
+
+    def test_add_member_no_overwrite_preserves_existing_row(self, storage):
+        storage.add_workspace_member("ws-1", "u1", WorkspaceRole.owner)
+        result = storage.add_workspace_member("ws-1", "u1", WorkspaceRole.member, overwrite=False)
+        assert result is None
+        # The existing (higher) role is untouched.
+        assert storage.get_workspace_member("ws-1", "u1").role is WorkspaceRole.owner
+
+    def test_add_member_no_overwrite_reraises_non_conditional_errors(self, storage):
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        error = ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException", "Message": ""}},
+            "PutItem",
+        )
+        with (
+            patch.object(storage.table, "put_item", side_effect=error),
+            pytest.raises(ClientError),
+        ):
+            storage.add_workspace_member("ws-1", "u1", overwrite=False)
+
     def test_list_members(self, storage):
         ws_id = "ws-1"
         storage.add_workspace_member(ws_id, "u1", WorkspaceRole.owner)

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -272,6 +272,35 @@ class TestAcceptInvite:
         assert storage.get_workspace_member(ws.workspace_id, "u2") is None
         assert _audit_events(storage, EventType.workspace_invite_accepted) == []
 
+    def test_invite_expiring_between_read_and_claim_raises(self, storage, monkeypatch):
+        ws = workspace_service.create_workspace(storage, name="Team", owner_user_id="u1")
+        invite = workspace_service.send_invite(
+            storage,
+            workspace_id=ws.workspace_id,
+            email="edge@example.com",
+            role=WorkspaceRole.member,
+            invited_by_user_id="u1",
+            expires_at=_future(),
+        )
+        # ``is_expired`` is evaluated twice in accept_invite: before the
+        # claim (not yet expired) and after (expired) — simulating the
+        # invite crossing expires_at mid-redemption.
+        calls = {"n": 0}
+
+        def _fake_now():
+            calls["n"] += 1
+            offset = timedelta(seconds=-1) if calls["n"] == 1 else timedelta(seconds=1)
+            return invite.expires_at + offset
+
+        monkeypatch.setattr("hive.models._now_utc", _fake_now)
+        with pytest.raises(workspace_service.InviteError):
+            workspace_service.accept_invite(storage, invite_id=invite.invite_id, user_id="u2")
+        # Expiry is enforced: no membership, no audit event; the invite was
+        # consumed by the claim, which is moot for an expired invite.
+        assert storage.get_workspace_member(ws.workspace_id, "u2") is None
+        assert storage.get_invite(invite.invite_id) is None
+        assert _audit_events(storage, EventType.workspace_invite_accepted) == []
+
     def test_existing_membership_raises_already_member_without_role_change(self, storage):
         ws = workspace_service.create_workspace(storage, name="Team", owner_user_id="u1")
         invite = workspace_service.send_invite(

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -282,17 +282,16 @@ class TestAcceptInvite:
             invited_by_user_id="u1",
             expires_at=_future(),
         )
-        # ``is_expired`` is evaluated twice in accept_invite: before the
-        # claim (not yet expired) and after (expired) — simulating the
-        # invite crossing expires_at mid-redemption.
-        calls = {"n": 0}
+        # The pre-claim ``is_expired`` check uses the real clock (invite
+        # still valid); the post-claim re-check reads the clock through
+        # ``workspace_service.datetime`` — patch it past expires_at to
+        # simulate the invite crossing expiry mid-redemption.
+        from types import SimpleNamespace
 
-        def _fake_now():
-            calls["n"] += 1
-            offset = timedelta(seconds=-1) if calls["n"] == 1 else timedelta(seconds=1)
-            return invite.expires_at + offset
-
-        monkeypatch.setattr("hive.models._now_utc", _fake_now)
+        monkeypatch.setattr(
+            "hive.workspace_service.datetime",
+            SimpleNamespace(now=lambda tz=None: invite.expires_at + timedelta(seconds=1)),
+        )
         with pytest.raises(workspace_service.InviteError):
             workspace_service.accept_invite(storage, invite_id=invite.invite_id, user_id="u2")
         # Expiry is enforced: no membership, no audit event; the invite was

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -293,6 +293,35 @@ class TestAcceptInvite:
         assert storage.get_invite(invite.invite_id) is None
         assert _audit_events(storage, EventType.workspace_invite_accepted) == []
 
+    def test_workspace_deleted_after_claim_raises_without_membership_or_audit(
+        self, storage, monkeypatch
+    ):
+        ws = workspace_service.create_workspace(storage, name="Team", owner_user_id="u1")
+        invite = workspace_service.send_invite(
+            storage,
+            workspace_id=ws.workspace_id,
+            email="late@example.com",
+            role=WorkspaceRole.member,
+            invited_by_user_id="u1",
+            expires_at=_future(),
+        )
+        real_claim = HiveStorage.claim_invite
+
+        def _claim_then_delete(self, invite_id):
+            # Simulate the workspace being deleted concurrently, right
+            # after the invite claim succeeds.
+            result = real_claim(self, invite_id)
+            storage.delete_workspace(ws.workspace_id)
+            return result
+
+        monkeypatch.setattr(HiveStorage, "claim_invite", _claim_then_delete)
+        with pytest.raises(workspace_service.WorkspaceNotFoundError):
+            workspace_service.accept_invite(storage, invite_id=invite.invite_id, user_id="u2")
+        # No orphaned MEMBER row; the invite is consumed; no audit event.
+        assert storage.list_workspace_members(ws.workspace_id) == []
+        assert storage.get_invite(invite.invite_id) is None
+        assert _audit_events(storage, EventType.workspace_invite_accepted) == []
+
     def test_workspace_deleted_after_invite_raises_without_membership_or_audit(self, storage):
         ws = workspace_service.create_workspace(storage, name="Doomed", owner_user_id="u1")
         invite = workspace_service.send_invite(

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -272,6 +272,27 @@ class TestAcceptInvite:
         assert storage.get_workspace_member(ws.workspace_id, "u2") is None
         assert _audit_events(storage, EventType.workspace_invite_accepted) == []
 
+    def test_existing_membership_raises_already_member_without_role_change(self, storage):
+        ws = workspace_service.create_workspace(storage, name="Team", owner_user_id="u1")
+        invite = workspace_service.send_invite(
+            storage,
+            workspace_id=ws.workspace_id,
+            email="already@example.com",
+            role=WorkspaceRole.member,
+            invited_by_user_id="u1",
+            expires_at=_future(),
+        )
+        # Membership gained through another path before redemption — e.g.
+        # a second invite accepted concurrently.
+        storage.add_workspace_member(ws.workspace_id, "u2", WorkspaceRole.admin)
+        with pytest.raises(workspace_service.AlreadyMemberError):
+            workspace_service.accept_invite(storage, invite_id=invite.invite_id, user_id="u2")
+        # The existing (higher) role is untouched, the invite is consumed,
+        # and no audit event is written since no mutation happened.
+        assert storage.get_workspace_member(ws.workspace_id, "u2").role is WorkspaceRole.admin
+        assert storage.get_invite(invite.invite_id) is None
+        assert _audit_events(storage, EventType.workspace_invite_accepted) == []
+
     def test_workspace_deleted_after_invite_raises_without_membership_or_audit(self, storage):
         ws = workspace_service.create_workspace(storage, name="Doomed", owner_user_id="u1")
         invite = workspace_service.send_invite(

--- a/tests/unit/test_workspaces_api.py
+++ b/tests/unit/test_workspaces_api.py
@@ -1,0 +1,795 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for the workspace management endpoints (#492).
+
+Covers the full role-authorization matrix (owner / admin / member /
+non-member) on every mutating endpoint, invite expiry, and the
+sole-owner 409 guards.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import boto3
+import pytest
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+os.environ.setdefault("HIVE_TABLE_NAME", "hive-unit-workspaces")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("HIVE_JWT_SECRET", "unit-test-secret")
+os.environ.pop("DYNAMODB_ENDPOINT", None)
+
+_TABLE = "hive-unit-workspaces"
+
+_OWNER = "ws-owner-1"
+_ADMIN = "ws-admin-1"
+_MEMBER = "ws-member-1"
+_OUTSIDER = "ws-outsider-1"
+_EMAILS = {
+    _OWNER: "owner@example.com",
+    _ADMIN: "admin@example.com",
+    _MEMBER: "member@example.com",
+    _OUTSIDER: "outsider@example.com",
+}
+
+
+def _create_table() -> None:
+    ddb = boto3.client("dynamodb", region_name="us-east-1")
+    ddb.create_table(
+        TableName=_TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "UserEmailIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI4PK", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+class Ctx:
+    """Test context: client + storage + claims switcher + seeded workspace."""
+
+    def __init__(
+        self, client: TestClient, storage: Any, claims: dict[str, Any], workspace_id: str
+    ) -> None:
+        self.client = client
+        self.storage = storage
+        self._claims = claims
+        self.workspace_id = workspace_id
+
+    def login(self, user_id: str, email: str | None = None) -> None:
+        self._claims.clear()
+        self._claims.update(
+            {
+                "sub": user_id,
+                "role": "user",
+                "email": _EMAILS.get(user_id, f"{user_id}@example.com") if email is None else email,
+            }
+        )
+
+    def login_claims(self, claims: dict[str, Any]) -> None:
+        self._claims.clear()
+        self._claims.update(claims)
+
+
+@pytest.fixture()
+def ctx():
+    with mock_aws():
+        _create_table()
+        from hive import workspace_service
+        from hive.api import _auth as auth_mod
+        from hive.api import workspaces as workspaces_mod
+        from hive.api.main import app
+        from hive.models import User, WorkspaceRole
+        from hive.storage import HiveStorage
+
+        storage = HiveStorage(table_name=_TABLE, region="us-east-1")
+        for user_id, email in _EMAILS.items():
+            storage.put_user(User(user_id=user_id, email=email, display_name=user_id, role="user"))
+
+        ws = workspace_service.create_workspace(storage, name="Team Alpha", owner_user_id=_OWNER)
+        storage.add_workspace_member(ws.workspace_id, _ADMIN, WorkspaceRole.admin)
+        storage.add_workspace_member(ws.workspace_id, _MEMBER, WorkspaceRole.member)
+
+        claims: dict[str, Any] = {}
+
+        def _override_mgmt_user() -> dict[str, Any]:
+            return dict(claims)
+
+        def _override_storage() -> HiveStorage:
+            return storage
+
+        app.dependency_overrides[auth_mod.require_mgmt_user] = _override_mgmt_user
+        app.dependency_overrides[workspaces_mod._storage] = _override_storage
+        context = Ctx(TestClient(app), storage, claims, ws.workspace_id)
+        context.login(_OWNER)
+        yield context
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def unauthed_client():
+    with mock_aws():
+        _create_table()
+        from hive.api.main import app
+
+        app.dependency_overrides.clear()
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+def _role_of(ctx: Ctx, workspace_id: str, user_id: str) -> str | None:
+    member = ctx.storage.get_workspace_member(workspace_id, user_id)
+    return None if member is None else member.role.value
+
+
+def _audit_events(ctx: Ctx, event_type: str) -> list[Any]:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return ctx.storage.get_audit_events_for_dates([today], event_type=event_type)
+
+
+class TestHelpers:
+    def test_storage_dep_returns_hive_storage(self):
+        with mock_aws():
+            _create_table()
+            from hive.api.workspaces import _storage
+            from hive.storage import HiveStorage
+
+            assert isinstance(_storage(), HiveStorage)
+
+    def test_invite_ttl_days_default(self, monkeypatch):
+        from hive.api.workspaces import _invite_ttl_days
+
+        monkeypatch.delenv("HIVE_INVITE_TTL_DAYS", raising=False)
+        assert _invite_ttl_days() == 7
+
+    def test_invite_ttl_days_env_override(self, monkeypatch):
+        from hive.api.workspaces import _invite_ttl_days
+
+        monkeypatch.setenv("HIVE_INVITE_TTL_DAYS", "1")
+        assert _invite_ttl_days() == 1
+
+
+class TestCreateWorkspace:
+    def test_creator_becomes_owner(self, ctx):
+        resp = ctx.client.post("/api/workspaces", json={"name": "Team Beta"})
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["name"] == "Team Beta"
+        assert body["role"] == "owner"
+        assert body["owner_user_id"] == _OWNER
+        assert body["is_personal"] is False
+        assert _role_of(ctx, body["workspace_id"], _OWNER) == "owner"
+
+    def test_name_is_stripped(self, ctx):
+        resp = ctx.client.post("/api/workspaces", json={"name": "  Padded Name  "})
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "Padded Name"
+
+    def test_description_round_trips(self, ctx):
+        resp = ctx.client.post(
+            "/api/workspaces", json={"name": "Documented", "description": "notes"}
+        )
+        assert resp.status_code == 201
+        assert resp.json()["description"] == "notes"
+
+    def test_duplicate_name_conflicts_case_insensitively(self, ctx):
+        resp = ctx.client.post("/api/workspaces", json={"name": "  team ALPHA "})
+        assert resp.status_code == 409
+
+    def test_same_name_allowed_for_different_user(self, ctx):
+        ctx.login(_OUTSIDER)
+        resp = ctx.client.post("/api/workspaces", json={"name": "Team Alpha"})
+        assert resp.status_code == 201
+
+    def test_blank_name_rejected(self, ctx):
+        resp = ctx.client.post("/api/workspaces", json={"name": "   "})
+        assert resp.status_code == 422
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.post("/api/workspaces", json={"name": "X"})
+        assert resp.status_code in (401, 403)
+
+
+class TestListWorkspaces:
+    @pytest.mark.parametrize(
+        ("user_id", "role"), [(_OWNER, "owner"), (_ADMIN, "admin"), (_MEMBER, "member")]
+    )
+    def test_lists_workspace_with_caller_role(self, ctx, user_id, role):
+        ctx.login(user_id)
+        resp = ctx.client.get("/api/workspaces")
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert [r["workspace_id"] for r in rows] == [ctx.workspace_id]
+        assert rows[0]["role"] == role
+
+    def test_non_member_sees_empty_list(self, ctx):
+        ctx.login(_OUTSIDER)
+        resp = ctx.client.get("/api/workspaces")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_vanished_membership_is_skipped(self, ctx, monkeypatch):
+        monkeypatch.setattr(ctx.storage, "get_workspace_member", lambda *a, **k: None)
+        resp = ctx.client.get("/api/workspaces")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.get("/api/workspaces")
+        assert resp.status_code in (401, 403)
+
+
+class TestRenameWorkspace:
+    @pytest.mark.parametrize("user_id", [_OWNER, _ADMIN])
+    def test_owner_and_admin_can_rename(self, ctx, user_id):
+        ctx.login(user_id)
+        resp = ctx.client.patch(
+            f"/api/workspaces/{ctx.workspace_id}", json={"name": f"Renamed by {user_id}"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == f"Renamed by {user_id}"
+        assert ctx.storage.get_workspace(ctx.workspace_id).name == f"Renamed by {user_id}"
+
+    def test_member_cannot_rename(self, ctx):
+        ctx.login(_MEMBER)
+        resp = ctx.client.patch(f"/api/workspaces/{ctx.workspace_id}", json={"name": "Nope"})
+        assert resp.status_code == 403
+
+    def test_non_member_cannot_rename(self, ctx):
+        ctx.login(_OUTSIDER)
+        resp = ctx.client.patch(f"/api/workspaces/{ctx.workspace_id}", json={"name": "Nope"})
+        assert resp.status_code == 403
+
+    def test_missing_workspace_404(self, ctx):
+        resp = ctx.client.patch("/api/workspaces/ghost", json={"name": "Nope"})
+        assert resp.status_code == 404
+
+    def test_rename_conflicts_with_another_owned_workspace(self, ctx):
+        assert ctx.client.post("/api/workspaces", json={"name": "Team Beta"}).status_code == 201
+        resp = ctx.client.patch(f"/api/workspaces/{ctx.workspace_id}", json={"name": "team beta"})
+        assert resp.status_code == 409
+
+    def test_rename_to_own_current_name_is_allowed(self, ctx):
+        resp = ctx.client.patch(f"/api/workspaces/{ctx.workspace_id}", json={"name": "Team Alpha"})
+        assert resp.status_code == 200
+
+    def test_workspace_vanishing_mid_rename_404(self, ctx, monkeypatch):
+        monkeypatch.setattr(ctx.storage, "rename_workspace", lambda *a, **k: False)
+        resp = ctx.client.patch(f"/api/workspaces/{ctx.workspace_id}", json={"name": "Gone"})
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.patch("/api/workspaces/x", json={"name": "X"})
+        assert resp.status_code in (401, 403)
+
+
+class TestDeleteWorkspace:
+    @pytest.mark.parametrize("user_id", [_ADMIN, _MEMBER])
+    def test_non_owner_roles_cannot_delete(self, ctx, user_id):
+        ctx.login(user_id)
+        resp = ctx.client.delete(f"/api/workspaces/{ctx.workspace_id}")
+        assert resp.status_code == 403
+
+    def test_non_member_cannot_delete(self, ctx):
+        ctx.login(_OUTSIDER)
+        resp = ctx.client.delete(f"/api/workspaces/{ctx.workspace_id}")
+        assert resp.status_code == 403
+
+    def test_delete_blocked_while_other_members_remain(self, ctx):
+        resp = ctx.client.delete(f"/api/workspaces/{ctx.workspace_id}")
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        remaining = {m["user_id"] for m in detail["members"]}
+        assert remaining == {_ADMIN, _MEMBER}
+        assert ctx.storage.get_workspace(ctx.workspace_id) is not None
+
+    def test_personal_workspace_cannot_be_deleted(self, ctx):
+        from hive import workspace_service
+
+        personal = workspace_service.create_workspace(
+            ctx.storage, name="My Personal", owner_user_id=_OWNER, is_personal=True
+        )
+        resp = ctx.client.delete(f"/api/workspaces/{personal.workspace_id}")
+        assert resp.status_code == 409
+        assert ctx.storage.get_workspace(personal.workspace_id) is not None
+
+    def test_sole_member_owner_can_delete(self, ctx):
+        created = ctx.client.post("/api/workspaces", json={"name": "Disposable"}).json()
+        resp = ctx.client.delete(f"/api/workspaces/{created['workspace_id']}")
+        assert resp.status_code == 204
+        assert ctx.storage.get_workspace(created["workspace_id"]) is None
+        deleted = [
+            e
+            for e in _audit_events(ctx, "workspace_deleted")
+            if e.metadata.get("workspace_id") == created["workspace_id"]
+        ]
+        assert len(deleted) == 1
+
+    def test_missing_workspace_404(self, ctx):
+        resp = ctx.client.delete("/api/workspaces/ghost")
+        assert resp.status_code == 404
+
+    def test_workspace_vanishing_mid_delete_404(self, ctx, monkeypatch):
+        created = ctx.client.post("/api/workspaces", json={"name": "Vanishing"}).json()
+        monkeypatch.setattr("hive.workspace_service.delete_workspace", lambda *a, **k: False)
+        resp = ctx.client.delete(f"/api/workspaces/{created['workspace_id']}")
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.delete("/api/workspaces/x")
+        assert resp.status_code in (401, 403)
+
+
+class TestListMembers:
+    def test_any_member_can_list(self, ctx):
+        ctx.login(_MEMBER)
+        resp = ctx.client.get(f"/api/workspaces/{ctx.workspace_id}/members")
+        assert resp.status_code == 200
+        rows = {r["user_id"]: r for r in resp.json()}
+        assert set(rows) == {_OWNER, _ADMIN, _MEMBER}
+        assert rows[_OWNER]["role"] == "owner"
+        assert rows[_ADMIN]["role"] == "admin"
+        assert rows[_MEMBER]["email"] == _EMAILS[_MEMBER]
+        assert rows[_MEMBER]["display_name"] == _MEMBER
+
+    def test_member_without_user_record_has_null_profile(self, ctx):
+        from hive.models import WorkspaceRole
+
+        ctx.storage.add_workspace_member(ctx.workspace_id, "ghost-user", WorkspaceRole.member)
+        resp = ctx.client.get(f"/api/workspaces/{ctx.workspace_id}/members")
+        rows = {r["user_id"]: r for r in resp.json()}
+        assert rows["ghost-user"]["email"] is None
+        assert rows["ghost-user"]["display_name"] is None
+
+    def test_non_member_cannot_list(self, ctx):
+        ctx.login(_OUTSIDER)
+        resp = ctx.client.get(f"/api/workspaces/{ctx.workspace_id}/members")
+        assert resp.status_code == 403
+
+    def test_missing_workspace_404(self, ctx):
+        resp = ctx.client.get("/api/workspaces/ghost/members")
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.get("/api/workspaces/x/members")
+        assert resp.status_code in (401, 403)
+
+
+class TestUpdateMemberRole:
+    def _put(self, ctx: Ctx, target: str, role: str, workspace_id: str | None = None):
+        return ctx.client.put(
+            f"/api/workspaces/{workspace_id or ctx.workspace_id}/members/{target}",
+            json={"role": role},
+        )
+
+    def test_owner_promotes_member_to_admin(self, ctx):
+        resp = self._put(ctx, _MEMBER, "admin")
+        assert resp.status_code == 200
+        assert resp.json()["role"] == "admin"
+        assert _role_of(ctx, ctx.workspace_id, _MEMBER) == "admin"
+
+    def test_owner_promotes_admin_to_owner(self, ctx):
+        resp = self._put(ctx, _ADMIN, "owner")
+        assert resp.status_code == 200
+        assert _role_of(ctx, ctx.workspace_id, _ADMIN) == "owner"
+
+    def test_admin_promotes_member_to_admin(self, ctx):
+        ctx.login(_ADMIN)
+        resp = self._put(ctx, _MEMBER, "admin")
+        assert resp.status_code == 200
+        assert _role_of(ctx, ctx.workspace_id, _MEMBER) == "admin"
+
+    def test_admin_demotes_another_admin(self, ctx):
+        from hive.models import WorkspaceRole
+
+        ctx.storage.add_workspace_member(ctx.workspace_id, "admin-2", WorkspaceRole.admin)
+        ctx.login(_ADMIN)
+        resp = self._put(ctx, "admin-2", "member")
+        assert resp.status_code == 200
+        assert _role_of(ctx, ctx.workspace_id, "admin-2") == "member"
+
+    def test_admin_cannot_grant_owner(self, ctx):
+        ctx.login(_ADMIN)
+        resp = self._put(ctx, _MEMBER, "owner")
+        assert resp.status_code == 403
+        assert _role_of(ctx, ctx.workspace_id, _MEMBER) == "member"
+
+    def test_admin_cannot_change_an_owner(self, ctx):
+        ctx.login(_ADMIN)
+        resp = self._put(ctx, _OWNER, "member")
+        assert resp.status_code == 403
+        assert _role_of(ctx, ctx.workspace_id, _OWNER) == "owner"
+
+    def test_member_cannot_change_roles(self, ctx):
+        ctx.login(_MEMBER)
+        resp = self._put(ctx, _ADMIN, "member")
+        assert resp.status_code == 403
+
+    def test_non_member_cannot_change_roles(self, ctx):
+        ctx.login(_OUTSIDER)
+        resp = self._put(ctx, _MEMBER, "admin")
+        assert resp.status_code == 403
+
+    def test_demoting_the_only_owner_conflicts(self, ctx):
+        resp = self._put(ctx, _OWNER, "member")
+        assert resp.status_code == 409
+        assert _role_of(ctx, ctx.workspace_id, _OWNER) == "owner"
+
+    def test_demoting_a_co_owner_is_allowed(self, ctx):
+        assert self._put(ctx, _ADMIN, "owner").status_code == 200
+        resp = self._put(ctx, _OWNER, "member")
+        assert resp.status_code == 200
+        assert _role_of(ctx, ctx.workspace_id, _OWNER) == "member"
+
+    def test_noop_role_change_skips_the_audit_trail(self, ctx):
+        resp = self._put(ctx, _MEMBER, "member")
+        assert resp.status_code == 200
+        assert resp.json()["role"] == "member"
+        assert _audit_events(ctx, "workspace_member_role_changed") == []
+
+    def test_target_not_a_member_404(self, ctx):
+        resp = self._put(ctx, _OUTSIDER, "admin")
+        assert resp.status_code == 404
+
+    def test_missing_workspace_404(self, ctx):
+        resp = self._put(ctx, _MEMBER, "admin", workspace_id="ghost")
+        assert resp.status_code == 404
+
+    def test_invalid_role_rejected(self, ctx):
+        resp = self._put(ctx, _MEMBER, "guest")
+        assert resp.status_code == 422
+
+    def test_membership_vanishing_mid_update_404(self, ctx, monkeypatch):
+        monkeypatch.setattr("hive.workspace_service.change_member_role", lambda *a, **k: False)
+        resp = self._put(ctx, _MEMBER, "admin")
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.put("/api/workspaces/x/members/y", json={"role": "member"})
+        assert resp.status_code in (401, 403)
+
+
+class TestRemoveMember:
+    def _delete(self, ctx: Ctx, target: str, workspace_id: str | None = None):
+        return ctx.client.delete(
+            f"/api/workspaces/{workspace_id or ctx.workspace_id}/members/{target}"
+        )
+
+    def test_owner_removes_member(self, ctx):
+        resp = self._delete(ctx, _MEMBER)
+        assert resp.status_code == 204
+        assert _role_of(ctx, ctx.workspace_id, _MEMBER) is None
+
+    def test_owner_removes_admin(self, ctx):
+        resp = self._delete(ctx, _ADMIN)
+        assert resp.status_code == 204
+
+    def test_admin_removes_member(self, ctx):
+        ctx.login(_ADMIN)
+        resp = self._delete(ctx, _MEMBER)
+        assert resp.status_code == 204
+
+    def test_admin_removes_another_admin(self, ctx):
+        from hive.models import WorkspaceRole
+
+        ctx.storage.add_workspace_member(ctx.workspace_id, "admin-2", WorkspaceRole.admin)
+        ctx.login(_ADMIN)
+        resp = self._delete(ctx, "admin-2")
+        assert resp.status_code == 204
+
+    def test_admin_cannot_remove_owner(self, ctx):
+        ctx.login(_ADMIN)
+        resp = self._delete(ctx, _OWNER)
+        assert resp.status_code == 403
+        assert _role_of(ctx, ctx.workspace_id, _OWNER) == "owner"
+
+    def test_member_cannot_remove_others(self, ctx):
+        ctx.login(_MEMBER)
+        resp = self._delete(ctx, _ADMIN)
+        assert resp.status_code == 403
+
+    def test_member_can_leave(self, ctx):
+        ctx.login(_MEMBER)
+        resp = self._delete(ctx, _MEMBER)
+        assert resp.status_code == 204
+        assert _role_of(ctx, ctx.workspace_id, _MEMBER) is None
+
+    def test_admin_can_leave(self, ctx):
+        ctx.login(_ADMIN)
+        resp = self._delete(ctx, _ADMIN)
+        assert resp.status_code == 204
+
+    def test_sole_owner_cannot_leave(self, ctx):
+        resp = self._delete(ctx, _OWNER)
+        assert resp.status_code == 409
+        assert _role_of(ctx, ctx.workspace_id, _OWNER) == "owner"
+
+    def test_owner_can_leave_when_another_owner_exists(self, ctx):
+        ctx.client.put(
+            f"/api/workspaces/{ctx.workspace_id}/members/{_ADMIN}", json={"role": "owner"}
+        )
+        resp = self._delete(ctx, _OWNER)
+        assert resp.status_code == 204
+        assert _role_of(ctx, ctx.workspace_id, _OWNER) is None
+
+    def test_non_member_cannot_remove(self, ctx):
+        ctx.login(_OUTSIDER)
+        resp = self._delete(ctx, _MEMBER)
+        assert resp.status_code == 403
+
+    def test_target_not_a_member_404(self, ctx):
+        resp = self._delete(ctx, _OUTSIDER)
+        assert resp.status_code == 404
+
+    def test_missing_workspace_404(self, ctx):
+        resp = self._delete(ctx, _MEMBER, workspace_id="ghost")
+        assert resp.status_code == 404
+
+    def test_membership_vanishing_mid_remove_404(self, ctx, monkeypatch):
+        monkeypatch.setattr("hive.workspace_service.remove_member", lambda *a, **k: False)
+        resp = self._delete(ctx, _MEMBER)
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.delete("/api/workspaces/x/members/y")
+        assert resp.status_code in (401, 403)
+
+
+class TestCreateInvite:
+    def _post(
+        self,
+        ctx: Ctx,
+        email: str = "newcomer@example.com",
+        role: str = "member",
+        workspace_id: str | None = None,
+    ):
+        return ctx.client.post(
+            f"/api/workspaces/{workspace_id or ctx.workspace_id}/invites",
+            json={"email": email, "role": role},
+        )
+
+    def test_owner_creates_invite(self, ctx):
+        resp = self._post(ctx)
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["email"] == "newcomer@example.com"
+        assert body["role"] == "member"
+        stored = ctx.storage.get_invite(body["invite_id"])
+        assert stored is not None
+        assert stored.invited_by_user_id == _OWNER
+        expires_at = datetime.fromisoformat(body["expires_at"])
+        expected = datetime.now(timezone.utc) + timedelta(days=7)
+        assert abs((expires_at - expected).total_seconds()) < 60
+
+    def test_admin_creates_admin_role_invite(self, ctx):
+        ctx.login(_ADMIN)
+        resp = self._post(ctx, role="admin")
+        assert resp.status_code == 201
+        assert resp.json()["role"] == "admin"
+
+    def test_email_is_normalized_to_lowercase(self, ctx):
+        resp = self._post(ctx, email="NewComer@Example.COM")
+        assert resp.status_code == 201
+        assert resp.json()["email"] == "newcomer@example.com"
+
+    def test_invite_ttl_env_override(self, ctx, monkeypatch):
+        monkeypatch.setenv("HIVE_INVITE_TTL_DAYS", "1")
+        resp = self._post(ctx)
+        expires_at = datetime.fromisoformat(resp.json()["expires_at"])
+        expected = datetime.now(timezone.utc) + timedelta(days=1)
+        assert abs((expires_at - expected).total_seconds()) < 60
+
+    def test_member_cannot_invite(self, ctx):
+        ctx.login(_MEMBER)
+        assert self._post(ctx).status_code == 403
+
+    def test_non_member_cannot_invite(self, ctx):
+        ctx.login(_OUTSIDER)
+        assert self._post(ctx).status_code == 403
+
+    def test_missing_workspace_404(self, ctx):
+        assert self._post(ctx, workspace_id="ghost").status_code == 404
+
+    def test_personal_workspace_cannot_invite(self, ctx):
+        from hive import workspace_service
+
+        personal = workspace_service.create_workspace(
+            ctx.storage, name="My Personal", owner_user_id=_OWNER, is_personal=True
+        )
+        resp = self._post(ctx, workspace_id=personal.workspace_id)
+        assert resp.status_code == 409
+
+    def test_owner_role_not_invitable(self, ctx):
+        assert self._post(ctx, role="owner").status_code == 422
+
+    def test_invalid_email_rejected(self, ctx):
+        assert self._post(ctx, email="not-an-email").status_code == 422
+
+    def test_existing_member_email_conflicts(self, ctx):
+        resp = self._post(ctx, email=_EMAILS[_MEMBER])
+        assert resp.status_code == 409
+
+    def test_duplicate_pending_invite_conflicts(self, ctx):
+        assert self._post(ctx).status_code == 201
+        assert self._post(ctx, email="NEWCOMER@example.com").status_code == 409
+
+    def test_workspace_vanishing_mid_invite_404(self, ctx, monkeypatch):
+        from hive.workspace_service import WorkspaceNotFoundError
+
+        def _raise(*a, **k):
+            raise WorkspaceNotFoundError("gone")
+
+        monkeypatch.setattr("hive.workspace_service.send_invite", _raise)
+        assert self._post(ctx).status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.post(
+            "/api/workspaces/x/invites", json={"email": "a@b.co", "role": "member"}
+        )
+        assert resp.status_code in (401, 403)
+
+
+class TestAcceptInvite:
+    def _invite(self, ctx: Ctx, email: str = _EMAILS[_OUTSIDER], role: str = "member") -> str:
+        resp = ctx.client.post(
+            f"/api/workspaces/{ctx.workspace_id}/invites",
+            json={"email": email, "role": role},
+        )
+        assert resp.status_code == 201
+        return resp.json()["invite_id"]
+
+    def test_accept_adds_member_and_consumes_invite(self, ctx):
+        invite_id = self._invite(ctx, role="admin")
+        ctx.login(_OUTSIDER)
+        resp = ctx.client.post(f"/api/invites/{invite_id}/accept")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["workspace_id"] == ctx.workspace_id
+        assert body["name"] == "Team Alpha"
+        assert body["role"] == "admin"
+        assert _role_of(ctx, ctx.workspace_id, _OUTSIDER) == "admin"
+        assert ctx.storage.get_invite(invite_id) is None
+        # Single-use: a second accept finds nothing.
+        assert ctx.client.post(f"/api/invites/{invite_id}/accept").status_code == 404
+
+    def test_email_match_is_case_insensitive(self, ctx):
+        invite_id = self._invite(ctx)
+        ctx.login(_OUTSIDER, email=_EMAILS[_OUTSIDER].upper())
+        resp = ctx.client.post(f"/api/invites/{invite_id}/accept")
+        assert resp.status_code == 200
+
+    def test_expired_invite_404(self, ctx):
+        from hive.models import Invite, WorkspaceRole
+
+        invite = Invite(
+            workspace_id=ctx.workspace_id,
+            email=_EMAILS[_OUTSIDER],
+            role=WorkspaceRole.member,
+            invited_by_user_id=_OWNER,
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        ctx.storage.put_invite(invite)
+        ctx.login(_OUTSIDER)
+        resp = ctx.client.post(f"/api/invites/{invite.invite_id}/accept")
+        assert resp.status_code == 404
+        assert _role_of(ctx, ctx.workspace_id, _OUTSIDER) is None
+
+    def test_missing_invite_404(self, ctx):
+        ctx.login(_OUTSIDER)
+        assert ctx.client.post("/api/invites/ghost/accept").status_code == 404
+
+    def test_email_mismatch_403(self, ctx):
+        invite_id = self._invite(ctx)
+        ctx.login(_OUTSIDER, email="someone-else@example.com")
+        resp = ctx.client.post(f"/api/invites/{invite_id}/accept")
+        assert resp.status_code == 403
+        assert ctx.storage.get_invite(invite_id) is not None
+
+    def test_claims_without_email_403(self, ctx):
+        invite_id = self._invite(ctx)
+        ctx.login_claims({"sub": _OUTSIDER, "role": "user"})
+        resp = ctx.client.post(f"/api/invites/{invite_id}/accept")
+        assert resp.status_code == 403
+
+    def test_existing_member_conflict_leaves_invite_pending(self, ctx):
+        from hive.models import Invite, WorkspaceRole
+
+        # Seed the invite directly — it pre-dates the membership in this
+        # scenario (the user joined through another path before accepting).
+        invite = Invite(
+            workspace_id=ctx.workspace_id,
+            email=_EMAILS[_MEMBER],
+            role=WorkspaceRole.admin,
+            invited_by_user_id=_OWNER,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        )
+        ctx.storage.put_invite(invite)
+        ctx.login(_MEMBER)
+        resp = ctx.client.post(f"/api/invites/{invite.invite_id}/accept")
+        assert resp.status_code == 409
+        assert ctx.storage.get_invite(invite.invite_id) is not None
+        # The existing (lower) role is untouched — accepting would have
+        # overwritten it with the invited role.
+        assert _role_of(ctx, ctx.workspace_id, _MEMBER) == "member"
+
+    def test_workspace_deleted_after_invite_404(self, ctx):
+        from hive.models import Invite, WorkspaceRole
+
+        invite = Invite(
+            workspace_id="ghost-workspace",
+            email=_EMAILS[_OUTSIDER],
+            role=WorkspaceRole.member,
+            invited_by_user_id=_OWNER,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        )
+        ctx.storage.put_invite(invite)
+        ctx.login(_OUTSIDER)
+        resp = ctx.client.post(f"/api/invites/{invite.invite_id}/accept")
+        assert resp.status_code == 404
+
+    def test_invite_claimed_concurrently_404(self, ctx, monkeypatch):
+        from hive.workspace_service import InviteError
+
+        invite_id = self._invite(ctx)
+
+        def _raise(*a, **k):
+            raise InviteError("claimed")
+
+        monkeypatch.setattr("hive.workspace_service.accept_invite", _raise)
+        ctx.login(_OUTSIDER)
+        assert ctx.client.post(f"/api/invites/{invite_id}/accept").status_code == 404
+
+    def test_workspace_vanishing_mid_accept_404(self, ctx, monkeypatch):
+        from hive.workspace_service import WorkspaceNotFoundError
+
+        invite_id = self._invite(ctx)
+
+        def _raise(*a, **k):
+            raise WorkspaceNotFoundError("gone")
+
+        monkeypatch.setattr("hive.workspace_service.accept_invite", _raise)
+        ctx.login(_OUTSIDER)
+        assert ctx.client.post(f"/api/invites/{invite_id}/accept").status_code == 404
+
+    def test_requires_auth(self, unauthed_client):
+        resp = unauthed_client.post("/api/invites/x/accept")
+        assert resp.status_code in (401, 403)

--- a/tests/unit/test_workspaces_api.py
+++ b/tests/unit/test_workspaces_api.py
@@ -162,8 +162,11 @@ def _role_of(ctx: Ctx, workspace_id: str, user_id: str) -> str | None:
 
 
 def _audit_events(ctx: Ctx, event_type: str) -> list[Any]:
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    return ctx.storage.get_audit_events_for_dates([today], event_type=event_type)
+    # Query today and yesterday so a test spanning midnight UTC cannot miss
+    # an event written just before the day boundary.
+    now = datetime.now(timezone.utc)
+    dates = [(now - timedelta(days=1)).strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d")]
+    return ctx.storage.get_audit_events_for_dates(dates, event_type=event_type)
 
 
 class TestHelpers:

--- a/tests/unit/test_workspaces_api.py
+++ b/tests/unit/test_workspaces_api.py
@@ -187,6 +187,13 @@ class TestHelpers:
         monkeypatch.setenv("HIVE_INVITE_TTL_DAYS", "1")
         assert _invite_ttl_days() == 1
 
+    @pytest.mark.parametrize("raw", ["not-a-number", "", "0", "-3"])
+    def test_invite_ttl_days_invalid_values_fall_back_to_default(self, monkeypatch, raw):
+        from hive.api.workspaces import _invite_ttl_days
+
+        monkeypatch.setenv("HIVE_INVITE_TTL_DAYS", raw)
+        assert _invite_ttl_days() == 7
+
 
 class TestCreateWorkspace:
     def test_creator_becomes_owner(self, ctx):

--- a/tests/unit/test_workspaces_api.py
+++ b/tests/unit/test_workspaces_api.py
@@ -766,6 +766,20 @@ class TestAcceptInvite:
         resp = ctx.client.post(f"/api/invites/{invite.invite_id}/accept")
         assert resp.status_code == 404
 
+    def test_membership_appearing_mid_accept_409(self, ctx, monkeypatch):
+        from hive.workspace_service import AlreadyMemberError
+
+        invite_id = self._invite(ctx)
+
+        def _raise(*a, **k):
+            raise AlreadyMemberError("already a member")
+
+        # Membership appeared between the endpoint's pre-check and the
+        # service's conditional membership write.
+        monkeypatch.setattr("hive.workspace_service.accept_invite", _raise)
+        ctx.login(_OUTSIDER)
+        assert ctx.client.post(f"/api/invites/{invite_id}/accept").status_code == 409
+
     def test_invite_claimed_concurrently_404(self, ctx, monkeypatch):
         from hive.workspace_service import InviteError
 

--- a/tests/unit/test_workspaces_api.py
+++ b/tests/unit/test_workspaces_api.py
@@ -613,10 +613,19 @@ class TestCreateInvite:
         assert resp.status_code == 201
         assert resp.json()["role"] == "admin"
 
-    def test_email_is_normalized_to_lowercase(self, ctx):
-        resp = self._post(ctx, email="NewComer@Example.COM")
+    def test_email_is_normalized_before_pattern_check(self, ctx):
+        # Trimming/lowercasing runs before the pattern constraint, so a
+        # pasted address with surrounding whitespace is accepted.
+        resp = self._post(ctx, email="  NewComer@Example.COM  ")
         assert resp.status_code == 201
         assert resp.json()["email"] == "newcomer@example.com"
+
+    def test_non_string_email_rejected(self, ctx):
+        resp = ctx.client.post(
+            f"/api/workspaces/{ctx.workspace_id}/invites",
+            json={"email": 123, "role": "member"},
+        )
+        assert resp.status_code == 422
 
     def test_invite_ttl_env_override(self, ctx, monkeypatch):
         monkeypatch.setenv("HIVE_INVITE_TTL_DAYS", "1")


### PR DESCRIPTION
Closes #492

## Summary

Adds the workspace management REST surface (part of epic #482), building on the #490 data model, the #491 auth claims, and the #495 mutation+audit service:

- `POST /api/workspaces` — create a shared workspace; caller becomes owner
- `GET /api/workspaces` — list the caller's workspaces with their role in each
- `PATCH /api/workspaces/{id}` — rename (owner/admin)
- `DELETE /api/workspaces/{id}` — delete (owner only; 409 for Personal workspaces and while other members remain)
- `GET /api/workspaces/{id}/members` — list members with role + profile (any member)
- `PUT /api/workspaces/{id}/members/{user_id}` — change role (owner/admin)
- `DELETE /api/workspaces/{id}/members/{user_id}` — remove a member / leave
- `POST /api/workspaces/{id}/invites` — create an email invite with `member`/`admin` role (owner/admin); expiry via `HIVE_INVITE_TTL_DAYS` (default 7) + DynamoDB TTL
- `POST /api/invites/{id}/accept` — redeem an invite (single-use, email must match the caller's login email)

Every membership mutation goes through `hive.workspace_service` (#495) so the compliance audit trail stays paired with the mutation — no raw-storage mutations in the router. `docs-site/public/openapi.json` regenerated via `inv export-openapi`.

## Authorization model

Roles are resolved per-request from the caller's membership row (`storage.get_workspace_member`), not from the JWT's `workspace_role` claim — the mgmt token may be scoped to a different workspace than the one being managed, and membership rows are the source of truth (#491). Status codes follow `POST /api/account/workspace-token`: 404 unknown workspace, 403 non-member/insufficient role.

| Action | owner | admin | member | non-member |
| --- | --- | --- | --- | --- |
| list / list members | yes | yes | yes | 403 |
| rename | yes | yes | 403 | 403 |
| delete workspace | yes* | 403 | 403 | 403 |
| change roles | any role | member↔admin, non-owners only | 403 | 403 |
| remove member | anyone* | non-owners | self only | 403 |
| create invite | yes | yes | 403 | 403 |

\* Sole-owner guards return 409, consistent with the #495 account-deletion guard: the only owner cannot demote themself or leave (transfer ownership first), and a workspace with other members cannot be deleted (remove them or transfer so the new owner decides — prevents destroying shared data out from under members).

## Approach — interpretations of the issue

- **Delete 409 semantics**: the issue sentence was ambiguous; implemented as "owner-only, blocked with 409 while other members remain (detail lists them), and blocked for Personal workspaces" — the same orphan-protection principle as the #495 sole-owner account-deletion guard, and the remedy chain works (remove members → delete workspace → delete account).
- **Owner not invitable**: invites carry `member`/`admin` only (422 otherwise); the owner role is granted post-join by an existing owner via the role endpoint. Prevents privilege escalation via admin-created invites.
- **Accept guards**: expiry enforced both at read time and via the atomic single-use claim in `workspace_service.accept_invite`; accepting while already a member returns 409 *without* consuming the invite (accepting would overwrite the existing, possibly higher, role).
- **Per-user name uniqueness** (#482 design decision 2): best-effort check against the caller's own workspace list on create/rename (409); display-only, no global uniqueness.
- **No-op role change** short-circuits so the audit trail records real transitions only.
- Rename is not audited — the #495 audit trail covers membership mutations; rename is display metadata only.

## Testing

- `tests/unit/test_workspaces_api.py` — 95 tests: full role-authz matrix (owner/admin/member/non-member) on every mutating endpoint, invite expiry, sole-owner 409s, race branches. `src/hive/api/workspaces.py` at 100% coverage.
- `tests/integration/test_workspaces_api.py` — full invite lifecycle against DynamoDB Local through the API (create → invite → accept → promote → leave → delete) asserting membership state, single-use semantics, expiry, and the #495 audit events; passing locally.
- `uv run inv pre-push` green (lint, mypy, 1270 unit tests, 905 frontend tests). Pre-existing local failures in `tests/integration/test_api.py` / `test_oauth.py` reproduce identically on clean `origin/development` (local DynamoDB-Local environment quirk, not this change).

Local e2e not run — CI will cover this on the development branch deploy.