### PR TITLE
feat(mcp): scope query tools and vector search to the caller's workspace

### DIFF
--- a/docs-site/concepts/memory-scoping.md
+++ b/docs-site/concepts/memory-scoping.md
@@ -21,11 +21,16 @@ Your account
 
 ## Scope comes from the token
 
-Every access token Hive issues carries a `workspace_id` claim. When an MCP
-client registers (via Dynamic Client Registration) it is bound to a
-workspace — either explicitly at registration time or automatically to your
-Personal workspace when you sign in — and every token minted for that client
-carries the binding.
+Access tokens minted since the workspace rollout carry a `workspace_id`
+claim. When an MCP client registers (via Dynamic Client Registration) it is
+bound to a workspace — either explicitly at registration time or
+automatically to your Personal workspace when you sign in — and tokens
+minted for that client carry the binding.
+
+Older tokens and API keys issued before the rollout carry no claim; Hive
+resolves their scope from the issuing client's workspace binding, falling
+back to the owner's Personal workspace, so existing credentials keep
+working without re-authentication.
 
 Tool calls never take a workspace parameter. To operate in a different
 workspace, an agent registers a client bound to that workspace and swaps

--- a/docs-site/concepts/memory-scoping.md
+++ b/docs-site/concepts/memory-scoping.md
@@ -2,37 +2,67 @@
 
 Understanding how memories are scoped helps you predict what your agent can and can't see.
 
-## The ownership model
+## The workspace model
 
-Every memory belongs to the **OAuth client** that created it. When your Claude Code instance stores a memory, that memory is owned by the Claude Code OAuth client.
+Every memory lives in a **workspace**. When you first sign in, Hive creates a
+Personal workspace for your account, and every memory your agents store lands
+there by default.
 
 ```
 Your account
-├── OAuth client: "Claude Code (laptop)"
+├── Workspace: "you@example.com's Personal"
 │   ├── memory: project/deadline
 │   ├── memory: preferences/code-style
 │   └── memory: ref/api-docs
-├── OAuth client: "Cursor (laptop)"
-│   ├── memory: project/current-task
-│   └── memory: ref/db-schema
-└── OAuth client: "Claude Desktop (home)"
-    └── memory: personal/reading-list
+└── Workspace: "Team Atlas"          (shared workspaces are rolling out)
+    ├── memory: project/current-task
+    └── memory: ref/db-schema
 ```
 
-## What each client sees
+## Scope comes from the token
 
-When an MCP client calls `recall`, `list_memories`, or `search_memories`, it only sees **memories owned by that client**. Claude Code can't read memories created by Cursor, and vice versa.
+Every access token Hive issues carries a `workspace_id` claim. When an MCP
+client registers (via Dynamic Client Registration) it is bound to a
+workspace — either explicitly at registration time or automatically to your
+Personal workspace when you sign in — and every token minted for that client
+carries the binding.
 
-This isolation is intentional — it prevents one client from accidentally reading or overwriting another client's context.
+Tool calls never take a workspace parameter. To operate in a different
+workspace, an agent registers a client bound to that workspace and swaps
+tokens.
+
+## What each token sees
+
+All MCP tools enforce the workspace boundary:
+
+- `recall`, `forget`, `memory_history`, `restore_memory`, and the other
+  key-addressed tools treat memories from another workspace as **not found**
+  — even if you know the exact key.
+- `remember` refuses to overwrite a key held by another workspace.
+- `list_memories`, `list_tags`, `search_memories`, `summarize_context`, and
+  `pack_context` only surface memories from the token's workspace — memories
+  stored in one workspace never appear in another workspace's listings,
+  tag sets, search results, or summaries.
+
+Within a workspace, memories are shared across all of your connected MCP
+clients: a memory stored by Claude Code is visible to Cursor as long as both
+are bound to the same workspace.
 
 ## The management UI sees everything
 
-When you browse memories in the management UI at [hive.warlordofmars.net](https://hive.warlordofmars.net), you see **all memories across all your clients**. You can browse, edit, and delete any of them regardless of which client created them.
+When you browse memories in the management UI at
+[hive.warlordofmars.net](https://hive.warlordofmars.net), you see all memories
+across your account. You can browse, edit, and delete any of them regardless
+of which client created them.
 
-## Sharing memories across clients
+## Memories from before workspaces
 
-If you want multiple clients to share memory, the simplest approach is to have each client use a common key convention and have the appropriate client write to it. Alternatively, you can create memories directly in the management UI — those will also be visible to all your clients that have read access.
+Memories created before your account was migrated to the workspace model are
+visible from any of your workspaces until the migration stamps them into your
+Personal workspace. They remain private to your account either way.
 
 ## Team sharing
 
-If multiple people use the same Hive instance (e.g. a shared team deployment), each person's account is isolated from others. Admin users can see all memories across all accounts via the management UI, but standard users only see their own.
+If multiple people use the same Hive instance, each account is isolated from
+others. Admin users can see all memories across all accounts via the
+management UI, but standard users only see their own.

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -262,20 +262,31 @@ def migrate_user_tags(
     so each memory's META ``workspace_id`` (the source of truth) is already
     populated. Idempotent: already-stamped items and rows whose memory is
     still unstamped are skipped.
+
+    In ``--dry-run`` mode each USERTAG row is read to report accurately:
+    already-stamped or missing rows count as skipped, mirroring the
+    conditional-update semantics of a real run. (Memories whose META is
+    still unstamped are not visited in dry-run — the memory phase hasn't
+    written its stamps — so the dry-run count reflects the table as-is.)
     """
     for memory in storage.iter_all_memories():
         if memory.workspace_id is None or memory.owner_user_id is None:
             continue
         for tag in memory.tags:
+            key = {
+                "PK": f"USERTAG#{memory.owner_user_id}",
+                "SK": f"TAG#{tag}#MEMORY#{memory.memory_id}",
+            }
             if dry_run:
-                stats.user_tags_stamped += 1
+                item = storage.table.get_item(Key=key).get("Item")
+                if item is None or "workspace_id" in item:
+                    stats.user_tags_skipped += 1
+                else:
+                    stats.user_tags_stamped += 1
                 continue
             try:
                 storage.table.update_item(
-                    Key={
-                        "PK": f"USERTAG#{memory.owner_user_id}",
-                        "SK": f"TAG#{tag}#MEMORY#{memory.memory_id}",
-                    },
+                    Key=key,
                     UpdateExpression="SET workspace_id = :wsid",
                     ExpressionAttributeValues={":wsid": memory.workspace_id},
                     ConditionExpression=(

--- a/scripts/migrate_workspaces.py
+++ b/scripts/migrate_workspaces.py
@@ -65,6 +65,8 @@ class MigrationStats:
     memories_seen: int = 0
     memories_migrated: int = 0
     memories_skipped: int = 0
+    user_tags_stamped: int = 0
+    user_tags_skipped: int = 0
     clients_seen: int = 0
     clients_migrated: int = 0
     clients_skipped: int = 0
@@ -78,6 +80,8 @@ class MigrationStats:
             f"memories_seen={self.memories_seen} "
             f"memories_migrated={self.memories_migrated} "
             f"memories_skipped={self.memories_skipped} "
+            f"user_tags_stamped={self.user_tags_stamped} "
+            f"user_tags_skipped={self.user_tags_skipped} "
             f"clients_seen={self.clients_seen} "
             f"clients_migrated={self.clients_migrated} "
             f"clients_skipped={self.clients_skipped} "
@@ -109,9 +113,7 @@ def _find_personal_workspace(
             return ws
     # Slow-path: scan for orphaned WORKSPACE META (partial prior run).
     scan_kwargs: dict[str, Any] = {
-        "FilterExpression": (
-            "SK = :sk AND begins_with(PK, :prefix) AND owner_user_id = :uid"
-        ),
+        "FilterExpression": ("SK = :sk AND begins_with(PK, :prefix) AND owner_user_id = :uid"),
         "ExpressionAttributeValues": {
             ":sk": "META",
             ":prefix": "WORKSPACE#",
@@ -245,6 +247,52 @@ def migrate_memories(
         stats.memories_migrated += 1
 
 
+def migrate_user_tags(
+    storage: HiveStorage,
+    stats: MigrationStats,
+    *,
+    dry_run: bool,
+) -> None:
+    """Stamp every USERTAG item with the ``workspace_id`` of its memory (#493).
+
+    ``list_tags`` filters on the ``workspace_id`` attribute of USERTAG items
+    (PK=USERTAG#{user_id}, SK=TAG#{tag}#MEMORY#{id}); items written before
+    the workspace cutover carry none, so their tag names stay visible in all
+    of the owner's workspaces until stamped. Runs after ``migrate_memories``
+    so each memory's META ``workspace_id`` (the source of truth) is already
+    populated. Idempotent: already-stamped items and rows whose memory is
+    still unstamped are skipped.
+    """
+    for memory in storage.iter_all_memories():
+        if memory.workspace_id is None or memory.owner_user_id is None:
+            continue
+        for tag in memory.tags:
+            if dry_run:
+                stats.user_tags_stamped += 1
+                continue
+            try:
+                storage.table.update_item(
+                    Key={
+                        "PK": f"USERTAG#{memory.owner_user_id}",
+                        "SK": f"TAG#{tag}#MEMORY#{memory.memory_id}",
+                    },
+                    UpdateExpression="SET workspace_id = :wsid",
+                    ExpressionAttributeValues={":wsid": memory.workspace_id},
+                    ConditionExpression=(
+                        "attribute_exists(PK) AND attribute_exists(SK)"
+                        " AND attribute_not_exists(workspace_id)"
+                    ),
+                )
+            except ClientError as exc:
+                if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                    # Already stamped, or the USERTAG row is missing (memory
+                    # deleted mid-migration) — both are safe to skip.
+                    stats.user_tags_skipped += 1
+                    continue
+                raise
+            stats.user_tags_stamped += 1
+
+
 def migrate_clients(
     storage: HiveStorage,
     user_to_workspace: dict[str, str],
@@ -314,6 +362,7 @@ def run(*, dry_run: bool = False, storage: HiveStorage | None = None) -> Migrati
 
     user_to_workspace = migrate_users(store, stats, dry_run=dry_run)
     migrate_memories(store, user_to_workspace, stats, dry_run=dry_run)
+    migrate_user_tags(store, stats, dry_run=dry_run)
     migrate_clients(store, user_to_workspace, stats, dry_run=dry_run)
 
     if dry_run:

--- a/src/hive/models.py
+++ b/src/hive/models.py
@@ -165,16 +165,21 @@ class Memory(BaseModel):
             raise ValueError("owner_user_id required to build USERTAG items")
         items = []
         for tag in self.tags:
-            items.append(
-                {
-                    "PK": f"USERTAG#{self.owner_user_id}",
-                    "SK": f"TAG#{tag}#MEMORY#{self.memory_id}",
-                    "memory_id": self.memory_id,
-                    "key": self.key,
-                    "owner_client_id": self.owner_client_id,
-                    "owner_user_id": self.owner_user_id,
-                }
-            )
+            item = {
+                "PK": f"USERTAG#{self.owner_user_id}",
+                "SK": f"TAG#{tag}#MEMORY#{self.memory_id}",
+                "memory_id": self.memory_id,
+                "key": self.key,
+                "owner_client_id": self.owner_client_id,
+                "owner_user_id": self.owner_user_id,
+            }
+            # Workspace scoping (#493): stamp tag entries so list_distinct_tags
+            # can filter by workspace without hydrating each memory. Unstamped
+            # entries (pre-migration) stay visible in every workspace of the
+            # owner, matching the memory-level compat rules.
+            if self.workspace_id is not None:
+                item["workspace_id"] = self.workspace_id
+            items.append(item)
         return items
 
     @classmethod

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1857,12 +1857,17 @@ async def relate_memories(
     owner_user_id = _require_owner_user_id(storage, client_id)
     # Workspace scoping (#493): filter foreign-workspace vectors at query time.
     workspace_id, _ = _caller_workspace_scope(storage)
+    # Request a wider pool than top_k (mirroring search_memories) so that
+    # pre-#493 vectors without workspace metadata — which pass the query
+    # filter's `$exists: false` arm but may be dropped by the authoritative
+    # DynamoDB check below — can't dominate a service-side truncation and
+    # starve the result set. The +1 keeps headroom for dropping the source.
+    candidate_pool = min(max(top_k * 3, 10), 50) + 1
     try:
-        # Fetch top_k+1 so that dropping the source still leaves up to top_k.
         pairs = _vector_store().search(
             query_value,
             owner_user_id,
-            top_k=top_k + 1,
+            top_k=candidate_pool,
             workspace_id=workspace_id,
             workspace_scoped=True,
         )

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -1708,7 +1708,11 @@ async def search_memories(
     await _report_progress(ctx, 0, 3, f"Running vector search for '{query}'...")
     try:
         pairs = _vector_store().search(
-            query, owner_user_id, top_k=search_top_k, workspace_id=workspace_id
+            query,
+            owner_user_id,
+            top_k=search_top_k,
+            workspace_id=workspace_id,
+            workspace_scoped=True,
         )
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
@@ -1856,7 +1860,11 @@ async def relate_memories(
     try:
         # Fetch top_k+1 so that dropping the source still leaves up to top_k.
         pairs = _vector_store().search(
-            query_value, owner_user_id, top_k=top_k + 1, workspace_id=workspace_id
+            query_value,
+            owner_user_id,
+            top_k=top_k + 1,
+            workspace_id=workspace_id,
+            workspace_scoped=True,
         )
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
@@ -2092,7 +2100,11 @@ async def pack_context(
     workspace_id, _ = _caller_workspace_scope(storage)
     try:
         pairs = _vector_store().search(
-            topic, owner_user_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL, workspace_id=workspace_id
+            topic,
+            owner_user_id,
+            top_k=_PACK_CONTEXT_CANDIDATE_POOL,
+            workspace_id=workspace_id,
+            workspace_scoped=True,
         )
     except VectorIndexNotFoundError:
         return _tool_result(_render_empty_within_budget(topic, budget), storage, client_id)

--- a/src/hive/server.py
+++ b/src/hive/server.py
@@ -277,6 +277,19 @@ def _check_workspace_access(storage: HiveStorage, memory: Memory, error: str) ->
         raise ToolError(error)
 
 
+def _workspace_visible(memory: Memory, workspace_id: str | None) -> bool:
+    """Query-path workspace visibility predicate (#493).
+
+    Mirrors ``_check_workspace_access`` for aggregate reads (list / search /
+    summarise / pack): memories without a ``workspace_id`` (pre-migration
+    rows) stay visible until the idempotent post-deploy migration stamps
+    them; stamped memories are visible only within the caller's resolved
+    workspace. A ``None`` caller workspace (unresolvable scope) fails closed
+    to unstamped memories only.
+    """
+    return memory.workspace_id is None or memory.workspace_id == workspace_id
+
+
 def _log(storage: HiveStorage, event: ActivityEvent) -> None:
     """Record the event in both the user-visible activity log and the
     immutable compliance audit log (#395).
@@ -1169,7 +1182,16 @@ async def forget_all(
         raise ToolError(
             "Client is not associated with a user account; per-user memory scoping is required."
         )
-    deleted = storage.delete_memories_by_tag(tag, owner_user_id=client.owner_user_id)
+    # Workspace boundary (#493): bulk deletion honours the same compat rules
+    # as the keyed `forget` guard — memories stamped with a foreign workspace
+    # survive, unstamped (pre-migration) rows remain deletable by their owner.
+    workspace_id, _ = _caller_workspace_scope(storage)
+    deleted = storage.delete_memories_by_tag(
+        tag,
+        owner_user_id=client.owner_user_id,
+        workspace_id=workspace_id,
+        workspace_scoped=True,
+    )
     _log(
         storage,
         ActivityEvent(
@@ -1407,10 +1429,18 @@ async def list_memories(
             "Client is not associated with a user account; per-user memory scoping is required."
         )
     owner_user_id = client.owner_user_id
+    # Workspace scoping (#493): aggregate reads only surface memories in the
+    # caller's resolved workspace (plus unstamped pre-migration rows).
+    workspace_id, _ = _caller_workspace_scope(storage)
 
     limit = max(1, min(limit, 500))
     memories, next_cursor = storage.list_memories_by_tag(
-        tag, limit=limit, cursor=cursor, owner_user_id=owner_user_id
+        tag,
+        limit=limit,
+        cursor=cursor,
+        owner_user_id=owner_user_id,
+        workspace_id=workspace_id,
+        workspace_scoped=True,
     )
     if not include_redacted:
         memories = [m for m in memories if not m.is_redacted]
@@ -1482,7 +1512,10 @@ async def list_tags(ctx: Context | None = None) -> dict[str, Any]:
         raise ToolError(
             "Client is not associated with a user account; per-user memory scoping is required."
         )
-    tags = storage.list_distinct_tags(client.owner_user_id)
+    # Workspace scoping (#493): only tags carried by memories visible in the
+    # caller's resolved workspace (plus unstamped pre-migration entries).
+    workspace_id, _ = _caller_workspace_scope(storage)
+    tags = storage.list_distinct_tags(client.owner_user_id, workspace_id, workspace_scoped=True)
     duration_ms = int((time.monotonic() - t0) * 1000)
     logger.info(
         "Listed %d distinct tags",
@@ -1533,9 +1566,18 @@ async def summarize_context(
             "Client is not associated with a user account; per-user memory scoping is required."
         )
     owner_user_id = client.owner_user_id
+    # Workspace scoping (#493): a summary must never synthesise from another
+    # workspace's memories.
+    workspace_id, _ = _caller_workspace_scope(storage)
 
     await _report_progress(ctx, 0, 2, f"Retrieving memories for '{topic}'...")
-    memories, _ = storage.list_memories_by_tag(topic, limit=500, owner_user_id=owner_user_id)
+    memories, _ = storage.list_memories_by_tag(
+        topic,
+        limit=500,
+        owner_user_id=owner_user_id,
+        workspace_id=workspace_id,
+        workspace_scoped=True,
+    )
     # Freshest first, so both the sampling prompt and the listed fallback lead
     # with the most recent memories (#658).
     memories.sort(key=lambda m: m.updated_at, reverse=True)
@@ -1660,9 +1702,14 @@ async def search_memories(
     search_top_k = 50 if required_tags else min(max(top_k * 3, 10), 50)
 
     owner_user_id = _require_owner_user_id(storage, client_id)
+    # Workspace scoping (#493): filter foreign-workspace vectors at query
+    # time so they never crowd the candidate pool.
+    workspace_id, _ = _caller_workspace_scope(storage)
     await _report_progress(ctx, 0, 3, f"Running vector search for '{query}'...")
     try:
-        pairs = _vector_store().search(query, owner_user_id, top_k=search_top_k)
+        pairs = _vector_store().search(
+            query, owner_user_id, top_k=search_top_k, workspace_id=workspace_id
+        )
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "query": query}, storage, client_id)
     except Exception:
@@ -1673,6 +1720,11 @@ async def search_memories(
         ctx, 1, 3, f"Vector search returned {len(pairs)} candidates; hydrating..."
     )
     hydrated = storage.hydrate_memory_ids(pairs)
+    # Authoritative workspace check against the DynamoDB rows, applied BEFORE
+    # ranking/limits: pre-#493 vectors carry no workspace metadata, so the
+    # query-time filter alone can't exclude a memory the migration stamped
+    # into a foreign workspace (#493).
+    hydrated = [(m, sem) for m, sem in hydrated if _workspace_visible(m, workspace_id)]
 
     # Score each hydrated memory. sem_map lets us pair each Memory with its
     # original cosine similarity; absent memories (hydrate dropped expired
@@ -1799,17 +1851,25 @@ async def relate_memories(
             )
 
     owner_user_id = _require_owner_user_id(storage, client_id)
+    # Workspace scoping (#493): filter foreign-workspace vectors at query time.
+    workspace_id, _ = _caller_workspace_scope(storage)
     try:
         # Fetch top_k+1 so that dropping the source still leaves up to top_k.
-        pairs = _vector_store().search(query_value, owner_user_id, top_k=top_k + 1)
+        pairs = _vector_store().search(
+            query_value, owner_user_id, top_k=top_k + 1, workspace_id=workspace_id
+        )
     except VectorIndexNotFoundError:
         return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
     except Exception:
         logger.warning("Vector search failed (non-fatal)", exc_info=True)
         return _tool_result({"items": [], "count": 0, "key": key}, storage, client_id)
 
-    pairs = [(mid, score) for mid, score in pairs if mid != memory.memory_id][:top_k]
+    pairs = [(mid, score) for mid, score in pairs if mid != memory.memory_id]
     results = storage.hydrate_memory_ids(pairs)
+    # Authoritative workspace check before the top_k truncation, so a
+    # foreign-workspace candidate (pre-#493 vector without workspace
+    # metadata) can neither surface nor crowd out a visible result (#493).
+    results = [(m, score) for m, score in results if _workspace_visible(m, workspace_id)][:top_k]
 
     _log(
         storage,
@@ -2028,8 +2088,12 @@ async def pack_context(
     )
 
     owner_user_id = _require_owner_user_id(storage, client_id)
+    # Workspace scoping (#493): filter foreign-workspace vectors at query time.
+    workspace_id, _ = _caller_workspace_scope(storage)
     try:
-        pairs = _vector_store().search(topic, owner_user_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL)
+        pairs = _vector_store().search(
+            topic, owner_user_id, top_k=_PACK_CONTEXT_CANDIDATE_POOL, workspace_id=workspace_id
+        )
     except VectorIndexNotFoundError:
         return _tool_result(_render_empty_within_budget(topic, budget), storage, client_id)
     except Exception:
@@ -2037,6 +2101,9 @@ async def pack_context(
         return _tool_result(_render_empty_within_budget(topic, budget), storage, client_id)
 
     hydrated = storage.hydrate_memory_ids(pairs)
+    # Authoritative workspace check before scoring/packing — a packed context
+    # block must never include another workspace's memories (#493).
+    hydrated = [(m, sem) for m, sem in hydrated if _workspace_visible(m, workspace_id)]
 
     # Score every candidate through the standard blend pipeline so the
     # `relevance+recency` mode matches search_memories exactly.

--- a/src/hive/storage.py
+++ b/src/hive/storage.py
@@ -113,6 +113,27 @@ class AuthCodeAlreadyUsed(Exception):
     """
 
 
+def _workspace_filter_passes(
+    memory: Memory,
+    workspace_id: str | None,
+    *,
+    workspace_scoped: bool,
+) -> bool:
+    """Evaluate the in-memory workspace filter for a hydrated memory.
+
+    ``workspace_scoped=False`` (default): a literal filter — ``workspace_id``
+    of ``None`` disables it, otherwise only exact matches pass.
+
+    ``workspace_scoped=True``: the MCP compat rules (#493) — unstamped
+    (pre-migration) memories always pass, stamped memories pass only when
+    they match ``workspace_id``, and ``workspace_id=None`` (unresolvable
+    caller) fails closed to unstamped memories only.
+    """
+    if workspace_scoped:
+        return memory.workspace_id is None or memory.workspace_id == workspace_id
+    return workspace_id is None or memory.workspace_id == workspace_id
+
+
 def _now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -612,7 +633,13 @@ class HiveStorage:
                 results.append((memory, score))
         return results
 
-    def list_distinct_tags(self, owner_user_id: str) -> list[str]:
+    def list_distinct_tags(
+        self,
+        owner_user_id: str,
+        workspace_id: str | None = None,
+        *,
+        workspace_scoped: bool = False,
+    ) -> list[str]:
         """Return the sorted distinct tags across the user account's memories.
 
         Queries the strongly-consistent USERTAG items (PK=USERTAG#{user_id},
@@ -620,6 +647,13 @@ class HiveStorage:
         ``owner_user_id`` boundary used by list_memories / summarize_context
         (#666) — and reads-your-writes without TagIndex GSI propagation lag
         (#653). The base table is never scanned.
+
+        With ``workspace_scoped=True`` the result applies the workspace compat
+        rules (#493): tag entries stamped with a foreign ``workspace_id`` are
+        dropped, unstamped entries (pre-migration rows, later stamped by
+        ``scripts/migrate_workspaces.py``) stay visible, and a ``None``
+        ``workspace_id`` (unresolvable caller) fails closed to unstamped
+        entries only. The default (``False``) keeps the account-wide view.
         """
         tags: set[str] = set()
         start_key: dict[str, Any] | None = None
@@ -627,13 +661,17 @@ class HiveStorage:
             kwargs: dict[str, Any] = {
                 "KeyConditionExpression": Key("PK").eq(f"USERTAG#{owner_user_id}")
                 & Key("SK").begins_with("TAG#"),
-                "ProjectionExpression": "SK",
+                "ProjectionExpression": "SK, workspace_id",
                 "ConsistentRead": True,
             }
             if start_key:
                 kwargs["ExclusiveStartKey"] = start_key
             resp = self.table.query(**kwargs)
             for item in resp.get("Items", []):
+                if workspace_scoped:
+                    item_ws = item.get("workspace_id")
+                    if item_ws is not None and item_ws != workspace_id:
+                        continue
                 sk = item.get("SK", "")
                 # SK = TAG#{tag}#MEMORY#{memory_id}; rsplit isolates the tag even
                 # if the tag itself contains '#'.
@@ -653,6 +691,8 @@ class HiveStorage:
         owner_user_id: str | None = None,
         owner_client_id: str | None = None,
         workspace_id: str | None = None,
+        *,
+        workspace_scoped: bool = False,
     ) -> tuple[list[Memory], str | None]:
         """Query for memories with a given tag.
 
@@ -667,6 +707,13 @@ class HiveStorage:
         the TagIndex GSI is used (eventually consistent). The ``workspace_id``
         filter is always applied in-memory on the hydrated results.
 
+        ``workspace_scoped=True`` switches the workspace filter to the compat
+        rules used by the MCP tool handlers (#493): memories stamped with a
+        foreign workspace are dropped, unstamped (pre-migration) memories stay
+        visible, and ``workspace_id=None`` (unresolvable caller) fails closed
+        to unstamped memories only. The default exact-match filter is kept for
+        callers that want a literal workspace slice.
+
         Returns (memories, next_cursor). next_cursor is None when exhausted.
         """
         if owner_user_id is not None:
@@ -678,6 +725,7 @@ class HiveStorage:
                     owner_client_id=owner_client_id,
                     limit=limit,
                     workspace_id=workspace_id,
+                    workspace_scoped=workspace_scoped,
                     start_key=decoded_cursor,
                 )
 
@@ -707,7 +755,7 @@ class HiveStorage:
                 continue
             if owner_client_id is not None and m.owner_client_id != owner_client_id:
                 continue
-            if workspace_id is not None and m.workspace_id != workspace_id:
+            if not _workspace_filter_passes(m, workspace_id, workspace_scoped=workspace_scoped):
                 continue
             memories.append(m)
 
@@ -722,6 +770,7 @@ class HiveStorage:
         owner_client_id: str | None = None,
         limit: int = 100,
         workspace_id: str | None = None,
+        workspace_scoped: bool = False,
         start_key: dict[str, Any] | None = None,
     ) -> tuple[list[Memory], str | None]:
         """Strongly-consistent tag query via USERTAG base-table items.
@@ -761,7 +810,7 @@ class HiveStorage:
                 continue
             if owner_client_id is not None and m.owner_client_id != owner_client_id:
                 continue
-            if workspace_id is not None and m.workspace_id != workspace_id:
+            if not _workspace_filter_passes(m, workspace_id, workspace_scoped=workspace_scoped):
                 continue
             memories.append(m)
 
@@ -830,6 +879,8 @@ class HiveStorage:
         owner_user_id: str | None = None,
         owner_client_id: str | None = None,
         workspace_id: str | None = None,
+        *,
+        workspace_scoped: bool = False,
     ) -> int:
         """Delete all memories with the given tag.
 
@@ -838,7 +889,11 @@ class HiveStorage:
         matching memories are deleted. Passing **no** filter deletes every
         memory with the tag across all owners, so a caller acting on behalf of
         a single tenant MUST pass its scope (``owner_client_id`` at minimum) to
-        avoid cross-tenant deletion. Returns the count of memories deleted.
+        avoid cross-tenant deletion. ``workspace_scoped=True`` applies the
+        workspace compat rules to the ``workspace_id`` filter (see
+        ``list_memories_by_tag``) so a workspace-scoped caller can never bulk
+        delete memories held by another workspace (#493). Returns the count of
+        memories deleted.
         """
         deleted = 0
         cursor: str | None = None
@@ -850,6 +905,7 @@ class HiveStorage:
                 owner_user_id=owner_user_id,
                 owner_client_id=owner_client_id,
                 workspace_id=workspace_id,
+                workspace_scoped=workspace_scoped,
             )
             for memory in items:
                 self._delete_tag_items(memory)

--- a/src/hive/vector_store.py
+++ b/src/hive/vector_store.py
@@ -117,6 +117,17 @@ class VectorStore:
             index_name = self._ensure_index(owner_user_id)
             text = f"{memory.key}: {memory.value}"
             embedding = self._embed(text)
+            metadata: dict[str, Any] = {
+                "memory_key": memory.key,
+                "tags": json.dumps(memory.tags),
+            }
+            # Workspace scoping (#493): stamp the vector with the memory's
+            # workspace so `search` can filter foreign-workspace vectors at
+            # query time. Unstamped memories (pre-migration rows) carry no
+            # key — the query filter's `$exists: false` arm keeps them
+            # reachable, mirroring the DynamoDB compat rules.
+            if memory.workspace_id is not None:
+                metadata["workspace_id"] = memory.workspace_id
             self._s3v.put_vectors(
                 vectorBucketName=self._bucket,
                 indexName=index_name,
@@ -124,10 +135,7 @@ class VectorStore:
                     {
                         "key": memory.memory_id,
                         "data": {"float32": embedding},
-                        "metadata": {
-                            "memory_key": memory.key,
-                            "tags": json.dumps(memory.tags),
-                        },
+                        "metadata": metadata,
                     }
                 ],
             )
@@ -167,6 +175,8 @@ class VectorStore:
         query: str,
         owner_user_id: str,
         top_k: int = 20,
+        *,
+        workspace_id: str | None = None,
     ) -> list[tuple[str, float]]:
         """Return ``(memory_id, score)`` pairs ranked by cosine similarity.
 
@@ -174,19 +184,39 @@ class VectorStore:
         scoped to the ``owner_user_id`` account index, so results span every DCR
         client of that account (consistent with list_memories, #666).
 
+        When ``workspace_id`` is given, an S3 Vectors metadata filter restricts
+        matches to vectors stamped with that workspace *or* carrying no
+        ``workspace_id`` metadata at all (#493). The ``$exists: false`` arm
+        keeps pre-#493 vectors (written before workspace stamping) reachable;
+        callers must still post-filter hydrated results against the
+        authoritative DynamoDB ``workspace_id`` — and do so before any
+        ranking/limit truncation — because a pre-#493 vector may belong to a
+        memory that the migration has since stamped into a foreign workspace.
+        ``None`` disables the filter (legacy account-wide search).
+
         Raises ``VectorIndexNotFoundError`` when the account has never written a
         memory (index does not exist yet).
         """
         index_name = self._index_name(owner_user_id)
+        query_kwargs: dict[str, Any] = {
+            "vectorBucketName": self._bucket,
+            "indexName": index_name,
+            "topK": min(top_k, 100),
+            "returnDistance": True,
+            "returnMetadata": False,
+        }
+        if workspace_id is not None:
+            query_kwargs["filter"] = {
+                "$or": [
+                    {"workspace_id": workspace_id},
+                    {"workspace_id": {"$exists": False}},
+                ]
+            }
         try:
             embedding = self._embed(query)
             resp = self._s3v.query_vectors(
-                vectorBucketName=self._bucket,
-                indexName=index_name,
                 queryVector={"float32": embedding},
-                topK=min(top_k, 100),
-                returnDistance=True,
-                returnMetadata=False,
+                **query_kwargs,
             )
         except self._s3v.exceptions.NotFoundException as exc:
             raise VectorIndexNotFoundError(

--- a/src/hive/vector_store.py
+++ b/src/hive/vector_store.py
@@ -177,6 +177,7 @@ class VectorStore:
         top_k: int = 20,
         *,
         workspace_id: str | None = None,
+        workspace_scoped: bool = False,
     ) -> list[tuple[str, float]]:
         """Return ``(memory_id, score)`` pairs ranked by cosine similarity.
 
@@ -184,15 +185,18 @@ class VectorStore:
         scoped to the ``owner_user_id`` account index, so results span every DCR
         client of that account (consistent with list_memories, #666).
 
-        When ``workspace_id`` is given, an S3 Vectors metadata filter restricts
-        matches to vectors stamped with that workspace *or* carrying no
-        ``workspace_id`` metadata at all (#493). The ``$exists: false`` arm
-        keeps pre-#493 vectors (written before workspace stamping) reachable;
-        callers must still post-filter hydrated results against the
-        authoritative DynamoDB ``workspace_id`` — and do so before any
-        ranking/limit truncation — because a pre-#493 vector may belong to a
-        memory that the migration has since stamped into a foreign workspace.
-        ``None`` disables the filter (legacy account-wide search).
+        ``workspace_scoped=True`` applies an S3 Vectors metadata filter using
+        the workspace compat rules (#493), mirroring the storage API: matches
+        are restricted to vectors stamped with ``workspace_id`` *or* carrying
+        no ``workspace_id`` metadata at all, and a ``None`` ``workspace_id``
+        (unresolvable caller) fails closed to unstamped vectors only. The
+        ``$exists: false`` arm keeps pre-#493 vectors (written before
+        workspace stamping) reachable; callers must still post-filter hydrated
+        results against the authoritative DynamoDB ``workspace_id`` — and do
+        so before any ranking/limit truncation — because a pre-#493 vector may
+        belong to a memory that the migration has since stamped into a foreign
+        workspace. The default (``False``) disables the filter entirely
+        (legacy account-wide search); ``workspace_id`` is ignored then.
 
         Raises ``VectorIndexNotFoundError`` when the account has never written a
         memory (index does not exist yet).
@@ -205,13 +209,12 @@ class VectorStore:
             "returnDistance": True,
             "returnMetadata": False,
         }
-        if workspace_id is not None:
-            query_kwargs["filter"] = {
-                "$or": [
-                    {"workspace_id": workspace_id},
-                    {"workspace_id": {"$exists": False}},
-                ]
-            }
+        if workspace_scoped:
+            no_stamp = {"workspace_id": {"$exists": False}}
+            if workspace_id is not None:
+                query_kwargs["filter"] = {"$or": [{"workspace_id": workspace_id}, no_stamp]}
+            else:
+                query_kwargs["filter"] = no_stamp
         try:
             embedding = self._embed(query)
             resp = self._s3v.query_vectors(

--- a/tests/integration/test_workspace_query_scoping.py
+++ b/tests/integration/test_workspace_query_scoping.py
@@ -114,6 +114,7 @@ def setup():
         BillingMode="PAY_PER_REQUEST",
     )
 
+    old_table = os.environ.get("HIVE_TABLE_NAME")
     os.environ["HIVE_TABLE_NAME"] = _TABLE
     from hive.storage import HiveStorage
 
@@ -141,7 +142,14 @@ def setup():
         )
         storage.put_token(token)
         jwts[ws] = issue_jwt(token)
-    return storage, jwts["ws-int-a"], jwts["ws-int-b"]
+    yield storage, jwts["ws-int-a"], jwts["ws-int-b"]
+
+    # Restore the env var so later integration modules in the same process
+    # keep their expected table binding.
+    if old_table is not None:
+        os.environ["HIVE_TABLE_NAME"] = old_table
+    else:
+        os.environ.pop("HIVE_TABLE_NAME", None)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_workspace_query_scoping.py
+++ b/tests/integration/test_workspace_query_scoping.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Integration tests for workspace scoping of the MCP query tools (#493)
+against DynamoDB Local.
+
+Two tokens share the same owner account but carry different workspace
+claims — the strict case where only the workspace boundary (not the
+account boundary) separates them. Writes made under workspace A must be
+invisible from workspace B through every read path: list_memories,
+list_tags, search_memories, and summarize_context; keyed recall stays
+not-found; forget_all never crosses the boundary.
+
+Usage:
+  docker run -p 8080:8000 amazon/dynamodb-local
+  DYNAMODB_ENDPOINT=http://localhost:8080 pytest tests/integration/
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+DYNAMO_ENDPOINT = os.environ.get("DYNAMODB_ENDPOINT")
+
+pytestmark = pytest.mark.skipif(
+    not DYNAMO_ENDPOINT,
+    reason="DYNAMODB_ENDPOINT not set — skipping integration tests",
+)
+
+_TABLE = "hive-integration-workspace-scoping"
+
+
+def _make_context(token_str: str):
+    """Build a minimal MCP Context with an Authorization header."""
+    ctx = MagicMock()
+    ctx.request_context = MagicMock()
+    ctx.request_context.meta = {"Authorization": f"Bearer {token_str}"}
+    return ctx
+
+
+def _text(r) -> str:
+    return r.content[0].text
+
+
+def _body(r) -> dict:
+    return r.structured_content
+
+
+@pytest.fixture(scope="module")
+def setup():
+    """Two workspace-scoped tokens (same owner account) + storage."""
+    import contextlib
+    from datetime import datetime, timedelta, timezone
+
+    import boto3
+
+    from hive.auth.tokens import issue_jwt
+    from hive.models import OAuthClient, Token
+
+    ddb = boto3.client(
+        "dynamodb",
+        endpoint_url=DYNAMO_ENDPOINT,
+        region_name="us-east-1",
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+    )
+    with contextlib.suppress(Exception):
+        ddb.delete_table(TableName=_TABLE)
+
+    ddb.create_table(
+        TableName=_TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI5PK", "AttributeType": "S"},
+            {"AttributeName": "GSI5SK", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "WorkspaceMemberIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    os.environ["HIVE_TABLE_NAME"] = _TABLE
+    from hive.storage import HiveStorage
+
+    storage = HiveStorage(
+        table_name=_TABLE,
+        region="us-east-1",
+        endpoint_url=DYNAMO_ENDPOINT,
+        aws_access_key_id="local",
+        aws_secret_access_key="local",
+    )
+
+    owner = "ws-scoping-user"
+    now = datetime.now(timezone.utc)
+    jwts = {}
+    for ws in ("ws-int-a", "ws-int-b"):
+        client = OAuthClient(client_name=f"WS client {ws}", owner_user_id=owner, workspace_id=ws)
+        storage.put_client(client)
+        token = Token(
+            client_id=client.client_id,
+            scope="memories:read memories:write",
+            issued_at=now,
+            expires_at=now + timedelta(hours=1),
+            workspace_id=ws,
+            workspace_role="owner",
+        )
+        storage.put_token(token)
+        jwts[ws] = issue_jwt(token)
+    return storage, jwts["ws-int-a"], jwts["ws-int-b"]
+
+
+@pytest.mark.asyncio
+class TestWorkspaceQueryScoping:
+    async def _seed(self, jwt_a, jwt_b):
+        from hive.server import remember
+
+        await remember("a-note", "alpha-secret", ["scoped"], ctx=_make_context(jwt_a))
+        await remember("b-note", "bravo-secret", ["scoped"], ctx=_make_context(jwt_b))
+
+    async def test_list_memories_is_mutually_invisible(self, setup):
+        from hive.server import list_memories
+
+        _, jwt_a, jwt_b = setup
+        await self._seed(jwt_a, jwt_b)
+
+        keys_a = {
+            m["key"]
+            for m in _body(await list_memories("scoped", ctx=_make_context(jwt_a)))["items"]
+        }
+        keys_b = {
+            m["key"]
+            for m in _body(await list_memories("scoped", ctx=_make_context(jwt_b)))["items"]
+        }
+        assert keys_a == {"a-note"}
+        assert keys_b == {"b-note"}
+
+    async def test_list_tags_is_mutually_invisible(self, setup):
+        from hive.server import list_tags, remember
+
+        _, jwt_a, jwt_b = setup
+        await remember("a-tagged", "v", ["only-in-a"], ctx=_make_context(jwt_a))
+        await remember("b-tagged", "v", ["only-in-b"], ctx=_make_context(jwt_b))
+
+        tags_a = _body(await list_tags(ctx=_make_context(jwt_a)))["tags"]
+        tags_b = _body(await list_tags(ctx=_make_context(jwt_b)))["tags"]
+        assert "only-in-a" in tags_a and "only-in-b" not in tags_a
+        assert "only-in-b" in tags_b and "only-in-a" not in tags_b
+
+    async def test_summarize_context_is_mutually_invisible(self, setup):
+        from hive.server import summarize_context
+
+        _, jwt_a, jwt_b = setup
+        await self._seed(jwt_a, jwt_b)
+
+        text_a = _text(await summarize_context("scoped", ctx=_make_context(jwt_a)))
+        text_b = _text(await summarize_context("scoped", ctx=_make_context(jwt_b)))
+        assert "alpha-secret" in text_a and "bravo-secret" not in text_a
+        assert "bravo-secret" in text_b and "alpha-secret" not in text_b
+
+    async def test_search_memories_is_mutually_invisible(self, setup):
+        """Even when the vector layer surfaces both candidates (e.g. pre-#493
+        vectors carrying no workspace metadata), the authoritative DynamoDB
+        check keeps foreign-workspace hits out of the results."""
+        from hive.server import search_memories
+
+        storage, jwt_a, jwt_b = setup
+        await self._seed(jwt_a, jwt_b)
+        mem_a = storage.get_memory_by_key("a-note")
+        mem_b = storage.get_memory_by_key("b-note")
+
+        mock_vs = MagicMock()
+        mock_vs.search.return_value = [
+            (mem_a.memory_id, 0.9),
+            (mem_b.memory_id, 0.9),
+        ]
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            keys_a = {
+                i["key"]
+                for i in _body(await search_memories("secret", ctx=_make_context(jwt_a)))["items"]
+            }
+            keys_b = {
+                i["key"]
+                for i in _body(await search_memories("secret", ctx=_make_context(jwt_b)))["items"]
+            }
+        assert keys_a == {"a-note"}
+        assert keys_b == {"b-note"}
+        # Each query pushed its own workspace claim down to the vector filter.
+        called_ws = [c.kwargs["workspace_id"] for c in mock_vs.search.call_args_list]
+        assert called_ws == ["ws-int-a", "ws-int-b"]
+
+    async def test_cross_workspace_recall_stays_not_found(self, setup):
+        from fastmcp.exceptions import ToolError
+
+        from hive.server import recall
+
+        _, jwt_a, jwt_b = setup
+        await self._seed(jwt_a, jwt_b)
+        with pytest.raises(ToolError, match="No memory found for key 'a-note'"):
+            await recall(key="a-note", ctx=_make_context(jwt_b))
+
+    async def test_forget_all_never_crosses_the_boundary(self, setup):
+        from hive.server import forget_all, remember
+
+        storage, jwt_a, jwt_b = setup
+        await remember("a-bulk", "v", ["bulk"], ctx=_make_context(jwt_a))
+        await remember("b-bulk", "v", ["bulk"], ctx=_make_context(jwt_b))
+
+        result = await forget_all(tag="bulk", ctx=_make_context(jwt_a))
+        assert "Deleted 1 memories" in _text(result)
+        assert storage.get_memory_by_key("a-bulk") is None
+        assert storage.get_memory_by_key("b-bulk") is not None

--- a/tests/unit/test_migrate_workspaces.py
+++ b/tests/unit/test_migrate_workspaces.py
@@ -135,6 +135,7 @@ class TestHelpers:
             workspaces_created=1,
             memories_seen=2,
             memories_migrated=2,
+            user_tags_stamped=4,
             clients_seen=1,
             clients_migrated=1,
             tokens_revoked=3,
@@ -143,6 +144,7 @@ class TestHelpers:
         assert "users_seen=1" in text
         assert "workspaces_created=1" in text
         assert "memories_migrated=2" in text
+        assert "user_tags_stamped=4" in text
         assert "clients_migrated=1" in text
         assert "tokens_revoked=3" in text
 
@@ -256,6 +258,106 @@ class TestMemoryMigration:
             stats = run(storage=storage)
         assert stats.memories_skipped == 1
         assert stats.memories_migrated == 0
+
+
+class TestUserTagMigration:
+    """USERTAG items gain the workspace stamp that list_tags filters on (#493)."""
+
+    def _user_tag_item(self, storage, mem: Memory, tag: str) -> dict | None:
+        resp = storage.table.get_item(
+            Key={
+                "PK": f"USERTAG#{mem.owner_user_id}",
+                "SK": f"TAG#{tag}#MEMORY#{mem.memory_id}",
+            }
+        )
+        return resp.get("Item")
+
+    def _seed_tagged_memory(self, storage, owner_user_id: str, tags: list[str]) -> Memory:
+        mem = Memory(
+            key="tagged",
+            value="v",
+            tags=tags,
+            owner_client_id="client-1",
+            owner_user_id=owner_user_id,
+        )
+        storage.put_memory(mem)
+        return mem
+
+    def test_stamps_workspace_id_on_user_tag_items(self, storage):
+        alice = _seed_user(storage)
+        mem = self._seed_tagged_memory(storage, alice.user_id, ["t1", "t2"])
+        stats = run(storage=storage)
+        assert stats.user_tags_stamped == 2
+        ws = storage.list_workspaces_for_user(alice.user_id)[0]
+        for tag in ("t1", "t2"):
+            item = self._user_tag_item(storage, mem, tag)
+            assert item["workspace_id"] == ws.workspace_id
+
+    def test_rerun_skips_already_stamped_user_tags(self, storage):
+        alice = _seed_user(storage)
+        self._seed_tagged_memory(storage, alice.user_id, ["t1"])
+        run(storage=storage)
+        stats2 = run(storage=storage)
+        assert stats2.user_tags_stamped == 0
+        assert stats2.user_tags_skipped == 1
+
+    def test_skips_user_tags_when_memory_meta_stays_unstamped(self, storage):
+        # A memory referencing an unknown user never gets a META stamp, so its
+        # USERTAG rows must stay unstamped too (no workspace to map to).
+        mem = self._seed_tagged_memory(storage, "ghost-user", ["t1"])
+        stats = run(storage=storage)
+        assert stats.user_tags_stamped == 0
+        assert stats.user_tags_skipped == 0
+        assert "workspace_id" not in self._user_tag_item(storage, mem, "t1")
+
+    def test_missing_user_tag_row_is_skipped(self, storage):
+        alice = _seed_user(storage)
+        mem = self._seed_tagged_memory(storage, alice.user_id, ["t1"])
+        # Simulate a USERTAG row lost before the migration (memory deleted
+        # mid-run): the conditional update fails and is counted as a skip.
+        storage.table.delete_item(
+            Key={
+                "PK": f"USERTAG#{alice.user_id}",
+                "SK": f"TAG#t1#MEMORY#{mem.memory_id}",
+            }
+        )
+        stats = run(storage=storage)
+        assert stats.user_tags_stamped == 0
+        assert stats.user_tags_skipped == 1
+
+    def test_unexpected_client_error_propagates(self, storage):
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        alice = _seed_user(storage)
+        self._seed_tagged_memory(storage, alice.user_id, ["t1"])
+        # First run stamps the META so the second run's only update_item call
+        # comes from the user-tag phase.
+        run(storage=storage)
+        error = ClientError(
+            {"Error": {"Code": "InternalServerError", "Message": "boom"}},
+            "UpdateItem",
+        )
+        with (
+            patch.object(storage.table, "update_item", side_effect=error),
+            pytest.raises(ClientError),
+        ):
+            run(storage=storage)
+
+    def test_dry_run_counts_user_tags_without_writing(self, storage):
+        alice = _seed_user(storage)
+        mem = self._seed_tagged_memory(storage, alice.user_id, ["t1"])
+        # Pre-stamp the META only (as a completed memory phase would have),
+        # leaving the USERTAG row unstamped.
+        storage.table.update_item(
+            Key={"PK": f"MEMORY#{mem.memory_id}", "SK": "META"},
+            UpdateExpression="SET workspace_id = :wsid",
+            ExpressionAttributeValues={":wsid": "ws-pre"},
+        )
+        stats = run(dry_run=True, storage=storage)
+        assert stats.user_tags_stamped == 1
+        assert "workspace_id" not in self._user_tag_item(storage, mem, "t1")
 
 
 class TestClientMigration:

--- a/tests/unit/test_migrate_workspaces.py
+++ b/tests/unit/test_migrate_workspaces.py
@@ -357,7 +357,25 @@ class TestUserTagMigration:
         )
         stats = run(dry_run=True, storage=storage)
         assert stats.user_tags_stamped == 1
+        assert stats.user_tags_skipped == 0
         assert "workspace_id" not in self._user_tag_item(storage, mem, "t1")
+
+    def test_dry_run_counts_already_stamped_and_missing_rows_as_skipped(self, storage):
+        # Dry-run must mirror the real run's conditional-update semantics:
+        # already-stamped rows and missing rows read as skipped, not as
+        # pending work (would overstate the remaining migration).
+        alice = _seed_user(storage)
+        mem = self._seed_tagged_memory(storage, alice.user_id, ["t1", "t2"])
+        run(storage=storage)  # real run stamps both USERTAG rows
+        storage.table.delete_item(
+            Key={
+                "PK": f"USERTAG#{alice.user_id}",
+                "SK": f"TAG#t2#MEMORY#{mem.memory_id}",
+            }
+        )
+        stats = run(dry_run=True, storage=storage)
+        assert stats.user_tags_stamped == 0
+        assert stats.user_tags_skipped == 2
 
 
 class TestClientMigration:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -82,6 +82,27 @@ class TestMemory:
             assert item["owner_client_id"] == "c1"
             assert item["owner_user_id"] == "user-1"
 
+    def test_to_dynamo_user_tag_items_stamps_workspace_id(self):
+        # Workspace scoping (#493): list_distinct_tags filters on the USERTAG
+        # item's workspace_id attribute, so it must round-trip through here.
+        m = Memory(
+            key="k",
+            value="v",
+            tags=["t"],
+            owner_client_id="c1",
+            owner_user_id="user-1",
+            workspace_id="ws-1",
+        )
+        (item,) = m.to_dynamo_user_tag_items()
+        assert item["workspace_id"] == "ws-1"
+
+    def test_to_dynamo_user_tag_items_omits_workspace_id_when_unstamped(self):
+        # Pre-migration rows carry no workspace attribute — the absence is
+        # what keeps them visible in every workspace of the owner.
+        m = Memory(key="k", value="v", tags=["t"], owner_client_id="c1", owner_user_id="user-1")
+        (item,) = m.to_dynamo_user_tag_items()
+        assert "workspace_id" not in item
+
     def test_to_dynamo_user_tag_items_no_tags(self):
         m = Memory(key="k", value="v", owner_client_id="c1", owner_user_id="user-1")
         assert m.to_dynamo_user_tag_items() == []

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -4443,6 +4443,184 @@ class TestWorkspaceStamping:
         assert _text(await recall(key="legacy-resolved", ctx=ctx)) == "v"
 
 
+@pytest.mark.asyncio
+class TestWorkspaceQueryScoping:
+    """Aggregate read paths are scoped to the caller's workspace (#493).
+
+    The strict case: the foreign memory shares the caller's ``owner_user_id``
+    (same account, different workspace) so only the workspace boundary — not
+    the account boundary — can keep it out of list / tags / search /
+    summarise / pack results.
+    """
+
+    def _seed_sibling_and_legacy(self, storage):
+        """Insert a same-account foreign-workspace memory and an unstamped
+        legacy memory alongside the ws-a caller from ``workspace_env``."""
+        from hive.models import Memory
+
+        sibling = Memory(
+            key="sibling-key",
+            value="sibling-secret",
+            tags=["shared", "ws-b-tag"],
+            owner_client_id="client-b2",
+            owner_user_id="user-a",
+            workspace_id="ws-b",
+        )
+        legacy = Memory(
+            key="legacy-key",
+            value="legacy-value",
+            tags=["shared", "legacy-tag"],
+            owner_client_id="client-old",
+            owner_user_id="user-a",
+        )
+        storage.put_memory(sibling)
+        storage.put_memory(legacy)
+        return sibling, legacy
+
+    async def test_list_memories_excludes_foreign_workspace(self, workspace_env):
+        from hive.server import list_memories, remember
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember("own-key", "own-value", ["shared"], ctx=ctx)
+        self._seed_sibling_and_legacy(storage)
+
+        result = await list_memories(tag="shared", ctx=ctx)
+        keys = {m["key"] for m in _body(result)["items"]}
+        # Unstamped legacy rows stay visible (compat); ws-b rows never do.
+        assert keys == {"own-key", "legacy-key"}
+
+    async def test_list_tags_excludes_foreign_workspace_tags(self, workspace_env):
+        from hive.server import list_tags, remember
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember("own-key", "own-value", ["own-tag"], ctx=ctx)
+        self._seed_sibling_and_legacy(storage)
+
+        tags = _body(await list_tags(ctx=ctx))["tags"]
+        assert "own-tag" in tags
+        assert "legacy-tag" in tags
+        assert "ws-b-tag" not in tags
+        # "shared" is carried by the visible legacy row too, so it stays.
+        assert "shared" in tags
+
+    async def test_summarize_context_excludes_foreign_workspace(self, workspace_env):
+        from hive.server import remember, summarize_context
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember("own-key", "own-value", ["shared"], ctx=ctx)
+        self._seed_sibling_and_legacy(storage)
+
+        text = _text(await summarize_context(topic="shared", ctx=ctx))
+        assert "own-value" in text
+        assert "legacy-value" in text
+        assert "sibling-secret" not in text
+
+    async def test_search_memories_excludes_foreign_workspace(self, workspace_env):
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember("own-key", "own-value", [], ctx=ctx)
+        sibling, legacy = self._seed_sibling_and_legacy(storage)
+        own = storage.get_memory_by_key("own-key")
+
+        mock_vs = _make_mock_vector_store(
+            [(sibling.memory_id, 0.99), (own.memory_id, 0.5), (legacy.memory_id, 0.4)]
+        )
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("secret", ctx=ctx)
+
+        keys = {item["key"] for item in _body(result)["items"]}
+        assert keys == {"own-key", "legacy-key"}
+        # The workspace claim is pushed down to the S3 Vectors query filter.
+        assert mock_vs.search.call_args.kwargs["workspace_id"] == "ws-a"
+
+    async def test_search_foreign_hits_cannot_crowd_out_results(self, workspace_env):
+        """The workspace filter applies before ranking/limits — a top-scoring
+        foreign candidate must not consume the only top_k slot."""
+        from unittest.mock import patch
+
+        from hive.server import remember, search_memories
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember("own-key", "own-value", [], ctx=ctx)
+        sibling, _ = self._seed_sibling_and_legacy(storage)
+        own = storage.get_memory_by_key("own-key")
+
+        mock_vs = _make_mock_vector_store([(sibling.memory_id, 0.99), (own.memory_id, 0.1)])
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await search_memories("secret", top_k=1, ctx=ctx)
+
+        body = _body(result)
+        assert body["count"] == 1
+        assert body["items"][0]["key"] == "own-key"
+
+    async def test_relate_memories_excludes_foreign_workspace(self, workspace_env):
+        from unittest.mock import patch
+
+        from hive.server import relate_memories, remember
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember("src-key", "source value", [], ctx=ctx)
+        await remember("own-key", "own-value", [], ctx=ctx)
+        sibling, _ = self._seed_sibling_and_legacy(storage)
+        src = storage.get_memory_by_key("src-key")
+        own = storage.get_memory_by_key("own-key")
+
+        # Foreign candidate outranks the visible one; with top_k=1 it would
+        # crowd out own-key if the filter ran after truncation.
+        mock_vs = _make_mock_vector_store(
+            [(src.memory_id, 1.0), (sibling.memory_id, 0.9), (own.memory_id, 0.5)]
+        )
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            result = await relate_memories(key="src-key", top_k=1, ctx=ctx)
+
+        body = _body(result)
+        assert [item["key"] for item in body["items"]] == ["own-key"]
+        assert mock_vs.search.call_args.kwargs["workspace_id"] == "ws-a"
+
+    async def test_pack_context_excludes_foreign_workspace(self, workspace_env):
+        from unittest.mock import patch
+
+        from hive.server import pack_context, remember
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember("own-key", "own-value", [], ctx=ctx)
+        sibling, _ = self._seed_sibling_and_legacy(storage)
+        own = storage.get_memory_by_key("own-key")
+
+        mock_vs = _make_mock_vector_store([(sibling.memory_id, 0.99), (own.memory_id, 0.5)])
+        with patch("hive.server._vector_store", return_value=mock_vs):
+            rendered = _text(await pack_context("secret", ctx=ctx))
+
+        assert "own-value" in rendered
+        assert "sibling-secret" not in rendered
+        assert mock_vs.search.call_args.kwargs["workspace_id"] == "ws-a"
+
+    async def test_forget_all_spares_foreign_workspace(self, workspace_env):
+        from hive.server import forget_all, remember
+
+        storage, _, jwt = workspace_env
+        ctx = _make_ctx(jwt)
+        await remember("own-key", "own-value", ["shared"], ctx=ctx)
+        sibling, legacy = self._seed_sibling_and_legacy(storage)
+
+        result = await forget_all(tag="shared", ctx=ctx)
+        assert "Deleted 2 memories" in _text(result)
+        assert storage.get_memory_by_key("own-key") is None
+        assert storage.get_memory_by_id(legacy.memory_id) is None
+        # The same-account foreign-workspace memory survives the bulk delete.
+        assert storage.get_memory_by_id(sibling.memory_id) is not None
+
+
 class TestWorkspaceScopeHelpers:
     def test_caller_scope_without_token_context_is_none(self, server_env):
         from unittest.mock import MagicMock as _MM

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1938,8 +1938,10 @@ class TestRelateMemories:
             await relate_memories("source", ctx=ctx)
 
         assert mock_vs.search.call_args.args[0] == "unique search phrase"
-        # top_k+1 requested so the source-memory drop still leaves headroom.
-        assert mock_vs.search.call_args.kwargs["top_k"] == 6
+        # Widened candidate pool (#493): min(max(top_k*3, 10), 50) + 1 so the
+        # source-memory drop and the workspace post-filter both have headroom.
+        # Default top_k=5 → pool of 16.
+        assert mock_vs.search.call_args.kwargs["top_k"] == 16
 
     async def test_missing_key_raises_tool_error(self, server_env):
         from fastmcp.exceptions import ToolError
@@ -4587,6 +4589,9 @@ class TestWorkspaceQueryScoping:
         assert [item["key"] for item in body["items"]] == ["own-key"]
         assert mock_vs.search.call_args.kwargs["workspace_id"] == "ws-a"
         assert mock_vs.search.call_args.kwargs["workspace_scoped"] is True
+        # A widened candidate pool (not top_k+1) so unstamped foreign vectors
+        # can't starve the results via service-side truncation.
+        assert mock_vs.search.call_args.kwargs["top_k"] == 11
 
     async def test_pack_context_excludes_foreign_workspace(self, workspace_env):
         from unittest.mock import patch

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -4539,6 +4539,7 @@ class TestWorkspaceQueryScoping:
         assert keys == {"own-key", "legacy-key"}
         # The workspace claim is pushed down to the S3 Vectors query filter.
         assert mock_vs.search.call_args.kwargs["workspace_id"] == "ws-a"
+        assert mock_vs.search.call_args.kwargs["workspace_scoped"] is True
 
     async def test_search_foreign_hits_cannot_crowd_out_results(self, workspace_env):
         """The workspace filter applies before ranking/limits — a top-scoring
@@ -4585,6 +4586,7 @@ class TestWorkspaceQueryScoping:
         body = _body(result)
         assert [item["key"] for item in body["items"]] == ["own-key"]
         assert mock_vs.search.call_args.kwargs["workspace_id"] == "ws-a"
+        assert mock_vs.search.call_args.kwargs["workspace_scoped"] is True
 
     async def test_pack_context_excludes_foreign_workspace(self, workspace_env):
         from unittest.mock import patch
@@ -4604,6 +4606,7 @@ class TestWorkspaceQueryScoping:
         assert "own-value" in rendered
         assert "sibling-secret" not in rendered
         assert mock_vs.search.call_args.kwargs["workspace_id"] == "ws-a"
+        assert mock_vs.search.call_args.kwargs["workspace_scoped"] is True
 
     async def test_forget_all_spares_foreign_workspace(self, workspace_env):
         from hive.server import forget_all, remember

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -3336,6 +3336,130 @@ class TestWorkspaceIdFiltering:
         assert [c.client_name for c in clients] == ["A"]
 
 
+class TestWorkspaceScopedFiltering:
+    """The ``workspace_scoped=True`` compat filter used by the MCP tool
+    handlers (#493): stamped-foreign memories are dropped, unstamped
+    (pre-migration) memories stay visible, and a ``None`` workspace fails
+    closed to unstamped memories only.
+    """
+
+    def _seed(self, storage):
+        own = Memory(
+            key="own",
+            value="v",
+            owner_client_id="c1",
+            owner_user_id="u1",
+            workspace_id="ws-a",
+            tags=["shared"],
+        )
+        foreign = Memory(
+            key="foreign",
+            value="v",
+            owner_client_id="c2",
+            owner_user_id="u1",
+            workspace_id="ws-b",
+            tags=["shared"],
+        )
+        legacy = Memory(
+            key="legacy",
+            value="v",
+            owner_client_id="c1",
+            owner_user_id="u1",
+            tags=["shared"],
+        )
+        for m in (own, foreign, legacy):
+            storage.put_memory(m)
+        return own, foreign, legacy
+
+    def test_consistent_path_scoped_keeps_unstamped_drops_foreign(self, storage):
+        own, foreign, legacy = self._seed(storage)
+        items, _ = storage.list_memories_by_tag(
+            "shared", owner_user_id="u1", workspace_id="ws-a", workspace_scoped=True
+        )
+        keys = {m.key for m in items}
+        assert keys == {"own", "legacy"}
+
+    def test_consistent_path_scoped_none_workspace_fails_closed(self, storage):
+        self._seed(storage)
+        items, _ = storage.list_memories_by_tag(
+            "shared", owner_user_id="u1", workspace_id=None, workspace_scoped=True
+        )
+        assert {m.key for m in items} == {"legacy"}
+
+    def test_gsi_path_scoped_keeps_unstamped_drops_foreign(self, storage):
+        self._seed(storage)
+        # No owner_user_id — exercises the TagIndex GSI branch of the filter.
+        items, _ = storage.list_memories_by_tag(
+            "shared", workspace_id="ws-a", workspace_scoped=True
+        )
+        assert {m.key for m in items} == {"own", "legacy"}
+
+    def test_exact_match_default_still_drops_unstamped(self, storage):
+        self._seed(storage)
+        # Without workspace_scoped the literal filter applies: only ws-a rows.
+        items, _ = storage.list_memories_by_tag("shared", owner_user_id="u1", workspace_id="ws-a")
+        assert {m.key for m in items} == {"own"}
+
+    def test_delete_by_tag_scoped_spares_foreign_workspace(self, storage):
+        own, foreign, legacy = self._seed(storage)
+        deleted = storage.delete_memories_by_tag(
+            "shared", owner_user_id="u1", workspace_id="ws-a", workspace_scoped=True
+        )
+        assert deleted == 2
+        assert storage.get_memory_by_id(own.memory_id) is None
+        assert storage.get_memory_by_id(legacy.memory_id) is None
+        assert storage.get_memory_by_id(foreign.memory_id) is not None
+
+
+class TestListDistinctTagsWorkspaceScoped:
+    """list_distinct_tags workspace filtering via stamped USERTAG items (#493)."""
+
+    def _seed(self, storage):
+        storage.put_memory(
+            Memory(
+                key="own",
+                value="v",
+                owner_client_id="c1",
+                owner_user_id="u1",
+                workspace_id="ws-a",
+                tags=["tag-a"],
+            )
+        )
+        storage.put_memory(
+            Memory(
+                key="foreign",
+                value="v",
+                owner_client_id="c2",
+                owner_user_id="u1",
+                workspace_id="ws-b",
+                tags=["tag-b"],
+            )
+        )
+        storage.put_memory(
+            Memory(
+                key="legacy",
+                value="v",
+                owner_client_id="c1",
+                owner_user_id="u1",
+                tags=["tag-legacy"],
+            )
+        )
+
+    def test_scoped_hides_foreign_workspace_tags(self, storage):
+        self._seed(storage)
+        tags = storage.list_distinct_tags("u1", "ws-a", workspace_scoped=True)
+        assert tags == ["tag-a", "tag-legacy"]
+
+    def test_scoped_none_workspace_fails_closed_to_unstamped(self, storage):
+        self._seed(storage)
+        tags = storage.list_distinct_tags("u1", None, workspace_scoped=True)
+        assert tags == ["tag-legacy"]
+
+    def test_unscoped_default_returns_account_wide_tags(self, storage):
+        self._seed(storage)
+        assert storage.list_distinct_tags("u1") == ["tag-a", "tag-b", "tag-legacy"]
+
+
 class TestRevokeAllTokens:
     """Bulk token revocation used by the workspaces migration (#490)."""
 

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -259,14 +259,14 @@ class TestSearch:
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
         assert vs.search("q", "u") == []
 
-    def test_workspace_id_adds_metadata_filter(self):
+    def test_workspace_scoped_adds_metadata_filter(self):
         # Workspace scoping (#493): foreign-workspace vectors are excluded at
         # query time; the `$exists: false` arm keeps pre-#493 vectors (no
         # workspace metadata) reachable for the caller-side compat check.
         s3v = _make_s3v_client()
         s3v.query_vectors.return_value = {"vectors": []}
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
-        vs.search("q", "u", workspace_id="ws-1")
+        vs.search("q", "u", workspace_id="ws-1", workspace_scoped=True)
         assert s3v.query_vectors.call_args.kwargs["filter"] == {
             "$or": [
                 {"workspace_id": "ws-1"},
@@ -274,7 +274,17 @@ class TestSearch:
             ]
         }
 
-    def test_no_workspace_id_omits_filter(self):
+    def test_workspace_scoped_none_workspace_fails_closed_to_unstamped(self):
+        # An unresolvable caller (workspace_id=None) must not fall back to an
+        # unfiltered account-wide query — only unstamped vectors may match.
+        s3v = _make_s3v_client()
+        s3v.query_vectors.return_value = {"vectors": []}
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
+        vs.search("q", "u", workspace_id=None, workspace_scoped=True)
+        assert s3v.query_vectors.call_args.kwargs["filter"] == {"workspace_id": {"$exists": False}}
+
+    def test_unscoped_default_omits_filter(self):
+        # Legacy account-wide search (management API) is unchanged.
         s3v = _make_s3v_client()
         s3v.query_vectors.return_value = {"vectors": []}
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -155,6 +155,23 @@ class TestUpsertMemory:
         # Must not raise
         vs.upsert_memory(_make_memory())
 
+    def test_stamps_workspace_id_metadata(self):
+        # Workspace scoping (#493): the query-time filter matches on this key.
+        s3v = _make_s3v_client()
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
+        vs.upsert_memory(_make_memory(workspace_id="ws-1"))
+        metadata = s3v.put_vectors.call_args.kwargs["vectors"][0]["metadata"]
+        assert metadata["workspace_id"] == "ws-1"
+
+    def test_omits_workspace_id_metadata_when_unstamped(self):
+        # Pre-migration memories carry no key so the `$exists: false` filter
+        # arm keeps them reachable (#493).
+        s3v = _make_s3v_client()
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
+        vs.upsert_memory(_make_memory(workspace_id=None))
+        metadata = s3v.put_vectors.call_args.kwargs["vectors"][0]["metadata"]
+        assert "workspace_id" not in metadata
+
 
 # ---------------------------------------------------------------------------
 # VectorStore.delete_memory
@@ -241,3 +258,25 @@ class TestSearch:
         s3v.query_vectors.return_value = {"vectors": []}
         vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
         assert vs.search("q", "u") == []
+
+    def test_workspace_id_adds_metadata_filter(self):
+        # Workspace scoping (#493): foreign-workspace vectors are excluded at
+        # query time; the `$exists: false` arm keeps pre-#493 vectors (no
+        # workspace metadata) reachable for the caller-side compat check.
+        s3v = _make_s3v_client()
+        s3v.query_vectors.return_value = {"vectors": []}
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
+        vs.search("q", "u", workspace_id="ws-1")
+        assert s3v.query_vectors.call_args.kwargs["filter"] == {
+            "$or": [
+                {"workspace_id": "ws-1"},
+                {"workspace_id": {"$exists": False}},
+            ]
+        }
+
+    def test_no_workspace_id_omits_filter(self):
+        s3v = _make_s3v_client()
+        s3v.query_vectors.return_value = {"vectors": []}
+        vs = VectorStore(bucket_name="b", _s3v_client=s3v, _bedrock_client=_make_bedrock_client())
+        vs.search("q", "u")
+        assert "filter" not in s3v.query_vectors.call_args.kwargs


### PR DESCRIPTION
Closes #493

## Summary

Completes workspace scoping for the MCP tool surface. #491 (PR #705) already landed the per-key guard (all 8 keyed tools deny cross-workspace access as not-found / key-in-use, and new memories are stamped with the caller's workspace). This PR delivers the deferred remainder — query-level scoping of every aggregate read path plus workspace filtering in the vector store:

- **`list_memories` / `summarize_context`** — the storage tag-query paths (consistent USERTAG + TagIndex GSI) gain a `workspace_scoped=True` mode applying the compat rules: memories stamped with a foreign workspace are dropped, unstamped (pre-migration) rows stay visible, and an unresolvable caller (`workspace_id=None`) fails closed to unstamped rows only.
- **`list_tags`** — USERTAG items are now stamped with the memory's `workspace_id` at write time (`Memory.to_dynamo_user_tag_items`), and `list_distinct_tags` filters on that attribute so foreign-workspace tag *names* don't leak. `scripts/migrate_workspaces.py` gains an idempotent `migrate_user_tags` phase that back-stamps existing USERTAG items from the (already-stamped) memory META.
- **`search_memories` / `relate_memories` / `pack_context`** — `VectorStore.search` accepts a `workspace_id` and pushes an S3 Vectors metadata filter into `query_vectors`; `upsert_memory` stamps `workspace_id` into vector metadata. All three tools also post-filter hydrated candidates against the authoritative DynamoDB `workspace_id` **before** ranking/limit truncation, so a foreign hit can neither surface nor crowd out visible results (`relate_memories` was restructured to hydrate-filter-truncate instead of truncating pre-hydration).
- **`forget_all`** — bulk deletion now passes the same workspace-scoped filter, so a workspace-scoped token can no longer bulk-delete the same account's memories held by a *different* workspace (previously reachable via the `owner_user_id`-only filter).
- **Docs** — `docs-site/concepts/memory-scoping.md` rewritten for the workspace model (it still described pre-#666 per-client isolation); #705 explicitly deferred this docs update to #493.

## Approach

**Deviation from the issue's acceptance criteria — no 401 on missing claim.** The issue says "No `workspace_id` on the token → MCP endpoint returns 401", but #491/#705 deliberately shipped a reviewed backwards-compat design instead: a missing claim falls back claim → client binding → owner's Personal workspace, so pre-migration tokens keep working. This PR honours that landed design — the compat chain always resolves the caller to a concrete workspace (or fails closed to unstamped rows only), so scoping still holds without breaking legacy tokens.

**Vector filter design.** S3 Vectors `query_vectors` supports metadata filtering, so the filter is applied at query time: `{"$or": [{"workspace_id": <ws>}, {"workspace_id": {"$exists": false}}]}`. The `$exists: false` arm keeps pre-#493 vectors (written before metadata stamping) reachable. Trade-off: such a vector may belong to a memory the migration has since stamped into a *foreign* workspace — the query filter alone can't see that — so the DynamoDB post-hydration check remains authoritative and runs before any ranking/limits. Query-time filtering is the crowd-out defence; DynamoDB is the correctness boundary. Vectors written/updated from now on carry the stamp, so the `$exists` arm's population only shrinks.

**Scope boundaries.**
- Storage's pre-existing exact-match `workspace_id` filters are untouched; the compat behaviour is an explicit opt-in (`workspace_scoped=True`) so future API-side callers wanting a literal workspace slice keep exact-match semantics.
- Management API endpoints (`api/memories.py` etc.) are deliberately untouched — #493 covers MCP tool handlers; workspaces API surface is #492 (in flight concurrently).
- Quota accounting stays per-account (`owner_user_id`) — billing is deferred per the product decisions, and moving quota to a workspace axis is a design question, not a scoping fix.
- MCP resources (`memory://`) need no change: they are scoped to `owner_client_id`, which is strictly narrower than a workspace (a client binds to exactly one workspace), so they cannot return foreign-workspace rows.

**Testing.** Unit: new `TestWorkspaceQueryScoping` (server) proves each aggregate path excludes a *same-account* foreign-workspace memory (the strict case where only the workspace boundary separates caller and row) including crowd-out tests for search/relate; storage/vector-store/models/migration tests cover every new branch. Integration (DynamoDB Local): new `test_workspace_query_scoping.py` proves two workspace-scoped tokens on the same account are mutually invisible across list/tags/search/summarize, keyed recall stays not-found, and `forget_all` never crosses the boundary. Combined coverage on `src/hive` remains 100%.

Pre-existing local failures in `tests/integration/test_api.py` / `test_oauth.py` (table-bootstrap ordering outside CI) reproduce identically on `origin/development` and are untouched here; they pass in CI.

Local e2e not run — CI will cover this on the development branch deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7D3HqD2QPs6DvtnVaRbzF