### PR TITLE
perf: query ApiKeyOwnerIndex GSI to list a user's API keys instead of scanning (#596)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,12 @@ hive/
     scan if the index is unavailable (e.g. still backfilling), so table
     fixtures without this GSI still work — but include it to exercise
     the fast path
+  - `ApiKeyOwnerIndex` — GSI keyed on the top-level `owner_user_id`
+    attribute with the table `PK` as sort key — lists a user's API keys
+    (#596). *Not* sparse (memories / clients / workspaces / USERTAG items
+    also carry `owner_user_id`); the `begins_with(PK, "APIKEY#")` sort-key
+    condition narrows queries to API key items. `list_api_keys_for_user`
+    falls back to the legacy table scan if the index is unavailable
 
 ## Management UI
 

--- a/infra/stacks/hive_stack.py
+++ b/infra/stacks/hive_stack.py
@@ -153,6 +153,31 @@ class HiveStack(cdk.Stack):
             projection_type=dynamodb.ProjectionType.ALL,
         )
 
+        # GSI 7 — ApiKeyOwnerIndex: list a user's API keys (#596).
+        # Keyed on the existing top-level ``owner_user_id`` attribute with the
+        # table's own ``PK`` as the sort key. Unlike ApiKeyHashIndex this index
+        # is NOT sparse — memories, OAuth clients, workspaces and USERTAG
+        # items also carry ``owner_user_id`` — but the
+        # ``begins_with(PK, "APIKEY#")`` sort-key condition confines every
+        # query to the API key items, so reads never touch a user's other
+        # entities. Keying on already-written attributes means the
+        # asynchronous GSI backfill projects every existing API key item
+        # automatically and no data migration is needed.
+        # storage.list_api_keys_for_user falls back to the legacy table scan
+        # while the index is still backfilling (or otherwise unavailable).
+        #
+        # Deploy note: DynamoDB allows only one GSI mutation per table update
+        # — this index must not deploy while ApiKeyHashIndex (#589) is still
+        # backfilling (status CREATING).
+        table.add_global_secondary_index(
+            index_name="ApiKeyOwnerIndex",
+            partition_key=dynamodb.Attribute(
+                name="owner_user_id", type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(name="PK", type=dynamodb.AttributeType.STRING),
+            projection_type=dynamodb.ProjectionType.ALL,
+        )
+
         # ----------------------------------------------------------------
         # SSM Parameters
         # ----------------------------------------------------------------

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -6,9 +6,10 @@ Single-table design — all entities share one table.
 Table name is read from the HIVE_TABLE_NAME environment variable.
 
 GSIs:
-  TagIndex        — GSI2PK (TAG#{tag}), GSI2SK (memory_id) → list_memories(tag)
-  ClientIndex     — GSI3PK (CLIENT#{client_id})            → client lookups
-  ApiKeyHashIndex — key_hash (sparse, APIKEY# items only)  → API key auth lookups
+  TagIndex         — GSI2PK (TAG#{tag}), GSI2SK (memory_id) → list_memories(tag)
+  ClientIndex      — GSI3PK (CLIENT#{client_id})            → client lookups
+  ApiKeyHashIndex  — key_hash (sparse, APIKEY# items only)  → API key auth lookups
+  ApiKeyOwnerIndex — owner_user_id + PK (not sparse)        → list a user's API keys
 """
 
 from __future__ import annotations
@@ -1977,6 +1978,66 @@ class HiveStorage:
             scan_kwargs["ExclusiveStartKey"] = last_key
 
     def list_api_keys_for_user(self, owner_user_id: str) -> list[ApiKey]:
+        """List a user's API keys via the ApiKeyOwnerIndex GSI (#596).
+
+        The index is keyed on the existing top-level ``owner_user_id``
+        attribute with the table's own ``PK`` as its sort key. Unlike
+        ApiKeyHashIndex it is *not* sparse — memories, OAuth clients,
+        workspaces and USERTAG items also carry ``owner_user_id`` — so the
+        ``begins_with(PK, "APIKEY#")`` sort-key condition does the
+        narrowing: the query reads only the user's API key items, never
+        their other entities.
+
+        If the query fails because the index is unavailable (still
+        backfilling after deployment, or absent on a table that predates
+        it), the listing degrades gracefully to the legacy scan. As with
+        get_api_key_by_hash (#589), the fallback is kept permanently as
+        resilience, not as a transitional shim.
+        """
+        query_kwargs: dict[str, Any] = {
+            "IndexName": "ApiKeyOwnerIndex",
+            "KeyConditionExpression": (
+                Key("owner_user_id").eq(owner_user_id) & Key("PK").begins_with(_APIKEY_PK_PREFIX)
+            ),
+            # Defensive shape filter — APIKEY# partitions only ever hold
+            # SK=META items today, but the filter keeps any future non-META
+            # row out of ApiKey.from_dynamo.
+            "FilterExpression": Attr("SK").eq("META"),
+        }
+        keys: list[ApiKey] = []
+        try:
+            while True:
+                resp = self.table.query(**query_kwargs)
+                keys.extend(ApiKey.from_dynamo(item) for item in resp.get("Items", []))
+                last_key = resp.get("LastEvaluatedKey")
+                if not last_key:
+                    return keys
+                query_kwargs["ExclusiveStartKey"] = last_key
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code not in ("ValidationException", "ResourceNotFoundException"):
+                raise
+            # The full error message is logged so an unexpected fallback
+            # cause (e.g. a genuine query bug rather than a backfilling
+            # index) is immediately diagnosable. The code is deliberately
+            # not narrowed by message substring — DynamoDB, DynamoDB Local
+            # and moto phrase these messages differently, and the fallback
+            # direction is fail-safe (a scan, the pre-GSI behaviour).
+            logger.warning(
+                "ApiKeyOwnerIndex unavailable (%s: %s) — falling back to table scan "
+                "for API key listing",
+                code,
+                exc.response["Error"].get("Message", ""),
+            )
+            return self._scan_api_keys_for_user(owner_user_id)
+
+    def _scan_api_keys_for_user(self, owner_user_id: str) -> list[ApiKey]:
+        """Legacy full-table-scan API key listing — fallback for ApiKeyOwnerIndex.
+
+        Paginates on ``LastEvaluatedKey``: a filtered Scan can return an
+        empty or partial page while matching items remain in later pages,
+        so keys are aggregated until the table is exhausted.
+        """
         scan_kwargs: dict[str, Any] = {
             "FilterExpression": "begins_with(PK, :prefix) AND SK = :sk AND owner_user_id = :uid",
             "ExpressionAttributeValues": {

--- a/tests/integration/test_api_key_index.py
+++ b/tests/integration/test_api_key_index.py
@@ -1,18 +1,20 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
 """
-Integration tests for #589 — API key lookup via the ApiKeyHashIndex GSI.
+Integration tests for #589 / #596 — API key lookups via the ApiKeyHashIndex
+and ApiKeyOwnerIndex GSIs.
 
 Runs against DynamoDB Local (Docker) — set DYNAMODB_ENDPOINT env var.
 
 Two tables are exercised:
 
-- one **with** ``ApiKeyHashIndex`` — proves ``get_api_key_by_hash`` resolves
-  keys through a single-partition GSI query (the fast path) against a real
+- one **with** ``ApiKeyHashIndex`` + ``ApiKeyOwnerIndex`` — proves
+  ``get_api_key_by_hash`` and ``list_api_keys_for_user`` resolve keys
+  through single-partition GSI queries (the fast paths) against a real
   DynamoDB query engine, not just moto;
-- one **without** the index — proves the graceful-degradation contract: a
+- one **without** the indexes — proves the graceful-degradation contract: a
   real ``ValidationException`` from DynamoDB Local triggers the legacy
   full-table-scan fallback, which is what production relies on while the
-  GSI is still backfilling after deployment.
+  GSIs are still backfilling after deployment.
 """
 
 from __future__ import annotations
@@ -66,7 +68,7 @@ def _storage_for(table_name: str):
 
 @pytest.fixture(scope="module")
 def storage_with_index():
-    """HiveStorage on a table carrying ApiKeyHashIndex (production schema)."""
+    """HiveStorage on a table carrying both API key GSIs (production schema)."""
     ddb = _ddb_client()
     table_name = "hive-integration-apikey-idx"
     with contextlib.suppress(Exception):
@@ -77,12 +79,21 @@ def storage_with_index():
             {"AttributeName": "PK", "AttributeType": "S"},
             {"AttributeName": "SK", "AttributeType": "S"},
             {"AttributeName": "key_hash", "AttributeType": "S"},
+            {"AttributeName": "owner_user_id", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
                 "IndexName": "ApiKeyHashIndex",
                 "KeySchema": [
                     {"AttributeName": "key_hash", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ApiKeyOwnerIndex",
+                "KeySchema": [
+                    {"AttributeName": "owner_user_id", "KeyType": "HASH"},
+                    {"AttributeName": "PK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
@@ -94,7 +105,7 @@ def storage_with_index():
 
 @pytest.fixture(scope="module")
 def storage_without_index():
-    """HiveStorage on a legacy-schema table lacking ApiKeyHashIndex."""
+    """HiveStorage on a legacy-schema table lacking both API key GSIs."""
     ddb = _ddb_client()
     table_name = "hive-integration-apikey-noidx"
     with contextlib.suppress(Exception):
@@ -146,3 +157,52 @@ class TestApiKeyHashIndexFallback:
 
     def test_fallback_miss_returns_none(self, storage_without_index):
         assert storage_without_index.get_api_key_by_hash("int-hash-nope") is None
+
+
+def _make_owned_key(owner_user_id: str, name: str) -> ApiKey:
+    return ApiKey(owner_user_id=owner_user_id, name=name, key_hash=f"int-hash-{name}")
+
+
+class TestApiKeyOwnerIndexQuery:
+    """Fast path — listings resolve through the GSI on a real DynamoDB engine."""
+
+    def test_list_hits_gsi(self, storage_with_index):
+        from unittest.mock import patch
+
+        k1 = _make_owned_key("int-owner-list", "owner-a")
+        k2 = _make_owned_key("int-owner-list", "owner-b")
+        storage_with_index.put_api_key(k1)
+        storage_with_index.put_api_key(k2)
+        storage_with_index.put_api_key(_make_owned_key("int-owner-other", "owner-c"))
+        # ApiKeyOwnerIndex is not sparse — a workspace item owned by the same
+        # user lands in the same index partition. The begins_with(PK, APIKEY#)
+        # sort-key condition must keep it out of the listing.
+        storage_with_index.table.put_item(
+            Item={
+                "PK": "WORKSPACE#int-ws",
+                "SK": "META",
+                "owner_user_id": "int-owner-list",
+                "name": "ws",
+            }
+        )
+        # Block the scan path entirely — the GSI query alone must resolve it.
+        with patch.object(storage_with_index.table, "scan") as mock_scan:
+            result = storage_with_index.list_api_keys_for_user("int-owner-list")
+        assert {k.name for k in result} == {"owner-a", "owner-b"}
+        mock_scan.assert_not_called()
+
+    def test_list_miss_returns_empty(self, storage_with_index):
+        assert storage_with_index.list_api_keys_for_user("int-owner-absent") == []
+
+
+class TestApiKeyOwnerIndexFallback:
+    """Degraded path — a table without the GSI still lists keys via scan."""
+
+    def test_list_falls_back_to_scan(self, storage_without_index):
+        key = _make_owned_key("int-owner-fallback", "owner-legacy")
+        storage_without_index.put_api_key(key)
+        result = storage_without_index.list_api_keys_for_user("int-owner-fallback")
+        assert [k.key_id for k in result] == [key.key_id]
+
+    def test_fallback_miss_returns_empty(self, storage_without_index):
+        assert storage_without_index.list_api_keys_for_user("int-owner-nope") == []

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -62,6 +62,7 @@ def _create_table():
             {"AttributeName": "GSI5PK", "AttributeType": "S"},
             {"AttributeName": "GSI5SK", "AttributeType": "S"},
             {"AttributeName": "key_hash", "AttributeType": "S"},
+            {"AttributeName": "owner_user_id", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
             {
@@ -99,6 +100,14 @@ def _create_table():
                 "IndexName": "ApiKeyHashIndex",
                 "KeySchema": [
                     {"AttributeName": "key_hash", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ApiKeyOwnerIndex",
+                "KeySchema": [
+                    {"AttributeName": "owner_user_id", "KeyType": "HASH"},
+                    {"AttributeName": "PK", "KeyType": "RANGE"},
                 ],
                 "Projection": {"ProjectionType": "ALL"},
             },
@@ -2504,11 +2513,12 @@ class TestHydrateMemoryIds:
 
 @pytest.fixture()
 def storage_no_apikey_index():
-    """HiveStorage on a table without ApiKeyHashIndex — legacy-schema table.
+    """HiveStorage on a table without the API key GSIs — legacy-schema table.
 
-    Exercises the graceful-degradation path of get_api_key_by_hash: the GSI
-    query fails with a real ValidationException and the lookup must fall
-    back to the legacy full-table scan.
+    Exercises the graceful-degradation paths of get_api_key_by_hash
+    (ApiKeyHashIndex) and list_api_keys_for_user (ApiKeyOwnerIndex): the
+    GSI query fails with a real ValidationException and the lookup must
+    fall back to the legacy full-table scan.
     """
     with mock_aws():
         ddb = boto3.client("dynamodb", region_name="us-east-1")
@@ -2648,8 +2658,45 @@ class TestApiKeyStorage:
         assert mock_scan.call_count == 2
         assert mock_scan.call_args_list[1].kwargs["ExclusiveStartKey"] == {"PK": "x", "SK": "y"}
 
+    def test_list_for_user_queries_gsi_not_scan(self, storage):
+        """The listing must hit ApiKeyOwnerIndex — never scan when the GSI works."""
+        from unittest.mock import patch
+
+        k1 = self._key("u1", "gsi1")
+        k2 = self._key("u1", "gsi2")
+        storage.put_api_key(k1)
+        storage.put_api_key(k2)
+        with patch.object(storage.table, "scan") as mock_scan:
+            result = storage.list_api_keys_for_user("u1")
+        assert {k.name for k in result} == {"gsi1", "gsi2"}
+        mock_scan.assert_not_called()
+
+    def test_list_for_user_excludes_other_owned_entities(self, storage):
+        """Non-APIKEY# items carrying owner_user_id never reach the result.
+
+        ApiKeyOwnerIndex is not sparse — memories, clients and workspaces
+        also carry ``owner_user_id`` — so the begins_with(PK, "APIKEY#")
+        sort-key condition must exclude them (ApiKey.from_dynamo would
+        raise on their shape if they leaked through).
+        """
+        storage.table.put_item(
+            Item={"PK": "WORKSPACE#w1", "SK": "META", "owner_user_id": "u1", "name": "ws"}
+        )
+        storage.table.put_item(
+            Item={"PK": "MEMORY#m1", "SK": "META", "owner_user_id": "u1", "key": "k"}
+        )
+        k = self._key("u1", "only-key")
+        storage.put_api_key(k)
+        result = storage.list_api_keys_for_user("u1")
+        assert [r.name for r in result] == ["only-key"]
+
+    def test_list_for_user_ignores_non_meta_apikey_items(self, storage):
+        """A non-META row in an APIKEY# partition is filtered out defensively."""
+        storage.table.put_item(Item={"PK": "APIKEY#rogue", "SK": "OTHER", "owner_user_id": "u1"})
+        assert storage.list_api_keys_for_user("u1") == []
+
     def test_list_for_user_follows_last_evaluated_key(self, storage):
-        """list_api_keys_for_user aggregates keys across scan pages."""
+        """list_api_keys_for_user aggregates keys across query pages."""
         from unittest.mock import patch
 
         k1 = self._key("u9", "page1")
@@ -2658,10 +2705,77 @@ class TestApiKeyStorage:
             {"Items": [k1.to_dynamo()], "LastEvaluatedKey": {"PK": "x", "SK": "y"}},
             {"Items": [k2.to_dynamo()]},
         ]
-        with patch.object(storage.table, "scan", side_effect=pages) as mock_scan:
+        with patch.object(storage.table, "query", side_effect=pages) as mock_query:
             result = storage.list_api_keys_for_user("u9")
         assert {k.name for k in result} == {"page1", "page2"}
+        assert mock_query.call_count == 2
+        assert mock_query.call_args_list[1].kwargs["ExclusiveStartKey"] == {"PK": "x", "SK": "y"}
+
+    def test_list_for_user_falls_back_when_index_missing(self, storage_no_apikey_index):
+        """A table without the GSI (legacy schema / backfilling) still lists keys."""
+        k1 = self._key("u1", "legacy1")
+        k2 = self._key("u1", "legacy2")
+        storage_no_apikey_index.put_api_key(k1)
+        storage_no_apikey_index.put_api_key(k2)
+        result = storage_no_apikey_index.list_api_keys_for_user("u1")
+        assert {k.name for k in result} == {"legacy1", "legacy2"}
+
+    def test_list_for_user_fallback_empty(self, storage_no_apikey_index):
+        assert storage_no_apikey_index.list_api_keys_for_user("no-such-user") == []
+
+    def test_list_for_user_falls_back_on_resource_not_found(self, storage):
+        """ResourceNotFoundException from the GSI query also triggers the scan."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        k = self._key("u1", "rnf")
+        storage.put_api_key(k)
+        with patch.object(
+            storage.table,
+            "query",
+            side_effect=ClientError(
+                {"Error": {"Code": "ResourceNotFoundException", "Message": "no index"}},
+                "Query",
+            ),
+        ):
+            result = storage.list_api_keys_for_user("u1")
+        assert [r.name for r in result] == ["rnf"]
+
+    def test_list_for_user_reraises_unrelated_errors(self, storage):
+        """Only index-unavailable errors degrade to a scan — others propagate."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        with (
+            patch.object(
+                storage.table,
+                "query",
+                side_effect=ClientError(
+                    {"Error": {"Code": "InternalServerError", "Message": "boom"}},
+                    "Query",
+                ),
+            ),
+            pytest.raises(ClientError),
+        ):
+            storage.list_api_keys_for_user("u1")
+
+    def test_scan_list_for_user_follows_last_evaluated_key(self, storage):
+        """The fallback scan aggregates keys across filtered pages."""
+        from unittest.mock import patch
+
+        k1 = self._key("u9", "scan1")
+        k2 = self._key("u9", "scan2")
+        pages = [
+            {"Items": [k1.to_dynamo()], "LastEvaluatedKey": {"PK": "x", "SK": "y"}},
+            {"Items": [k2.to_dynamo()]},
+        ]
+        with patch.object(storage.table, "scan", side_effect=pages) as mock_scan:
+            result = storage._scan_api_keys_for_user("u9")
+        assert {k.name for k in result} == {"scan1", "scan2"}
         assert mock_scan.call_count == 2
+        assert mock_scan.call_args_list[1].kwargs["ExclusiveStartKey"] == {"PK": "x", "SK": "y"}
 
     def test_get_by_hash_reraises_unrelated_errors(self, storage):
         """Only index-unavailable errors degrade to a scan — others propagate."""


### PR DESCRIPTION
Closes #596

> **Merge note: ensure the #710 `ApiKeyHashIndex` has finished backfilling (index ACTIVE) before merging — one GSI mutation at a time per table.** DynamoDB rejects a table update that creates a GSI while another GSI is still in `CREATING` state; #710's index deployed recently, so verify it is `ACTIVE` on the dev (and later prod) table before this PR's deploy runs.

## Summary

`list_api_keys_for_user` performed a full table scan on every `GET /api/keys` request. This PR adds an `ApiKeyOwnerIndex` GSI and rewrites the listing to a single-partition query, mirroring the `ApiKeyHashIndex` work from #710 (#589) — including the permanent graceful fallback to the legacy scan (`ValidationException` / `ResourceNotFoundException` → warning log + scan) so the endpoint keeps working while the index is backfilling or on tables that predate it.

## Approach

- **Keyed on existing attributes → zero migration.** `owner_user_id` is already a top-level attribute on every `APIKEY#` item (sole writer for those items: `ApiKey.to_dynamo`), so the asynchronous GSI backfill projects all existing API keys automatically — same no-migration story as #710.
- **Not sparse, unlike `ApiKeyHashIndex` — mitigated with a sort key.** `owner_user_id` is also written by `Memory`, `OAuthClient`, `Workspace`, and `USERTAG` items, so the index necessarily contains every owner-attributed item (this corrects the "sparse like #710" assumption — the attribute check surfaced multiple writers). To keep the *read* path from paging through a user's memories, the GSI uses the table's own `PK` as its sort key: the query's key condition is `owner_user_id = :uid AND begins_with(PK, "APIKEY#")`, which confines the read to API key items only. `PK` is already in `AttributeDefinitions`, so this adds no extra attribute definition.
  - Trade-off (flagged for the human reviewer): with `ProjectionType.ALL` (mirroring every existing GSI incl. #710's), the non-sparse index stores a copy of each owner-attributed item and adds a write to the index on each of their writes. Reads are unaffected by this (the sort-key condition skips non-key items). If that storage/write amplification is unacceptable, the alternative is a dedicated sparse attribute (e.g. `GSI7PK=APIKEYOWNER#{user_id}`) — but that requires a data migration for existing keys, which this approach deliberately avoids.
- **Defensive shape filter + pagination.** The query keeps a server-side `SK = "META"` filter (defence in depth, as in #710) and follows `LastEvaluatedKey`, aggregating across pages.
- **Fallback extracted, unchanged in behaviour.** The legacy scan body moved to `_scan_api_keys_for_user` (paginated, exactly as #710 left it) and remains permanently as the resilience path.

## Infra diff

Verified by synthesizing `HiveStack` at this branch and at the base commit (`f53810a`) and structurally diffing the CloudFormation templates. The delta to `AWS::DynamoDB::Table` (`HiveTableA6FD3490`) is **exactly**:

- `AttributeDefinitions`: +1 entry — `{"AttributeName": "owner_user_id", "AttributeType": "S"}` (appended; all existing entries byte-identical)
- `GlobalSecondaryIndexes`: +1 entry — `{"IndexName": "ApiKeyOwnerIndex", "KeySchema": [{"AttributeName": "owner_user_id", "KeyType": "HASH"}, {"AttributeName": "PK", "KeyType": "RANGE"}], "Projection": {"ProjectionType": "ALL"}}` (appended; all existing GSIs byte-identical)

No key-schema change, no table replacement, no modification or removal of existing GSIs, no other table property touched. The only other template diffs are the Lambda code-asset hash rotations (and the derived `McpFunction` version/alias logical IDs) that accompany any `src/` change. Full `uv run inv synth` (including the cdk-nag hard gate) passes.

## Testing

- Unit (moto): GSI-hit listing asserting the scan path is never touched; exclusion of non-`APIKEY#` items sharing the index partition (workspace/memory items owned by the same user); defensive non-META filter; `LastEvaluatedKey` aggregation across query pages; fallback on a **real** `ValidationException` from an index-less table; fallback on `ResourceNotFoundException`; unrelated `ClientError` re-raises; paginated fallback scan. Test-table fixture updated to carry the new GSI.
- Integration (DynamoDB Local): fast-path listing against a table **with** the index (scan blocked, foreign owner-attributed item in the same index partition excluded by the sort-key condition) and empty-result miss; fallback listing and miss against a legacy-schema table **without** it. All 8 tests in `test_api_key_index.py` pass locally against DynamoDB Local.
- `uv run inv pre-push` passes (lint, mypy, copyright, 1183 unit tests, 905 frontend tests). `uv run inv synth` passes.

Local e2e not run — CI will cover this on the development branch deploy.
